### PR TITLE
feat(radar): assumir a demanda direto do Radar (alça de ação)

### DIFF
--- a/app/app/radar/_components/RiskRadarList.tsx
+++ b/app/app/radar/_components/RiskRadarList.tsx
@@ -1,8 +1,12 @@
 "use client";
 import Link from "next/link";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useClaimConversation } from "@/hooks/inbox/useClaimConversation";
 import { useAtRiskLeads, type AtRiskLead } from "@/hooks/leads/useAtRiskLeads";
 import type { RiskBucket } from "@/lib/leads/risk-radar";
 import {
@@ -87,19 +91,40 @@ function RadarRow({ lead }: { lead: AtRiskLead }) {
     ? `/app/inbox?id=${lead.conversation_id}`
     : `/app/pipelines/${lead.pipeline_id}`;
 
+  const claim = useClaimConversation();
+  const qc = useQueryClient();
+
+  const owned = Boolean(lead.owner_user_id) || lead.assignee_kind === "user";
   const assignee =
     lead.assignee_kind === "ai"
       ? { icon: <Robot size={13} aria-hidden />, text: "Assistente" }
-      : lead.owner_user_id || lead.assignee_kind === "user"
+      : owned
         ? { icon: null, text: "Com atendente" }
         : { icon: null, text: "Sem dono" };
 
+  // Só é possível assumir demandas que têm conversa e ainda não têm dono humano.
+  const canClaim = Boolean(lead.conversation_id) && !owned;
+
+  function handleClaim() {
+    if (!lead.conversation_id) return;
+    claim.mutate(
+      { conversation_id: lead.conversation_id },
+      {
+        onSuccess: () => {
+          qc.invalidateQueries({ queryKey: ["leads-at-risk"] });
+          toast.success("Você assumiu a demanda");
+        },
+      },
+    );
+  }
+
   return (
-    <li data-testid="radar-item" data-risk={lead.risk}>
-      <Link
-        href={href}
-        className="flex items-start gap-3 px-4 py-3 transition-colors hover:bg-accent/50"
-      >
+    <li
+      data-testid="radar-item"
+      data-risk={lead.risk}
+      className="flex items-start gap-2 pr-3 transition-colors hover:bg-accent/50"
+    >
+      <Link href={href} className="flex min-w-0 flex-1 items-start gap-3 px-4 py-3">
         <Badge variant={meta.variant} className="mt-0.5 shrink-0">
           {meta.label}
         </Badge>
@@ -111,7 +136,7 @@ function RadarRow({ lead }: { lead: AtRiskLead }) {
               <ClockCountdown size={13} aria-hidden />
               {coldFor(lead.hours_since_activity)}
             </span>
-            <span className="inline-flex items-center gap-1">
+            <span className="inline-flex items-center gap-1" data-testid="radar-assignee">
               {assignee.icon}
               {assignee.text}
             </span>
@@ -128,8 +153,21 @@ function RadarRow({ lead }: { lead: AtRiskLead }) {
             </p>
           )}
         </div>
-        <ArrowRight size={16} className="mt-1 shrink-0 text-muted-foreground" aria-hidden />
       </Link>
+      <div className="flex shrink-0 items-center gap-2 self-center">
+        {canClaim ? (
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={claim.isPending}
+            onClick={handleClaim}
+            data-testid="radar-claim"
+          >
+            Assumir
+          </Button>
+        ) : null}
+        <ArrowRight size={16} className="text-muted-foreground" aria-hidden />
+      </div>
     </li>
   );
 }

--- a/scripts/seed-e2e-radar.ts
+++ b/scripts/seed-e2e-radar.ts
@@ -1,10 +1,13 @@
 /**
- * Seed E2E do Radar de Risco (C1): um lead ABERTO cuja última atividade foi há 5
- * dias e SEM follow-up agendado — o caso "crítico / sem próximo passo" que o radar
- * existe para tornar visível. Alimenta tests/e2e/risk-radar.spec.ts.
+ * Seed E2E do Radar de Risco (C1) e sua alça de ação. Cria:
+ *   - 1 contato + 1 channel_session + 1 conversa ABERTA e SEM dono (claimável);
+ *   - 1 lead ABERTO vinculado a esse contato, com última atividade há 5 dias e
+ *     sem follow-up agendado → aparece no radar como "crítico / sem próximo passo",
+ *     com o botão "Assumir" (porque tem conversa).
  *
- * Idempotente: upsert por (organization_id, title). Depende de .e2e-creds.json
- * (rode scripts/seed-e2e-credentials.ts antes). Grava o bloco `radar` em .e2e-creds.json.
+ * Idempotente E auto-reset: devolve a conversa ao estado sem dono a cada run (o
+ * teste de "assumir" pode rodar de novo). Depende de .e2e-creds.json
+ * (rode scripts/seed-e2e-credentials.ts antes). Grava o bloco `radar`.
  *
  * Run: npx tsx scripts/seed-e2e-radar.ts
  */
@@ -31,10 +34,81 @@ const admin = createClient(SUPABASE_URL, SERVICE_ROLE, {
 
 const CREDS_PATH = path.join(process.cwd(), ".e2e-creds.json");
 const AT_RISK_TITLE = "Demanda E2E em risco (radar)";
+const CONTACT_NAME = "Cliente Radar E2E";
+const SESSION_NAME = "e2e-radar-session";
 
 interface Creds {
   org_id: string;
   radar?: unknown;
+}
+
+async function ensureSession(orgId: string): Promise<string> {
+  const { data: existing } = await admin
+    .from("channel_sessions")
+    .select("id")
+    .eq("organization_id", orgId)
+    .eq("waha_session_name", SESSION_NAME)
+    .maybeSingle();
+  if (existing) return (existing as { id: string }).id;
+  const { data, error } = await admin
+    .from("channel_sessions")
+    .insert({
+      organization_id: orgId,
+      waha_session_name: SESSION_NAME,
+      display_name: "Número Radar E2E",
+      webhook_secret_encrypted: "\\x00",
+    } as never)
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`insert channel_session: ${error?.message}`);
+  return (data as { id: string }).id;
+}
+
+async function ensureContact(orgId: string): Promise<string> {
+  const { data: existing } = await admin
+    .from("contacts")
+    .select("id")
+    .eq("organization_id", orgId)
+    .eq("display_name", CONTACT_NAME)
+    .maybeSingle();
+  if (existing) return (existing as { id: string }).id;
+  const { data, error } = await admin
+    .from("contacts")
+    .insert({ organization_id: orgId, display_name: CONTACT_NAME } as never)
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`insert contact: ${error?.message}`);
+  return (data as { id: string }).id;
+}
+
+async function ensureConversation(orgId: string, contactId: string, sessionId: string): Promise<string> {
+  // Estado claimável: aberta, sem dono.
+  const state = {
+    assigned_to_user_id: null,
+    assignee_kind: null,
+    assigned_at: null,
+    status: "open",
+    last_message_preview: "Oi, ainda dá pra resolver meu caso?",
+  };
+  const { data: existing } = await admin
+    .from("conversations")
+    .select("id")
+    .eq("organization_id", orgId)
+    .eq("contact_id", contactId)
+    .eq("channel_session_id", sessionId)
+    .maybeSingle();
+  if (existing) {
+    const id = (existing as { id: string }).id;
+    await admin.from("conversations").update(state as never).eq("id", id);
+    return id;
+  }
+  const { data, error } = await admin
+    .from("conversations")
+    .insert({ organization_id: orgId, contact_id: contactId, channel_session_id: sessionId, ...state } as never)
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(`insert conversation: ${error?.message}`);
+  return (data as { id: string }).id;
 }
 
 async function main(): Promise<void> {
@@ -61,8 +135,18 @@ async function main(): Promise<void> {
   if (sErr || !stage) throw new Error(`stage not found: ${sErr?.message}`);
   const stageId = (stage as { id: string }).id;
 
-  // 5 dias sem atividade → crítico; sem contato/follow-up → "sem próximo passo".
+  const sessionId = await ensureSession(orgId);
+  const contactId = await ensureContact(orgId);
+  const conversationId = await ensureConversation(orgId, contactId, sessionId);
+
+  // 5 dias sem atividade → crítico; sem follow-up → "sem próximo passo".
   const coldAt = new Date(Date.now() - 5 * 24 * 3_600_000).toISOString();
+  const leadFields = {
+    stage_id: stageId,
+    contact_id: contactId,
+    owner_user_id: null,
+    last_activity_at: coldAt,
+  };
 
   const { data: existing } = await admin
     .from("crm_leads")
@@ -74,34 +158,35 @@ async function main(): Promise<void> {
   let leadId: string;
   if (existing) {
     leadId = (existing as { id: string }).id;
-    await admin
-      .from("crm_leads")
-      .update({ stage_id: stageId, owner_user_id: null, last_activity_at: coldAt } as never)
-      .eq("id", leadId);
-    console.log(`[seed] radar lead existing: ${leadId}`);
+    await admin.from("crm_leads").update(leadFields as never).eq("id", leadId);
+    console.info(`[seed] radar lead existing: ${leadId}`);
   } else {
     const { data, error } = await admin
       .from("crm_leads")
       .insert({
         organization_id: orgId,
         pipeline_id: pipelineId,
-        stage_id: stageId,
         title: AT_RISK_TITLE,
-        owner_user_id: null,
         position_in_stage: 3000,
         source: "manual",
-        last_activity_at: coldAt,
+        ...leadFields,
       } as never)
       .select("id")
       .single();
     if (error || !data) throw new Error(`insert radar lead: ${error?.message}`);
     leadId = (data as { id: string }).id;
-    console.log(`[seed] radar lead created: ${leadId}`);
+    console.info(`[seed] radar lead created: ${leadId}`);
   }
 
-  creds.radar = { pipeline_id: pipelineId, at_risk_lead_id: leadId, at_risk_title: AT_RISK_TITLE };
+  creds.radar = {
+    pipeline_id: pipelineId,
+    at_risk_lead_id: leadId,
+    at_risk_title: AT_RISK_TITLE,
+    contact_id: contactId,
+    conversation_id: conversationId,
+  };
   fs.writeFileSync(CREDS_PATH, JSON.stringify(creds, null, 2));
-  console.log(`\n✅ Radar seed completo. lead=${leadId} (frio desde ${coldAt})`);
+  console.info(`\n✅ Radar seed completo. lead=${leadId} conv=${conversationId} (frio desde ${coldAt})`);
 }
 
 main().catch((err) => {

--- a/tests/e2e/risk-radar.spec.ts
+++ b/tests/e2e/risk-radar.spec.ts
@@ -1,10 +1,12 @@
 /**
  * Radar de Risco (C1 — desilhamento da doutrina do sistema vivo). Prova, na
- * perspectiva do usuário real: o atendente entra no Radar e VÊ a demanda aberta
- * que esfriou (5 dias sem atividade, sem próximo passo) — o que antes morria
- * invisível no engine. Login como manager (sem MFA; vê todos os leads da org).
+ * perspectiva do usuário real: (1) o atendente entra no Radar e VÊ a demanda
+ * aberta que esfriou (5 dias sem atividade, sem próximo passo) — o que antes
+ * morria invisível no engine; (2) ele ASSUME a demanda direto da linha e a
+ * responsabilidade passa a ser dele. Login como manager (sem MFA).
  *
- * Pré-requisito: seed de credenciais + seed do radar (rodados aqui se faltarem).
+ * O seed do radar roda a cada execução (reseta a conversa para "sem dono"), então
+ * o teste de assumir é repetível.
  */
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
@@ -29,12 +31,9 @@ function loadCreds(): Creds {
   if (needsBase()) {
     execFileSync("npx", ["tsx", "scripts/seed-e2e-credentials.ts"], { stdio: "inherit" });
   }
-  let c = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
-  if (!c.radar?.at_risk_title) {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-radar.ts"], { stdio: "inherit" });
-    c = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
-  }
-  return c;
+  // Sempre reseta o fixture do radar (conversa volta a ficar sem dono).
+  execFileSync("npx", ["tsx", "scripts/seed-e2e-radar.ts"], { stdio: "inherit" });
+  return JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
 }
 
 const creds = loadCreds();
@@ -47,22 +46,38 @@ async function login(page: Page, email: string): Promise<void> {
   await page.waitForURL(/\/app\//);
 }
 
-test("o atendente vê no Radar a demanda aberta que esfriou sem próximo passo", async ({ page }) => {
-  await login(page, creds.users.manager!.email);
-
-  // Navega pelo menu lateral — como um usuário real, não por deep-link.
+async function gotoRadar(page: Page): Promise<void> {
   await page.getByRole("link", { name: "Radar" }).click();
   await page.waitForURL(/\/app\/radar/);
   await expect(page.getByRole("heading", { name: "Radar de risco" })).toBeVisible();
+}
 
-  // A demanda em risco seedada aparece como um item do radar.
-  const item = page.locator('[data-testid="radar-item"]', {
-    hasText: creds.radar!.at_risk_title,
-  });
+function radarItem(page: Page) {
+  return page.locator('[data-testid="radar-item"]', { hasText: creds.radar!.at_risk_title });
+}
+
+test("o atendente vê no Radar a demanda aberta que esfriou sem próximo passo", async ({ page }) => {
+  await login(page, creds.users.manager!.email);
+  await gotoRadar(page);
+
+  const item = radarItem(page);
   await expect(item).toBeVisible();
-
-  // ...classificada como crítica e sinalizada como sem próximo passo agendado.
   await expect(item).toHaveAttribute("data-risk", "critico");
   await expect(item.getByText("Crítico")).toBeVisible();
   await expect(item.getByText(/Sem próximo passo/)).toBeVisible();
+});
+
+test("o atendente assume a demanda direto do Radar e vira o responsável", async ({ page }) => {
+  await login(page, creds.users.manager!.email);
+  await gotoRadar(page);
+
+  const item = radarItem(page);
+  await expect(item).toBeVisible();
+  await expect(item.getByTestId("radar-assignee")).toHaveText("Sem dono");
+
+  await item.getByTestId("radar-claim").click();
+
+  // Após assumir, o radar recarrega: a demanda passa a ter atendente e o botão some.
+  await expect(radarItem(page).getByTestId("radar-assignee")).toHaveText("Com atendente");
+  await expect(radarItem(page).getByTestId("radar-claim")).toHaveCount(0);
 });


### PR DESCRIPTION
## O que

Evolui o Radar de Risco (#42) fechando a **alça de ação**: o atendente assume a demanda na própria linha, sem sair para o inbox. Antes o Radar só mostrava; agora ele deixa **agir**.

## Como (reuso, não reinvenção)

Reusa o endpoint existente `POST /api/v1/conversations/[id]/claim` via o hook `useClaimConversation`:
- `fn_conversation_assign` (lock otimista) faz o UPDATE + evento na mesma transação;
- emite `audit("conversation.claimed")` + `emit_event` — a ação é **logada e visível** (invariante 3);
- **zero endpoint novo, zero migration.**

Botão "Assumir" aparece só quando a demanda tem conversa e ainda não tem dono humano. Ao assumir, o Radar recarrega, a linha vira "Com atendente" e o botão some. Toast de confirmação.

## Doutrina

Fecha o edge de saída do Radar como **ação real** (não só navegação): humano assume → conversa muda → atividade logada → radar atualiza. A demanda deixa de estar órfã.

## Prova

- E2E `tests/e2e/risk-radar.spec.ts`: novo caso "o atendente assume a demanda direto do Radar e vira o responsável" — **verde** contra dev server real (2/2 testes passam).
- Seed atualizado cria contato + conversa claimável ligada ao lead (auto-reset por run).
- typecheck + lint zerados. Screenshot anexado na conversa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)