### PR TITLE
fix(kit): install.sh re-executado matava o baseline no meio e poluía o terminal

### DIFF
--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -184,10 +184,47 @@ if [ -f supabase/baseline.sql ]; then
     >/dev/null 2>&1 \
     && c_grn "✓ extensões (vector, citext, pg_trgm) habilitadas no public" \
     || c_ylw "⚠ não consegui habilitar as extensões — o schema pode falhar abaixo."
-  docker run --rm -i -v "$PROJECT_DIR/supabase/baseline.sql:/baseline.sql:ro" \
-    postgres:17-alpine psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f /baseline.sql \
-    && c_grn "✓ schema aplicado" \
-    || c_ylw "⚠ baseline retornou aviso/erro (pode já estar aplicado — idempotente). Verifique o log acima."
+  SCHEMA_LOG="$PROJECT_DIR/baseline-apply.log"
+  # Banco novo ou re-execução? Re-aplicar com ON_ERROR_STOP pararia no primeiro
+  # "já existe" (ex.: multiple primary keys) e PULARIA o resto do arquivo —
+  # inclusive o apêndice com as migrations novas. Banco existente = modo update
+  # (mesmo contrato do update.sh); banco novo = ON_ERROR_STOP e falha é FATAL
+  # (schema pela metade = app sem RLS).
+  has_schema="$(docker run --rm postgres:17-alpine psql "$SUPABASE_DB_URL" -tAc \
+    "select 1 from information_schema.tables where table_schema='public' and table_name='organizations' limit 1" 2>/dev/null | tr -d '[:space:]')"
+
+  if [ "$has_schema" = "1" ]; then
+    c_ylw "• schema já existe — re-aplicando em modo update (erros 'já existe' são esperados e ficam no log)"
+    raw="$(docker run --rm -i -v "$PROJECT_DIR/supabase/baseline.sql:/baseline.sql:ro" \
+          postgres:17-alpine psql "$SUPABASE_DB_URL" -q -f /baseline.sql 2>&1 || true)"
+    printf '%s\n' "$raw" > "$SCHEMA_LOG"
+    benign='already exists|multiple primary keys|multiple default values|is already a member|already a partition'
+    unexpected="$(printf '%s\n' "$raw" | grep -iE 'ERROR|FATAL' | grep -viE "$benign" || true)"
+    if [ -n "$unexpected" ]; then
+      c_ylw "⚠ Erros no banco que NÃO são os esperados (log completo: $SCHEMA_LOG):"
+      printf '%s\n' "$unexpected" | head -20
+    else
+      c_grn "✓ schema re-aplicado (apêndice de migrations incluído)"
+    fi
+  else
+    if docker run --rm -i -v "$PROJECT_DIR/supabase/baseline.sql:/baseline.sql:ro" \
+        postgres:17-alpine psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f /baseline.sql \
+        > "$SCHEMA_LOG" 2>&1; then
+      c_grn "✓ schema aplicado (log: $SCHEMA_LOG)"
+    else
+      tail -5 "$SCHEMA_LOG"
+      die "baseline falhou num banco NOVO — o schema ficaria incompleto (sem RLS). Log completo: $SCHEMA_LOG"
+    fi
+  fi
+
+  # Verificação real, não wishful thinking: o app precisa das tabelas core.
+  n_tables="$(docker run --rm postgres:17-alpine psql "$SUPABASE_DB_URL" -tAc \
+    "select count(*) from information_schema.tables where table_schema='public'" 2>/dev/null | tr -d '[:space:]')"
+  if [ "${n_tables:-0}" -ge 30 ]; then
+    c_grn "✓ verificação: ${n_tables} tabelas no schema public"
+  else
+    c_ylw "⚠ verificação: só ${n_tables:-0} tabelas no schema public — confira $SCHEMA_LOG"
+  fi
 else
   c_ylw "⚠ supabase/baseline.sql não encontrado — pulei (aplique o schema manualmente)."
 fi


### PR DESCRIPTION
Bug reportado pelo Rafael instalando via kit numa VPS que já tinha uma execução anterior: `psql:/baseline.sql:1910: ERROR: multiple primary keys for table "ai_agent_runs"` + terminal inundado de `CREATE TABLE`/`ALTER TABLE`.

**Causa raiz:** re-execução do `install.sh` sobre banco já instalado aplicava o baseline com `ON_ERROR_STOP=1` — o psql morre no primeiro `ADD CONSTRAINT ... PRIMARY KEY` (não-idempotente por natureza no dump) e **pula o resto do arquivo, inclusive o apêndice com migrations novas**. A doutrina do repo já previa: re-aplicação = modo update, sem a flag.

**Fix (passo 7 do install.sh):**
- Detecta banco existente (`organizations` no `information_schema`) → aplica em **modo update**, mesmo contrato do `update.sh` (erros benignos filtrados, só problema real aparece).
- Banco **novo** → `ON_ERROR_STOP=1` com falha **fatal** (`die`) — antes um baseline quebrado num banco novo virava aviso amarelo e o app subia sem RLS.
- Output completo vai para `baseline-apply.log`; o terminal mostra só o resumo.
- Verificação pós-aplicação de verdade: contagem de tabelas do `public` (≥30).

**Prova** (pg17 descartável + `scripts/selfhost-prelude.sql`):
- fresh com `ON_ERROR_STOP=1`: ✅ aplica limpo, 75 tabelas.
- re-apply modo update: ✅ 307 erros, todos benignos (inclusive o exato `multiple primary keys` do report), 0 inesperados, arquivo processado até o fim.
- `bash -n` ok; shellcheck sem findings novos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01454SGvQ7wBAvah8ZPnnWXv