### PR TITLE
fix(agente): instalação nova testava o agente contra um stub, não o agente

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,8 +65,10 @@ OPENAI_API_KEY=
 # --- Workers -----------------------------------------------------------------
 # Opt-in pra rodar consumers de event_log. Default false em dev; true em prod cron.
 EVENT_LOG_WORKER_ENABLED=false
-# Stub interno do endpoint de teste do agente. Use false em produção quando o runtime real estiver ativo.
-INTERNAL_AGENT_RUN_STUB=true
+# Stub do endpoint de teste do agente: 'true' devolve trace fabricado em vez de
+# executar o agente. Deixe false — o runtime real já existe. Só ligue para
+# exercitar o render da UI sem gastar token.
+INTERNAL_AGENT_RUN_STUB=false
 
 # --- Sentry ------------------------------------------------------------------
 SENTRY_DSN=

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -17,7 +17,9 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          # 22 como o job `ci` e o `.nvmrc`. Buildar numa versão que o
+          # `engines` (>=22) não suporta esconde quebra ou inventa falha.
+          node-version: 22
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/app/api/v1/ai/agents/[id]/versions/[vid]/test/route.test.ts
+++ b/app/api/v1/ai/agents/[id]/versions/[vid]/test/route.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Runtime real do "Testar agente" (issue #71).
+ *
+ * O default do `INTERNAL_AGENT_RUN_STUB` virou `false`, então o caminho que
+ * roda numa instalação nova é o runtime de verdade — e o modo de falha comum
+ * dessa instalação é não ter credencial de IA. Este teste fixa o contrato
+ * desse erro: a pessoa lê o porquê na tela, em vez de um 500 mudo que só
+ * aparece no log do servidor.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { requireRole } from "@/lib/auth/require-role";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { ROLE_RANK, type AuthUser, type Role } from "@/lib/auth/types";
+
+vi.mock("@/lib/auth/require-role", () => ({ requireRole: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
+vi.mock("@/lib/audit", () => ({ audit: vi.fn(async () => undefined) }));
+vi.mock("@/lib/ai/runtime/agent", () => ({
+  runAgent: vi.fn(async () => {
+    throw new Error("AI_GATEWAY_API_KEY ausente");
+  }),
+}));
+
+const ORG = "22222222-2222-4222-8222-222222222222";
+const USER = "11111111-1111-4111-8111-111111111111";
+const AGENT = "33333333-3333-4333-8333-333333333333";
+const VERSION = "44444444-4444-4444-8444-444444444444";
+
+function stubAdmin() {
+  return {
+    from: (table: string) => {
+      if (table === "ai_agent_versions") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                eq: () => ({
+                  maybeSingle: async () => ({
+                    data: {
+                      id: VERSION,
+                      agent_id: AGENT,
+                      organization_id: ORG,
+                      system_prompt: "oi",
+                      provider: "anthropic",
+                      model: "claude-sonnet-4-6",
+                      channel_session_id: null,
+                      max_steps: 3,
+                      token_budget: 1000,
+                      cost_budget_cents: 100,
+                      tool_ids: [],
+                    },
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      // ai_agent_runs
+      return {
+        insert: () => ({
+          select: () => ({ single: async () => ({ data: { id: "run-1" }, error: null }) }),
+        }),
+        update: () => ({ eq: async () => ({ error: null }) }),
+      };
+    },
+  };
+}
+
+describe("POST .../versions/:vid/test — runtime real", () => {
+  beforeEach(() => {
+    const user: AuthUser = {
+      id: USER,
+      email: "a@example.com",
+      full_name: null,
+      avatar_url: null,
+      is_platform_admin: false,
+      organizations: [{ organization_id: ORG, organization_name: "Org", role: "admin" }],
+    };
+    vi.mocked(requireRole).mockImplementation(async (min: Role) =>
+      ROLE_RANK["admin"] >= ROLE_RANK[min]
+        ? { ok: true, user, org: { orgId: ORG, name: "Org", role: "admin" } }
+        : ({ ok: false, response: null } as never),
+    );
+    vi.mocked(createAdminClient).mockReturnValue(stubAdmin() as never);
+  });
+
+  it("falha do runtime vira mensagem legível, não 500 mudo", async () => {
+    const { POST } = await import("./route");
+    const req = new NextRequest("http://localhost/x", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sample_message: "oi" }),
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ id: AGENT, vid: VERSION }) });
+    const body = (await res.json()) as { error?: { message?: string } };
+
+    expect(res.status).toBe(500);
+    expect(body.error?.message).toContain("Não consegui executar o agente");
+    expect(body.error?.message).toContain("AI_GATEWAY_API_KEY ausente");
+  });
+});

--- a/app/api/v1/ai/agents/[id]/versions/[vid]/test/route.ts
+++ b/app/api/v1/ai/agents/[id]/versions/[vid]/test/route.ts
@@ -1,12 +1,12 @@
 /**
  * POST /api/v1/ai/agents/:id/versions/:vid/test (admin)
  *
- * Spec 10 §4.4. Cria ai_agent_runs com is_dry_run=true e dispara o runtime
- * interno. Wave 6 ainda não tem o runtime real (S-13.08 entrega) — quando
- * INTERNAL_AGENT_RUN_STUB=true, o endpoint roda um trace fake síncrono
- * direto na row pra UI conseguir renderizar test mode antes do runtime
- * landar. Quando a flag virar false (após S-13.08), o handler delega via
- * fetch para /api/internal/agents/run.
+ * Spec 10 §4.4. Cria ai_agent_runs com is_dry_run=true e executa o runtime
+ * real (S-13.08) via `callInternalRuntime` → `runAgent`. Esse é o default.
+ *
+ * INTERNAL_AGENT_RUN_STUB=true troca a execução por um trace fabricado —
+ * serve para exercitar o render da UI sem gastar token, e NÃO é o default:
+ * numa instalação nova, "Testar agente" tem que testar o agente.
  *
  * Crítico: dry_run=true → bypass do partial unique
  *   ai_agent_runs_one_running_per_conv (que filtra is_dry_run=false), por
@@ -107,14 +107,26 @@ export async function POST(req: NextRequest, ctx: Ctx): Promise<Response> {
       startedAt,
     });
   } else {
-    // Real runtime delega via fetch interno. S-13.08 entrega.
-    resultPayload = await callInternalRuntime({
-      runId: runRow.id,
-      orgId: activeOrg.orgId,
-      versionId: vid,
-      sampleMessage: parsed.data.sample_message,
-      sampleContact: parsed.data.sample_contact,
-    });
+    // Runtime real (S-13.08). Falha aqui é o caso comum de instalação nova —
+    // credencial de IA ausente. Um 500 cru mandaria a pessoa pro log do
+    // servidor; devolvemos o porquê legível na própria tela.
+    try {
+      resultPayload = await callInternalRuntime({
+        runId: runRow.id,
+        orgId: activeOrg.orgId,
+        versionId: vid,
+        sampleMessage: parsed.data.sample_message,
+        sampleContact: parsed.data.sample_contact,
+      });
+    } catch (err) {
+      const detalhe = err instanceof Error ? err.message : String(err);
+      return fail(
+        "internal_error",
+        `Não consegui executar o agente: ${detalhe}. Confira as credenciais de IA da organização.`,
+        500,
+        { requestId },
+      );
+    }
   }
 
   void audit({

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -105,13 +105,14 @@ const schema = z.object({
     .default("false")
     .transform((v) => v === "true"),
 
-  // EPIC-13 wave 6: enquanto S-13.08 (runtime real) não landa, o endpoint
-  // :test devolve um trace fake quando esta flag = 'true'. Default 'true' em
-  // dev, deve virar 'false' em produção quando a wave 8 estiver mergeada.
+  // O endpoint :test devolve um trace fake quando esta flag = 'true'.
+  // Default 'false' desde que a S-13.08 landou: `callInternalRuntime` executa
+  // o `runAgent` real, então quem instala do zero testa o agente de verdade.
+  // Ligue 'true' só para exercitar o render da UI sem gastar token.
   INTERNAL_AGENT_RUN_STUB: z
     .enum(["true", "false"])
     .optional()
-    .default("true")
+    .default("false")
     .transform((v) => v === "true"),
 
   // Sentry


### PR DESCRIPTION
Fecha #71 e #68.

## O problema principal (#71)

`INTERNAL_AGENT_RUN_STUB` vinha `true` por default desde a wave 6, quando o runtime real ainda não existia. Ele existe desde a S-13.08 — `callInternalRuntime` executa o `runAgent` — mas o default nunca virou. O comentário no próprio `lib/env.ts` pedia a troca:

> "Default 'true' em dev, deve virar 'false' em produção quando a wave 8 estiver mergeada."

Efeito prático: quem instala numa VPS e clica em **Testar agente** recebe `[STUB] Resposta simulada`. Não é enganoso (o rótulo está lá), mas é o oposto do que a pessoa foi fazer — e acontece na primeira vez que ela experimenta o produto.

## O que mudou

- **`lib/env.ts`** — default `false`. O stub continua disponível para exercitar o render da UI sem gastar token; deixa de ser o que roda por padrão.
- **`.env.example`** — documenta `false` e explica para que serve ligar.
- **rota `:test`** — falha do runtime real vira mensagem legível na tela em vez de 500 mudo. O modo de falha comum de instalação nova é credencial de IA ausente, e a pessoa precisa ler isso onde clicou.
- **teste novo** — fixa esse contrato de erro.
- **`perf.yml`** (#68) — Node 20 → 22, alinhado ao job `ci`, ao `.nvmrc` e ao `engines: >=22`.

## Verificação

- `tsc --noEmit`: exit 0.
- `eslint` nos arquivos tocados: 0 problemas.
- Teste novo: passa. **Sabotado** (removendo o `try/catch`) para confirmar que fica vermelho — fica, com `Error: AI_GATEWAY_API_KEY ausente` escapando cru, que é exatamente o que ele guarda.
- `tests/unit/env-example-sync.test.ts` (que chegou no #69) continua verde com a mudança no `.env.example`.

## Decisão embutida, aberta a discordância

Sem credencial de IA, o caminho real erra e o stub "funciona". Optei pelo erro honesto: é a doutrina do próprio repo — ver o comentário do *terceiro estado* em `components/inbox/CRMSidePanel.tsx`, que distingue "não tem" de "não consegui ler". Se preferir manter o stub como default de dev via `.env.local`, o caminho continua aberto.