### PR TITLE
fix(app): raiz redireciona para /app (login direto, sem pré-página)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,35 +1,7 @@
+import { redirect } from "next/navigation";
+
+// A raiz não tem conteúdo próprio: manda pro painel. O middleware redireciona
+// visitante não autenticado para /login?next=/app automaticamente.
 export default function HomePage() {
-  return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-bg p-8">
-      <div className="max-w-2xl text-center">
-        <h1 className="text-4xl font-bold tracking-tight text-text">
-          DeskcommCRM
-        </h1>
-        <p className="mt-4 text-lg leading-relaxed text-text-muted">
-          CRM operacional multi-tenant para e-commerce, com IA conversacional
-          integrada, WhatsApp via WAHA e LGPD nativa.
-        </p>
-        <p className="mt-6 text-sm text-text-muted">
-          MVP em desenvolvimento. Acesse o painel via{" "}
-          <code className="rounded-sm bg-surface-elevated px-2 py-0.5 font-mono text-xs text-text">
-            /app
-          </code>{" "}
-          ou{" "}
-          <code className="rounded-sm bg-surface-elevated px-2 py-0.5 font-mono text-xs text-text">
-            /admin
-          </code>
-          .
-        </p>
-        <p className="mt-2 text-xs text-text-subtle">
-          Health check:{" "}
-          <a
-            className="text-accent underline decoration-1 underline-offset-4 hover:decoration-2"
-            href="/api/v1/health"
-          >
-            /api/v1/health
-          </a>
-        </p>
-      </div>
-    </main>
-  );
+  redirect("/app");
 }


### PR DESCRIPTION
## O quê
Acessar `/` caía numa página de boas-vindas de MVP ("Acesse o painel via /app ou /admin"). Agora `/` redireciona server-side para `/app`.

## Comportamento
- Visitante sem sessão: `/` → `307 /app` → middleware → `/login?next=/app` (após login, cai direto no painel).
- Usuário logado: `/` → painel direto, sem passar pela tela de login.

## Validação
- `npm run typecheck` ✅, `npm run lint` ✅, `npm run build` ✅ (worktree limpo a partir da main)
- Testado em dev server local: `curl /` → `307 → /app`; seguindo redirects sem sessão → `200` em `/login?next=%2Fapp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx84HFMpE2kdycFZFUPmV3