### PR TITLE
fix: preserve contact source on partial patch

### DIFF
--- a/lib/schemas/contacts.test.ts
+++ b/lib/schemas/contacts.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from "vitest";
 import {
   contactCreateSchema,
   contactListQuerySchema,
+  contactPatchSchema,
   isValidCpf,
   lgpdAnonymizeSchema,
 } from "./contacts";
@@ -79,6 +80,15 @@ describe("contactCreateSchema", () => {
   it("rejects malformed birthdate", () => {
     const r = contactCreateSchema.safeParse({ birthdate: "01/01/1990" });
     expect(r.success).toBe(false);
+  });
+});
+
+describe("contactPatchSchema", () => {
+  it("não materializa source=manual quando PATCH omite source", () => {
+    const parsed = contactPatchSchema.parse({ tags: ["vip"] });
+
+    expect(parsed).toEqual({ tags: ["vip"] });
+    expect("source" in parsed).toBe(false);
   });
 });
 

--- a/lib/schemas/contacts.ts
+++ b/lib/schemas/contacts.ts
@@ -40,7 +40,10 @@ export const contactCreateSchema = z.object({
     .regex(PHONE_REGEX, "Telefone deve estar em formato E.164 (+5511999998888)")
     .optional(),
   cpf: z.string().refine(isValidCpf, "CPF inválido").optional(),
-  birthdate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  birthdate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
   tags: z.array(z.string()).optional(),
   source: z.string().min(1).default("manual"),
   source_metadata: z.record(z.string(), z.unknown()).optional(),
@@ -48,7 +51,9 @@ export const contactCreateSchema = z.object({
 });
 export type ContactCreate = z.infer<typeof contactCreateSchema>;
 
-export const contactPatchSchema = contactCreateSchema.partial();
+export const contactPatchSchema = contactCreateSchema.partial().extend({
+  source: z.string().min(1).optional(),
+});
 export type ContactPatch = z.infer<typeof contactPatchSchema>;
 
 export const contactListQuerySchema = z.object({


### PR DESCRIPTION
## Resumo

Closes #62.

- Faz `contactPatchSchema` remover o default herdado de `source`, para PATCH parcial não materializar `source: "manual"` quando o cliente só envia campos como `tags`.
- Mantém `contactCreateSchema` com `source = "manual"` por padrão para criação.
- Adiciona regressão cobrindo o payload `{ tags: ["vip"] }`.

## Evidências

- `pnpm vitest run lib/schemas/contacts.test.ts`
- `pnpm test:unit -- lib/schemas/contacts.test.ts` — 1366 passed
- `pnpm typecheck`
- `pnpm lint -- lib/schemas/contacts.ts lib/schemas/contacts.test.ts` — 0 errors, warnings preexistentes no repo
- `pnpm exec prettier --check lib/schemas/contacts.ts lib/schemas/contacts.test.ts`
- `git diff --check`
