### PR TITLE
fix(supabase): seed ai_models no baseline.sql (seletor de modelo vazio)

### DIFF
--- a/hostgator-setup-kit/CLAUDE.md
+++ b/hostgator-setup-kit/CLAUDE.md
@@ -114,6 +114,11 @@ Se mesmo assim aparecerem, aqui está o diagnóstico pronto:
 7. **`/api/v1/health` diz "unhealthy" mas o site funciona** — versões antigas checavam
    rotas erradas (`/ping`, `/api/health`). A imagem atual já checa as rotas certas; se ver
    isso, garanta que a imagem do app está na tag `latest` mais nova (`bash update.sh`).
+8. **Criar agente de IA: seletor de modelo vazio em todo provedor** — `baseline.sql` é um
+   dump `--schema-only`, não traz o seed de 8 modelos (`ai_models`, migration 0023). O
+   `baseline.sql` atual já inclui esse insert (seção "COMPLEMENTO DO BASELINE" no fim do
+   arquivo); se ver a tabela vazia mesmo assim, rode o insert manualmente via `psql_run`
+   (ver `_common.sh`) — não é problema de credencial, é dado que faltou popular.
 
 ## Depois de instalado
 

--- a/supabase/baseline.sql
+++ b/supabase/baseline.sql
@@ -4065,3 +4065,18 @@ begin
     end if;
   end loop;
 end $$;
+
+-- ---- ai_models: catálogo curado global (migration 0023, §Seed Spec 10 §2.2) ----
+-- Também não capturado pelo dump --schema-only. Sem isto, /api/v1/ai/providers/:p/models
+-- devolve lista vazia pra todo provedor e o seletor de modelo do agente fica sem opções.
+insert into public.ai_models (provider, model_id, display_name, description, context_window, input_price_per_million_cents, output_price_per_million_cents, supports_tools, is_default_for_provider)
+values
+  ('anthropic', 'claude-opus-4-7',    'Claude Opus 4.7',    'Flagship Anthropic — raciocínio complexo',                  200000,  1500, 7500, true, false),
+  ('anthropic', 'claude-sonnet-4-6',  'Claude Sonnet 4.6',  'Default recomendado — equilíbrio custo/qualidade',           200000,   300, 1500, true, true),
+  ('anthropic', 'claude-haiku-4-5',   'Claude Haiku 4.5',   'Cheap/fast — atendimentos curtos e classificação',           200000,   100,  500, true, false),
+  ('openai',    'gpt-5',              'GPT-5',              'Flagship OpenAI',                                           400000,   500, 4000, true, false),
+  ('openai',    'gpt-5-mini',         'GPT-5 Mini',         'Cheap/fast OpenAI',                                         400000,   150,  600, true, true),
+  ('openai',    'gpt-4o',             'GPT-4o (legacy)',    'Compat — uso legado',                                       128000,   250, 1000, true, false),
+  ('google',    'gemini-2.5-pro',     'Gemini 2.5 Pro',     'Flagship Google',                                          1000000,   125,  500, true, false),
+  ('google',    'gemini-2.5-flash',   'Gemini 2.5 Flash',   'Cheap/fast Google',                                        1000000,    30,  120, true, true)
+on conflict (provider, model_id) do nothing;


### PR DESCRIPTION
## Problema

Ao criar/editar um Agente de IA, o seletor de modelo aparece vazio pra
**qualquer** provedor (Anthropic, OpenAI, Google) — "Nenhum modelo disponível" —
mesmo com a credencial validada corretamente.

## Causa raiz

`GET /api/v1/ai/providers/:provider/models` lê da tabela global `public.ai_models`.
Essa tabela é populada por um `insert` na migration `20260505140000_0023_ai_agents_module.sql`
(8 modelos curados), mas `supabase/baseline.sql` é um dump `--schema-only` — ele recria a
tabela e as policies, porém sem as linhas de dado. Resultado: instalação nova via
`install.sh` (que aplica só o `baseline.sql`) sobe com `ai_models` vazia.

Confirmei rodando contra uma instância de produção (self-host, HostGator): a tabela
realmente estava com 0 linhas antes do fix e o seletor voltou a funcionar depois do insert.

## Fix

- Adiciona o mesmo `insert ... on conflict (provider, model_id) do nothing` da migration
  0023 ao final de `supabase/baseline.sql`, seguindo o padrão já usado ali pra seed dos
  buckets de storage (seção "COMPLEMENTO DO BASELINE").
- Documenta a armadilha no `hostgator-setup-kit/CLAUDE.md` (item 8 da lista de
  "Armadilhas já mapeadas"), pra quem instalar de novo já saber diagnosticar de cara.

## Teste

- [x] Rodei o insert manualmente contra uma instância de produção já rodando (schema
      já aplicado) e confirmei via `select provider, count(*) from ai_models group by provider`
      que os 8 modelos entram corretamente nas 3 categorias de provedor.
- [ ] Reinstalação limpa via `bash install.sh --yes` num VPS novo, pra confirmar que o
      `baseline.sql` atualizado já sobe com `ai_models` populada de cara (não testado
      neste PR — só a correção do arquivo).