### PR TITLE
test: guard real agent test runtime default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,8 +65,9 @@ OPENAI_API_KEY=
 # --- Workers -----------------------------------------------------------------
 # Opt-in pra rodar consumers de event_log. Default false em dev; true em prod cron.
 EVENT_LOG_WORKER_ENABLED=false
-# Stub interno do endpoint de teste do agente. Default false: usa o runtime real.
-# Use true só em dev/teste quando quiser um trace fake sem LLM.
+# Stub do endpoint de teste do agente: 'true' devolve trace fabricado em vez de
+# executar o agente. Deixe false — o runtime real já existe. Só ligue para
+# exercitar o render da UI sem gastar token.
 INTERNAL_AGENT_RUN_STUB=false
 
 # --- Sentry ------------------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -65,8 +65,9 @@ OPENAI_API_KEY=
 # --- Workers -----------------------------------------------------------------
 # Opt-in pra rodar consumers de event_log. Default false em dev; true em prod cron.
 EVENT_LOG_WORKER_ENABLED=false
-# Stub interno do endpoint de teste do agente. Use false em produção quando o runtime real estiver ativo.
-INTERNAL_AGENT_RUN_STUB=true
+# Stub interno do endpoint de teste do agente. Default false: usa o runtime real.
+# Use true só em dev/teste quando quiser um trace fake sem LLM.
+INTERNAL_AGENT_RUN_STUB=false
 
 # --- Sentry ------------------------------------------------------------------
 SENTRY_DSN=

--- a/app/api/v1/ai/agents/[id]/versions/[vid]/test/route.ts
+++ b/app/api/v1/ai/agents/[id]/versions/[vid]/test/route.ts
@@ -168,10 +168,7 @@ async function runStubbedTest(args: StubArgs): Promise<Record<string, unknown>> 
       step: 1,
       tool_name: "(stub)",
       args: { sample_message: args.sampleMessage },
-      result: {
-        ok: true,
-        note: "INTERNAL_AGENT_RUN_STUB=true — runtime real bypassed for this test.",
-      },
+      result: { ok: true, note: "INTERNAL_AGENT_RUN_STUB=true — runtime real chega na S-13.08." },
       started_at: args.startedAt.toISOString(),
       ended_at: finishedAt.toISOString(),
     },
@@ -219,8 +216,8 @@ async function callInternalRuntime(args: {
   sampleMessage: string;
   sampleContact?: { name?: string; phone?: string };
 }): Promise<Record<string, unknown>> {
-  // We invoke `runAgent` in-process to avoid a fetch loopback (no cold-start,
-  // no INTERNAL_SECRET required in dev).
+  // S-13.08 wires the real runtime. We invoke `runAgent` in-process to avoid
+  // a fetch loopback (no cold-start, no INTERNAL_SECRET required in dev).
   // The run row is already in is_dry_run=true mode so the runtime bypasses
   // WAHA dispatch + outbound message insert.
   const { runAgent } = await import("@/lib/ai/runtime/agent");

--- a/app/api/v1/ai/agents/[id]/versions/[vid]/test/route.ts
+++ b/app/api/v1/ai/agents/[id]/versions/[vid]/test/route.ts
@@ -2,11 +2,8 @@
  * POST /api/v1/ai/agents/:id/versions/:vid/test (admin)
  *
  * Spec 10 §4.4. Cria ai_agent_runs com is_dry_run=true e dispara o runtime
- * interno. Wave 6 ainda não tem o runtime real (S-13.08 entrega) — quando
- * INTERNAL_AGENT_RUN_STUB=true, o endpoint roda um trace fake síncrono
- * direto na row pra UI conseguir renderizar test mode antes do runtime
- * landar. Quando a flag virar false (após S-13.08), o handler delega via
- * fetch para /api/internal/agents/run.
+ * interno real por padrão. Quando INTERNAL_AGENT_RUN_STUB=true, o endpoint roda
+ * um trace fake síncrono direto na row para desenvolvimento/testes sem LLM.
  *
  * Crítico: dry_run=true → bypass do partial unique
  *   ai_agent_runs_one_running_per_conv (que filtra is_dry_run=false), por
@@ -107,7 +104,8 @@ export async function POST(req: NextRequest, ctx: Ctx): Promise<Response> {
       startedAt,
     });
   } else {
-    // Real runtime delega via fetch interno. S-13.08 entrega.
+    // Real runtime in-process. Retorna status failed com error_code/error_message
+    // quando faltar credencial/configuração, em vez de mascarar com stub.
     resultPayload = await callInternalRuntime({
       runId: runRow.id,
       orgId: activeOrg.orgId,
@@ -156,7 +154,10 @@ async function runStubbedTest(args: StubArgs): Promise<Record<string, unknown>> 
       step: 1,
       tool_name: "(stub)",
       args: { sample_message: args.sampleMessage },
-      result: { ok: true, note: "INTERNAL_AGENT_RUN_STUB=true — runtime real chega na S-13.08." },
+      result: {
+        ok: true,
+        note: "INTERNAL_AGENT_RUN_STUB=true — runtime real bypassed for this test.",
+      },
       started_at: args.startedAt.toISOString(),
       ended_at: finishedAt.toISOString(),
     },
@@ -204,8 +205,8 @@ async function callInternalRuntime(args: {
   sampleMessage: string;
   sampleContact?: { name?: string; phone?: string };
 }): Promise<Record<string, unknown>> {
-  // S-13.08 wires the real runtime. We invoke `runAgent` in-process to avoid
-  // a fetch loopback (no cold-start, no INTERNAL_SECRET required in dev).
+  // We invoke `runAgent` in-process to avoid a fetch loopback (no cold-start,
+  // no INTERNAL_SECRET required in dev).
   // The run row is already in is_dry_run=true mode so the runtime bypasses
   // WAHA dispatch + outbound message insert.
   const { runAgent } = await import("@/lib/ai/runtime/agent");

--- a/app/api/v1/ai/agents/[id]/versions/[vid]/test/route.ts
+++ b/app/api/v1/ai/agents/[id]/versions/[vid]/test/route.ts
@@ -1,9 +1,12 @@
 /**
  * POST /api/v1/ai/agents/:id/versions/:vid/test (admin)
  *
- * Spec 10 §4.4. Cria ai_agent_runs com is_dry_run=true e dispara o runtime
- * interno real por padrão. Quando INTERNAL_AGENT_RUN_STUB=true, o endpoint roda
- * um trace fake síncrono direto na row para desenvolvimento/testes sem LLM.
+ * Spec 10 §4.4. Cria ai_agent_runs com is_dry_run=true e executa o runtime
+ * real (S-13.08) via `callInternalRuntime` → `runAgent`. Esse é o default.
+ *
+ * INTERNAL_AGENT_RUN_STUB=true troca a execução por um trace fabricado —
+ * serve para exercitar o render da UI sem gastar token, e NÃO é o default:
+ * numa instalação nova, "Testar agente" tem que testar o agente.
  *
  * Crítico: dry_run=true → bypass do partial unique
  *   ai_agent_runs_one_running_per_conv (que filtra is_dry_run=false), por
@@ -104,15 +107,26 @@ export async function POST(req: NextRequest, ctx: Ctx): Promise<Response> {
       startedAt,
     });
   } else {
-    // Real runtime in-process. Retorna status failed com error_code/error_message
-    // quando faltar credencial/configuração, em vez de mascarar com stub.
-    resultPayload = await callInternalRuntime({
-      runId: runRow.id,
-      orgId: activeOrg.orgId,
-      versionId: vid,
-      sampleMessage: parsed.data.sample_message,
-      sampleContact: parsed.data.sample_contact,
-    });
+    // Runtime real (S-13.08). Falha aqui é o caso comum de instalação nova —
+    // credencial de IA ausente. Um 500 cru mandaria a pessoa pro log do
+    // servidor; devolvemos o porquê legível na própria tela.
+    try {
+      resultPayload = await callInternalRuntime({
+        runId: runRow.id,
+        orgId: activeOrg.orgId,
+        versionId: vid,
+        sampleMessage: parsed.data.sample_message,
+        sampleContact: parsed.data.sample_contact,
+      });
+    } catch (err) {
+      const detalhe = err instanceof Error ? err.message : String(err);
+      return fail(
+        "internal_error",
+        `Não consegui executar o agente: ${detalhe}. Confira as credenciais de IA da organização.`,
+        500,
+        { requestId },
+      );
+    }
   }
 
   void audit({

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -103,8 +103,10 @@ const schema = z.object({
     .default("false")
     .transform((v) => v === "true"),
 
-  // Endpoint de teste do agente. Default false: o runtime real roda por padrão;
-  // ligue explicitamente em dev/teste quando quiser um trace fake sem LLM.
+  // O endpoint :test devolve um trace fake quando esta flag = 'true'.
+  // Default 'false' desde que a S-13.08 landou: `callInternalRuntime` executa
+  // o `runAgent` real, então quem instala do zero testa o agente de verdade.
+  // Ligue 'true' só para exercitar o render da UI sem gastar token.
   INTERNAL_AGENT_RUN_STUB: z
     .enum(["true", "false"])
     .optional()

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -28,9 +28,7 @@ const isBuildPhase = process.env.NEXT_PHASE === "phase-production-build";
  * pra permitir setup parcial (ex: dev sem WAHA quando trabalhando só na UI).
  */
 const required = (name: string) =>
-  isProd
-    ? z.string().min(1, `${name} é obrigatória em produção`)
-    : z.string().default("");
+  isProd ? z.string().min(1, `${name} é obrigatória em produção`) : z.string().default("");
 
 const requiredAlways = (name: string) => z.string().min(1, `${name} é obrigatória`);
 
@@ -105,13 +103,12 @@ const schema = z.object({
     .default("false")
     .transform((v) => v === "true"),
 
-  // EPIC-13 wave 6: enquanto S-13.08 (runtime real) não landa, o endpoint
-  // :test devolve um trace fake quando esta flag = 'true'. Default 'true' em
-  // dev, deve virar 'false' em produção quando a wave 8 estiver mergeada.
+  // Endpoint de teste do agente. Default false: o runtime real roda por padrão;
+  // ligue explicitamente em dev/teste quando quiser um trace fake sem LLM.
   INTERNAL_AGENT_RUN_STUB: z
     .enum(["true", "false"])
     .optional()
-    .default("true")
+    .default("false")
     .transform((v) => v === "true"),
 
   // Sentry
@@ -139,14 +136,8 @@ const schema = z.object({
     .transform((v) => v === "true"),
 
   // App URLs
-  NEXT_PUBLIC_APP_URL: z
-    .string()
-    .url()
-    .default("http://localhost:3000"),
-  NEXT_PUBLIC_ADMIN_URL: z
-    .string()
-    .url()
-    .default("http://localhost:3000"),
+  NEXT_PUBLIC_APP_URL: z.string().url().default("http://localhost:3000"),
+  NEXT_PUBLIC_ADMIN_URL: z.string().url().default("http://localhost:3000"),
 
   // Marca da instalação (white-label) — ver lib/branding.ts.
   // Sem prefixo NEXT_PUBLIC_ de propósito: essas seriam queimadas no bundle

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -28,7 +28,9 @@ const isBuildPhase = process.env.NEXT_PHASE === "phase-production-build";
  * pra permitir setup parcial (ex: dev sem WAHA quando trabalhando só na UI).
  */
 const required = (name: string) =>
-  isProd ? z.string().min(1, `${name} é obrigatória em produção`) : z.string().default("");
+  isProd
+    ? z.string().min(1, `${name} é obrigatória em produção`)
+    : z.string().default("");
 
 const requiredAlways = (name: string) => z.string().min(1, `${name} é obrigatória`);
 
@@ -138,8 +140,14 @@ const schema = z.object({
     .transform((v) => v === "true"),
 
   // App URLs
-  NEXT_PUBLIC_APP_URL: z.string().url().default("http://localhost:3000"),
-  NEXT_PUBLIC_ADMIN_URL: z.string().url().default("http://localhost:3000"),
+  NEXT_PUBLIC_APP_URL: z
+    .string()
+    .url()
+    .default("http://localhost:3000"),
+  NEXT_PUBLIC_ADMIN_URL: z
+    .string()
+    .url()
+    .default("http://localhost:3000"),
 
   // Marca da instalação (white-label) — ver lib/branding.ts.
   // Sem prefixo NEXT_PUBLIC_ de propósito: essas seriam queimadas no bundle

--- a/tests/unit/env-example-sync.test.ts
+++ b/tests/unit/env-example-sync.test.ts
@@ -24,4 +24,14 @@ describe(".env.example", () => {
 
     expect(missing).toEqual([]);
   });
+
+  it("deixa o teste de agente real ligado por default", () => {
+    const envSource = readFileSync(join(root, "lib/env.ts"), "utf8");
+    const example = readFileSync(join(root, ".env.example"), "utf8");
+
+    expect(envSource).toContain(
+      'INTERNAL_AGENT_RUN_STUB: z\n    .enum(["true", "false"])\n    .optional()\n    .default("false")',
+    );
+    expect(example).toContain("INTERNAL_AGENT_RUN_STUB=false");
+  });
 });

--- a/tests/unit/env-example-sync.test.ts
+++ b/tests/unit/env-example-sync.test.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const root = process.cwd();
+const ORIGINAL_INTERNAL_AGENT_RUN_STUB = process.env.INTERNAL_AGENT_RUN_STUB;
 
 function schemaEnvKeys(): string[] {
   const envSource = readFileSync(join(root, "lib/env.ts"), "utf8");
@@ -18,6 +19,15 @@ function exampleEnvKeys(): string[] {
 }
 
 describe(".env.example", () => {
+  afterEach(() => {
+    if (ORIGINAL_INTERNAL_AGENT_RUN_STUB === undefined) {
+      delete process.env.INTERNAL_AGENT_RUN_STUB;
+    } else {
+      process.env.INTERNAL_AGENT_RUN_STUB = ORIGINAL_INTERNAL_AGENT_RUN_STUB;
+    }
+    vi.resetModules();
+  });
+
   it("documenta todas as variáveis validadas em lib/env.ts", () => {
     const documented = new Set(exampleEnvKeys());
     const missing = schemaEnvKeys().filter((key) => !documented.has(key));
@@ -25,13 +35,12 @@ describe(".env.example", () => {
     expect(missing).toEqual([]);
   });
 
-  it("deixa o teste de agente real ligado por default", () => {
-    const envSource = readFileSync(join(root, "lib/env.ts"), "utf8");
-    const example = readFileSync(join(root, ".env.example"), "utf8");
+  it("mantém o teste de agente real ligado por default", async () => {
+    vi.resetModules();
+    delete process.env.INTERNAL_AGENT_RUN_STUB;
 
-    expect(envSource).toContain(
-      'INTERNAL_AGENT_RUN_STUB: z\n    .enum(["true", "false"])\n    .optional()\n    .default("false")',
-    );
-    expect(example).toContain("INTERNAL_AGENT_RUN_STUB=false");
+    const { env } = await import("@/lib/env");
+
+    expect(env.INTERNAL_AGENT_RUN_STUB).toBe(false);
   });
 });


### PR DESCRIPTION
## Resumo

Mantém o guard comportamental sugerido no review para impedir regressão do default de `INTERNAL_AGENT_RUN_STUB`.

A `main` já contém a mudança principal (`default("false")`). Este PR agora adiciona o teste que garante que, sem env configurada, o parse de `@/lib/env` exponha `env.INTERNAL_AGENT_RUN_STUB === false`.

Nota operacional: tentei rebasear diretamente em `main`, mas o push foi recusado porque os commits recentes da base alteram `.github/workflows/e2e.yml` e o token disponível não tem escopo `workflow`. Para evitar trazer commit de workflow para o fork, mantive a branch existente e subi um commit de redução/compatibilidade com a `main`.

## Testes

- RED medido localmente alterando temporariamente `lib/env.ts` para `.default("true")`: `pnpm vitest run tests/unit/env-example-sync.test.ts` falha com `expected true to be false`.
- GREEN: `pnpm vitest run tests/unit/env-example-sync.test.ts`
- `pnpm typecheck`
- `pnpm lint -- tests/unit/env-example-sync.test.ts` (0 errors; warnings preexistentes fora do arquivo)
- `git diff --check`