### PR TITLE
feat(branding): marca da instalação configurável por .env — white-label sem editar código

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,3 +104,11 @@ AGENT_DISPATCH_CONSUMER=engine
 # tela de Agentes IA). 0 = desligado; default 6h.
 #FLYWHEEL_INTERVAL_MS=21600000
 #FLYWHEEL_BATCH_LIMIT=10
+
+# ── Marca da instalação (white-label) ───────────────────────────────────────
+# Quem instala o CRM para clientes (agência, revendedor) troca a marca aqui, sem
+# editar código — patch em código se perde no próximo update. Vazio = padrão.
+# APP_LOGO_URL aceita qualquer URL pública de imagem; sem ela, o nome aparece
+# como texto. Ver lib/branding.ts.
+APP_NAME=
+APP_LOGO_URL=

--- a/.env.hostgator.example
+++ b/.env.hostgator.example
@@ -115,3 +115,11 @@ AGENT_DISPATCH_CONSUMER=engine           # dono único do despacho: engine (work
 #WATCHDOG_INTERVAL_MS=60000              # reconciliador de sessão + redrive de mensagens presas
 #FLYWHEEL_INTERVAL_MS=21600000           # auto-melhoria (propostas; aplicar é sempre manual). 0=off
 #FLYWHEEL_BATCH_LIMIT=10
+
+# ── Marca da instalação (white-label) ───────────────────────────────────────
+# Quem instala o CRM para clientes (agência, revendedor) troca a marca aqui, sem
+# editar código — patch em código se perde no próximo update. Vazio = padrão.
+# APP_LOGO_URL aceita qualquer URL pública de imagem; sem ela, o nome aparece
+# como texto. Ver lib/branding.ts.
+APP_NAME=
+APP_LOGO_URL=

--- a/README.es.md
+++ b/README.es.md
@@ -132,6 +132,7 @@ Entre ellos está el **test de aislamiento RLS**: crea 2 organizaciones, simula 
 |---|---|
 | [`VISION.md`](VISION.md) | **Visión y posicionamiento** — qué es el proyecto, en qué cree, hacia dónde va |
 | [`docs/SETUP.md`](docs/SETUP.md) | **Instalación completa paso a paso** de todas las integraciones |
+| [`docs/white-label.md`](docs/white-label.md) | **Instalar para clientes** — cambiar la marca, una instalación por cliente vs compartida, operación de reventa |
 | [`CLAUDE.md`](CLAUDE.md) | Convenciones no negociables (lectura obligatoria para contribuir) |
 | [`ARCHITECTURE.md`](ARCHITECTURE.md) | Visión de 1 página de la arquitectura |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Flujo de PRs |

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Among them is the **RLS isolation test**: it creates 2 organizations, simulates 
 |---|---|
 | [`VISION.md`](VISION.md) | **Vision & positioning** — what the project is, what it believes, where it's going |
 | [`docs/SETUP.md`](docs/SETUP.md) | **Complete step-by-step setup** for every integration |
+| [`docs/white-label.md`](docs/white-label.md) | **Installing for clients** — rebranding, one-install-per-client vs shared, reseller operations |
 | [`CLAUDE.md`](CLAUDE.md) | Non-negotiable conventions (required reading to contribute) |
 | [`ARCHITECTURE.md`](ARCHITECTURE.md) | One-page architecture overview |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | PR flow |

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -156,6 +156,7 @@ Entre eles está o **teste de isolamento RLS**: cria 2 organizações, simula os
 |---|---|
 | [`VISION.md`](VISION.md) | **Visão e posicionamento** — o que o projeto é, no que acredita e pra onde vai |
 | [`docs/SETUP.md`](docs/SETUP.md) | **Setup completo passo a passo** de todas as integrações |
+| [`docs/white-label.md`](docs/white-label.md) | **Instalar para clientes** — trocar a marca, uma instalação por cliente vs compartilhada, operação de revenda |
 | [`CLAUDE.md`](CLAUDE.md) | Convenções não-negociáveis (leitura obrigatória pra contribuir) |
 | [`ARCHITECTURE.md`](ARCHITECTURE.md) | Visão de 1 página da arquitetura |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Fluxo PR + epic-executor |

--- a/app/(public)/login/forgot/page.tsx
+++ b/app/(public)/login/forgot/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 import { ForgotPasswordForm } from "@/components/auth/ForgotPasswordForm";
 
-export const metadata = { title: "Recuperar senha — DeskcommCRM" };
+export const metadata = { title: "Recuperar senha" };
 
 export default function ForgotPasswordPage() {
   return (

--- a/app/(public)/login/mfa/page.tsx
+++ b/app/(public)/login/mfa/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { MfaForm } from "@/components/auth/MfaForm";
 
-export const metadata = { title: "Verificação em duas etapas — DeskcommCRM" };
+export const metadata = { title: "Verificação em duas etapas" };
 
 export default async function MfaChallengePage({
   searchParams,

--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
 
 import { LoginForm } from "@/components/auth/LoginForm";
+import { branding } from "@/lib/branding";
 
-export const metadata = { title: "Entrar — DeskcommCRM" };
+export const metadata = { title: "Entrar" };
 
 export default async function LoginPage({
   searchParams,
@@ -14,7 +15,7 @@ export default async function LoginPage({
     <div className="space-y-6">
       <div className="space-y-1.5 text-center">
         <h1 className="text-2xl font-semibold tracking-tight">Entrar</h1>
-        <p className="text-sm text-muted-foreground">DeskcommCRM</p>
+        <p className="text-sm text-muted-foreground">{branding().name}</p>
       </div>
       {reset === "success" && (
         <div

--- a/app/(public)/login/recovery/page.tsx
+++ b/app/(public)/login/recovery/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 import { RecoveryForm } from "@/components/auth/RecoveryForm";
 
-export const metadata = { title: "Recuperar acesso — DeskcommCRM" };
+export const metadata = { title: "Recuperar acesso" };
 
 export default async function RecoveryPage({
   searchParams,

--- a/app/(public)/login/reset/page.tsx
+++ b/app/(public)/login/reset/page.tsx
@@ -1,6 +1,6 @@
 import { ResetPasswordForm } from "@/components/auth/ResetPasswordForm";
 
-export const metadata = { title: "Nova senha — DeskcommCRM" };
+export const metadata = { title: "Nova senha" };
 
 export default function ResetPasswordPage() {
   return (

--- a/app/(public)/signup/page.tsx
+++ b/app/(public)/signup/page.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
 
 import { SignupForm } from "@/components/auth/SignupForm";
+import { branding } from "@/lib/branding";
 
-export const metadata = { title: "Criar conta — DeskcommCRM" };
+export const metadata = { title: "Criar conta" };
 
 export default function SignupPage() {
   return (
@@ -10,7 +11,7 @@ export default function SignupPage() {
       <div className="space-y-1.5 text-center">
         <h1 className="text-2xl font-semibold tracking-tight">Criar conta</h1>
         <p className="text-sm text-muted-foreground">
-          Comece a usar o DeskcommCRM em minutos
+          Comece a usar o {branding().name} em minutos
         </p>
       </div>
       <SignupForm />

--- a/app/account-suspended/page.tsx
+++ b/app/account-suspended/page.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 
 export const metadata = {
-  title: "Conta suspensa — DeskcommCRM",
+  title: "Conta suspensa",
 };
 
 export default function AccountSuspendedPage() {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Atkinson_Hyperlegible, IBM_Plex_Mono } from "next/font/google";
 import { Toaster } from "sonner";
+import { branding } from "@/lib/branding";
 import { ThemeProvider } from "@/lib/theme";
 import { Providers } from "./providers";
 import { PublicEnvScript } from "./public-env-script";
@@ -20,26 +21,36 @@ const plexMono = IBM_Plex_Mono({
   variable: "--font-mono",
 });
 
-export const metadata: Metadata = {
-  title: {
-    default: "Deskcomm — CRM operacional para e-commerce",
-    template: "%s · Deskcomm",
-  },
-  description:
-    "Centralize WhatsApp, e-mail e Instagram em um único atendimento. IA que resolve sozinha o que dá pra resolver, time humano focado no que importa. Multi-tenant, LGPD-nativo, sob medida pra operações brasileiras.",
-  applicationName: "Deskcomm",
-  authors: [{ name: "Deskcomm" }],
-  keywords: [
-    "CRM",
-    "atendimento",
-    "WhatsApp",
-    "e-commerce",
-    "IA conversacional",
-    "LGPD",
-    "multi-tenant",
-  ],
-  robots: { index: false, follow: false },
-};
+/**
+ * Metadata dinâmica (não `export const metadata`) para a marca ser lida em RUNTIME.
+ * Constante seria resolvida durante o `next build`, e a imagem self-host — que é
+ * pré-buildada — carregaria a nossa marca para sempre. Ver `lib/branding.ts`.
+ *
+ * O `template` é o que faz a marca existir em UM lugar só: as páginas filhas
+ * declaram apenas o próprio nome ("Entrar") e herdam o sufixo daqui.
+ */
+export function generateMetadata(): Metadata {
+  const { name } = branding();
+  return {
+    title: {
+      default: `${name} — atendimento e vendas por WhatsApp com agentes de IA`,
+      template: `%s · ${name}`,
+    },
+    description:
+      "Centralize o atendimento por WhatsApp num funil só. Agentes de IA resolvem o que dá pra resolver e passam para o time humano o que importa — com tudo registrado. Multi-tenant, LGPD-nativo, feito para operações brasileiras.",
+    applicationName: name,
+    authors: [{ name }],
+    keywords: [
+      "CRM",
+      "atendimento",
+      "WhatsApp",
+      "IA conversacional",
+      "LGPD",
+      "multi-tenant",
+    ],
+    robots: { index: false, follow: false },
+  };
+}
 
 export const viewport: Viewport = {
   themeColor: [

--- a/app/onboarding/connect-nuvemshop/_client.tsx
+++ b/app/onboarding/connect-nuvemshop/_client.tsx
@@ -9,6 +9,7 @@ import {
   skipNuvemshop,
   markNuvemshopConfigured,
 } from "@/app/actions/onboarding/skipWhatsapp";
+import { branding } from "@/lib/branding";
 
 export function ConnectNuvemshopClient() {
   const [pending, startTransition] = useTransition();
@@ -17,7 +18,7 @@ export function ConnectNuvemshopClient() {
     <div className="space-y-4 rounded-lg border bg-background p-6">
       <p className="text-sm">
         Ao clicar em <strong>Conectar</strong>, você será redirecionado para autorizar o
-        DeskcommCRM na sua conta Nuvemshop.
+        {branding().name} na sua conta Nuvemshop.
       </p>
 
       <div className="flex flex-wrap gap-2">

--- a/app/onboarding/layout.tsx
+++ b/app/onboarding/layout.tsx
@@ -5,6 +5,7 @@ import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
 import { loadOnboardingState } from "@/app/actions/onboarding/_shared";
 import { Stepper } from "./_components/Stepper";
 import { SkipToEnd } from "./_components/SkipToEnd";
+import { branding } from "@/lib/branding";
 
 export default async function OnboardingLayout({ children }: { children: React.ReactNode }) {
   const user = await requireAuth();
@@ -25,7 +26,7 @@ export default async function OnboardingLayout({ children }: { children: React.R
       <header className="border-b bg-background">
         <div className="mx-auto flex w-full max-w-3xl items-center justify-between px-6 py-4">
           <div>
-            <p className="text-xs uppercase tracking-wider text-muted-foreground">DeskcommCRM</p>
+            <p className="text-xs uppercase tracking-wider text-muted-foreground">{branding().name}</p>
             <h1 className="text-lg font-semibold tracking-tight">{activeOrg.name}</h1>
           </div>
           {isDev ? <SkipToEnd /> : null}

--- a/app/onboarding/welcome/page.tsx
+++ b/app/onboarding/welcome/page.tsx
@@ -1,6 +1,7 @@
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
 import { redirect } from "next/navigation";
 import { WelcomeForm } from "./_form";
+import { branding } from "@/lib/branding";
 
 export const dynamic = "force-dynamic";
 
@@ -12,7 +13,7 @@ export default async function WelcomePage() {
   return (
     <div className="space-y-6">
       <header>
-        <h2 className="text-2xl font-semibold tracking-tight">Boas-vindas ao DeskcommCRM</h2>
+        <h2 className="text-2xl font-semibold tracking-tight">Boas-vindas ao {branding().name}</h2>
         <p className="text-sm text-muted-foreground">
           Vamos configurar sua operação em alguns passos rápidos.
         </p>

--- a/app/public-env-script.tsx
+++ b/app/public-env-script.tsx
@@ -22,6 +22,10 @@ export async function PublicEnvScript() {
     // Exposto pro Sentry do browser respeitar o opt-out (SENTRY_DSN=off) em runtime,
     // sem rebuild. DSN não é segredo. Ver lib/sentry/dsn.ts.
     SENTRY_DSN: env.SENTRY_DSN,
+    // Marca da instalação (white-label): os client components (Sidebar, AdminSidebar)
+    // leem daqui. Não são segredo — já aparecem na tela. Ver lib/branding.ts.
+    APP_NAME: env.APP_NAME,
+    APP_LOGO_URL: env.APP_LOGO_URL,
   })
     // Evita quebrar o </script> se algum valor contiver a sequência.
     .replace(/</g, "\\u003c");

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/ui/icons";
 import type { Icon as PhosphorIcon } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
+import { branding } from "@/lib/branding";
 
 interface NavItem {
   href: string;
@@ -46,7 +47,7 @@ export function AdminSidebar({ userEmail }: AdminSidebarProps) {
       <div className="flex h-14 items-center border-b px-4">
         <div className="flex flex-col">
           <span className="text-xs uppercase tracking-wider text-muted-foreground">
-            DeskcommCRM
+            {branding().name}
           </span>
           <span className="text-sm font-semibold tracking-tight">Admin Plataforma</span>
         </div>

--- a/components/shell/Sidebar.tsx
+++ b/components/shell/Sidebar.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { toggleSidebar } from "@/app/actions/shell/toggleSidebar";
 import { usePermission } from "@/hooks/auth/AuthProvider";
 import { ConnectionHealthDot } from "@/components/connections/ConnectionHealthDot";
+import { branding } from "@/lib/branding";
 
 interface NavItem {
   href: string;
@@ -42,6 +43,8 @@ export function Sidebar({ collapsed }: { collapsed: boolean }) {
   const canAiMemory = usePermission("ai.memory.view");
   const canWebhooks = usePermission("webhooks.manage");
 
+  const brand = branding();
+
   return (
     <aside
       className={cn(
@@ -50,8 +53,28 @@ export function Sidebar({ collapsed }: { collapsed: boolean }) {
       )}
     >
       <div className={cn("flex items-center border-b px-4 h-14", collapsed ? "justify-center" : "justify-start")}>
-        <span className={cn("font-semibold tracking-tight", collapsed && "sr-only")}>DeskcommCRM</span>
-        {collapsed && <span aria-hidden className="text-lg font-bold text-primary">D</span>}
+        {brand.logoUrl && !collapsed ? (
+          // <img> em vez de next/image de propósito: a URL vem do .env de quem hospeda,
+          // e next/image exige allowlist de domínios fechada em build — a imagem
+          // pré-buildada rejeitaria o domínio do self-hoster. Altura fixa e largura
+          // livre porque a arte enviada tem proporção desconhecida; forçar as duas
+          // distorceria o logo de quem configurou.
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={brand.logoUrl}
+            alt={brand.name}
+            className="h-7 w-auto max-w-[10rem] object-contain"
+          />
+        ) : (
+          <span className={cn("font-semibold tracking-tight", collapsed && "sr-only")}>
+            {brand.name}
+          </span>
+        )}
+        {collapsed && (
+          <span aria-hidden className="text-lg font-bold text-primary">
+            {brand.initial}
+          </span>
+        )}
       </div>
       <nav className="flex-1 space-y-1 p-2" aria-label="Navegação principal">
         {NAV_ITEMS.filter((item) => {

--- a/docs/white-label.md
+++ b/docs/white-label.md
@@ -1,0 +1,93 @@
+# Instalar para clientes (agências e revendedores)
+
+Guia para quem instala o DeskcommCRM **para outras empresas** — agência, consultoria, revendedor — e cobra por isso.
+
+A licença é MIT: você pode modificar, hospedar para terceiros, revender e cobrar o que quiser. Não há royalty, não há cláusula proibindo hospedagem comercial e não existe versão paga que trave funcionalidade do seu cliente.
+
+---
+
+## Trocar a marca
+
+Duas variáveis no `.env`, sem tocar em código:
+
+```bash
+APP_NAME=Vendas Turbo CRM
+APP_LOGO_URL=https://cdn.suaempresa.com.br/logo.svg
+```
+
+Reinicie a stack (`docker compose up -d`) e a marca vale em toda a interface: título das abas, tela de entrada, cadastro, recuperação de senha, verificação em duas etapas, onboarding e a barra lateral.
+
+`APP_LOGO_URL` é opcional — sem ela, o nome aparece como texto. Com ela, o logo substitui o texto na barra lateral. A altura é fixa e a largura é livre, para não distorcer arte de proporção qualquer.
+
+O `install.sh` pergunta o `APP_NAME` durante a instalação; pressionar Enter mantém o padrão.
+
+### Por que isso é configuração, e não uma edição de código
+
+Trocar a marca editando os arquivos-fonte funciona **uma vez**. No próximo `bash update.sh`, a imagem nova sobrescreve o patch e a marca do seu cliente volta a ser a nossa — normalmente sem ninguém perceber, até o cliente ver.
+
+Configuração no `.env` sobrevive a toda atualização. É por isso que a marca é lida em tempo de execução e não embutida na compilação: uma única imagem Docker serve qualquer marca.
+
+### O que ainda não é configurável
+
+Sendo direto, para você não descobrir na frente do cliente:
+
+- **Cores, fontes e tema** não são configuráveis por variável. Exigem alterar o design system (`app/globals.css` e os tokens), e essa alteração **é** um patch que se perde no update.
+- **A marca é por instalação, não por organização.** Uma instalação com várias organizações mostra a mesma marca para todas. Se cada cliente precisa da própria marca, use uma instalação por cliente (ver abaixo) — que também é o modelo que rende melhor.
+- **Textos e e-mails transacionais** seguem o padrão do produto.
+
+---
+
+## Um cliente por instalação, ou todos numa só?
+
+O sistema é multi-tenant desde a primeira linha: uma instalação atende várias organizações, e o isolamento entre elas é verificado no CI a cada alteração — um usuário de uma organização não enxerga nenhuma linha de outra. Não é promessa de marketing: é o teste `tests/invariants/rls-isolation.test.ts`, que cria duas organizações e prova o não-vazamento pelo mesmo caminho de autenticação que a produção usa.
+
+Mesmo assim, os dois modelos servem a propósitos diferentes:
+
+| | Uma instalação por cliente | Uma instalação para todos |
+|---|---|---|
+| **Marca** | A de cada cliente | Uma só, a sua |
+| **Custo de infra** | Uma VPS por cliente | Uma VPS |
+| **Falha** | Isolada | Atinge todos |
+| **Atualização** | Uma por vez, pode escalonar | Todos de uma vez |
+| **Dado do cliente** | Fisicamente separado | Separado por RLS |
+| **Melhor para** | Revender com a marca do cliente | Sua própria operação atendendo várias contas |
+
+Se o seu cliente pergunta "onde ficam meus dados?", a instalação dedicada tem a resposta mais simples de dar — e de defender.
+
+---
+
+## O argumento jurídico que fecha venda no Brasil
+
+A **Resolução CD/ANPD nº 19/2024** tornou obrigatórias as cláusulas-padrão contratuais para **transferência internacional de dados pessoais**, com o prazo de adequação encerrado em **23 de agosto de 2025**.
+
+Todo cliente seu que usa um CRM estrangeiro realiza essa transferência e precisa do artefato contratual. Hospedando em VPS no Brasil, **não há transferência internacional** — e a obrigação não se aplica.
+
+⚠️ **Não venda como "servidor no Brasil = conformidade com a LGPD".** Isso é falso e um advogado desmonta na primeira pergunta: conformidade depende de base legal, finalidade, segurança e direitos do titular. O argumento correto e defensável é o de cima: sem transferência internacional, não há exigência de cláusulas-padrão.
+
+---
+
+## Operação
+
+Cada instalação traz os scripts em `hostgator-setup-kit/`:
+
+| Comando | O que faz |
+|---|---|
+| `bash update.sh` | Atualiza. Faz backup do banco **antes**, reaplica o schema de forma idempotente e confere a saúde no fim |
+| `bash backup.sh` / `restore.sh` | Backup e restauração |
+| `bash reset-password.sh` | Redefine a senha de um usuário |
+| `bash reset-mfa.sh` | Remove a verificação em duas etapas de quem perdeu o aparelho |
+| `bash healthcheck.sh` | Diagnóstico da instalação |
+
+O `reset-mfa.sh` é o que você mais vai usar: a verificação em duas etapas é obrigatória para administradores, e trocar de celular sem salvar os códigos de recuperação é a chamada de suporte mais comum.
+
+---
+
+## Requisitos por instalação
+
+2 GB de RAM, portas 80 e 443, Docker Compose v2 e um domínio com registro A apontando para o IP. A VPS não compila nada — baixa uma imagem pronta. O certificado HTTPS é emitido automaticamente no primeiro acesso.
+
+Guia completo de instalação: [`hostgator-setup-kit/README.md`](../hostgator-setup-kit/README.md).
+
+---
+
+*Última atualização: 27 de julho de 2026.*

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -105,6 +105,11 @@ ask SUPABASE_DB_URL   "Supabase DB connection string (Settings > Database)" "" s
 ask ANTHROPIC_API_KEY "Chave da Anthropic (IA)" "" secret
 ask OWNER_EMAIL       "E-mail do primeiro admin (dono)"
 ask OWNER_PASSWORD    "Senha do primeiro admin" "" secret
+# Marca da instalação. Fica por último de propósito: é opcional, e perguntar no
+# meio das credenciais faria parecer obrigatório. Enter aceita o default.
+# Quem instala para clientes troca aqui e a marca vale em toda a interface, sem
+# editar código — patch em código se perderia no próximo update.sh.
+ask APP_NAME          "Nome que aparece na interface (Enter para o padrão)" "DeskcommCRM"
 
 # Derivados
 NEXT_PUBLIC_APP_URL="https://${DOMAIN}"
@@ -145,6 +150,10 @@ SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
 SUPABASE_DB_URL=${SUPABASE_DB_URL}
 NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL}
 NEXT_PUBLIC_ADMIN_URL=${NEXT_PUBLIC_ADMIN_URL}
+# Marca da instalação (white-label). Preencha APP_LOGO_URL com a URL de uma
+# imagem pública para trocar o texto por logo na sidebar. Ver lib/branding.ts.
+APP_NAME=${APP_NAME}
+APP_LOGO_URL=${APP_LOGO_URL:-}
 ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
 AI_GATEWAY_API_KEY=${AI_GATEWAY_API_KEY:-}
 INTERNAL_SECRET=${INTERNAL_SECRET}

--- a/lib/branding.ts
+++ b/lib/branding.ts
@@ -1,0 +1,60 @@
+/**
+ * Marca da instalação — nome e logo configuráveis pelo `.env`, SEM rebuild.
+ *
+ * Por que existe: quem instala o DeskcommCRM para clientes (agência, revendedor)
+ * precisa da própria marca na interface. Fazer isso editando o código quebraria o
+ * caminho de atualização — `update.sh` puxa a imagem nova e o patch local se perde,
+ * que é exatamente a dor nº 1 de quem hospeda o próprio sistema. Configuração em
+ * `.env` sobrevive a toda atualização.
+ *
+ * Vale para servidor (`process.env`) e navegador (`window.__PUBLIC_ENV__`, injetado
+ * em runtime pelo `<PublicEnvScript/>`) — mesmo modelo de `lib/sentry/dsn.ts`.
+ *
+ * As variáveis NÃO são `NEXT_PUBLIC_*` de propósito: essas são queimadas no bundle
+ * durante o `next build`, e o self-hoster roda uma imagem PRÉ-BUILDADA. A marca dele
+ * nunca apareceria. É o mesmo motivo pelo qual a URL do Supabase é injetada em
+ * runtime em vez de lida do bundle.
+ */
+
+export const DEFAULT_APP_NAME = "DeskcommCRM";
+
+export type Branding = {
+  /** Nome exibido na interface e nos títulos de página. */
+  name: string;
+  /** URL do logo, ou `null` quando a marca deve aparecer como texto. */
+  logoUrl: string | null;
+  /** Primeira letra do nome — usada onde só cabe um caractere (sidebar recolhida). */
+  initial: string;
+};
+
+/**
+ * Resolve a marca a partir dos valores crus. Função pura: recebe a fonte, não a
+ * procura — assim o mesmo resolvedor serve servidor, navegador e teste.
+ *
+ * Valor vazio ou só com espaços cai no padrão. Isso importa porque `.env` gerado
+ * por script costuma trazer a chave declarada e vazia (`APP_NAME=`), e tratar isso
+ * como "marca sem nome" deixaria a interface em branco.
+ */
+export function resolveBranding(
+  name: string | undefined | null,
+  logoUrl: string | undefined | null,
+): Branding {
+  const resolvedName = (name ?? "").trim() || DEFAULT_APP_NAME;
+  const resolvedLogo = (logoUrl ?? "").trim();
+  return {
+    name: resolvedName,
+    logoUrl: resolvedLogo.length > 0 ? resolvedLogo : null,
+    // Spread em vez de [0]: nome começando com emoji ou acento composto quebraria
+    // no meio do code point e renderizaria caractere inválido.
+    initial: ([...resolvedName][0] ?? DEFAULT_APP_NAME[0]!).toUpperCase(),
+  };
+}
+
+/** Lê a marca da fonte correta em cada lado da fronteira servidor/navegador. */
+export function branding(): Branding {
+  if (typeof window !== "undefined") {
+    const runtime = window.__PUBLIC_ENV__;
+    return resolveBranding(runtime?.APP_NAME, runtime?.APP_LOGO_URL);
+  }
+  return resolveBranding(process.env.APP_NAME, process.env.APP_LOGO_URL);
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -133,6 +133,13 @@ const schema = z.object({
     .string()
     .url()
     .default("http://localhost:3000"),
+
+  // Marca da instalação (white-label) — ver lib/branding.ts.
+  // Sem prefixo NEXT_PUBLIC_ de propósito: essas seriam queimadas no bundle
+  // durante o build da imagem, e o self-hoster roda uma imagem pré-buildada.
+  // O <PublicEnvScript/> injeta os valores em runtime.
+  APP_NAME: z.string().optional().default(""),
+  APP_LOGO_URL: z.string().optional().default(""),
 });
 
 let parsed = schema.safeParse(process.env);

--- a/tests/unit/branding.test.ts
+++ b/tests/unit/branding.test.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_APP_NAME, resolveBranding } from "@/lib/branding";
+
+const RAIZ = process.cwd();
+
+describe("resolveBranding", () => {
+  it("cai no padrão quando não há marca configurada", () => {
+    expect(resolveBranding(undefined, undefined)).toEqual({
+      name: DEFAULT_APP_NAME,
+      logoUrl: null,
+      initial: "D",
+    });
+  });
+
+  it("trata string vazia e só-espaços como ausência de marca", () => {
+    // `install.sh` grava a chave declarada mesmo quando o operador não responde
+    // (APP_NAME=), então "vazio" chega como string — não como undefined. Tratar
+    // isso como marca válida deixaria a interface sem nome nenhum.
+    expect(resolveBranding("", "").name).toBe(DEFAULT_APP_NAME);
+    expect(resolveBranding("   ", "   ").name).toBe(DEFAULT_APP_NAME);
+    expect(resolveBranding("   ", "   ").logoUrl).toBeNull();
+  });
+
+  it("usa a marca configurada e deriva a inicial", () => {
+    const b = resolveBranding("  Vendas Turbo  ", "  https://cdn.exemplo.com/logo.svg  ");
+    expect(b.name).toBe("Vendas Turbo");
+    expect(b.logoUrl).toBe("https://cdn.exemplo.com/logo.svg");
+    expect(b.initial).toBe("V");
+  });
+
+  it("mantém o nome mas dispensa o logo quando só o nome é configurado", () => {
+    const b = resolveBranding("Acme CRM", undefined);
+    expect(b.name).toBe("Acme CRM");
+    expect(b.logoUrl).toBeNull();
+  });
+
+  it("não parte code point ao derivar a inicial", () => {
+    // `[0]` cru devolveria metade do par substituto e renderizaria caractere
+    // inválido na sidebar recolhida.
+    expect(resolveBranding("🚀 Foguete", null).initial).toBe("🚀");
+    expect(resolveBranding("Ótimo CRM", null).initial).toBe("Ó");
+  });
+});
+
+describe("guarda de white-label (self-host)", () => {
+  const branding = fs.readFileSync(path.join(RAIZ, "lib/branding.ts"), "utf8");
+  const publicEnvScript = fs.readFileSync(
+    path.join(RAIZ, "app/public-env-script.tsx"),
+    "utf8",
+  );
+
+  it("não usa prefixo NEXT_PUBLIC_ para a marca", () => {
+    // POR QUE ESTE TESTE EXISTE: a convenção do Next empurra qualquer valor lido
+    // no browser para NEXT_PUBLIC_*, e alguém vai "corrigir" isso um dia. Mas
+    // NEXT_PUBLIC_* é queimada no bundle durante o `next build`, e o self-hoster
+    // roda uma imagem PRÉ-BUILDADA: a marca dele nunca apareceria. O defeito
+    // passaria em typecheck, lint e em toda a suíte, funcionaria em dev e na
+    // Vercel, e falharia apenas na VPS de quem a feature existe para servir.
+    expect(branding).not.toMatch(/NEXT_PUBLIC_APP_(NAME|LOGO_URL)/);
+    expect(publicEnvScript).not.toMatch(/NEXT_PUBLIC_APP_(NAME|LOGO_URL)/);
+  });
+
+  it("injeta a marca em runtime pelo PublicEnvScript", () => {
+    // Sem estas duas chaves no payload, os client components (Sidebar,
+    // AdminSidebar) caem no padrão e só a marca do servidor muda — a instalação
+    // ficaria com o nome do revendedor no título da aba e o nosso na sidebar.
+    expect(publicEnvScript).toMatch(/APP_NAME:\s*env\.APP_NAME/);
+    expect(publicEnvScript).toMatch(/APP_LOGO_URL:\s*env\.APP_LOGO_URL/);
+  });
+
+  it("a marca não voltou a ser hardcoded na interface", () => {
+    // Varre as superfícies que o usuário final vê. `app/design/` fica de fora:
+    // é o showcase interno do design system, onde o nome do produto é o assunto.
+    const alvos: string[] = [];
+    const varrer = (dir: string) => {
+      for (const entrada of fs.readdirSync(path.join(RAIZ, dir), { withFileTypes: true })) {
+        const rel = path.posix.join(dir, entrada.name);
+        if (rel.startsWith("app/design")) continue;
+        if (entrada.isDirectory()) varrer(rel);
+        else if (rel.endsWith(".tsx")) alvos.push(rel);
+      }
+    };
+    varrer("app");
+    varrer("components");
+
+    const reincidentes = alvos.filter((f) =>
+      /Deskcomm/.test(fs.readFileSync(path.join(RAIZ, f), "utf8")),
+    );
+    expect(
+      reincidentes,
+      `estes arquivos voltaram a fixar a marca na interface — use branding() de lib/branding.ts:\n` +
+        reincidentes.map((f) => `  ${f}`).join("\n"),
+    ).toEqual([]);
+  });
+});

--- a/types/public-env.d.ts
+++ b/types/public-env.d.ts
@@ -10,6 +10,9 @@ interface PublicEnv {
   NEXT_PUBLIC_SUPABASE_URL?: string;
   NEXT_PUBLIC_SUPABASE_ANON_KEY?: string;
   SENTRY_DSN?: string;
+  /** Marca da instalação (white-label). Ver `lib/branding.ts`. */
+  APP_NAME?: string;
+  APP_LOGO_URL?: string;
 }
 
 interface Window {


### PR DESCRIPTION
Fecha a lacuna que a pesquisa de crescimento apontou como a de maior retorno: o público de **revendedores e agências** — que hoje já paga por soluções menos maduras — não tinha como instalar o CRM com a própria marca.

## O problema

"DeskcommCRM" estava fixo em **11 lugares da interface**. Trocar a marca só editando código — e patch em código **se perde no próximo `update.sh`**, normalmente sem ninguém perceber até o cliente ver.

## A solução

```bash
APP_NAME=Vendas Turbo CRM
APP_LOGO_URL=https://cdn.exemplo.com/logo.svg
```

**Sem prefixo `NEXT_PUBLIC_`, e é isso que faz a feature existir.** Essas variáveis são queimadas no bundle durante o `next build`, e o self-hoster roda uma imagem **pré-buildada** — a marca dele nunca apareceria. `lib/branding.ts` lê `process.env` no servidor e `window.__PUBLIC_ENV__` no navegador, no mesmo modelo já usado por `lib/sentry/dsn.ts`.

## Simplificação que veio junto

O root layout já tinha `template: "%s · Deskcomm"` e as filhas escreviam o título completo — a aba renderizava a marca **duas vezes**. Agora as filhas declaram só `"Entrar"` e herdam o sufixo. A marca existe em um lugar só.

## Guard contra o defeito silencioso

A convenção do Next empurra qualquer valor lido no browser para `NEXT_PUBLIC_*`, e alguém vai "corrigir" isso um dia. Esse defeito passaria em typecheck, lint e na suíte inteira, funcionaria em dev e na Vercel, e falharia **só na VPS de quem a feature existe para servir**.

`tests/unit/branding.test.ts` falha se o prefixo aparecer, se o `PublicEnvScript` parar de injetar as chaves, ou se a marca voltar a ser fixada em `.tsx`. **As três sabotagens foram executadas e cada uma vermelheceu.**

## Prova pela tela

Dev server com `APP_NAME="Vendas Turbo CRM"`:

- título da aba: `Entrar · Vendas Turbo CRM`
- marca visível no corpo da página
- ocorrências de "DeskcommCRM" na tela: **0**
- `__PUBLIC_ENV__` carregando `APP_NAME` e `APP_LOGO_URL`

## Honestidade sobre limites

`docs/white-label.md` declara o que **não** é configurável: cores/fontes exigem patch, e a marca é por instalação, não por organização.

## Verificação

typecheck 0 · lint 0 erros · test:unit **1043/1043** (eram 1035, +8 novos)