### PR TITLE
fix(inbox): botões "Tag" e "Lead" do painel lateral não faziam nada

### DIFF
--- a/app/api/v1/pipelines/default/route.ts
+++ b/app/api/v1/pipelines/default/route.ts
@@ -1,0 +1,54 @@
+/**
+ * GET /api/v1/pipelines/default — pipeline padrão da org ativa (o primeiro
+ * não-arquivado, se nenhum estiver marcado `is_default`), com estágios.
+ *
+ * Existe pra fluxos que precisam "de algum pipeline" sem exigir o role
+ * `manager` da listagem completa (GET /api/v1/pipelines) — ex.: criar lead a
+ * partir do painel do Inbox, onde quem atende é `agent`.
+ */
+import { randomUUID } from "node:crypto";
+
+import { ok, fail } from "@/lib/api/wrappers";
+import { requireRole } from "@/lib/auth/require-role";
+import { createClient } from "@/lib/supabase/server";
+import type { Pipeline, Stage } from "@/lib/kanban/types";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(): Promise<Response> {
+  const requestId = randomUUID();
+  const authz = await requireRole("agent", { requestId, resource: "pipelines" });
+  if (!authz.ok) return authz.response;
+  const { org } = authz;
+
+  const supabase = await createClient();
+
+  const { data: pipeline, error: pipelineErr } = await supabase
+    .from("crm_pipelines")
+    .select("*")
+    .eq("organization_id", org.orgId)
+    .eq("is_archived", false)
+    .order("is_default", { ascending: false })
+    .order("position", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (pipelineErr) return fail("internal_error", pipelineErr.message, 500, { requestId });
+  if (!pipeline) {
+    return fail("resource_not_found", "Nenhum funil configurado nesta organização.", 404, {
+      requestId,
+    });
+  }
+
+  const { data: stages, error: stagesErr } = await supabase
+    .from("crm_stages")
+    .select("*")
+    .eq("pipeline_id", (pipeline as Pipeline).id)
+    .eq("is_archived", false)
+    .order("position");
+  if (stagesErr) return fail("internal_error", stagesErr.message, 500, { requestId });
+
+  return ok(
+    { pipeline: pipeline as Pipeline, stages: (stages ?? []) as Stage[] },
+    { requestId },
+  );
+}

--- a/components/inbox/CRMSidePanel.tsx
+++ b/components/inbox/CRMSidePanel.tsx
@@ -10,9 +10,13 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Separator } from "@/components/ui/separator";
 import { Tag, Receipt, Users, ArrowRight } from "@/lib/ui/icons";
 import { apiClient } from "@/lib/api/client";
+import { toast } from "sonner";
 import type { ConversationWithContact } from "@/hooks/inbox/useConversationsRealtime";
 import { activityLabel, actorLabel, actorShape } from "@/lib/leads/activity-vocabulary";
 import { ConversationTagsEditor } from "./ConversationTagsEditor";
+import { ContactTagsEditor } from "./ContactTagsEditor";
+import { useDefaultPipeline } from "@/hooks/pipelines/useDefaultPipeline";
+import { NewLeadDialog } from "@/components/kanban/NewLeadDialog";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -113,6 +117,17 @@ export function CRMSidePanel({ conversation }: Props) {
   const [erro, setErro] = useState(false);
   const [tentativa, setTentativa] = useState(0);
 
+  const [tagEditorOpen, setTagEditorOpen] = useState(false);
+  const [leadDialogOpen, setLeadDialogOpen] = useState(false);
+  const defaultPipeline = useDefaultPipeline(leadDialogOpen);
+
+  useEffect(() => {
+    if (leadDialogOpen && defaultPipeline.isError) {
+      toast.error("Nenhum funil configurado nesta organização.");
+      setLeadDialogOpen(false);
+    }
+  }, [leadDialogOpen, defaultPipeline.isError]);
+
   useEffect(() => {
     if (!contactId) {
       setLeads(null);
@@ -201,11 +216,25 @@ export function CRMSidePanel({ conversation }: Props) {
             </div>
           )}
           <div className="flex flex-wrap gap-2 pt-1">
-            <Button size="sm" variant="outline" className="h-7 px-2 text-xs">
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 px-2 text-xs"
+              disabled={!contactId}
+              aria-pressed={tagEditorOpen}
+              onClick={() => setTagEditorOpen((v) => !v)}
+            >
               <Tag size={12} className="mr-1" weight="regular" aria-hidden /> Tag
             </Button>
-            <Button size="sm" variant="outline" className="h-7 px-2 text-xs">
-              <Users size={12} className="mr-1" weight="regular" aria-hidden /> Lead
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 px-2 text-xs"
+              disabled={!contactId || (leadDialogOpen && defaultPipeline.isLoading)}
+              onClick={() => setLeadDialogOpen(true)}
+            >
+              <Users size={12} className="mr-1" weight="regular" aria-hidden />
+              {leadDialogOpen && defaultPipeline.isLoading ? "Carregando…" : "Lead"}
             </Button>
             {contactId && (
               <Button asChild size="sm" variant="ghost" className="h-7 px-2 text-xs">
@@ -216,8 +245,19 @@ export function CRMSidePanel({ conversation }: Props) {
               </Button>
             )}
           </div>
+          {tagEditorOpen && contactId && <ContactTagsEditor contactId={contactId} tags={tags} />}
         </Card>
       </section>
+
+      {contactId && defaultPipeline.data && (
+        <NewLeadDialog
+          open={leadDialogOpen}
+          onOpenChange={setLeadDialogOpen}
+          pipelineId={defaultPipeline.data.pipeline.id}
+          stages={defaultPipeline.data.stages}
+          contactId={contactId}
+        />
+      )}
 
       <Separator />
 

--- a/components/inbox/ContactTagsEditor.tsx
+++ b/components/inbox/ContactTagsEditor.tsx
@@ -1,0 +1,87 @@
+"use client";
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { X, Plus } from "@/lib/ui/icons";
+import { useUpdateContact } from "@/hooks/contacts/useUpdateContact";
+
+interface Props {
+  contactId: string;
+  tags: string[];
+}
+
+/** Edita as tags do CONTATO (distinto de ConversationTagsEditor, que edita as
+ * tags da conversa) — aberto pelo botão "Tag" do painel do Inbox. */
+export function ContactTagsEditor({ contactId, tags }: Props) {
+  const [draft, setDraft] = useState("");
+  const mutation = useUpdateContact(contactId);
+
+  function apply(next: string[]) {
+    mutation.mutate({ tags: next });
+  }
+
+  function add(raw: string) {
+    const tag = raw.trim().toLowerCase().slice(0, 40);
+    if (!tag || tags.includes(tag) || tags.length >= 20) return;
+    apply([...tags, tag]);
+    setDraft("");
+  }
+
+  function remove(tag: string) {
+    apply(tags.filter((t) => t !== tag));
+  }
+
+  return (
+    <div className="mt-2 space-y-2 rounded-md border border-border p-2">
+      <div className="flex flex-wrap gap-1">
+        {tags.length > 0 ? (
+          tags.map((t) => (
+            <Badge key={t} variant="secondary" className="h-5 gap-1 px-1.5 text-[10px]">
+              {t}
+              <button
+                type="button"
+                onClick={() => remove(t)}
+                disabled={mutation.isPending}
+                aria-label={`Remover tag ${t}`}
+                className="rounded-sm hover:text-destructive"
+              >
+                <X size={10} weight="bold" aria-hidden />
+              </button>
+            </Badge>
+          ))
+        ) : (
+          <span className="text-xs text-muted-foreground">Sem tags no contato.</span>
+        )}
+      </div>
+
+      <div className="flex gap-1">
+        <Input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              add(draft);
+            }
+          }}
+          placeholder="Nova tag…"
+          maxLength={40}
+          disabled={mutation.isPending || tags.length >= 20}
+          className="h-7 text-xs"
+          aria-label="Adicionar tag ao contato"
+        />
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-7 px-2"
+          onClick={() => add(draft)}
+          disabled={mutation.isPending || !draft.trim() || tags.length >= 20}
+          aria-label="Adicionar tag"
+        >
+          <Plus size={12} weight="regular" aria-hidden />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/kanban/NewLeadDialog.tsx
+++ b/components/kanban/NewLeadDialog.tsx
@@ -41,6 +41,8 @@ interface Props {
   onOpenChange: (v: boolean) => void;
   pipelineId: string;
   stages: Stage[];
+  /** Vincula o lead criado a este contato de origem (ex.: painel do Inbox). */
+  contactId?: string | null;
 }
 
 function defaultStageId(stages: Stage[]): string {
@@ -48,7 +50,7 @@ function defaultStageId(stages: Stage[]): string {
   return open?.id ?? stages[0]?.id ?? "";
 }
 
-export function NewLeadDialog({ open, onOpenChange, pipelineId, stages }: Props) {
+export function NewLeadDialog({ open, onOpenChange, pipelineId, stages, contactId }: Props) {
   const create = useCreateLead(pipelineId);
   const initialStage = useMemo(() => defaultStageId(stages), [stages]);
 
@@ -94,6 +96,7 @@ export function NewLeadDialog({ open, onOpenChange, pipelineId, stages }: Props)
       source: "manual",
       tags,
     };
+    if (contactId) payload.contact_id = contactId;
     if (values.description.trim()) payload.description = values.description.trim();
     if (valueCents !== null) payload.value_cents = valueCents;
     if (values.expected_close_date) payload.expected_close_date = values.expected_close_date;

--- a/hooks/contacts/useUpdateContact.ts
+++ b/hooks/contacts/useUpdateContact.ts
@@ -14,6 +14,10 @@ export function useUpdateContact(id: string) {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["contact", id] });
       qc.invalidateQueries({ queryKey: ["contacts"] });
+      // O Inbox (CRMSidePanel) lê o contato via conversation.contacts, não via
+      // ["contact", id] — sem isto, editar tags/nome do contato por aqui não
+      // refletia na tela até trocar de conversa (parecia "não fez nada").
+      qc.invalidateQueries({ queryKey: ["conversations"] });
     },
   });
 }

--- a/hooks/pipelines/useDefaultPipeline.ts
+++ b/hooks/pipelines/useDefaultPipeline.ts
@@ -1,0 +1,26 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "@/lib/api/client";
+import type { Pipeline, Stage } from "@/lib/kanban/types";
+
+export interface DefaultPipelineData {
+  pipeline: Pipeline;
+  stages: Stage[];
+}
+
+/** Pipeline padrão da org ativa + estágios — usado por fluxos "crie um lead
+ * daqui" que não têm um pipeline no contexto (ex.: painel do Inbox). */
+export function useDefaultPipeline(enabled: boolean) {
+  return useQuery({
+    queryKey: ["default-pipeline"],
+    enabled,
+    staleTime: 60_000,
+    queryFn: async (): Promise<DefaultPipelineData> => {
+      const res = await apiClient.get<{ data: DefaultPipelineData }>(
+        "/api/v1/pipelines/default",
+      );
+      return res.data;
+    },
+  });
+}


### PR DESCRIPTION
## O que estava errado

No `CRMSidePanel` (painel de contato ao lado da conversa, no Inbox), os botões **"Tag"** e **"Lead"** nunca tiveram `onClick` — placeholders visuais desde a criação do componente. Clicar não fazia nada.

## O que mudou

- **"Tag"**: clique abre um editor inline (`ContactTagsEditor`, mesmo padrão do `ConversationTagsEditor` já existente) que edita `contacts.tags` via `PATCH /api/v1/contacts/{id}` (`useUpdateContact` — `contactPatchSchema` já aceitava `{ tags }` sozinho).
- **"Lead"**: clique abre o `NewLeadDialog` já usado na tela de pipeline, agora com um `contactId` opcional propagado como `contact_id` no `POST /api/v1/leads` (`createLeadSchema` já suportava o campo). O pipeline/estágios usados vêm de uma rota nova, `GET /api/v1/pipelines/default` (role mínimo `agent` — a listagem completa em `/api/v1/pipelines` exige `manager`, e quem atende no Inbox normalmente é `agent`), que devolve o pipeline `is_default` da org (ou o primeiro não-arquivado, se nenhum estiver marcado).
- **Bug residual encontrado no caminho**: `useUpdateContact` invalidava só `["contact", id]` e `["contacts"]`, mas o Inbox lê o contato via `conversation.contacts` (cache de `["conversations", filters]`). Sem invalidar essa também, a tag salvava certinho no banco mas não aparecia atualizada na tela até trocar de conversa — reproduzindo o mesmo sintoma original. Corrigido junto.

Sem migration: `tags`, `contact_id` e `is_default` já existiam no schema.

## Testes

- `pnpm typecheck` e `pnpm lint` rodados localmente — limpos (lint só com os 2 warnings pré-existentes de `react-hooks/set-state-in-effect`, mesmo padrão já presente no arquivo antes desta mudança).
- Validado manualmente numa instalação self-host real (build da imagem a partir deste branch, deploy, teste ponta a ponta pela tela).
- Não adicionei teste automatizado (unit/e2e) para os cliques — não há suíte hoje cobrindo esse painel, e um teste completo pediria estender a doutrina de "QA Visual com Recursos Reais" do `CLAUDE.md` (banco fresco + Playwright) que não rodei nesta sessão. Fico à disposição para adicionar se pedirem.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)