### PR TITLE
docs(branding): reposicionamento — de CRM de e-commerce para AI Sales OS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 ## Visão (1 parágrafo)
 
-DeskcommCRM é um CRM operacional multi-tenant para e-commerce com IA conversacional nativa. Unifica atendimento humano, chatbot RAG por tenant, gestão de pedidos e pós-venda — WhatsApp como canal primário (via WAHA). Modo atual = BPO (operadora atende N tenants); modo futuro = SaaS direto pra lojistas. Arquitetura multi-tenant com RLS desde o dia 1; LGPD nativa; MCP-ready.
+DeskcommCRM é um sistema operacional de vendas open source com agentes de IA nativos — multi-nicho (e-commerce, clínicas, imobiliárias, infoprodutos, serviços), com WhatsApp como canal primário (via WAHA). Agentes com RAG por tenant atendem, qualificam e movem o funil junto com humanos; CRM inteiro exposto via MCP. Monetização = self-host em VPS (parceria HostGator), não assinatura. Arquitetura multi-tenant com RLS desde o dia 1; LGPD nativa. Posicionamento completo: `VISION.md`.
 
 ---
 

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,227 @@
+<div align="center">
+
+[🇧🇷 Português](README.md) · 🇺🇸 English
+
+# 🛠️ DeskcommCRM — The AI Sales OS
+
+**AI agents that answer, qualify and sell on WhatsApp — inside an open-source CRM running on your own server.**
+**No subscription, no gated features, your data stays yours. The open alternative to Kommo, Octadesk and Intercom.**
+
+[![Next.js 16](https://img.shields.io/badge/Next.js-16-black?logo=next.js)](https://nextjs.org)
+[![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6?logo=typescript)](https://www.typescriptlang.org)
+[![Supabase](https://img.shields.io/badge/Supabase-Postgres%2BAuth%2BStorage-3ecf8e?logo=supabase)](https://supabase.com)
+[![Self-hosted](https://img.shields.io/badge/self--hosted-one%20command-orange)](hostgator-setup-kit/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+
+[**🧭 Vision**](VISION.md) · [**📘 Setup Guide**](docs/SETUP.md) · [**🏗️ Architecture**](ARCHITECTURE.md) · [**🤝 Contributing**](CONTRIBUTING.md) · [**📋 PRDs**](docs/prd/) · [**🗺️ Roadmap**](#%EF%B8%8F-roadmap)
+
+</div>
+
+---
+
+> ### ☁️ Run this CRM in production with one command
+>
+> DeskcommCRM is developed in **partnership with HostGator**: the [`hostgator-setup-kit/`](hostgator-setup-kit/)
+> installs the full CRM (app + WAHA + database) on a VPS with a single command, and the
+> [production runbook](docs/runbooks/waha-hostgator.md) assumes that environment.
+>
+> **[👉 Get the HostGator VPS with the partnership discount](https://www.hostgator.com.br/52708-141-3-52.html)** —
+> São Paulo datacenter, ideal for WhatsApp running 24/7. *(partner link — subscribing through it supports the project and costs you less)*
+
+## ✨ What is it
+
+**Deskcomm** comes from **Desk** + **comm** (commerce): your entire sales operation on a single desk, run by people and AI agents working together.
+
+The project was born as an e-commerce CRM — and the open-source community took it much further: today it runs in **clinics, real-estate agencies, info-product businesses, agencies, stores and service providers** — any business that sells over WhatsApp. The product followed that shift and became a **sales operating system**: AI agents with per-tenant RAG answer customers, qualify leads, move them through the pipeline, trigger automations and know when to hand off to a human — with the whole CRM exposed via **MCP** so agents can truly operate it. The full story is in [`VISION.md`](VISION.md).
+
+### Why it's different
+
+- 🤖 **AI agents that operate the CRM** — per-tenant RAG, sentiment analysis, audited AI→human handoff, AI as a first-class assignee and per-org budget control. Not a decorative chatbot: the agent answers, qualifies and moves the funnel.
+- 🔁 **Self-improving agents** — resolved conversations become new RAG knowledge; handoffs mark where the agent falls short; metrics close the loop. Every month of operation makes the agent better, with a human gate where it matters.
+- 🧩 **Multi-niche by design** — configurable vocabulary per pipeline: a lead becomes a *Customer*, *Patient* or *Buyer*; "won" becomes *Paid*, *Booked* or *Closed*. The same core serves e-commerce (our birthplace, with native Nuvemshop integration), clinics, real estate or info-products.
+- 🔌 **MCP-ready** — internal MCP server for the built-in agents; a public contract for external agents is in the works. The CRM as infrastructure for any AI agent.
+- 💬 **WhatsApp-native via WAHA** — multi-number, anti-ban (throttle + jitter + time windows), media via Storage, STOP detection.
+- 👥 **Support governance** — real server-side RBAC, audited assignment/transfer, queue with position, automatic routing and per-role visibility scopes.
+- 🏢 **Multi-tenant + privacy by design (LGPD)** — RLS on every tenant-aware table with an isolation test as a CI gate; anonymization preferred over deletion; append-only audit log with 5-year retention.
+- 🖥️ **Truly self-hosted** — your data on your VPS; one-command install; no paid tier, no gated features.
+
+### 🔌 Webhooks & Automations
+
+Every tenant can create **capture sources**: a public endpoint (`/api/v1/webhooks/in/<token>`) that receives leads from landing pages, custom forms or tools like Zapier/n8n via POST (JSON or `application/x-www-form-urlencoded`) and drops them straight into the chosen pipeline/stage — no code, no per-tenant custom integration. On top of those sources (and the other CRM events — lead changed stage, got a tag, WhatsApp message arrived), tenants build **automations**: WHEN/IF/THEN rules that add tags, move leads, assign agents, send WhatsApp messages or notify external systems via outgoing webhooks.
+
+In the UI everything lives under **Webhooks** in the sidebar (visible only to `manager`/`admin` roles). Three tabs: **Receive data** (create a source, copy the ready-made endpoint/form, fire a test lead, see recent deliveries), **Automations** (build rules, which are always born paused until reviewed and enabled) and **Activity** (a timeline of each run, with per-action results and manual retry when an external webhook call fails).
+
+Under the hood, every event becomes a row in `event_log` — no database trigger ever makes an HTTP call. The `/api/v1/cron/event-log-drain` route drains the queue every minute. On Vercel that's a managed Cron Job; **on the HostGator self-host kit** (`hostgator-setup-kit/`), `install.sh`/`update.sh` automatically configures a `crontab` line that hits the route every minute with the `INTERNAL_SECRET` from `.env`.
+
+---
+
+## 🚀 Quickstart (see it running in 5 minutes)
+
+```bash
+# 1. Clone
+git clone https://github.com/melgarafael/DeskcommCRM.git
+cd DeskcommCRM
+
+# 2. Node 20 + pnpm
+nvm use                    # or install Node 20+
+npm install -g pnpm
+pnpm install
+
+# 3. Env vars
+cp .env.example .env.local
+# Edit .env.local — full guide in docs/SETUP.md
+
+# 4. Local WAHA (optional in dev without WhatsApp)
+docker compose up -d
+
+# 5. Supabase migrations
+supabase link --project-ref <your-ref>
+supabase db push
+
+# 6. Run the app
+pnpm dev
+```
+
+App: <http://localhost:3000> · Health check: <http://localhost:3000/api/v1/health>
+
+> 🆕 **First time? Don't skip steps.** [`docs/SETUP.md`](docs/SETUP.md) is the complete step-by-step tutorial for **every integration** (Supabase, WAHA, Anthropic, Upstash, Sentry, Resend, Nuvemshop) — written for people who have never configured any of this. ~60–90 min from zero to a running app. *(Docs are in Brazilian Portuguese; translations welcome!)*
+
+---
+
+## 🧱 Stack
+
+| Layer | Choice | Why |
+|---|---|---|
+| **Frontend** | Next.js 16 App Router (Turbopack) + React 19 + strict TypeScript 6 | Server Components + Route Handlers in one repo |
+| **Styling** | Tailwind + shadcn/ui (`new-york`, neutral) | Customizable without lock-in |
+| **DB** | Supabase (Postgres + RLS + `vector`) | Native multi-tenancy, embeddings for RAG |
+| **Auth** | Supabase Auth via `@supabase/ssr` | SameSite=Strict, HttpOnly cookies |
+| **Realtime** | Supabase Realtime | postgres_changes + broadcast |
+| **Storage** | Supabase Storage (signed URLs) | Private `whatsapp-media` bucket |
+| **WhatsApp** | WAHA Plus (NOWEB engine) | Multi-tenant, retry, S3 |
+| **Queues** | `event_log` table + workers (cron) | No Inngest/Trigger in the MVP |
+| **Rate limit** | Upstash Redis (sliding window) | Serverless, free tier is enough |
+| **AI** | Vercel AI SDK v7 (Anthropic/Google/OpenAI providers v4) via AI Gateway | Automatic fallback, ZDR |
+| **Validation** | Zod | External input, env, payloads |
+| **Observability** | Sentry (sanitized `beforeSend`) | No PII in breadcrumbs |
+| **Hosting** | Vercel (app) + HostGator VPS Turing/SP (WAHA) | Edge + dedicated box for WhatsApp; Brazil datacenter |
+
+Details: [`ARCHITECTURE.md`](ARCHITECTURE.md).
+
+---
+
+## 🧪 Tests
+
+```bash
+pnpm typecheck     # tsc --noEmit (strict)
+pnpm lint          # eslint next/core-web-vitals
+pnpm test:unit     # Vitest
+pnpm test:e2e      # Playwright (requires dev server)
+```
+
+CI runs everything before merge. **The RLS isolation test is a mandatory gate** — it creates 2 tenants and verifies no leakage. The **governance invariants suite** (100+ tests) locks down RBAC, assignment, scoping and routing against regressions.
+
+---
+
+## 📚 Documentation
+
+| Doc | What's in it |
+|---|---|
+| [`VISION.md`](VISION.md) | **Vision & positioning** — what the project is, what it believes, where it's going |
+| [`docs/SETUP.md`](docs/SETUP.md) | **Complete step-by-step setup** for every integration |
+| [`CLAUDE.md`](CLAUDE.md) | Non-negotiable conventions (required reading to contribute) |
+| [`ARCHITECTURE.md`](ARCHITECTURE.md) | One-page architecture overview |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | PR flow |
+| [`docs/prd/`](docs/prd/) | PRDs (master, platform, customer 360, WhatsApp, pipeline, AI-RAG, Nuvemshop) |
+| [`docs/specs/`](docs/specs/) | Technical specs 01–13 (SQL schema, payloads, MCP, governance) |
+| [`docs/runbooks/waha-hostgator.md`](docs/runbooks/waha-hostgator.md) | Full production runbook for WAHA (HostGator VPS) |
+
+> Most docs are written in Brazilian Portuguese — our primary community. Translation contributions are very welcome.
+
+---
+
+## 🤝 Contributing
+
+This project is open source for the community. Every contribution is welcome — from doc typo fixes to new features.
+
+1. Read [`CLAUDE.md`](CLAUDE.md) (~5 min) — non-negotiable conventions (multi-tenancy, RLS, audit, privacy).
+2. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) — branch flow, commits.
+3. Follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+**Definition of Done:** zero typecheck errors, zero lint errors, relevant tests green, RLS tested if a tenant-aware table is touched, audit log emitted on mutations, versioned migration if the schema changes.
+
+---
+
+## 🐛 Reporting bugs
+
+Open an [issue](https://github.com/melgarafael/DeskcommCRM/issues/new/choose) — the template asks for what we need (environment, `/api/v1/health`, steps).
+
+For **security vulnerabilities**, **do NOT open a public issue** — use [private vulnerability reporting](https://github.com/melgarafael/DeskcommCRM/security/advisories/new). Details in [`SECURITY.md`](SECURITY.md).
+
+---
+
+## 🗺️ Roadmap
+
+### ✅ Shipped
+
+- **Foundation & platform** — auth (MFA for admins), multi-tenancy with RLS + isolation test, 4-role RBAC, append-only audit log, tenant onboarding.
+- **WhatsApp support** — real-time 3-pane inbox, multi-number WAHA connections, media via Storage, anti-ban (throttle + jitter + time windows), STOP detection.
+- **CRM & orders** — kanban with per-niche configurable vocabulary (fractional indexing), customer 360, contacts, tags, Nuvemshop integration for e-commerce.
+- **Native AI** — agents with per-tenant RAG (pgvector), sentiment analysis, AI→human handoff, per-org budget control, internal MCP server.
+- **Privacy (LGPD)** — export and redact via workers, cascading anonymization, audited consent.
+- **Self-host** — `hostgator-setup-kit` (app + WAHA + database with one command), self-healing `baseline.sql`, production runbook.
+- **Webhooks & automation** — capture sources + WHEN/IF/THEN rules + triggers for external systems.
+- **Support governance** — server-side RBAC across the API, audited assignment/transfer (AI as a first-class assignee), per-role visibility (RLS) + per-agent metrics, automatic routing with queue and management panel, and a governance contract for external AI agents ([`docs/specs/14`](docs/specs/14-contrato-governanca-agentes-externos.md)). Epic driven by 100+ invariants (G1–G6).
+- **Visible operation** — screens that let operators understand the agent: anti-ban hold reasons translated in the conversation, a notice center with severities, send-protection controls (window/pace/cap) and flywheel proposals applicable as a new version (human-gated).
+
+### 🔮 Next
+
+- **Phase FG** — the Vendaval agent consumes governance via `ai_dispatch_mode=external` 🔜 *(awaiting owner prioritization)*
+
+- **Public MCP** — CRM capabilities exposed to the agent ecosystem: plug in any agent and it operates Deskcomm.
+- **Self-improvement flywheel** — the resolved-conversation → knowledge → better-agent loop, measured and human-gated.
+- **Niche templates** — ready-made pipelines and vocabularies for clinics, real estate, info-products and services (e-commerce already shipped).
+- **Integrations** — VTEX and Shopify via the adapter pattern (Nuvemshop already shipped).
+- **Probabilistic identity** — contact unification across channels.
+
+---
+
+## 💬 Community
+
+- **Discussions:** [GitHub Discussions](https://github.com/melgarafael/DeskcommCRM/discussions)
+- **Issues:** [GitHub Issues](https://github.com/melgarafael/DeskcommCRM/issues)
+- **Instagram:** [@melgarafael](https://www.instagram.com/melgarafael)
+- **YouTube:** [youtube.com/@melgarafael](https://www.youtube.com/@melgarafael)
+
+---
+
+## 📜 License
+
+Distributed under the **MIT** license — see [`LICENSE`](LICENSE). You may use, modify and distribute freely, including commercially. The software is provided **"as is", without warranties**.
+
+---
+
+## 🛟 Support & responsibilities (self-host)
+
+This is a **self-hosted** project: each person runs the CRM on their **own infrastructure** (own VPS, Supabase database and AI key). That means:
+
+- **Support is community-based and "as-is".** No SLA — it's open source maintained by goodwill.
+- **You are responsible for your installation**, including updates (`bash hostgator-setup-kit/update.sh`) and backups.
+- **Data protection:** whoever **hosts** the instance is the **controller** of the personal data processed there. The project maintainers **have no access** to your data.
+- **Telemetry (Sentry):** by default, **anonymized** errors (no PII) are sent to the community Sentry. Set `SENTRY_DSN=off` to disable, or `SENTRY_DSN=<your-dsn>` to use your own.
+
+---
+
+## 🙏 Acknowledgements
+
+- **WAHA** ([devlikeapro](https://waha.devlikeapro.com/)) — WhatsApp engine.
+- **Supabase**, **Vercel**, **Anthropic** (Claude), **shadcn/ui**.
+- The community that took Deskcomm from e-commerce to clinics, real estate, info-products and beyond — you defined what this project is.
+
+---
+
+<div align="center">
+
+**Built with ☕ in Brasil** · **Made for the community**
+
+</div>

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 <div align="center">
 
-# 🛠️ DeskcommCRM
+🇧🇷 Português · [🇺🇸 English](README.en.md)
 
-**CRM operacional multi-tenant para e-commerce, com IA conversacional nativa, WhatsApp via WAHA e LGPD by-design.**
+# 🛠️ DeskcommCRM — Sistema Operacional de Vendas com Agentes de IA
+
+**Agentes de IA que atendem, qualificam e vendem no WhatsApp — dentro de um CRM open source rodando no seu servidor.**
+**Sem mensalidade, sem feature travada, seus dados com você. A alternativa aberta a Kommo, Octadesk e Intercom.**
 
 [![Next.js 16](https://img.shields.io/badge/Next.js-16-black?logo=next.js)](https://nextjs.org)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6?logo=typescript)](https://www.typescriptlang.org)
 [![Supabase](https://img.shields.io/badge/Supabase-Postgres%2BAuth%2BStorage-3ecf8e?logo=supabase)](https://supabase.com)
-[![Tailwind](https://img.shields.io/badge/Tailwind-CSS-38bdf8?logo=tailwindcss)](https://tailwindcss.com)
+[![Self-hosted](https://img.shields.io/badge/self--hosted-1%20comando-orange)](hostgator-setup-kit/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-[**📘 Setup Guide**](docs/SETUP.md) · [**🏗️ Arquitetura**](ARCHITECTURE.md) · [**🤝 Contribuir**](CONTRIBUTING.md) · [**📋 PRDs**](docs/prd/) · [**🗺️ Roadmap**](#%EF%B8%8F-roadmap)
+[**🧭 Visão**](VISION.md) · [**📘 Setup Guide**](docs/SETUP.md) · [**🏗️ Arquitetura**](ARCHITECTURE.md) · [**🤝 Contribuir**](CONTRIBUTING.md) · [**📋 PRDs**](docs/prd/) · [**🗺️ Roadmap**](#%EF%B8%8F-roadmap)
 
 </div>
 
@@ -27,19 +30,20 @@
 
 ## ✨ O que é
 
-DeskcommCRM unifica **atendimento humano**, **agentes de IA com RAG por tenant**, **gestão de pedidos** e **pipeline de pós-venda** numa única plataforma. Canal primário: **WhatsApp via WAHA**. Multi-tenant desde o dia 1. LGPD nativa.
+**Deskcomm** vem de **Desk** (mesa) + **comm** (comércio): **o comercial de mesa** — toda a operação de vendas do seu negócio numa mesa só, operada por pessoas e agentes de IA juntos.
 
-> **Modo atual:** BPO interno (uma operadora atende N tenants).
-> **Modo futuro:** SaaS direto pra lojistas.
+O projeto nasceu como CRM de e-commerce e a comunidade o levou muito além: hoje roda em **clínicas, imobiliárias, infoprodutos, agências, lojas e prestadores de serviço** — qualquer negócio que vende pelo WhatsApp. O produto acompanhou essa virada e virou um **sistema operacional de vendas**: agentes de IA com RAG por tenant atendem, qualificam, movem leads no funil, disparam automações e sabem a hora de passar pra um humano — com o CRM inteiro exposto via **MCP** pros agentes operarem de verdade. A história completa está em [`VISION.md`](VISION.md).
 
 ### Diferenciais
 
-- 🤖 **IA operando o atendimento** — agentes com RAG por tenant, análise de sentimento, handoff IA→humano auditado e controle de budget. Não é chatbot decorativo, é triagem real.
-- 🛒 **E-commerce-native** — vocabulário desenhado pro ciclo *Carrinho abandonado → Pago → Enviado → Entregue → Pós-venda*.
-- 🇧🇷 **LGPD by-design** — webhooks `customer/redact` e `customer/data_request` da Nuvemshop como contrato de primeira-classe; anonimização preferida sobre delete; audit append-only com retenção 5 anos.
+- 🤖 **Agentes de IA que operam o CRM** — RAG por tenant, análise de sentimento, handoff IA→humano auditado, IA como assignee de primeira classe e controle de budget por organização. Não é chatbot decorativo: o agente atende, qualifica e move o funil.
+- 🔁 **Agentes que se auto-aprimoram** — conversas resolvidas viram conhecimento novo na base RAG; handoffs marcam onde o agente ainda não alcança; métricas fecham o loop. Cada mês de operação torna o agente melhor, com gate humano no que importa.
+- 🧩 **Multi-nicho por design** — vocabulário configurável por pipeline: lead vira *Cliente*, *Paciente* ou *Comprador*; won vira *Pago*, *Agendado* ou *Fechado*. O mesmo core serve e-commerce (nosso berço, com integração Nuvemshop), clínica, imobiliária ou infoproduto.
+- 🔌 **MCP-ready** — MCP server interno pros agentes; contrato público pra agentes externos em construção. O CRM como infraestrutura pra qualquer agente de IA.
+- 💬 **WhatsApp-native via WAHA** — multi-número, anti-banimento (throttle + jitter + janela de horário), mídia via Storage, STOP detection.
 - 👥 **Governança de atendimento** — RBAC server-side de verdade, atribuição/transferência auditada, fila com posição, roteamento automático e escopo de visualização por papel.
-- 🔌 **MCP-ready** — MCP server interno pros agentes; contrato público pra agentes externos em construção.
-- 🏢 **Multi-tenant de verdade** — RLS em toda tabela tenant-aware, teste de isolamento como gate de CI.
+- 🏢 **Multi-tenant + LGPD by-design** — RLS em toda tabela tenant-aware com teste de isolamento como gate de CI; anonimização preferida sobre delete; audit append-only com retenção 5 anos.
+- 🖥️ **Self-hosted de verdade** — seus dados na sua VPS; instalação com 1 comando; sem versão paga, sem feature travada.
 
 ### 🔌 Webhooks & Automações
 
@@ -147,6 +151,7 @@ CI roda todos antes de merge. **Teste de isolamento RLS é gate obrigatório** �
 
 | Doc | O que tem |
 |---|---|
+| [`VISION.md`](VISION.md) | **Visão e posicionamento** — o que o projeto é, no que acredita e pra onde vai |
 | [`docs/SETUP.md`](docs/SETUP.md) | **Setup completo passo a passo** de todas as integrações |
 | [`CLAUDE.md`](CLAUDE.md) | Convenções não-negociáveis (leitura obrigatória pra contribuir) |
 | [`ARCHITECTURE.md`](ARCHITECTURE.md) | Visão de 1 página da arquitetura |
@@ -198,11 +203,11 @@ Pra **vulnerabilidades de segurança**, **NÃO abra issue pública** — use o [
 
 - **Fundação & plataforma** — auth (MFA pra admin), multi-tenancy com RLS + teste de isolamento, RBAC 4 papéis, audit log append-only, onboarding de tenant.
 - **Atendimento WhatsApp** — inbox 3 painéis em tempo real, conexões WAHA multi-número, mídia via Storage, anti-banimento (throttle + jitter + janela de horário), STOP detection.
-- **CRM & pedidos** — kanban com vocabulário e-commerce (fractional indexing), customer 360, contatos, tags, integração Nuvemshop.
+- **CRM & pedidos** — kanban com vocabulário configurável por nicho (fractional indexing), customer 360, contatos, tags, integração Nuvemshop pra e-commerce.
 - **IA nativa** — agentes com RAG por tenant (pgvector), análise de sentimento, handoff IA→humano, controle de budget por org, MCP server interno.
 - **LGPD** — export e redact via workers, anonimização em cascata, consentimento auditado.
 - **Self-host** — `hostgator-setup-kit` (app + WAHA + banco com 1 comando), `baseline.sql` auto-curativo, runbook de produção.
-- **Webhooks & automação** — gatilhos de eventos do CRM pra sistemas externos.
+- **Webhooks & automação** — fontes de captação + regras QUANDO/SE/ENTÃO + gatilhos pra sistemas externos.
 - **Governança de atendimento** — RBAC server-side em toda a API, atribuição e transferência auditadas (IA como assignee de 1ª classe), visualização por papel (RLS) + métricas por atendente, roteamento automático com fila e painel de gestão, e contrato de governança pra agentes de IA externos ([`docs/specs/14`](docs/specs/14-contrato-governanca-agentes-externos.md)). Épico guiado por 100+ invariantes (G1–G6).
 - **Operação visível** — telas pro operador entender o agente: motivo da retenção anti-ban traduzido na conversa, central de avisos com severidade, controle de proteção de envio (janela/ritmo/teto) e propostas do flywheel aplicáveis como versão nova (com gate humano).
 
@@ -210,10 +215,11 @@ Pra **vulnerabilidades de segurança**, **NÃO abra issue pública** — use o [
 
 - **Fase FG** — agente Vendaval consome a governança via `ai_dispatch_mode=external` 🔜 *(aguardando priorização do dono)*
 
-- **MCP público** — capabilities do CRM expostas pro ecossistema de agentes.
+- **MCP público** — capabilities do CRM expostas pro ecossistema de agentes: plugue o agente que quiser e ele opera o Deskcomm.
+- **Flywheel de auto-aprimoramento** — o loop conversa resolvida → conhecimento → agente melhor, medido e com gate humano.
+- **Templates por nicho** — pipelines e vocabulários prontos pra clínica, imobiliária, infoproduto e serviços (e-commerce já entregue).
 - **Integrações** — VTEX e Shopify via adapter pattern (Nuvemshop já entregue).
 - **Identity probabilística** — unificação de contatos entre canais.
-- **Modo SaaS** — self-service direto pra lojistas (hoje: BPO single-operator).
 
 ---
 
@@ -264,7 +270,7 @@ Este é um projeto **self-host**: cada pessoa roda o CRM na **própria infraestr
 - **Vercel** — hosting + AI Gateway.
 - **Anthropic** (Claude) — IA conversacional.
 - **shadcn/ui** — base de componentes.
-- Comunidade brasileira de e-commerce que validou as primeiras hipóteses.
+- A comunidade que nos levou do e-commerce pra clínicas, imobiliárias, infoprodutos e além — vocês definiram o que este projeto é.
 
 ---
 

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,79 @@
+# 🧭 Visão — DeskcommCRM
+
+> **O sistema operacional de vendas com agentes de IA, open source, nativo no WhatsApp.**
+> Este documento é a fonte da verdade do posicionamento do projeto. Tudo que for público (README, site, docs, descrições) deriva daqui.
+
+---
+
+## O nome
+
+**Deskcomm** vem de **Desk** (mesa) + **comm** (comércio): **o comercial de mesa**.
+A ideia que o nome carrega: toda a operação comercial de um negócio — atendimento, qualificação, funil, pós-venda — operada a partir de uma única mesa, por pessoas e por agentes de IA trabalhando juntos.
+
+O "CRM" no nome é a categoria de entrada, não o teto. O DeskcommCRM é **mais que um CRM**: é o sistema onde a venda acontece.
+
+## De onde viemos, pra onde vamos
+
+O projeto nasceu em 2026 como um CRM operacional para **e-commerce brasileiro** — WhatsApp via WAHA, integração Nuvemshop, LGPD nativa. Quando abrimos o código, a comunidade decidiu outra coisa: a maioria dos adopters passou a rodar o Deskcomm em **clínicas, infoprodutos, imobiliárias, agências e prestadores de serviço** — qualquer negócio que vende conversando.
+
+Os pedidos de feature dessa comunidade empurraram o produto na direção que hoje é a nossa identidade: **agentes de IA cada vez mais capazes, integrados ao sistema via MCP, operando o CRM de verdade**. O e-commerce continua sendo um caso de uso de primeira classe (foi nosso berço e a integração Nuvemshop prova isso) — mas ele é **um** vertical, não **o** produto.
+
+**A transição, em uma frase:** de "CRM de e-commerce com IA" para **"sistema operacional de vendas com agentes de IA, para qualquer negócio que vende pelo WhatsApp"**.
+
+## O que acreditamos sobre agentes de IA
+
+1. **Agente que opera, não chatbot que enfeita.** Nosso agente lê contexto real (histórico, perfil, pedido), consulta a base de conhecimento do tenant (RAG por organização), responde, qualifica, move o lead no funil — e é **assignee de primeira classe** no sistema, com as mesmas regras de governança de um atendente humano.
+
+2. **Agentes que se auto-aprimoram.** O sistema é desenhado como um flywheel: conversas resolvidas viram conhecimento novo na base RAG; handoffs pro humano marcam onde o agente ainda não alcança; métricas e budget por tenant fecham o loop. Cada dia de operação torna o agente melhor — com **gate humano** nas decisões que importam. Essa é a aposta central do roadmap.
+
+3. **MCP como sistema nervoso.** O CRM inteiro é exposto como tools MCP — primeiro para os agentes internos, depois como contrato público. Um negócio deve poder plugar o agente que quiser (Claude, o que vier) e ele **opera** o Deskcomm: cria lead, responde cliente, agenda, consulta pedido. O CRM vira infraestrutura para agentes.
+
+4. **Humano no comando.** Handoff auditado, escopo por papel (RBAC), fila com posição, budget de IA por organização. Autonomia do agente cresce na medida em que a governança prova que ele acerta.
+
+## Os pilares do produto
+
+| Pilar | O que significa na prática |
+|---|---|
+| **Agentes de IA nativos** | RAG por tenant, análise de sentimento, handoff IA→humano auditado, IA como assignee, budget por org |
+| **CRM automatizado pela IA** | O agente move leads, aplica tags, dispara automações QUANDO/SE/ENTÃO — o funil anda sozinho |
+| **Ferramentas de apoio ao comercial** | Inbox em tempo real, kanban com fractional indexing, customer 360, métricas por atendente, roteamento automático |
+| **WhatsApp-native** | WAHA multi-número, anti-banimento, mídia, STOP detection — o canal onde o Brasil vende |
+| **Multi-nicho por design** | `vocabulary` configurável por pipeline (lead = Cliente/Paciente/Comprador; won = Pago/Agendado/Fechado) — o mesmo core serve e-commerce, clínica, imobiliária, infoproduto |
+| **Self-hosted de verdade** | Seus dados na sua VPS, kit de instalação com 1 comando, `baseline.sql` auto-curativo, atualização com 1 script |
+| **Compliance nativo** | Multi-tenant com RLS testada em CI, LGPD by-design (redact, data_request, anonimização), audit append-only |
+
+## Posicionamento
+
+**Categoria de entrada (âncora):** a alternativa **open source e self-hosted** às plataformas fechadas de atendimento e vendas por WhatsApp (Kommo, Octadesk, Intercom, Zendesk).
+
+**Categoria própria (bandeira):** **sistema operacional de vendas com agentes de IA** — *AI Sales OS*. É pra onde a âncora nos leva: os incumbentes vendem assinatura de chat com bot acoplado; nós entregamos um sistema onde o agente de IA é operador nativo e o código é seu.
+
+**Uma frase (pt-br):**
+> DeskcommCRM é o sistema operacional de vendas open source com agentes de IA nativos e WhatsApp — self-hosted, multi-tenant, para qualquer negócio que vende conversando.
+
+**One-liner (en):**
+> Open-source AI sales OS: a self-hosted CRM where AI agents natively operate sales and support over WhatsApp — an open alternative to Kommo, Octadesk and Intercom.
+
+**Público:** negócios brasileiros (e além) que vendem pelo WhatsApp — e-commerce, clínicas, imobiliárias, infoprodutores, agências, serviços — e a comunidade dev/self-hosted que instala pra si ou pra clientes.
+
+## Modelo do projeto (sem letra miúda)
+
+- **O software é 100% open source (MIT), completo, sem versão paga.** Não vendemos assinatura. Não existe feature travada.
+- **A monetização é por infraestrutura:** o projeto é desenvolvido em parceria com a **HostGator** — o caminho recomendado de produção é a VPS deles (datacenter em São Paulo), instalada pelo `hostgator-setup-kit` com 1 comando. Assinar pelo link de parceiro apoia o projeto e sai mais barato pra quem assina.
+- **O caminho genérico nunca é sabotado:** `docker compose` e o kit self-host funcionam em qualquer VPS. A parceria é o caminho recomendado, nunca o único. (Regra de ouro do open source sustentável: percepção de pegadinha mata a marca.)
+
+## Princípios de comunicação
+
+1. **Keyword primeiro, jargão depois.** Em todo título público: "open source", "AI agents", "WhatsApp", "CRM", "self-hosted" antes de qualquer nome interno de subsistema.
+2. **Mostrar, não descrever.** Screenshot/GIF do produto no primeiro scroll de qualquer página.
+3. **Âncora explícita.** "Alternativa open source a X" aparece no About do GitHub, no README e no site — é assim que a demanda dos incumbentes nos encontra (busca e LLMs).
+4. **E-commerce é exemplo, não definição.** Ao citar casos de uso, sempre em lista multi-nicho ("e-commerce, clínicas, imobiliárias...").
+5. **Transparência de modelo.** Parceria HostGator e telemetria declaradas em linguagem humana no README, nunca escondidas.
+
+## Norte de 3 anos
+
+Ser a resposta padrão — do Google, do ChatGPT, do Reddit e do dev brasileiro — para a pergunta **"qual o melhor CRM open source com agentes de IA e WhatsApp?"**; com milhares de instâncias self-hosted rodando, um ecossistema de agentes plugados via MCP público, e um flywheel de auto-aprimoramento que faça cada instância vender melhor a cada mês de operação.
+
+---
+
+*Última revisão: 2026-07-19 — reposicionamento e-commerce → multi-nicho / AI Sales OS.*

--- a/docs/deploy-selfhost/README.md
+++ b/docs/deploy-selfhost/README.md
@@ -1,7 +1,8 @@
 # DeskcommCRM self-hosted — instalação em VPS (com agente de IA)
 
-> CRM operacional para e-commerce com agente SDR de IA integrado (WhatsApp via
-> WAHA). Este guia sobe TUDO numa VPS com `docker compose`: app web, worker do
+> Sistema operacional de vendas open source com agente SDR de IA integrado
+> (WhatsApp via WAHA) — pra qualquer negócio que vende conversando.
+> Este guia sobe TUDO numa VPS com `docker compose`: app web, worker do
 > agente, WAHA e proxy com HTTPS automático. Tempo estimado: ~30 min.
 
 ## O que você precisa antes

--- a/docs/prd/00-prd-master.md
+++ b/docs/prd/00-prd-master.md
@@ -1,8 +1,8 @@
 ---
 title: DeskcommCRM — PRD-Mestre
-version: 0.1
+version: 0.2
 status: em revisão
-date: 2026-04-28
+date: 2026-07-19
 owner: Rafael Melgaço
 referencia_arquitetural: docs/research/reference-synthesis.md
 ---
@@ -13,19 +13,32 @@ referencia_arquitetural: docs/research/reference-synthesis.md
 
 ---
 
+## 0. Nota de transição (2026-07) — de "CRM de e-commerce" para "AI Sales OS"
+
+Este PRD nasceu (v0.1, abril/2026) com o produto posicionado como **CRM operacional para e-commerce**. Após a abertura do código, a realidade da adoção mudou o produto: a maioria da comunidade roda o Deskcomm em **clínicas, infoprodutos, imobiliárias, agências e serviços**, e os pedidos de feature nos especializaram em **agentes de IA integrados via MCP**. O posicionamento vigente está em [`VISION.md`](../../VISION.md):
+
+> **Sistema operacional de vendas open source com agentes de IA nativos e WhatsApp — self-hosted, multi-tenant, para qualquer negócio que vende conversando.**
+
+Implicações de leitura deste documento e dos sub-PRDs:
+- **E-commerce passa de definição do produto a primeiro vertical.** Referências a Nuvemshop, pipeline de pedidos e vocabulário de e-commerce continuam válidas como o template do vertical de origem — o mecanismo que as generaliza é o `vocabulary` configurável por pipeline (Sub-PRD 02 §3.7).
+- **O modelo comercial é open source + infraestrutura** (parceria HostGator para self-host em VPS), não venda de assinatura. Menções a "modo SaaS" descrevem uma opção arquitetural preservada, não o plano comercial corrente.
+- Requisitos, contratos e decisões técnicas dos sub-PRDs permanecem válidos — a arquitetura multi-tenant com `vocabulary` configurável foi o que permitiu a expansão multi-nicho sem refactor.
+
+---
+
 ## 1. Sumário Executivo
 
-**O que é.** DeskcommCRM é um CRM operacional especializado em e-commerce, com IA conversacional integrada nativamente. Unifica atendimento humano, chatbot com RAG por tenant, gestão de pedidos e pipeline de pós-venda numa única plataforma multi-tenant, tendo WhatsApp como canal primário (via WAHA, API não-oficial).
+**O que é.** DeskcommCRM é um sistema operacional de vendas open source com agentes de IA nativos — um CRM operacional onde a IA atende, qualifica e move o funil junto com humanos. Unifica atendimento humano, agentes com RAG por tenant, gestão de pedidos/negócios e pipeline de pós-venda numa única plataforma multi-tenant, tendo WhatsApp como canal primário (via WAHA, API não-oficial). Nasceu especializado em e-commerce (vertical de origem, com integração Nuvemshop); hoje serve qualquer negócio que vende conversando — ver Nota de transição (§0).
 
 **Quem usa.** Hoje, em modo BPO: a empresa operadora (TBD) usa o DeskcommCRM internamente pra prestar atendimento como serviço aos e-commerces clientes contratados. Atendentes humanos operam múltiplos tenants através de uma "caixa de entrada unificada" via *super-admin role*. Amanhã, em modo SaaS: o mesmo produto será comercializado direto pra e-commerces operarem por conta própria. Toda a arquitetura é multi-tenant desde o dia 1, sem refactor previsto pro pivot.
 
-**Quem é o cliente alvo (tenant).** PME brasileiro de e-commerce na plataforma Nuvemshop, com ~5 mil pedidos/mês, ~300 atendimentos/dia, 2–5 atendentes humanos e 1–2 números WhatsApp.
+**Quem é o cliente alvo (tenant).** PME brasileira que vende pelo WhatsApp — e-commerce, clínica, imobiliária, infoprodutor, agência ou serviço — na faixa de ~300 atendimentos/dia, 2–5 atendentes humanos e 1–2 números WhatsApp. O perfil de calibração original (e-commerce Nuvemshop com ~5 mil pedidos/mês) segue sendo a referência de carga.
 
-**Diferencial competitivo.** Quatro elementos juntos — ausentes nos concorrentes incumbentes (Pipedrive, RD CRM, Zendesk, Octadesk):
-1. **IA operando o atendimento** com RAG por tenant (FAQ + política da loja + catálogo Nuvemshop sincronizado + conversas resolvidas), não chatbot decorativo.
-2. **E-commerce-native**: pipeline, vocabulário e métricas desenhados pro ciclo de e-commerce ("Carrinho abandonado → Pago → Enviado → Entregue → Pós-venda"), não pro funil B2B SaaS.
-3. **MCP-ready**: arquitetura inclui MCP server (Fase 2) com 19 tools canônicas pra LLMs operarem o sistema.
-4. **LGPD nativa**: webhooks `customer/redact` e `customer/data_request` da Nuvemshop são contrato de primeira-classe, não afterthought.
+**Diferencial competitivo.** Quatro elementos juntos — ausentes nos concorrentes incumbentes (Kommo, Octadesk, Zendesk, Pipedrive, RD CRM):
+1. **Agentes de IA operando o CRM** com RAG por tenant (FAQ + políticas do negócio + catálogo sincronizado + conversas resolvidas), não chatbot decorativo — com trilha de auto-aprimoramento: conversas resolvidas realimentam a base de conhecimento.
+2. **Multi-nicho por design**: pipeline, vocabulário e métricas configuráveis por tenant (`vocabulary` por pipeline) — o ciclo de e-commerce ("Carrinho abandonado → Pago → Enviado → Entregue → Pós-venda") é o template do vertical de origem, não o limite do produto.
+3. **MCP-ready**: arquitetura inclui MCP server (interno hoje; contrato público na Fase 2) com 19 tools canônicas pra LLMs operarem o sistema.
+4. **LGPD nativa**: redact e data_request como contrato de primeira-classe (incluindo os webhooks da Nuvemshop no vertical e-commerce), não afterthought.
 
 **Restrições principais.** MVP-B em produção em **8–12 semanas**. Stack obrigatória: bundle adotado (Next.js 14+ App Router + Supabase + WAHA Plus + Vercel + MCP server separado em Node ESM). LGPD desde o dia 1. Arquitetura multi-tenant com RLS Postgres em toda tabela tenant-aware.
 
@@ -41,15 +54,15 @@ referencia_arquitetural: docs/research/reference-synthesis.md
 
 3. **LGPD em pé de fragilidade.** Lojistas raramente têm processo formal de redact e data_request. Multas vêm crescendo desde 2023 e passam pra eles em primeiro lugar — e pro fornecedor de software, em segundo. Não é compliance opcional.
 
-4. **CRMs B2B genéricos não servem pra e-commerce.** Pipedrive, RD CRM e similares foram desenhados pra venda de SaaS — funil "Lead → Proposta → Negociação → Fechado". E-commerce tem ciclo curto, automatizado, repetitivo. Vender no e-commerce não é vender SaaS.
+4. **CRMs B2B genéricos não servem pra quem vende conversando.** Pipedrive, RD CRM e similares foram desenhados pra venda de SaaS — funil "Lead → Proposta → Negociação → Fechado". Venda conversacional (e-commerce, clínica, imobiliária, infoproduto) tem ciclo curto, automatizado, repetitivo, centrado no WhatsApp. O vocabulário e o ritmo são outros — e cada nicho precisa do seu (`vocabulary` configurável).
 
 5. **Sem MCP nativo no mercado.** Lojistas que querem operar o CRM via Claude Desktop ou agentes IA hoje não têm plataforma que exponha CRUD do CRM como tools MCP. Tendência forte pós-2025; janela competitiva aberta.
 
 ### Visão
 
-> "DeskcommCRM é a plataforma onde IA e humanos atendem juntos os clientes finais de PMEs de e-commerce no WhatsApp, com Customer 360° unificado, compliance LGPD nativa e operação multi-tenant pronta pra escala."
+> "DeskcommCRM é o sistema operacional de vendas onde agentes de IA e humanos atendem juntos os clientes de qualquer negócio que vende pelo WhatsApp, com Customer 360° unificado, compliance LGPD nativa, operação multi-tenant pronta pra escala — e agentes que se auto-aprimoram a cada conversa resolvida."
 
-Em três anos: dominar o nicho de BPO de atendimento de e-commerce no Brasil; abrir SaaS direto pra lojistas; expandir pra VTEX, Shopify, e demais plataformas; oferecer MCP público como diferencial pra clientes power-user que querem orquestrar o CRM via agentes IA próprios.
+Em três anos: ser a resposta padrão pra "melhor CRM open source com agentes de IA e WhatsApp" — milhares de instâncias self-hosted (VPS HostGator como caminho recomendado), ecossistema de agentes plugados via MCP público, templates prontos por nicho (e-commerce, clínica, imobiliária, infoproduto), e o flywheel de auto-aprimoramento medido em produção. Posicionamento completo em [`VISION.md`](../../VISION.md).
 
 ---
 
@@ -293,7 +306,7 @@ Roadmap revisado a cada 4 semanas. Estimativa otimista; recalibrar a cada milest
 
 ## 11. Glossário
 
-- **Tenant** — uma organização cliente do DeskcommCRM (um e-commerce). No DB = `organizations`. Sinônimo: organização.
+- **Tenant** — uma organização cliente do DeskcommCRM (um negócio que vende pelo WhatsApp: e-commerce, clínica, imobiliária, infoprodutor, etc.). No DB = `organizations`. Sinônimo: organização.
 - **Operador BPO** — funcionário da empresa operadora que atende múltiplos tenants. Tem role super-admin de plataforma.
 - **Super-admin de plataforma** — role que cruza tenants. Distinto do `admin` de um tenant específico.
 - **Lead / Cliente** — registro central no CRM (`crm_leads`). No vocabulary de e-commerce, lead = "Cliente". Engloba cliente em qualquer estágio (interesse, comprou, pós-venda).

--- a/docs/prd/05-prd-ai-rag-handoff.md
+++ b/docs/prd/05-prd-ai-rag-handoff.md
@@ -11,7 +11,7 @@ referencia_arquitetural: docs/research/reference-synthesis.md
 
 # Sub-PRD 05 — IA Conversacional + RAG por tenant + Sentiment Detection + Handoff
 
-> Camada de inteligência operacional do DeskcommCRM. Define como o chatbot responde inbounds com contexto rico (perfil + último pedido + base de conhecimento do tenant), como o sistema detecta frustração em tempo real, e como o produto orquestra a transição bot→humano sem perda de contexto. Sem essa camada, o produto vira CRM convencional com WhatsApp colado; com ela, é o diferencial que justifica a tese e-commerce-native.
+> Camada de inteligência operacional do DeskcommCRM. Define como o chatbot responde inbounds com contexto rico (perfil + último pedido + base de conhecimento do tenant), como o sistema detecta frustração em tempo real, e como o produto orquestra a transição bot→humano sem perda de contexto. Sem essa camada, o produto vira CRM convencional com WhatsApp colado; com ela, é o diferencial que justifica a tese do AI Sales OS — agentes de IA operando a venda de verdade (ver `VISION.md`).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "deskcomm-crm",
   "version": "0.1.0",
   "private": true,
-  "description": "DeskcommCRM — CRM operacional multi-tenant para e-commerce com IA conversacional, WhatsApp via WAHA e LGPD nativa.",
+  "description": "DeskcommCRM — sistema operacional de vendas open source com agentes de IA nativos e WhatsApp (WAHA). Self-hosted, multi-tenant, LGPD by-design.",
   "engines": {
     "node": ">=20"
   },

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,26 @@
+# DeskcommCRM
+
+> Open-source AI sales OS: a self-hosted, multi-tenant CRM where AI agents natively operate sales and support over WhatsApp. An open alternative to Kommo, Octadesk and Intercom — for any business that sells through conversations (e-commerce, clinics, real estate, info-products, agencies, services). MIT-licensed, no paid tier; the recommended production path is a one-command install on a HostGator VPS.
+
+Key facts:
+- Category: open-source CRM / AI sales operating system / WhatsApp customer platform
+- AI: per-tenant RAG agents (pgvector) that answer, qualify and move leads; sentiment analysis; audited AI→human handoff; AI as first-class assignee; per-org AI budget; self-improvement loop (resolved conversations feed the knowledge base)
+- MCP: internal MCP server today; public MCP contract on the roadmap — any AI agent can operate the CRM
+- WhatsApp: via WAHA (multi-number, anti-ban throttling, media, STOP detection)
+- Multi-niche: configurable vocabulary per pipeline (lead = Customer/Patient/Buyer; won = Paid/Booked/Closed); Nuvemshop integration for the e-commerce vertical
+- Compliance: multi-tenant Postgres RLS (isolation tested in CI), LGPD by design (redact, data_request, anonymization), append-only audit log
+- Stack: Next.js 16, React 19, TypeScript, Supabase (Postgres + Auth + Realtime + Storage), Vercel AI SDK, WAHA
+- License: MIT. Fully self-hosted; your data stays on your VPS.
+
+## Docs
+
+- [README (Portuguese)](https://github.com/melgarafael/DeskcommCRM/blob/main/README.md): project overview, quickstart, stack
+- [README (English)](https://github.com/melgarafael/DeskcommCRM/blob/main/README.en.md): English overview
+- [Vision & positioning](https://github.com/melgarafael/DeskcommCRM/blob/main/VISION.md): what the project believes about self-improving AI agents
+- [Architecture](https://github.com/melgarafael/DeskcommCRM/blob/main/ARCHITECTURE.md): one-page architecture
+- [Setup guide](https://github.com/melgarafael/DeskcommCRM/blob/main/docs/SETUP.md): step-by-step setup of every integration
+- [Self-host on a VPS](https://github.com/melgarafael/DeskcommCRM/blob/main/docs/deploy-selfhost/README.md): docker compose deploy on any VPS
+
+## Repository
+
+- [GitHub](https://github.com/melgarafael/DeskcommCRM): source code, issues, discussions


### PR DESCRIPTION
## O que muda

Reposicionamento público do projeto: de **"CRM operacional para e-commerce"** para **"sistema operacional de vendas open source com agentes de IA, nativo no WhatsApp"** — refletindo a adoção multi-nicho da comunidade (clínicas, imobiliárias, infoprodutos, agências) e a especialização em agentes de IA via MCP.

### Arquivos

- **`VISION.md`** (novo) — fonte da verdade do posicionamento: Deskcomm = Desk (mesa) + comm (comércio), "o comercial de mesa"; princípios sobre agentes que se auto-aprimoram (flywheel com gate humano); modelo open source + infraestrutura (parceria HostGator) declarado sem letra miúda.
- **`README.md`** — hero novo orientado a benefício ("Agentes de IA que atendem, qualificam e vendem no WhatsApp") + âncora de categoria ("alternativa aberta a Kommo, Octadesk e Intercom"); seletor de idioma; bloco HostGator preservado intocado; roadmap sincronizado com a main (governança G1–G6 ✅ + operação visível).
- **`README.en.md`** (novo) — versão em inglês pra comunidade internacional.
- **`public/llms.txt`** (novo) — GEO: resumo estruturado do produto pra crawlers de IA (ChatGPT/Perplexity/Claude).
- **`docs/prd/00-prd-master.md`** — nota de transição §0 documentando a virada; sumário executivo, visão, diferenciais e glossário atualizados (e-commerce = primeiro vertical, não definição do produto).
- **`docs/prd/05-prd-ai-rag-handoff.md`**, **`docs/deploy-selfhost/README.md`**, **`CLAUDE.md`**, **`package.json`** — frases de enquadramento alinhadas.

### O que NÃO muda

- Bloco/link de parceria HostGator no README (caractere por caractere).
- Specs técnicas (decisão deliberada — contexto histórico preservado).
- Nenhum código, schema ou comportamento.

Metadados do repo (description + topics: `self-hosted`, `ai-agents`, `mcp`, etc.) já atualizados via `gh repo edit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARJNvbYiBAtSV5W1rLg5zj