### PR TITLE
chore(oss): higiene open-source + README com estado real do projeto

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,42 @@
+name: 🐛 Bug report
+description: Algo quebrou ou não funciona como documentado
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Obrigado por reportar! Para **vulnerabilidades de segurança**, NÃO abra issue — use o [relato privado](https://github.com/melgarafael/DeskcommCRM/security/advisories/new).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: O que aconteceu?
+      description: Descreva o bug e o que você esperava que acontecesse.
+      placeholder: Ao clicar em X na tela Y, acontece Z em vez de W.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Passos para reproduzir
+      placeholder: |
+        1. Acesse '...'
+        2. Clique em '...'
+        3. Veja o erro
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Ambiente
+      description: Versão do Node, pnpm, SO, e onde roda (local / Vercel / VPS HostGator).
+      placeholder: |
+        Node 20.x · pnpm 9.x · macOS 15 · self-host via hostgator-setup-kit
+        Output de /api/v1/health: ...
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshot
+      description: Stack trace, print ou output relevante (remova dados pessoais!).
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 Perguntas e ideias
+    url: https://github.com/melgarafael/DeskcommCRM/discussions
+    about: Dúvidas de setup, ideias e showcase vão melhor em Discussions.
+  - name: 🔒 Vulnerabilidade de segurança
+    url: https://github.com/melgarafael/DeskcommCRM/security/advisories/new
+    about: Relato privado — nunca abra issue pública para falha de segurança.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: 💡 Feature request
+description: Sugira uma melhoria ou funcionalidade nova
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Qual problema isso resolve?
+      description: Descreva a dor real de quem opera o CRM, não só a solução.
+      placeholder: Como atendente, eu preciso de X porque Y.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solução proposta
+      description: Como você imagina que isso funcionaria?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternativas consideradas
+      description: Outras formas de resolver, ou como você contorna hoje.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+# O que este PR faz
+
+<!-- 1-3 frases. Se resolve issue, referencie: Closes #123 -->
+
+## Checklist (Definition of Done)
+
+- [ ] `pnpm typecheck` zerado
+- [ ] `pnpm lint` zerado
+- [ ] Testes relevantes existem e passam (`pnpm test:unit` / `pnpm test:e2e`)
+- [ ] RLS testada, se toca tabela tenant-aware
+- [ ] Audit log emitido, se há mutação relevante
+- [ ] Zod valida todo input externo novo
+- [ ] Sem `console.log` esquecido
+- [ ] Mudança de schema saiu como migration versionada + apêndice no `baseline.sql` + linha no MANIFEST
+- [ ] Doc atualizada se mudou contrato (PRD/spec)
+
+Convenções completas em [`CLAUDE.md`](../CLAUDE.md) · fluxo em [`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ loop/logs/
 loop/locks/
 loop/STOP
 loop/run-session.sh
+
+# graphify (análise local de knowledge graph)
+graphify-out/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Código de Conduta — Contributor Covenant
+
+## Nosso compromisso
+
+Nós, como membros, contribuidores e líderes, nos comprometemos a fazer da participação em nossa comunidade uma experiência livre de assédio para todos, independentemente de idade, corpo, deficiência visível ou invisível, etnia, características sexuais, identidade e expressão de gênero, nível de experiência, educação, status socioeconômico, nacionalidade, aparência pessoal, raça, religião ou identidade e orientação sexual.
+
+Comprometemo-nos a agir e interagir de maneiras que contribuam para uma comunidade aberta, acolhedora, diversa, inclusiva e saudável.
+
+## Nossos padrões
+
+Exemplos de comportamento que contribuem para um ambiente positivo:
+
+- Demonstrar empatia e bondade com outras pessoas
+- Respeitar opiniões, pontos de vista e experiências divergentes
+- Dar e receber feedback construtivo com elegância
+- Assumir responsabilidade, pedir desculpas a quem for afetado por nossos erros e aprender com a experiência
+- Focar no que é melhor não só para nós individualmente, mas para a comunidade como um todo
+
+Exemplos de comportamento inaceitável:
+
+- Uso de linguagem ou imagens sexualizadas e atenção ou avanços sexuais de qualquer tipo
+- Trolling, comentários insultuosos ou depreciativos e ataques pessoais ou políticos
+- Assédio público ou privado
+- Publicar informações privadas de terceiros, como endereço físico ou de e-mail, sem permissão explícita
+- Outras condutas que poderiam razoavelmente ser consideradas inadequadas em ambiente profissional
+
+## Responsabilidades de aplicação
+
+Os mantenedores do projeto são responsáveis por esclarecer e aplicar nossos padrões de comportamento aceitável e tomarão ações corretivas apropriadas e justas em resposta a qualquer comportamento que considerem inadequado, ameaçador, ofensivo ou nocivo.
+
+## Escopo
+
+Este Código de Conduta se aplica a todos os espaços da comunidade (issues, PRs, discussions) e também quando um indivíduo representa oficialmente a comunidade em espaços públicos.
+
+## Aplicação
+
+Casos de comportamento abusivo, de assédio ou de outra forma inaceitável podem ser reportados aos mantenedores em **rafael@maudibrasil.com.br**. Todas as reclamações serão analisadas e investigadas de forma rápida e justa, respeitando a privacidade e a segurança de quem reportar.
+
+## Atribuição
+
+Este Código de Conduta é adaptado do [Contributor Covenant](https://www.contributor-covenant.org), versão 2.1, disponível em <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6?logo=typescript)](https://www.typescriptlang.org)
 [![Supabase](https://img.shields.io/badge/Supabase-Postgres%2BAuth%2BStorage-3ecf8e?logo=supabase)](https://supabase.com)
 [![Tailwind](https://img.shields.io/badge/Tailwind-CSS-38bdf8?logo=tailwindcss)](https://tailwindcss.com)
-[![License: TBD](https://img.shields.io/badge/license-TBD-lightgrey)](#licença)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-[**📘 Setup Guide**](docs/SETUP.md) · [**🏗️ Arquitetura**](ARCHITECTURE.md) · [**🤝 Contribuir**](CONTRIBUTING.md) · [**📋 PRDs**](docs/prd/) · [**🗺️ Roadmap**](docs/stories/epics/MASTER.md)
+[**📘 Setup Guide**](docs/SETUP.md) · [**🏗️ Arquitetura**](ARCHITECTURE.md) · [**🤝 Contribuir**](CONTRIBUTING.md) · [**📋 PRDs**](docs/prd/) · [**🗺️ Roadmap**](#%EF%B8%8F-roadmap)
 
 </div>
 
@@ -27,17 +27,18 @@
 
 ## ✨ O que é
 
-DeskcommCRM unifica **atendimento humano**, **chatbot com RAG por tenant**, **gestão de pedidos** e **pipeline de pós-venda** numa única plataforma. Canal primário: **WhatsApp via WAHA**. Multi-tenant desde o dia 1. LGPD nativa.
+DeskcommCRM unifica **atendimento humano**, **agentes de IA com RAG por tenant**, **gestão de pedidos** e **pipeline de pós-venda** numa única plataforma. Canal primário: **WhatsApp via WAHA**. Multi-tenant desde o dia 1. LGPD nativa.
 
 > **Modo atual:** BPO interno (uma operadora atende N tenants).
 > **Modo futuro:** SaaS direto pra lojistas.
 
 ### Diferenciais
 
-- 🤖 **IA operando o atendimento** com RAG por tenant — não é chatbot decorativo, é triagem real.
+- 🤖 **IA operando o atendimento** — agentes com RAG por tenant, análise de sentimento, handoff IA→humano auditado e controle de budget. Não é chatbot decorativo, é triagem real.
 - 🛒 **E-commerce-native** — vocabulário desenhado pro ciclo *Carrinho abandonado → Pago → Enviado → Entregue → Pós-venda*.
 - 🇧🇷 **LGPD by-design** — webhooks `customer/redact` e `customer/data_request` da Nuvemshop como contrato de primeira-classe; anonimização preferida sobre delete; audit append-only com retenção 5 anos.
-- 🔌 **MCP-ready** (Fase 2) — exporta capabilities pro ecossistema de agentes.
+- 👥 **Governança de atendimento** — RBAC server-side de verdade, atribuição/transferência auditada, fila com posição, roteamento automático e escopo de visualização por papel.
+- 🔌 **MCP-ready** — MCP server interno pros agentes; contrato público pra agentes externos em construção.
 - 🏢 **Multi-tenant de verdade** — RLS em toda tabela tenant-aware, teste de isolamento como gate de CI.
 
 ---
@@ -104,17 +105,19 @@ DeskcommCRM/
 ├── app/                    # Next.js App Router
 │   ├── (admin)/            # Rotas super-admin (impersonate, tenants)
 │   ├── (public)/           # Login, recovery
-│   ├── app/                # Rotas autenticadas (inbox, kanban, contacts, audit)
+│   ├── app/                # Rotas autenticadas: inbox, kanban, contacts,
+│   │                       #   connections, ai (agentes), integrations,
+│   │                       #   metrics, lgpd, audit, team, settings
 │   └── api/v1/             # API REST canônica
-├── components/             # React (ui/, empty/, feedback/, shell/)
-├── lib/                    # supabase/, waha/, ai/, api/, logger.ts, env.ts
+├── components/             # React (ui/, inbox/, kanban/, shell/, ...)
+├── lib/                    # supabase/, waha/, ai/, api/, routing/, env.ts
 ├── hooks/
-├── supabase/migrations/    # SQL versionado
-├── tests/{e2e,unit}/
+├── supabase/migrations/    # SQL versionado (+ baseline.sql pro self-host)
+├── workers/                # consumers de event_log (IA, RAG, LGPD, rotinas)
+├── tests/{e2e,unit,invariants}/
 ├── scripts/                # seeds, qa-waves, manutenção
 ├── docs/                   # PRDs, specs, stories, SETUP.md
-├── workers/                # consumers de event_log
-└── tasks/                  # backlog ativo
+└── hostgator-setup-kit/    # instalação self-host com 1 comando
 ```
 
 ---
@@ -128,17 +131,7 @@ pnpm test:unit     # Vitest
 pnpm test:e2e      # Playwright (requer dev server)
 ```
 
-CI roda todos antes de merge. **Teste de isolamento RLS é gate obrigatório** — cria 2 tenants e verifica não-vazamento.
-
----
-
-## ⌨️ Atalhos de teclado
-
-- `Tab` / `Shift+Tab` — navegação focável (login, formulários, kanban cards)
-- `Enter` — confirma ações primárias
-- `Esc` — fecha dialogs/sheets
-
-Documentação completa de keyboard shortcuts vem com EPIC-04 (kanban) e EPIC-03 (inbox).
+CI roda todos antes de merge. **Teste de isolamento RLS é gate obrigatório** — cria 2 tenants e verifica não-vazamento. A suíte de **invariantes de governança** (100+ testes) trava regressões de RBAC, atribuição, escopo e roteamento.
 
 ---
 
@@ -151,57 +144,75 @@ Documentação completa de keyboard shortcuts vem com EPIC-04 (kanban) e EPIC-03
 | [`ARCHITECTURE.md`](ARCHITECTURE.md) | Visão de 1 página da arquitetura |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Fluxo PR + epic-executor |
 | [`docs/prd/`](docs/prd/) | PRDs (master, platform, customer 360, WhatsApp, pipeline, IA-RAG, Nuvemshop) |
-| [`docs/specs/`](docs/specs/) | Specs técnicas detalhadas (schema SQL, payloads exatos) |
+| [`docs/specs/`](docs/specs/) | Specs técnicas 01–13 (schema SQL, payloads, MCP, governança) |
 | [`docs/business-rules/`](docs/business-rules/) | Regras de negócio fora do código |
-| [`docs/stories/epics/MASTER.md`](docs/stories/epics/MASTER.md) | Plano de execução wave-by-wave |
 | [`docs/DEPLOY-CHECKLIST.md`](docs/DEPLOY-CHECKLIST.md) | Preflight pré-go-live |
 | [`docs/runbooks/waha-hostgator.md`](docs/runbooks/waha-hostgator.md) | Runbook completo de WAHA em produção (VPS Hostgator) |
+| [`docs/ATUALIZANDO.md`](docs/ATUALIZANDO.md) | Como atualizar uma instalação self-host |
 
 ---
 
 ## 🤝 Contribuindo
 
-Esse projeto é open source pra comunidade. Toda contribuição é bem-vinda — desde fix de typo em doc até epic novo.
+Esse projeto é open source pra comunidade. Toda contribuição é bem-vinda — desde fix de typo em doc até feature nova.
 
 **Antes de abrir PR:**
 
 1. Leia [`CLAUDE.md`](CLAUDE.md) (~5 min) — convenções não-negociáveis (multi-tenancy, RLS, audit, LGPD).
 2. Leia [`CONTRIBUTING.md`](CONTRIBUTING.md) — fluxo de branches, commits, epic-executor.
-3. Identifique o epic em [`docs/stories/epics/MASTER.md`](docs/stories/epics/MASTER.md).
+3. Siga o [Código de Conduta](CODE_OF_CONDUCT.md).
 
 **Fluxo curto:**
 
 ```bash
-git checkout -b feat/EPIC-XX-short-slug
+git checkout -b feat/short-slug
 # implementa + testes
 pnpm typecheck && pnpm lint && pnpm test:unit
-git commit -m "feat(EPIC-XX): descrição"
-# abre PR
+git commit -m "feat(escopo): descrição"
+# abre PR — o template já traz o checklist de Definition of Done
 ```
 
-**Definition of Done:** typecheck zero, lint zero, testes relevantes verdes, RLS testada se toca tabela tenant-aware, audit log emitido em mutações, sem `console.log` esquecido. Detalhes em [`CLAUDE.md`](CLAUDE.md#definition-of-done).
+**Definition of Done:** typecheck zero, lint zero, testes relevantes verdes, RLS testada se toca tabela tenant-aware, audit log emitido em mutações, migration versionada se muda schema. Detalhes em [`CLAUDE.md`](CLAUDE.md#definition-of-done).
 
 ---
 
 ## 🐛 Reportando bugs
 
-Abra uma [issue](https://github.com/melgarafael/DeskcommCRM/issues) com:
-- Versão do Node, pnpm e SO.
-- Output do `/api/v1/health`.
-- Stack trace ou screenshot.
-- Steps to reproduce.
+Abra uma [issue](https://github.com/melgarafael/DeskcommCRM/issues/new/choose) — o template pede o que precisamos (ambiente, `/api/v1/health`, steps).
 
-Pra **vulnerabilidades de segurança**, **NÃO abra issue pública**. Mande email pra `security@deskcomm.app` (a definir) ou DM ao mantenedor.
+Pra **vulnerabilidades de segurança**, **NÃO abra issue pública** — use o [relato privado de vulnerabilidades](https://github.com/melgarafael/DeskcommCRM/security/advisories/new). Detalhes em [`SECURITY.md`](SECURITY.md).
 
 ---
 
-## 🗺️ Roadmap (alto nível)
+## 🗺️ Roadmap
 
-- ✅ **Fase 1 — MVP (8–12 semanas)**: Auth, multi-tenancy, inbox WhatsApp, kanban, customer 360, RAG, integração Nuvemshop, LGPD.
-- 🔜 **Fase 1.5 — Hardening (+4–8 semanas)**: observability, performance, anti-banimento avançado.
-- 🔜 **Fase 2 — Escala**: MCP público, identity probabilística, integrações VTEX/Shopify, modo SaaS direto.
+### ✅ Entregue
 
-Detalhe wave-by-wave: [`docs/stories/epics/MASTER.md`](docs/stories/epics/MASTER.md).
+- **Fundação & plataforma** — auth (MFA pra admin), multi-tenancy com RLS + teste de isolamento, RBAC 4 papéis, audit log append-only, onboarding de tenant.
+- **Atendimento WhatsApp** — inbox 3 painéis em tempo real, conexões WAHA multi-número, mídia via Storage, anti-banimento (throttle + jitter + janela de horário), STOP detection.
+- **CRM & pedidos** — kanban com vocabulário e-commerce (fractional indexing), customer 360, contatos, tags, integração Nuvemshop.
+- **IA nativa** — agentes com RAG por tenant (pgvector), análise de sentimento, handoff IA→humano, controle de budget por org, MCP server interno.
+- **LGPD** — export e redact via workers, anonimização em cascata, consentimento auditado.
+- **Self-host** — `hostgator-setup-kit` (app + WAHA + banco com 1 comando), `baseline.sql` auto-curativo, runbook de produção.
+- **Webhooks & automação** — gatilhos de eventos do CRM pra sistemas externos.
+
+### 🔄 Em andamento — Governança de Atendimento
+
+Épico guiado por invariantes (suíte de 100+ testes como eval), fase a fase:
+
+- ✅ **G1** — provas & fundação (invariantes dos 7 eixos de dor, CI consolidado)
+- ✅ **G2** — RBAC server-side em toda a API (matriz papel×endpoint)
+- ✅ **G3** — atribuição & transferência auditadas; IA como assignee de 1ª classe; tags
+- ✅ **G4** — escopo de visualização por papel (RLS) + métricas por atendente
+- 🔄 **G5** — roteamento automático, fila com posição e painel de gestão *(fechando)*
+- 🔜 **G6** — contrato de governança pra agentes de IA externos (MCP tools públicas)
+
+### 🔮 Próximo
+
+- **MCP público** — capabilities do CRM expostas pro ecossistema de agentes.
+- **Integrações** — VTEX e Shopify via adapter pattern (Nuvemshop já entregue).
+- **Identity probabilística** — unificação de contatos entre canais.
+- **Modo SaaS** — self-service direto pra lojistas (hoje: BPO single-operator).
 
 ---
 
@@ -209,7 +220,8 @@ Detalhe wave-by-wave: [`docs/stories/epics/MASTER.md`](docs/stories/epics/MASTER
 
 - **Discussões:** [GitHub Discussions](https://github.com/melgarafael/DeskcommCRM/discussions) — pra perguntas, ideias, showcase.
 - **Issues:** [GitHub Issues](https://github.com/melgarafael/DeskcommCRM/issues) — bugs e tasks.
-- **Twitter / X:** [@rafaelmelgaco](https://twitter.com) (a confirmar).
+- **Instagram:** [@melgarafael](https://www.instagram.com/melgarafael)
+- **YouTube:** [youtube.com/@melgarafael](https://www.youtube.com/@melgarafael)
 
 ---
 
@@ -258,5 +270,7 @@ Este é um projeto **self-host**: cada pessoa roda o CRM na **própria infraestr
 <div align="center">
 
 **Built with ☕ in Brasil** · **Made for the community**
+
+Siga o desenvolvimento: [Instagram](https://www.instagram.com/melgarafael) · [YouTube](https://www.youtube.com/@melgarafael)
 
 </div>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Política de Segurança
+
+## Versões suportadas
+
+O DeskcommCRM é distribuído em rolling release a partir da branch `main`. Correções de segurança são aplicadas apenas à versão mais recente — mantenha sua instalação atualizada (`bash hostgator-setup-kit/update.sh` em self-host).
+
+| Versão | Suportada |
+| --- | --- |
+| `main` (mais recente) | ✅ |
+| Snapshots antigos | ❌ |
+
+## Reportando uma vulnerabilidade
+
+**Não abra issue pública para vulnerabilidades.**
+
+Use o [relato privado de vulnerabilidades do GitHub](https://github.com/melgarafael/DeskcommCRM/security/advisories/new) — o relato chega só aos mantenedores, e o histórico fica auditável.
+
+O que esperar:
+
+- **Confirmação de recebimento** em até 7 dias.
+- **Avaliação e resposta** em até 30 dias, com plano de correção quando confirmada.
+- **Crédito** no advisory publicado, se você quiser.
+
+## Escopo
+
+Interessam especialmente relatos sobre:
+
+- Vazamento entre tenants (bypass de RLS ou de filtro `organization_id`)
+- Bypass de autenticação/RBAC (roles `viewer`/`agent`/`manager`/`admin`, super-admin)
+- Exposição de dados pessoais (LGPD): contatos, conversas, mídia do WhatsApp
+- Injeção via payloads de webhook (WAHA, Nuvemshop) ou da API `/api/v1`
+- Vazamento de segredos (API keys, tokens bearer, cookies de sessão)
+
+Instalações self-host são responsabilidade de quem hospeda; problemas de configuração do servidor (firewall, TLS do VPS etc.) estão fora do escopo do projeto, mas melhorias no kit de instalação são bem-vindas como issue normal.


### PR DESCRIPTION
## O quê

Deixa o repositório com o perfil de comunidade completo e o README fiel ao estado atual.

### Arquivos novos
- `SECURITY.md` — política de segurança apontando pro relato privado de vulnerabilidades (habilitado no repo)
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1 em pt-BR
- Templates de issue (bug com campos obrigatórios, feature, config com links pra Discussions/advisories) e de PR (checklist do Definition of Done)
- `.github/dependabot.yml` — npm + github-actions semanal, minor/patch agrupados

### README
- Badge de licença corrigida (TBD → MIT, o `LICENSE` já era MIT)
- Roadmap reescrito com o estado real: MVP entregue (IA/RAG, LGPD, Nuvemshop, admin, self-host kit) + épico de Governança de Atendimento em fases (G1–G4 ✅, G5 fechando, G6 planejada)
- Segurança: e-mail "a definir" → relato privado do GitHub
- Comunidade: Instagram @melgarafael + YouTube @melgarafael (Twitter "a confirmar" removido)
- Estrutura de pastas atualizada (workers, invariantes, ai/lgpd/metrics/connections)

### Configurações já aplicadas no repo (fora deste diff)
Secret scanning + push protection, Dependabot alerts + security updates, private vulnerability reporting, Discussions, topics, auto-merge, delete-branch-on-merge, branch protection na `main` exigindo o check `verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx84HFMpE2kdycFZFUPmV3