### PR TITLE
feat(ai): abas de navegação na área de IA — Credenciais acessível pela UI

### DIFF
--- a/app/app/ai/_components/AiSectionTabs.tsx
+++ b/app/app/ai/_components/AiSectionTabs.tsx
@@ -1,0 +1,49 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/utils";
+
+const TABS = [
+  { href: "/app/ai/agents", label: "Agentes" },
+  { href: "/app/ai/credentials", label: "Credenciais" },
+  { href: "/app/ai/knowledge", label: "Conhecimento" },
+  { href: "/app/ai/usage", label: "Uso" },
+  { href: "/app/ai/inbox", label: "Inbox" },
+];
+
+const HUB_PATHS = new Set(TABS.map((t) => t.href));
+
+/**
+ * Abas da área de IA. Renderiza só nos hubs (lista de agents, credenciais,
+ * conhecimento, uso, inbox) — telas de edição ([id]) ficam limpas.
+ */
+export function AiSectionTabs() {
+  const pathname = usePathname();
+  if (!HUB_PATHS.has(pathname)) return null;
+
+  return (
+    <nav aria-label="Seções de IA" className="border-b bg-background px-6">
+      <div className="flex gap-1 overflow-x-auto">
+        {TABS.map((tab) => {
+          const isActive = pathname === tab.href;
+          return (
+            <Link
+              key={tab.href}
+              href={tab.href}
+              aria-current={isActive ? "page" : undefined}
+              className={cn(
+                "whitespace-nowrap border-b-2 px-3 py-2.5 text-sm transition-colors",
+                isActive
+                  ? "border-primary font-medium text-foreground"
+                  : "border-transparent text-muted-foreground hover:border-border hover:text-foreground",
+              )}
+            >
+              {tab.label}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/app/app/ai/agents/[id]/_components/CredentialPicker.tsx
+++ b/app/app/ai/agents/[id]/_components/CredentialPicker.tsx
@@ -1,5 +1,6 @@
 "use client";
 import * as React from "react";
+import Link from "next/link";
 import {
   Select,
   SelectContent,
@@ -58,7 +59,13 @@ export function CredentialPicker({ provider, credentials, value, onChange, disab
       </Select>
       {filtered.length === 0 ? (
         <p className="text-xs text-muted-foreground">
-          Cadastre em <code>/app/ai/credentials</code>.
+          <Link
+            href="/app/ai/credentials"
+            className="font-medium text-foreground underline underline-offset-4"
+          >
+            Cadastrar credencial {provider}
+          </Link>{" "}
+          na aba Credenciais.
         </p>
       ) : null}
     </div>

--- a/app/app/ai/layout.tsx
+++ b/app/app/ai/layout.tsx
@@ -1,0 +1,10 @@
+import { AiSectionTabs } from "./_components/AiSectionTabs";
+
+export default function AiLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-full flex-col">
+      <AiSectionTabs />
+      <div className="min-h-0 flex-1">{children}</div>
+    </div>
+  );
+}

--- a/scripts/screenshot-ai-tabs.ts
+++ b/scripts/screenshot-ai-tabs.ts
@@ -1,0 +1,84 @@
+/**
+ * Prova visual da aba de Credenciais (protocolo execução visível).
+ * Loga como o admin do seed (com TOTP real) e fotografa as telas novas.
+ * Uso: pnpm exec tsx scripts/screenshot-ai-tabs.ts <baseURL> <outDir>
+ */
+import { chromium } from "@playwright/test";
+import { createHmac } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const [, , baseURL = "http://localhost:3210", outDir = "/tmp"] = process.argv;
+
+function base32Decode(s: string): Buffer {
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+  let bits = 0;
+  let value = 0;
+  const out: number[] = [];
+  for (const ch of s.replace(/=+$/, "")) {
+    value = (value << 5) | alphabet.indexOf(ch);
+    bits += 5;
+    if (bits >= 8) {
+      out.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+  return Buffer.from(out);
+}
+
+function totp(secret: string, at = Date.now()): string {
+  const counter = Math.floor(at / 1000 / 30);
+  const buf = Buffer.alloc(8);
+  buf.writeBigUInt64BE(BigInt(counter));
+  const hmac = createHmac("sha1", base32Decode(secret)).update(buf).digest();
+  const offset = hmac[hmac.length - 1]! & 0xf;
+  const code = (hmac.readUInt32BE(offset) & 0x7fffffff) % 1_000_000;
+  return code.toString().padStart(6, "0");
+}
+
+async function main() {
+  const creds = JSON.parse(readFileSync(".e2e-creds.json", "utf-8"));
+  const email: string = creds.users.admin.email;
+  const password: string = creds.password;
+  const secret: string = creds.admin_totp.secret;
+
+  const browser = await chromium.launch({ headless: false });
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+
+  await page.goto(`${baseURL}/login`);
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Senha").fill(password);
+  await page.getByRole("button", { name: "Entrar" }).click();
+  await page.waitForURL(/\/login\/mfa/, { timeout: 20_000 });
+  console.log("etapa: /login/mfa alcançado");
+  // Input OTP com auto-submit no onComplete — digitar via teclado, não fill().
+  await page.locator("input").first().click();
+  await page.keyboard.type(totp(secret), { delay: 60 });
+  await page.waitForURL(/\/(app|onboarding)\//, { timeout: 30_000 });
+  console.log("etapa: autenticado em", page.url());
+
+  await page.goto(`${baseURL}/app/ai/agents`);
+  await page.getByRole("navigation", { name: "Seções de IA" }).waitFor({ timeout: 15_000 });
+  await page.screenshot({ path: join(outDir, "ai-tabs-agents.png") });
+  console.log("url agents:", page.url());
+
+  await page.getByRole("link", { name: "Credenciais" }).click();
+  await page.waitForURL(/\/app\/ai\/credentials/);
+  await page.waitForLoadState("networkidle");
+  await page.screenshot({ path: join(outDir, "ai-tabs-credentials.png") });
+
+  const addBtn = page.getByRole("button", { name: /credencial/i }).first();
+  if (await addBtn.isVisible().catch(() => false)) {
+    await addBtn.click();
+    await page.waitForTimeout(600);
+    await page.screenshot({ path: join(outDir, "ai-credentials-dialog.png") });
+  }
+
+  await browser.close();
+  console.log("SCREENSHOTS_OK");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Reporte do Rafael: a área de Agentes de IA não tinha caminho na UI para criar credenciais — o dropdown dentro do agente mandava digitar a rota na mão.

**Diagnóstico:** as páginas de Credenciais, Conhecimento e Uso já existiam completas (com gates manager+/admin corretos), mas eram **órfãs** — nenhum link chegava nelas.

**Entrega:**
- Barra de abas da área de IA (`Agentes · Credenciais · Conhecimento · Uso · Inbox`) via `app/app/ai/layout.tsx` + `AiSectionTabs` — visível nos hubs, oculta nas telas de edição de agente.
- Empty-state do `CredentialPicker` vira link real para a aba Credenciais (antes: `<code>/app/ai/credentials</code>`).
- `scripts/screenshot-ai-tabs.ts`: prova visual reproduzível com login real (senha + TOTP do seed E2E).

**Prova:** typecheck / lint / vitest 335/335 verdes; screenshots headed contra `next start` + Supabase local, jornada completa login→MFA→Agentes→aba Credenciais→dialog "Adicionar credencial".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01454SGvQ7wBAvah8ZPnnWXv