### PR TITLE
fix(ai): aba Conhecimento apontava para rota inexistente (404)

### DIFF
--- a/app/app/ai/_components/AiSectionTabs.tsx
+++ b/app/app/ai/_components/AiSectionTabs.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
 const TABS = [
   { href: "/app/ai/agents", label: "Agentes" },
   { href: "/app/ai/credentials", label: "Credenciais" },
-  { href: "/app/ai/knowledge", label: "Conhecimento" },
+  { href: "/app/ai/knowledge/sources", label: "Conhecimento" },
   { href: "/app/ai/usage", label: "Uso" },
   { href: "/app/ai/inbox", label: "Inbox" },
 ];


### PR DESCRIPTION
Censo completo de páginas órfãs (69 rotas × todos os literais de navegação do código):

- **Única órfã real**: `/app/ai/knowledge/sources` — a aba "Conhecimento" do PR #30 apontava para `/app/ai/knowledge`, que **não existe** (404 atrás do gate de auth). Fix: href correto; `HUB_PATHS` deriva de `TABS`, então a barra também passa a aparecer na página de Conhecimento.
- Falsos positivos verificados um a um: `/app/settings/tenant/whatsapp` (redirect deliberado p/ Conexões), `/app/inbox/[id]` (deep-link → `?id=`), `/403`/`/503`/`/account-suspended` (páginas de sistema), `/design`/`/sentry-example-page` (dev).

**Prova:** `app-path-routes-manifest.json` do build de produção não contém `/app/ai/knowledge` e contém `/app/ai/knowledge/sources`; typecheck / lint / build verdes. A barra de abas em si já foi provada visualmente no PR #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01454SGvQ7wBAvah8ZPnnWXv