### PR TITLE
fix(admin): criação de tenant violava check constraint de status

### DIFF
--- a/app/api/v1/admin/tenants/route.ts
+++ b/app/api/v1/admin/tenants/route.ts
@@ -100,7 +100,10 @@ export async function GET(req: NextRequest) {
     .order("id", { ascending: false })
     .limit(limit + 1);
 
-  if (status) {
+  if (status === "onboarding") {
+    // Estado derivado: ativo no banco, onboarding ainda não concluído.
+    query = query.eq("status", "active").is("onboarded_at", null);
+  } else if (status) {
     query = query.eq("status", status);
   }
 
@@ -195,7 +198,9 @@ export async function POST(req: NextRequest) {
       slug,
       legal_name: legal_name ?? null,
       cnpj: cnpj ?? null,
-      status: "onboarding",
+      // A check constraint de organizations.status não tem 'onboarding' — o
+      // marcador de onboarding é onboarded_at null (mesmo modelo do signup).
+      status: "active",
       settings: { plan },
       created_by: adminCtx.user.id,
     })

--- a/components/admin/tenants/TenantActions.tsx
+++ b/components/admin/tenants/TenantActions.tsx
@@ -11,7 +11,7 @@ import { ImpersonateButton } from "@/components/admin/ImpersonateButton";
 
 interface TenantActionsProps {
   organizationId: string;
-  status: "active" | "suspended" | "onboarding" | "redacted";
+  status: "active" | "suspended" | "redacted";
   displayName: string;
 }
 
@@ -27,7 +27,7 @@ export function TenantActions({
   const [suspendOpen, setSuspendOpen] = useState(false);
   const [reactivateOpen, setReactivateOpen] = useState(false);
 
-  const canSuspend = status === "active" || status === "onboarding";
+  const canSuspend = status === "active";
   const isSuspended = status === "suspended";
   const isRedacted = status === "redacted";
 

--- a/components/admin/tenants/TenantsTable.tsx
+++ b/components/admin/tenants/TenantsTable.tsx
@@ -35,10 +35,18 @@ const STATUS_LABELS: Record<string, string> = {
   redacted: "Redigido",
 };
 
-function StatusBadge({ status }: { status: string }) {
+function StatusBadge({
+  status,
+  onboardedAt,
+}: {
+  status: string;
+  onboardedAt: string | null;
+}) {
+  // 'onboarding' não existe no banco — é derivado: ativo sem onboarding concluído.
+  const effective = status === "active" && !onboardedAt ? "onboarding" : status;
   return (
-    <Badge variant={STATUS_VARIANTS[status] ?? "neutral"}>
-      {STATUS_LABELS[status] ?? status}
+    <Badge variant={STATUS_VARIANTS[effective] ?? "neutral"}>
+      {STATUS_LABELS[effective] ?? effective}
     </Badge>
   );
 }
@@ -158,7 +166,7 @@ export function TenantsTable({
                   {shortCnpj(row.cnpj)}
                 </TableCell>
                 <TableCell>
-                  <StatusBadge status={row.status} />
+                  <StatusBadge status={row.status} onboardedAt={row.onboarded_at} />
                 </TableCell>
                 <TableCell className="text-right tabular-nums">
                   {extractCount(row.user_count)}

--- a/hooks/useTenantDetail.ts
+++ b/hooks/useTenantDetail.ts
@@ -12,7 +12,9 @@ export interface TenantOrganization {
   display_name: string;
   legal_name: string | null;
   cnpj: string | null;
-  status: "active" | "suspended" | "onboarding" | "redacted";
+  // 'onboarding' não existe na check constraint do banco — é estado derivado
+  // (active + onboarded_at null), nunca vem numa linha real.
+  status: "active" | "suspended" | "redacted";
   onboarded_at: string | null;
   suspended_at: string | null;
   created_at: string;


### PR DESCRIPTION
Bug latente registrado no PR #27: `POST /api/v1/admin/tenants` inseria `status: "onboarding"`, valor que a check constraint de `organizations.status` nunca aceitou — toda criação de tenant pelo admin 500ava.

**Causa raiz e fix:** o marcador de onboarding do produto é `onboarded_at` null (modelo usado pelo signup self-service e pelo gate de `/onboarding`). O insert passa a `status: "active"`; o filtro `status=onboarding` do GET e o badge da listagem viram estado **derivado** (`active` + `onboarded_at is null`) — o dropdown "Onboarding" do admin, que nunca casava nada, agora funciona. Tipos de linha deixam de declarar um status que o banco não produz.

**Sem migration:** a constraint sempre bloqueou o INSERT, então não existe linha com o valor inválido em nenhum clone.

**Prova:** typecheck / lint / vitest 335/335 verdes (o typecheck foi o que caçou o último consumidor do tipo antigo em `[id]/_client.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01454SGvQ7wBAvah8ZPnnWXv