### PR TITLE
fix(waha): envio pra contato @lid falha (missing_phone_number) + external_id vira JSON

### DIFF
--- a/app/api/v1/messages/_handler.ts
+++ b/app/api/v1/messages/_handler.ts
@@ -14,6 +14,7 @@ import { audit } from "@/lib/audit";
 import type { ListMessagesQuery, SendMessageInput } from "@/lib/schemas";
 import type { Message } from "@/lib/types/messaging";
 import { getWahaClient } from "@/lib/waha/client";
+import { resolveWahaChatId } from "@/lib/waha/send";
 
 type SB = SupabaseClient;
 
@@ -121,7 +122,7 @@ export async function sendMessageHandler(
   const { data: conv, error: convErr } = await supabase
     .from("conversations")
     .select(
-      "id, organization_id, contact_id, channel_session_id, is_group, group_chat_id, contacts:contact_id(phone_number, is_blocked), channel_sessions:channel_session_id(waha_session_name, status)",
+      "id, organization_id, contact_id, channel_session_id, is_group, group_chat_id, contacts:contact_id(phone_number, wa_identity, is_blocked), channel_sessions:channel_session_id(waha_session_name, status)",
     )
     .eq("id", input.conversation_id)
     .maybeSingle();
@@ -140,7 +141,7 @@ export async function sendMessageHandler(
     channel_session_id: string;
     is_group: boolean;
     group_chat_id: string | null;
-    contacts: { phone_number: string | null; is_blocked: boolean } | null;
+    contacts: { phone_number: string | null; wa_identity: string | null; is_blocked: boolean } | null;
     channel_sessions: { waha_session_name: string; status: string } | null;
   };
   const c = conv as unknown as Joined;
@@ -194,12 +195,12 @@ export async function sendMessageHandler(
   let message = created as unknown as Message;
 
   const waha = getWahaClient();
-  const phone = c.contacts?.phone_number;
-  const chatId = c.is_group && c.group_chat_id
-    ? c.group_chat_id
-    : phone
-      ? `${phone.replace(/\D/g, "")}@c.us`
-      : null;
+  const chatId = resolveWahaChatId({
+    isGroup: c.is_group,
+    groupChatId: c.group_chat_id,
+    phoneNumber: c.contacts?.phone_number,
+    waIdentity: c.contacts?.wa_identity,
+  });
 
   if (!waha) {
     const { data: updated } = await supabase
@@ -242,8 +243,14 @@ export async function sendMessageHandler(
         c.channel_sessions.waha_session_name,
         chatId,
         input.body ?? "",
-      )) as { id?: string };
-      const externalId = wahaRes?.id ?? null;
+      )) as { id?: string | { _serialized?: string } };
+      // WAHA/NOWEB returns `id` as a WAMessageKey object ({fromMe, remote, id,
+      // _serialized}), not a plain string — storing it raw got JSON-stringified
+      // into external_id, which never matched the plain-string id the WAHA
+      // webhook uses later, so the ack/status update inserted a duplicate row
+      // instead of updating this one.
+      const rawId = wahaRes?.id;
+      const externalId = typeof rawId === "string" ? rawId : (rawId?._serialized ?? null);
       const { data: updated } = await supabase
         .from("messages")
         .update({ status: "sent", external_id: externalId, ack: 0 })

--- a/lib/ai/runtime/agent.ts
+++ b/lib/ai/runtime/agent.ts
@@ -36,6 +36,7 @@ import { loadHistoryWithBudget } from "./history";
 import { mintEphemeralToken, revokeEphemeralToken } from "./mcp_token";
 import { pickToolsFromMcp, type RuntimeHandoffSignal } from "./tools";
 import { serializeSteps } from "./serialize";
+import { resolveWahaChatId } from "@/lib/waha/send";
 
 export interface RunAgentInput {
   runId: string;
@@ -264,7 +265,7 @@ export async function runAgent(input: RunAgentInput): Promise<RunAgentResult> {
       const { data: convRaw } = await admin
         .from("conversations")
         .select(
-          "id, group_chat_id, is_group, contacts:contact_id(phone_number), channel_sessions:channel_session_id(waha_session_name)",
+          "id, group_chat_id, is_group, contacts:contact_id(phone_number, wa_identity), channel_sessions:channel_session_id(waha_session_name)",
         )
         .eq("id", run.conversation_id)
         .eq("organization_id", run.organization_id)
@@ -273,17 +274,17 @@ export async function runAgent(input: RunAgentInput): Promise<RunAgentResult> {
         id: string;
         group_chat_id: string | null;
         is_group: boolean;
-        contacts: { phone_number: string | null } | null;
+        contacts: { phone_number: string | null; wa_identity: string | null } | null;
         channel_sessions: { waha_session_name: string } | null;
       } | null;
       if (conv) {
         waSessionName = conv.channel_sessions?.waha_session_name ?? null;
-        const phone = conv.contacts?.phone_number ?? null;
-        chatId = conv.is_group && conv.group_chat_id
-          ? conv.group_chat_id
-          : phone
-            ? `${phone.replace(/\D/g, "")}@c.us`
-            : null;
+        chatId = resolveWahaChatId({
+          isGroup: conv.is_group,
+          groupChatId: conv.group_chat_id,
+          phoneNumber: conv.contacts?.phone_number,
+          waIdentity: conv.contacts?.wa_identity,
+        });
       }
     }
 

--- a/lib/waha/send.ts
+++ b/lib/waha/send.ts
@@ -14,6 +14,28 @@ export interface SendWahaInput {
   text: string;
 }
 
+export interface ResolveWahaChatIdInput {
+  isGroup: boolean;
+  groupChatId: string | null;
+  phoneNumber: string | null | undefined;
+  /** `contacts.wa_identity` (migration 0027): 'phone:+E164' | 'lid:<digits>' | null. */
+  waIdentity: string | null | undefined;
+}
+
+/**
+ * Resolves the WAHA-addressable chat id for a 1:1 or group conversation.
+ * Falls back to the `lid:<digits>` identity (migration 0027) when the
+ * contact has no `phone_number` — WhatsApp's privacy-mode contacts (Linked
+ * ID) never expose a real phone number, but WAHA/NOWEB still accepts sending
+ * to `<digits>@lid`.
+ */
+export function resolveWahaChatId(input: ResolveWahaChatIdInput): string | null {
+  if (input.isGroup && input.groupChatId) return input.groupChatId;
+  if (input.phoneNumber) return `${input.phoneNumber.replace(/\D/g, "")}@c.us`;
+  if (input.waIdentity?.startsWith("lid:")) return `${input.waIdentity.slice(4)}@lid`;
+  return null;
+}
+
 export async function sendWAHA(input: SendWahaInput): Promise<unknown | null> {
   const client = getWahaClient();
   if (!client) return null;


### PR DESCRIPTION
## Contexto

Depois do #5 (fix do AI Gateway), a IA já responde de verdade, mas em
produção o envio pelo WhatsApp continuava falhando pra alguns contatos:

\`\`\`
status: "failed", error_code: "missing_phone_number"
\`\`\`

## Causa raiz 1 — sem fallback pra identidade @lid

\`sendMessageHandler\` (\`app/api/v1/messages/_handler.ts\`) monta o \`chatId\`
só a partir de \`contacts.phone_number\`:

\`\`\`ts
const chatId = c.is_group && c.group_chat_id
  ? c.group_chat_id
  : phone ? \`\${phone.replace(/\\D/g, "")}@c.us\` : null;
\`\`\`

Contatos \`@lid\` (WhatsApp em modo privacidade, sem número exposto) têm
\`phone_number\` sempre \`null\` — mesmo depois da migration 0027 (unificação
de conversas) já ter dado a esses contatos uma identidade canônica
(\`contacts.wa_identity = 'lid:<dígitos>'\`), o envio nunca tinha destino.

Confirmei em produção: **28 dos 28 contatos** dessa instância eram \`@lid\`
puro (\`phone_number is null\`) antes da 0027 rodar.

## Fix 1

\`lib/waha/send.ts\` ganha \`resolveWahaChatId()\`: cai pra \`<dígitos>@lid\`
quando não há telefone. Usado no handler de envio e no preview de
\`lib/ai/runtime/agent.ts\` (mesma lógica, um lugar só).

## Causa raiz 2 (achada testando o fix 1) — external_id vira JSON

O \`id\` que o WAHA/NOWEB devolve no POST de envio é um objeto
(\`{fromMe, remote, id, _serialized}\`), não string. \`wahaRes.id\` gravado
cru em \`external_id\` (coluna \`text\`) virava um JSON serializado. O
webhook de ack manda o id já como string (\`_serialized\`), que não batia
com esse JSON — a atualização de status por \`external_id\` não encontrava
a linha e **inseria uma linha outbound duplicada** em vez de atualizar
(uma travada em \`sent\` pra sempre, outra \`delivered\` órfã, sem
\`run_id\`/metadata).

## Fix 2

Extrai \`rawId._serialized\` quando \`id\` não é string.

## Teste

- [x] \`pnpm run typecheck\` e \`pnpm run lint\` limpos sobre o \`main\` atual
      (pós #5 + baseline com a 0027).
- [x] Testado ponta a ponta em produção (self-host): contato @lid real,
      canal WORKING, agente publicado → \`would_send_to.chat_id\` resolvido
      pro \`<lid>@lid\` certo, mensagem \`status: "delivered"\`, \`external_id\`
      limpo (string), sem linha duplicada.
- [ ] Reinstalação limpa (não testada neste PR — sem mudança de schema,
      não deveria ser afetada).

Sem mudança de schema — só código de aplicação, não precisa de
migration/baseline/manifest.