### PR TITLE
ci(e2e): pôr as specs Playwright para rodar no CI (subconjunto)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,91 @@
+name: e2e
+
+# Issue #63: as 19 specs de tests/e2e/ não rodavam em lugar nenhum. Este job
+# fecha o buraco começando pelo subconjunto que não depende de serviço externo.
+#
+# NÃO-BLOQUEANTE de propósito (continue-on-error) enquanto medimos estabilidade.
+# Quando N execuções seguidas passarem sem flake, remova a flag e ponha `e2e`
+# na lista de checks obrigatórios da branch protection. Enquanto a flag existir,
+# vermelho aqui NÃO segura merge — leia o log, não ignore.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      # Sobe Postgres + Auth (GoTrue) + PostgREST + Storage. Auth de verdade é
+      # requisito: os specs de login exercitam o GoTrue, não um mock.
+      - name: Subir Supabase local
+        run: supabase start
+
+      - name: Exportar credenciais do stack local
+        run: |
+          supabase status -o env > /tmp/sb.env
+          {
+            echo "NEXT_PUBLIC_SUPABASE_URL=$(grep '^API_URL=' /tmp/sb.env | cut -d'"' -f2)"
+            echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=$(grep '^ANON_KEY=' /tmp/sb.env | cut -d'"' -f2)"
+            echo "SUPABASE_SERVICE_ROLE_KEY=$(grep '^SERVICE_ROLE_KEY=' /tmp/sb.env | cut -d'"' -f2)"
+          } >> "$GITHUB_ENV"
+
+      - name: Build de produção
+        run: pnpm build
+        env:
+          NEXT_TELEMETRY_DISABLED: "1"
+
+      - name: Instalar o browser
+        run: pnpm exec playwright install --with-deps chromium
+
+      # Subconjunto deliberado: specs que não precisam de fixture semeada nem de
+      # serviço externo. O que ficou DE FORA (e por quê) está no passo seguinte —
+      # cobertura parcial silenciosa se lê como cobertura total.
+      - name: E2E (subconjunto sem dependência externa)
+        run: pnpm exec playwright test smoke.spec.ts auth.spec.ts error-pages.spec.ts
+
+      - name: Declarar o que este job ainda NÃO cobre
+        if: always()
+        run: |
+          {
+            echo "## E2E — cobertura deste job"
+            echo ""
+            echo "Rodou: smoke, auth, error-pages."
+            echo ""
+            echo "**Não rodou** (16 specs), por dependerem de fixture semeada ou serviço externo:"
+            echo "- WAHA: followup-journey, webhooks"
+            echo "- WAHA + Redis + Resend + Nuvemshop: vps-fresh-onboarding"
+            echo "- fixture semeada (scripts/seed-e2e-*.ts): followup-builder, followup-queue,"
+            echo "  inbox-scope, invite-lifecycle, kanban-owner-filter, queue-assign, rbac-roles,"
+            echo "  risk-radar, signup-journey, password-recovery, reset-password-mfa,"
+            echo "  degradacao-silenciosa, vps-webhook-outbound-ssrf"
+            echo ""
+            echo "Expandir o subconjunto é trabalho de seguimento — ver issue #63."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,10 +3,14 @@ name: e2e
 # Issue #63: as 19 specs de tests/e2e/ não rodavam em lugar nenhum. Este job
 # fecha o buraco começando pelo subconjunto que não depende de serviço externo.
 #
-# NÃO-BLOQUEANTE de propósito (continue-on-error) enquanto medimos estabilidade.
-# Quando N execuções seguidas passarem sem flake, remova a flag e ponha `e2e`
-# na lista de checks obrigatórios da branch protection. Enquanto a flag existir,
-# vermelho aqui NÃO segura merge — leia o log, não ignore.
+# NÃO-BLOQUEANTE por ausência, não por mordaça: `e2e` não está na lista de
+# checks obrigatórios da branch protection, então falhar aqui não segura merge.
+# O job em si falha honestamente — a primeira versão deste arquivo usava
+# `continue-on-error: true` no job inteiro e reportou VERDE com o `supabase
+# start` quebrado e zero teste executado. Verde que não distingue "passou" de
+# "nem rodou" é pior que vermelho.
+#
+# Quando N execuções seguidas passarem limpas, adicionar `e2e` aos obrigatórios.
 on:
   pull_request:
     branches: [main]
@@ -17,7 +21,6 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v7
 
@@ -36,8 +39,22 @@ jobs:
 
       # Sobe Postgres + Auth (GoTrue) + PostgREST + Storage. Auth de verdade é
       # requisito: os specs de login exercitam o GoTrue, não um mock.
-      - name: Subir Supabase local
-        run: supabase start
+      #
+      # A pasta de migrations sai do caminho ANTES do start: a cadeia não sobe
+      # em banco novo (quebra na 0010, `alter table public.contacts` sobre uma
+      # tabela que ainda não existe) — está no CLAUDE.md e foi confirmado neste
+      # CI. O que o self-hoster aplica é o `baseline.sql`, então é ele que o
+      # e2e aplica: o banco do teste fica igual ao de quem instalou o produto.
+      - name: Subir Supabase local (sem a cadeia de migrations)
+        run: |
+          mv supabase/migrations /tmp/migrations-off
+          mkdir -p supabase/migrations
+          supabase start
+
+      - name: Aplicar o baseline.sql (o mesmo que o install.sh do kit aplica)
+        run: |
+          psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" \
+            -v ON_ERROR_STOP=1 -q -f supabase/baseline.sql
 
       - name: Exportar credenciais do stack local
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,6 +51,22 @@ jobs:
           mkdir -p supabase/migrations
           supabase start
 
+      # O baseline é um dump `--schema-only`: ele USA os tipos das extensões
+      # (public.vector, citext, gin_trgm_ops) mas não as cria. O stack local do
+      # Supabase traz os binários e não as habilita — mesmo prelúdio que o
+      # scripts/test-db.sh faz para o Postgres cru, só a parte de extensões
+      # (roles e schema auth já vêm prontos aqui).
+      - name: Habilitar extensões exigidas pelo baseline
+        run: |
+          psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -v ON_ERROR_STOP=1 -q <<'SQL'
+          create schema if not exists extensions;
+          create extension if not exists "uuid-ossp" with schema extensions;
+          create extension if not exists pgcrypto with schema extensions;
+          create extension if not exists vector with schema public;
+          create extension if not exists citext with schema public;
+          create extension if not exists pg_trgm with schema public;
+          SQL
+
       - name: Aplicar o baseline.sql (o mesmo que o install.sh do kit aplica)
         run: |
           psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -92,8 +92,25 @@ jobs:
       # Subconjunto deliberado: specs que não precisam de fixture semeada nem de
       # serviço externo. O que ficou DE FORA (e por quê) está no passo seguinte —
       # cobertura parcial silenciosa se lê como cobertura total.
+      # `next start` roda com NODE_ENV=production, e aí toda var marcada
+      # `required()` no lib/env.ts passa a ser obrigatória — inclusive as de
+      # serviço que este subconjunto nem toca. Os valores abaixo são
+      # PLACEHOLDERS FALSOS, existem só para o boot passar da validação Zod.
+      # Nenhum segredo real entra aqui: este job roda em PR de fork, onde
+      # secrets não são expostos por design.
       - name: E2E (subconjunto sem dependência externa)
         run: pnpm exec playwright test smoke.spec.ts auth.spec.ts error-pages.spec.ts
+        env:
+          INTERNAL_SECRET: ci-placeholder-nao-e-segredo
+          CPF_ENCRYPTION_KEY: ci-placeholder-nao-e-segredo
+          WAHA_BYO_ENCRYPTION_KEY: ci-placeholder-nao-e-segredo
+          AI_CRED_AES_KEY: ci-placeholder-nao-e-segredo
+          SUPABASE_DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+          WAHA_API_BASE_URL: http://127.0.0.1:3999
+          WAHA_API_KEY: ci-placeholder-nao-e-segredo
+          WAHA_WEBHOOK_BASE_URL: http://127.0.0.1:3001
+          UPSTASH_REDIS_REST_URL: http://127.0.0.1:3998
+          UPSTASH_REDIS_REST_TOKEN: ci-placeholder-nao-e-segredo
 
       - name: Declarar o que este job ainda NÃO cobre
         if: always()

--- a/app/500/page.tsx
+++ b/app/500/page.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+/**
+ * `/500` — irmã de `/403` e `/503`, e faltava.
+ *
+ * `lib/auth/public-paths.ts` já isenta esta rota de auth desde sempre: o
+ * sistema contava com a página. Sem ela, quem caísse aqui (proxy, link de
+ * runbook, redirect de borda) via "página não encontrada" — a mensagem errada
+ * sobre o que aconteceu.
+ *
+ * Distinta de `app/error.tsx`, que trata exceção em runtime dentro do React.
+ * Esta é a página estática, alcançável por URL.
+ */
+export default function InternalErrorPage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center p-8">
+      <Card className="w-full max-w-md p-8 text-center">
+        <h1 className="text-2xl font-semibold">500 — Erro interno</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Algo quebrou do nosso lado. Já registramos o ocorrido; tente de novo em instantes.
+        </p>
+        <div className="mt-6 flex justify-center gap-2">
+          <Button asChild>
+            <Link href="/">Voltar</Link>
+          </Button>
+        </div>
+      </Card>
+    </main>
+  );
+}


### PR DESCRIPTION
Fecha parcialmente #63.

## O buraco

As 19 specs de `tests/e2e/` não rodavam em nenhum workflow. Entre elas, a jornada que a doutrina de QA Visual classifica como o caminho mais crítico do produto.

## O que este job faz

Sobe **Supabase local de verdade** (Postgres + GoTrue + PostgREST + Storage), builda em modo produção e roda um subconjunto pelo Playwright. Auth real é requisito, não detalhe: os specs de login exercitam o GoTrue — mock não provaria nada ali.

Roda: `smoke`, `auth`, `error-pages` — as que não precisam de fixture semeada nem serviço externo.

## Não-bloqueante, de propósito

`continue-on-error: true` enquanto medimos estabilidade. Um job novo que ainda não sabemos se é flaky não pode segurar merge — e um X vermelho permanente ensina o time a ignorar vermelho. Quando N execuções seguidas passarem limpas, tiro a flag e ponho `e2e` nos checks obrigatórios.

## Cobertura parcial declarada, não escondida

O job escreve no summary as **16 specs que não cobre e por quê** (WAHA, Redis/Resend/Nuvemshop, ou fixture semeada). Cobertura parcial silenciosa se lê como cobertura total — e o repo já tem um doc dizendo isso melhor que eu.

Expandir o subconjunto (semear fixtures, subir WAHA fake) é trabalho de seguimento; a issue #63 fica aberta até lá.