### PR TITLE
chore: fixa packageManager pnpm@9.15.9 (alinha Vercel/CI/local)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -14,8 +14,6 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -103,5 +103,6 @@
     "typescript-eslint": "^8.64.0",
     "vite": "^8.1.5",
     "vitest": "^4.1.10"
-  }
+  },
+  "packageManager": "pnpm@9.15.9"
 }


### PR DESCRIPTION
O log de build do Vercel mostrou que ele escolhe **pnpm@10** por heurística de data de criação do projeto, enquanto o CI do GitHub e o `pnpm-lock.yaml` usam **pnpm 9** — divergência de resolução esperando pra acontecer (mesma família do bug do vite@5 no lock, pego no #24). Fixar `packageManager` via corepack faz todos os ambientes usarem a mesma versão — solução recomendada pelo próprio log do Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)