### PR TITLE
fix(hostgator-setup-kit): detecta colagem duplicada em campo secreto do install.sh

### DIFF
--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -39,9 +39,23 @@ ask() {
   local input
   if [ "$secret" = "secret" ]; then
     read -r -s -p "$prompt${default:+ [$default]}: " input; echo
-  else
-    read -r -p "$prompt${default:+ [$default]}: " input
+    input="${input:-$default}"
+    # Campo secreto não ecoa o que foi colado — a pessoa não vê se colou, então
+    # tende a colar de novo "pra garantir", e cola duas vezes na mesma linha
+    # (sem separador, vira um valor só, dobrado). Isso gera chaves/connection
+    # strings inválidas com erro críptico lá na frente (ex.: psql de socket).
+    # Detecta o padrão (metade == outra metade) e barra aqui, na origem.
+    if [ -n "$input" ]; then
+      local len=${#input} half=$((${#input} / 2))
+      if [ $((len % 2)) -eq 0 ] && [ "${input:0:half}" = "${input:half}" ]; then
+        die "Parece que esse valor foi colado 2x seguidas na mesma linha (comum: o campo é secreto e não mostra o que você cola, então não dá pra saber se colou). Rode de novo e cole uma vez só."
+      fi
+      c_grn "  ✓ recebido (${len} caracteres)"
+    fi
+    printf -v "$var" '%s' "$input"
+    return 0
   fi
+  read -r -p "$prompt${default:+ [$default]}: " input
   printf -v "$var" '%s' "${input:-$default}"
 }
 


### PR DESCRIPTION
## Contexto

Durante instalação real numa VPS, o `bash install.sh` quebrou no passo de aplicar o schema com erros crípticos (extensões não habilitadas, depois `psql` caindo num erro de socket local). Nenhum dos dois apontava pra causa real.

## Causa raiz

`ask()` pede `SUPABASE_SERVICE_ROLE_KEY` e `SUPABASE_DB_URL` num prompt secreto (`read -r -s`), que não ecoa nada ao colar. Sem feedback, a pessoa colava de novo por garantia — na mesma linha, sem separador — e o `read` recebia o valor duplicado (`postgres://...db` + `postgres://...db` grudados). Esse valor inválido só explodia adiante, em erros sem relação óbvia com a origem.

## Fix

`ask()`, para campos secretos, agora:
1. Confirma o recebimento sem revelar o segredo (`✓ recebido (N caracteres)`).
2. Detecta quando o valor é exatamente duas cópias do mesmo texto grudadas (metade == outra metade) e para ali com uma mensagem que nomeia a causa.

Um guard só, no único ponto onde os 4 campos secretos (`service_role`, `connection string`, chave Anthropic, senha do admin) são coletados.

## Test plan
- [x] `bash -n install.sh` passa
- [x] Lógica de detecção testada isoladamente: valor dobrado real → detectado; connection string normal → sem falso positivo
- [x] Sem mudança de schema envolvida