### PR TITLE
fix: document validated env vars in example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,8 @@ SUPABASE_SERVICE_ROLE_KEY=
 # --- Cron / interno ----------------------------------------------------------
 # Bearer secret pros endpoints /api/v1/cron/*. DIFERENTE do service role key.
 INTERNAL_SECRET=
+# Secret dedicado opcional pros endpoints de cron. Se vazio, cai pra INTERNAL_SECRET.
+INTERNAL_CRON_SECRET=
 
 # --- Encryption keys (pgcrypto) ----------------------------------------------
 # Chave separada pra criptografar CPF em contacts (PII sensível LGPD).
@@ -56,14 +58,30 @@ OPENAI_API_KEY=
 # --- Workers -----------------------------------------------------------------
 # Opt-in pra rodar consumers de event_log. Default false em dev; true em prod cron.
 EVENT_LOG_WORKER_ENABLED=false
+# Stub interno do endpoint de teste do agente. Use false em produção quando o runtime real estiver ativo.
+INTERNAL_AGENT_RUN_STUB=true
 
 # --- Sentry ------------------------------------------------------------------
 SENTRY_DSN=
+
+# --- Impersonate / suporte ----------------------------------------------------
+# Segredo HMAC do cookie de impersonate. Mínimo 32 chars quando a feature é usada.
+IMPERSONATE_COOKIE_SECRET=
+
+# --- LGPD ---------------------------------------------------------------------
+# Chave usada para assinar exports de dados LGPD.
+LGPD_SIGNING_KEY=
+# Email do DPO exibido em fluxos/exports LGPD.
+LGPD_DPO_EMAIL=
+# Prazo, em horas, antes de um export LGPD expirar.
+LGPD_EXPORT_EXPIRES_HOURS=72
 
 # --- Nuvemshop OAuth ---------------------------------------------------------
 # Obtenha em https://partners.tiendanube.com/ (criar app → copiar credenciais).
 # Deixe vazio em dev/staging se ainda não tiver app aprovado — a integração
 # degrada graciosamente e a UI mostra "Integração não configurada".
+# Liga a integração Nuvemshop. Quando true, exige as credenciais abaixo.
+NUVEMSHOP_ENABLED=false
 # APP_ID aparece na URL do painel do app no portal de parceiros.
 NUVEMSHOP_APP_ID=
 NUVEMSHOP_CLIENT_ID=

--- a/tests/unit/env-example-sync.test.ts
+++ b/tests/unit/env-example-sync.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+
+function schemaEnvKeys(): string[] {
+  const envSource = readFileSync(join(root, "lib/env.ts"), "utf8");
+  return Array.from(envSource.matchAll(/^\s{2}([A-Z][A-Z0-9_]{3,}):/gm), (match) => match[1]!)
+    .filter((key) => key !== "NODE_ENV")
+    .sort();
+}
+
+function exampleEnvKeys(): string[] {
+  const example = readFileSync(join(root, ".env.example"), "utf8");
+  return Array.from(example.matchAll(/^([A-Z][A-Z0-9_]{3,})=/gm), (match) => match[1]!).sort();
+}
+
+describe(".env.example", () => {
+  it("documenta todas as variáveis validadas em lib/env.ts", () => {
+    const documented = new Set(exampleEnvKeys());
+    const missing = schemaEnvKeys().filter((key) => !documented.has(key));
+
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Resumo

Closes #65.

- Adiciona ao `.env.example` as variáveis validadas em `lib/env.ts` que ainda não estavam documentadas.
- Inclui comentários curtos sobre uso/obrigatoriedade das vars de cron, impersonate, LGPD, Nuvemshop e stub interno de agente.
- Adiciona um teste unitário para impedir drift futuro entre `lib/env.ts` e `.env.example`.

## Evidências

- `pnpm vitest run tests/unit/env-example-sync.test.ts`
- `pnpm test:unit -- tests/unit/env-example-sync.test.ts` — 1366 passed
- `pnpm typecheck`
- `pnpm lint -- tests/unit/env-example-sync.test.ts` — 0 errors, warnings preexistentes no repo
- `pnpm exec prettier --check tests/unit/env-example-sync.test.ts`
- `git diff --check`
