### PR TITLE
fix(ai): runtime do agente usa AI Gateway com chave crua do provedor (sempre falha)

### DIFF
--- a/lib/ai/runtime/agent.ts
+++ b/lib/ai/runtime/agent.ts
@@ -18,7 +18,10 @@
  *   - Dry-run path bypasses concurrency unique guard, WAHA dispatch, outbound row.
  *   - Plaintext API keys are never logged.
  */
-import { createGateway, generateText, stepCountIs, type StopCondition, type ToolSet } from "ai";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateText, stepCountIs, type LanguageModel, type StopCondition, type ToolSet } from "ai";
 
 import { CredentialUnavailableError, loadCredential } from "@/lib/ai/credentials";
 import { createAdminClient } from "@/lib/supabase/admin";
@@ -103,6 +106,31 @@ function buildSentinelRegex(keywords: string[]): RegExp | null {
   if (cleaned.length === 0) return null;
   const escaped = cleaned.map((k) => k.trim().replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
   return new RegExp(`(${escaped.join("|")})`, "i");
+}
+
+/**
+ * Builds the LM directly against the provider's own API using the org's BYOK
+ * credential (`ai_provider_credentials`, decrypted by `loadCredential`).
+ *
+ * NOT routed through Vercel AI Gateway (`createGateway`): the Gateway
+ * authenticates the CALLER with a Vercel-issued `AI_GATEWAY_API_KEY`, then
+ * uses Vercel's own configured provider keys — it does not accept a tenant's
+ * raw Anthropic/OpenAI/Google key as a substitute credential. Passing
+ * `credentialApiKey` to `createGateway({ apiKey })` always failed with
+ * "Unauthenticated. Configure AI_GATEWAY_API_KEY or use a provider module.",
+ * which is exactly what this does — a direct provider module per `provider`.
+ */
+function buildModel(provider: string, apiKey: string, modelId: string): LanguageModel {
+  switch (provider) {
+    case "anthropic":
+      return createAnthropic({ apiKey })(modelId);
+    case "openai":
+      return createOpenAI({ apiKey })(modelId);
+    case "google":
+      return createGoogleGenerativeAI({ apiKey })(modelId);
+    default:
+      throw new Error(`unsupported_provider: ${provider}`);
+  }
 }
 
 function totalUsage(steps: ReadonlyArray<{ usage?: { inputTokens?: number; outputTokens?: number } }>) {
@@ -344,9 +372,8 @@ export async function runAgent(input: RunAgentInput): Promise<RunAgentResult> {
         })
       : [];
 
-    // 9) Build LM via gateway.
-    const gatewayProvider = createGateway({ apiKey: credentialApiKey });
-    const model = gatewayProvider(`${version.provider}/${version.model}`);
+    // 9) Build LM directly against the provider (BYOK credential — see buildModel doc).
+    const model = buildModel(version.provider, credentialApiKey, version.model);
 
     // 10) Cost/token guard. Fires BEFORE the next step is taken.
     let abortReason: string | null = null;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "test:unit": "vitest run"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.94",
+    "@ai-sdk/google": "^3.0.89",
     "@ai-sdk/openai": "^3.0.53",
     "@hello-pangea/dnd": "^17.0.0",
     "@hookform/resolvers": "^3.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.94
+        version: 3.0.94(zod@3.25.76)
+      '@ai-sdk/google':
+        specifier: ^3.0.89
+        version: 3.0.89(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: ^3.0.53
         version: 3.0.53(zod@3.25.76)
@@ -231,8 +237,20 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
+  '@ai-sdk/anthropic@3.0.94':
+    resolution: {integrity: sha512-sRENM4zDL4Cd/TBifbZ/X88Vv9vK8r7G5f2DDMi69+89QjXOVtASWj7y2d3kYBPGPEGHWHkSKq/nQ+pSYWY14w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.104':
     resolution: {integrity: sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/google@3.0.89':
+    resolution: {integrity: sha512-/FCPSbFqSdrDmhLoLf2e0dnQMoZWEciBAut5qcRJ+DKpa4TIfKOqCEUOmPI9DOuPzKPgVnUWUfmFFXpAlnhxCw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -248,6 +266,16 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.36':
+    resolution: {integrity: sha512-hy0V+eyKcYyjmIxdcSh1jvy4+zNC7DbP0/V45jkRmfVnz+lI6GslT0qsd0V/bfJKo/A+P2t1tYFypTQJdOH1Sg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.13':
+    resolution: {integrity: sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw==}
+    engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
@@ -5287,11 +5315,23 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
+  '@ai-sdk/anthropic@3.0.94(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.13
+      '@ai-sdk/provider-utils': 4.0.36(zod@3.25.76)
+      zod: 3.25.76
+
   '@ai-sdk/gateway@3.0.104(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
       '@vercel/oidc': 3.2.0
+      zod: 3.25.76
+
+  '@ai-sdk/google@3.0.89(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.13
+      '@ai-sdk/provider-utils': 4.0.36(zod@3.25.76)
       zod: 3.25.76
 
   '@ai-sdk/openai@3.0.53(zod@3.25.76)':
@@ -5306,6 +5346,17 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.8
       zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.36(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.13
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 3.25.76
+
+  '@ai-sdk/provider@3.0.13':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.8':
     dependencies:


### PR DESCRIPTION
## Problema

Depois de publicar um Agente de IA (com credencial validada e canal
conectado), toda execução falha. Rodando o runner direto:

\`\`\`json
{"error_code":"runtime_error","error_message":"Unauthenticated. Configure AI_GATEWAY_API_KEY or use a provider module. Learn more: https://ai-sdk.dev/unauthenticated-ai-gateway"}
\`\`\`

O agente nunca responde no WhatsApp — não é um problema do canal (que está
"working" e recebendo mensagens normalmente), é a chamada ao modelo que
nunca sai do chão.

## Causa raiz

\`lib/ai/runtime/agent.ts\` monta o LM assim:

\`\`\`ts
const gatewayProvider = createGateway({ apiKey: credentialApiKey });
const model = gatewayProvider(\`${version.provider}/${version.model}\`);
\`\`\`

\`credentialApiKey\` é a chave **crua** que o tenant colou em Configurações >
Credenciais de IA (BYOK — ex. \`sk-ant-...\`, decrypted via \`loadCredential\`).

\`createGateway\` é o cliente do **Vercel AI Gateway**: ele autentica quem
está chamando usando uma chave emitida pela própria Vercel
(\`AI_GATEWAY_API_KEY\`), e o Gateway então usa as credenciais de provider
configuradas do lado da Vercel — ele não aceita a chave crua de um provider
como se fosse uma chave do Gateway. Resultado: a chamada ao Gateway falha
autenticação **sempre**, pra qualquer provider, qualquer credential, em
qualquer instalação (self-host ou não) — porque nenhuma delas tem uma
\`AI_GATEWAY_API_KEY\` real da Vercel.

## Fix

Chama o provider diretamente, um módulo por \`version.provider\`
(\`@ai-sdk/anthropic\`, \`@ai-sdk/openai\`, \`@ai-sdk/google\`), passando a
credencial BYOK do tenant como \`apiKey\` do próprio provider — é
literalmente o que a mensagem de erro do SDK sugere (\"or use a provider
module\").

- Adiciona \`@ai-sdk/anthropic\` e \`@ai-sdk/google\` como dependências,
  pinadas na major \`3.x\` — a mesma major já usada por \`@ai-sdk/openai\`
  nesse projeto. As versões \`4.x\` (as que o pnpm resolve por padrão) geram
  \`LanguageModelV4\`, incompatível com o \`LanguageModel\` exportado por
  \`ai@^6\` (o core já usado aqui) — quebra o typecheck.
- \`lib/ai/gateway.ts\` (o wrapper do Gateway global, via
  \`AI_GATEWAY_API_KEY\`/\`ANTHROPIC_API_KEY\`) **não foi tocado** — é um
  caminho separado, não usado pelo runtime de Agentes configuráveis
  (EPIC-13). Só o runtime de agente (BYOK per-org) precisa do provider
  direto.

## Teste

- [x] \`pnpm run typecheck\` limpo.
- [x] \`pnpm run lint\` limpo (só warnings pré-existentes, não relacionados).
- [x] Testado em produção (self-host): reset de um run que falhava com
      \`channel_session_offline\`/depois \`Unauthenticated\` pra \`pending\`,
      invocação direta de \`/api/internal/agents/run\` → resposta real gerada
      pelo modelo (\`status: "completed"\`, texto coerente com o
      \`system_prompt\` do agente, tokens/custo computados corretamente).
- [ ] Reinstalação limpa via \`bash install.sh --yes\` (não testada neste PR).

Nota: durante o teste em produção também encontrei que **contatos sem
\`phone_number\` resolvido** (identidade \`@lid\`) fazem o outbound falhar
depois que o modelo já respondeu — parece já estar endereçado por outro
fix (\`fix(whatsapp): unifica conversas por contato/número na ingestão
WAHA\`), não duplicado aqui.