### PR TITLE
fix(agent): schedule_followup limita 1 follow-up pendente por lead (anti-spam)

### DIFF
--- a/lib/agent-engine/agent/schedule-followup.test.ts
+++ b/lib/agent-engine/agent/schedule-followup.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import type pg from 'pg';
+
+import { applyScheduleFollowup } from './schedule-followup';
+
+/**
+ * Pool fake: roteia por conteúdo da SQL. O guard anti-empilhamento faz um SELECT
+ * (`enabled = true`); a criação faz o INSERT (`insert into cron_jobs`). Cada teste
+ * decide o que o SELECT devolve — com ou sem pendente.
+ */
+function fakePool(pendentes: Array<{ id: string; promised_at: string | null }>): {
+  db: pg.Pool;
+  inserts: number;
+} {
+  let inserts = 0;
+  const db = {
+    async query(sql: string) {
+      if (/insert into cron_jobs/i.test(sql)) {
+        inserts += 1;
+        return { rows: [{ id: 'cron-novo', next_run_at: new Date('2026-07-25T13:00:00Z') }] };
+      }
+      // guard SELECT
+      return { rows: pendentes };
+    },
+  } as unknown as pg.Pool;
+  return { db, get inserts() { return inserts; } } as { db: pg.Pool; inserts: number };
+}
+
+const CFG = {
+  clock: () => new Date('2026-07-23T12:00:00Z'),
+  knobs: { minAheadMs: 30 * 60_000, maxAheadMs: 30 * 86_400_000, staggerWindowMs: 60_000 },
+};
+const IDS = { tenantId: 'org-1', leadId: 'lead-1' };
+const VALID = {
+  reason: 'reconfirmar call',
+  promised_at: '2026-07-25T13:00:00Z',
+  promise: 'confirmar a call de diagnóstico',
+  context_snapshot: null,
+};
+
+describe('applyScheduleFollowup — guard anti-empilhamento (1 pendente por lead)', () => {
+  it('lead JÁ tem follow-up pendente → already_pending, NÃO cria segundo', async () => {
+    const p = fakePool([{ id: 'cron-existente', promised_at: '2026-07-25T10:00:00Z' }]);
+    const res = await applyScheduleFollowup(p.db, CFG, IDS, VALID);
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('esperava falha');
+    expect(res.error.code).toBe('already_pending');
+    expect(res.error.message).toContain('2026-07-25T10:00:00Z');
+    expect(p.inserts).toBe(0); // o insert do cron NÃO rodou — sem empilhar
+  });
+
+  it('lead SEM pendente → agenda normalmente (cria 1)', async () => {
+    const p = fakePool([]);
+    const res = await applyScheduleFollowup(p.db, CFG, IDS, VALID);
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('esperava sucesso');
+    expect(res.cronJobId).toBe('cron-novo');
+    expect(p.inserts).toBe(1);
+  });
+
+  it('o ensino manda usar data ABSOLUTA (anti "amanhã")', async () => {
+    const p = fakePool([{ id: 'x', promised_at: null }]);
+    const res = await applyScheduleFollowup(p.db, CFG, IDS, VALID);
+    if (res.ok) throw new Error('esperava falha');
+    expect(res.error.message.toLowerCase()).toContain('absoluta');
+    expect(res.error.message).toContain('amanhã');
+  });
+});

--- a/lib/agent-engine/agent/schedule-followup.ts
+++ b/lib/agent-engine/agent/schedule-followup.ts
@@ -42,7 +42,7 @@ export type ScheduleFollowupResult =
   | {
       ok: false;
       error: {
-        code: 'invalid_payload' | 'promised_at_in_past' | 'promised_at_out_of_window';
+        code: 'invalid_payload' | 'promised_at_in_past' | 'promised_at_out_of_window' | 'already_pending';
         message: string;
       };
     };
@@ -113,6 +113,37 @@ export async function applyScheduleFollowup(
         message:
           `horário fora da janela aceitável de follow-up: agende o retorno entre ` +
           `${humanizeMs(minAheadMs)} e ${humanizeMs(maxAheadMs)} a partir de agora.`,
+      },
+    };
+  }
+
+  // Guard anti-empilhamento (1 follow-up VIVO por lead): sem isto, o agente marca
+  // um "reconfirmar amanhã" a cada turno e o lead vira alvo de N sequências
+  // paralelas com data relativa congelada — o bug de spam de produção. Um follow-up
+  // pendente já cobre o retorno; o modelo é ENSINADO a não duplicar (não é erro
+  // fatal, é continue-sem-agendar). Espelha a exclusividade org-wide do sistema de
+  // fluxos (migration 0064), aplicada aqui à tool de demanda.
+  const { rows: pendentes } = await db.query<{ id: string; promised_at: string | null }>(
+    `select id, (payload->>'promised_at') as promised_at
+       from cron_jobs
+      where organization_id = $1 and contact_id = $2
+        and job_kind = 'followup_turn' and enabled = true
+      order by next_run_at asc
+      limit 1`,
+    [ids.tenantId, ids.leadId],
+  );
+  if (pendentes.length > 0) {
+    const quando = pendentes[0]!.promised_at;
+    return {
+      ok: false,
+      error: {
+        code: 'already_pending',
+        message:
+          `este lead JÁ tem um follow-up agendado${quando ? ` para ${quando}` : ''} — ` +
+          `não agende outro (evita bombardear o lead com confirmações repetidas). ` +
+          `Se precisa mudar o horário, encerre o turno; o follow-up existente vai disparar no horário combinado. ` +
+          `Use SEMPRE data ABSOLUTA (ex.: "2026-07-25T13:00:00Z"), nunca relativa como "amanhã" — ` +
+          `a promessa é lida dias depois e "amanhã" fica sem sentido.`,
       },
     };
   }


### PR DESCRIPTION
## Bug de produção
Um agente na VPS empilhou **19 follow-ups** num contato só ("reconfirmar call amanhã"), disparando confirmações repetidas por 3 dias — com a data relativa "amanhã" congelada no texto da promessa.

## Causa raiz
`schedule_followup` não tinha guard: o agente marcava um novo follow-up a cada turno.

## Fix
- Guard: se o lead já tem follow-up pendente (`cron_jobs` enabled, kind followup_turn), a tool retorna `already_pending` — ensina o modelo a **não duplicar** em vez de criar outro.
- Ensino extra: usar data **absoluta** (`2026-07-25T13:00:00Z`), nunca "amanhã".
- Espelha a exclusividade 1-por-lead do sistema de fluxos (migration 0064), aplicada à tool de demanda.
- 3 testes unit (guard bloqueia 2º / sem pendente agenda / ensino de data absoluta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)