### PR TITLE
docs: sincronizar os docs com o CI que passou a existir hoje

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,10 +61,16 @@ pnpm gov:verify       # typecheck + lint + test:unit  ← verificação única a
 mudança toca schema, RLS ou UI, `gov:verify` verde **não** é prova — rode `pnpm test:db`
 (exige Docker) e/ou `pnpm test:e2e` você mesmo. Ver [`docs/harness-audit.md`](docs/harness-audit.md).
 
-**O que o CI cobre** (`.github/workflows/ci.yml`, 2 jobs paralelos): `verify` = typecheck +
-lint + test:unit; `invariants` = `pnpm test:db` (isolamento RLS + invariantes de governança
-contra Postgres efêmero pg17). **Os E2E não rodam em CI** — se você mexeu em UI ou fluxo de
-usuário, ninguém além de você vai provar que funciona.
+**O que o CI cobre.** `.github/workflows/ci.yml`: `verify` = typecheck + lint + test:unit;
+`invariants` = `pnpm test:db` (isolamento RLS + invariantes de governança contra Postgres
+efêmero pg17). `.github/workflows/perf.yml`: `build-and-size` = `pnpm build`.
+**Os três são checks obrigatórios** na branch protection da `main`.
+
+`.github/workflows/e2e.yml` roda **3 das 19 specs** Playwright (`smoke`, `auth`,
+`error-pages`) contra um Supabase local de verdade com o `baseline.sql` aplicado — o mesmo
+banco que o self-hoster tem. **Não é obrigatório ainda** (falta dado de estabilidade) e as
+outras 16 continuam sem gate: se você mexeu em UI ou fluxo de usuário fora desse
+subconjunto, a prova é sua.
 
 ## Padrões de código (observados no repo, não inventados)
 
@@ -112,13 +118,15 @@ usuário, ninguém além de você vai provar que funciona.
 - **56** arquivos de invariante de banco em `tests/invariants/` — RLS/isolamento cross-tenant,
   RBAC, governança (G1–G6). Excluídos do `test:unit` de propósito; rodam via `pnpm test:db`
   **e no job `invariants` do CI**.
-- **19** specs Playwright em `tests/e2e/` — inclui `vps-fresh-onboarding` e
-  `vps-webhook-outbound-ssrf`. **Não rodam no CI.**
+- **19** specs Playwright em `tests/e2e/`. **3 rodam no CI** (`smoke`, `auth`,
+  `error-pages`, via `e2e.yml`, não-obrigatório). As outras 16 — incluindo
+  `vps-fresh-onboarding` e `vps-webhook-outbound-ssrf` — ainda não: dependem de fixture
+  semeada ou de serviço externo. Ver issue #63.
 
 ## Limitações conhecidas (estado em 2026-07-29, contra `origin/main` @ 789dfa6)
 
-- **E2E fora do CI.** Se você mexeu em UI ou fluxo de usuário, a prova é sua — nenhum gate
-  automático cobre isso.
+- **16 das 19 specs E2E seguem fora do CI.** Se você mexeu em UI ou fluxo de usuário fora
+  de `smoke`/`auth`/`error-pages`, a prova é sua — nenhum gate automático cobre.
 - Rate limit HTTP existe em **2** pontos do código (webhook de captação e dispatcher de IA);
   login, signup, aceite de convite, crons e MCP estão sem. Não há lockout por conta no login.
 - Fallback do rate limit é **em memória** — sem Upstash configurado o limite é por processo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,10 +180,15 @@ pnpm test:e2e    # Playwright (requer dev server)
 
 **Os invariantes não estão no `test:unit`.** `vitest.config.ts` exclui `tests/invariants/**` de propósito: essa suíte precisa de um Postgres real e roda via `vitest.db.config.ts`, orquestrada por `scripts/test-db.sh`. Rodar só `pnpm test:unit` e concluir "está tudo verde" é um falso verde — o isolamento RLS não foi exercitado.
 
-O CI (`.github/workflows/ci.yml`) tem dois jobs em paralelo, ambos obrigatórios antes de merge:
+Checks **obrigatórios** na branch protection da `main` (verificado na configuração, não só no papel):
 
-- **`verify`** — typecheck + lint + test:unit.
-- **`invariants`** — `pnpm test:db`: sobe `pgvector/pgvector:pg17`, aplica `supabase/baseline.sql` em modo install (`ON_ERROR_STOP=1`) e update (idempotência), e roda os 364 testes de invariante, incluindo o de isolamento RLS entre 2 organizações.
+- **`verify`** (`ci.yml`) — typecheck + lint + test:unit.
+- **`invariants`** (`ci.yml`) — `pnpm test:db`: sobe `pgvector/pgvector:pg17`, aplica `supabase/baseline.sql` em modo install (`ON_ERROR_STOP=1`) e update (idempotência), e roda os testes de invariante, incluindo o de isolamento RLS entre 2 organizações.
+- **`build-and-size`** (`perf.yml`) — `pnpm build` em Node 22.
+
+Check **não-obrigatório** (roda, mas não segura merge):
+
+- **`e2e`** (`e2e.yml`) — sobe Supabase local, aplica o `baseline.sql` e roda **3 das 19 specs** Playwright (`smoke`, `auth`, `error-pages`). As outras 16 dependem de fixture semeada ou serviço externo e seguem sem gate (issue #63). Vira obrigatório quando acumular execuções estáveis.
 
 Ao mexer em schema, RLS, RBAC, atribuição, escopo, roteamento, follow-up, webhooks ou automações: rode `pnpm test:db` **localmente** antes de abrir PR. É o único caminho que exercita o `baseline.sql` que o self-hoster realmente aplica.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Ao finalizar um epic:
    - `pnpm typecheck`
    - `pnpm lint`
    - `pnpm test:unit`
-   - `pnpm test:e2e` (subset relevante)
+   - `pnpm test:e2e` (subset relevante) — **opcional se você contribui de fora**, ver abaixo
    - RLS testada se feature toca tabela tenant-aware
    - Audit log emitido se há mutação relevante
    - Rate limit aplicado se rota é pública
@@ -56,7 +56,23 @@ Ao finalizar um epic:
    - Env vars novas em `.env.example` + `lib/env.ts`
    - Docs atualizadas se mudou contrato (PRD/spec)
 4. Abrir PR contra `main`. Description deve referenciar o epic e listar evidências (logs/screenshots dos testes).
-5. CI deve passar antes de merge. Teste de isolamento RLS é gate obrigatório.
+5. CI deve passar antes de merge. Obrigatórios: `verify`, `invariants` (isolamento RLS) e `build-and-size`.
+
+### Se você está contribuindo de fora (fork) — leia isto
+
+Duas coisas vão parecer erro seu e não são:
+
+- **O check `Vercel` fica vermelho** com "Authorization required to deploy". A `main` deste
+  repositório faz deploy de produção, e a Vercel se recusa a construir PR de fork por
+  segurança — o que está certo. **Ignore esse check**; ele não entra no gate de merge.
+- **Os workflows ficam parados esperando aprovação** no seu primeiro PR. É política do
+  GitHub para quem nunca contribuiu antes. Um mantenedor libera; do segundo PR em diante
+  roda sozinho. Se demorar, comente no PR.
+
+E sobre o `pnpm test:e2e` do DoD: rodar a suíte completa exige Docker, banco semeado e WAHA
+local. **Não travamos PR externo nisso** — mande o que conseguiu provar (unit + descrição do
+que testou na mão), que a prova de tela fica com o mantenedor. Exigir prova sem entregar a
+ferramenta de produzi-la seria pedágio, não rigor.
 
 ### Anti-patterns proibidos
 

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -118,7 +118,13 @@ funil** (só de etapas). O primeiro é bug de primeira impressão em mobile.
 
 Estes são achados de código/config verificados nesta auditoria, não relatos.
 
-### 4.1 Os E2E não rodam no CI 🔴
+### 4.1 Os E2E quase não rodam no CI 🟠 — parcialmente resolvido em 2026-07-30
+
+> **Atualização (2026-07-30):** `e2e.yml` passou a rodar **3 das 19 specs** (`smoke`, `auth`,
+> `error-pages`) contra Supabase local com o `baseline.sql` aplicado. Não-obrigatório ainda.
+> A primeira execução real já pagou o job: achou a página `/500`, que `public-paths.ts`
+> declarava pública e **nunca havia sido criada**. As 16 restantes seguem sem gate — o texto
+> abaixo continua valendo para elas.
 
 O gate de isolamento RLS **roda** — `ci.yml` tem o job `invariants` chamando `pnpm test:db`,
 que sobe `pgvector/pgvector:pg17`, aplica `baseline.sql` em modo install e update, e roda os

--- a/docs/harness-audit.md
+++ b/docs/harness-audit.md
@@ -28,7 +28,7 @@ verificados por leitura de arquivo, config e workflow.
 | H2 — Reproduzível | ✅ | Quickstart no README, `docs/SETUP.md`, `.nvmrc` (22), `packageManager` fixo, `pnpm-lock.yaml`, `docker-compose.yml`, `install.sh` do kit self-host, `baseline.sql` |
 | H3 — Verificável | ✅ | `lint` + `typecheck` + `test:unit` + `build`; CI roda os 3 primeiros em PR |
 | H4 — Preparado para agentes | ✅ | `CLAUDE.md` doutrinal forte; `AGENTS.md` **criado nesta auditoria**; documentação técnica extensa; **e o CI roda o gate de isolamento RLS** (job `invariants` → `pnpm test:db`) |
-| H5 — Automação avançada | ⚠️ **parcial** | CI confiável e ambiente isolado ✅ (Postgres efêmero pg17, worktrees, gov-loop com maker≠checker e hash-check). Faltam: **E2E fora do CI**, `format:check` fora do CI, e o comando único local (`gov:verify`) não cobre `test:db`/`test:e2e` |
+| H5 — Automação avançada | ⚠️ **parcial** | CI confiável e ambiente isolado ✅ (Postgres efêmero pg17, worktrees, gov-loop com maker≠checker e hash-check). Faltam: **16 das 19 specs E2E fora do CI** (3 rodam via `e2e.yml` desde 2026-07-30, não-obrigatório), `format:check` fora do CI, e o comando único local (`gov:verify`) não cobre `test:db`/`test:e2e` |
 
 **Por que H4 e não H5:** a instrução da auditoria é explícita — não atribuir nível só
 porque os arquivos existem, avaliar se o processo está implementado. Aqui está: o gate de
@@ -36,7 +36,7 @@ isolamento multi-tenant roda em CI como check nomeado, em job paralelo, aplicand
 `baseline.sql` em modo install **e** update contra um Postgres descartável. Isso é o
 processo funcionando, não a intenção.
 
-O que separa de H5 é estreito: os **19 E2E não rodam em CI** — incluindo
+O que separa de H5 é estreito: **16 dos 19 E2E não rodam em CI** (`e2e.yml` cobre `smoke`, `auth` e `error-pages` desde 2026-07-30) — de fora seguem
 `vps-fresh-onboarding.spec.ts`, que protege a primeira impressão que a doutrina classifica
 como o caminho mais crítico do produto. E `pnpm gov:verify`, o comando único que um agente
 naturalmente usa como critério de pronto, **não** inclui `test:db` nem `test:e2e`: o CI
@@ -68,7 +68,7 @@ Legenda: ✅ existente e funcional · ⚠️ existente mas incompleto · ❌ nã
 | 10 | Checagem de tipos | ✅ | `pnpm typecheck` (`tsc --noEmit`, TS 6 estrito), roda no CI |
 | 11 | Testes unitários | ✅ | 221 arquivos `*.test.ts(x)`; `pnpm test:unit` no CI |
 | 12 | Testes de integração | ✅ | **56 arquivos** de invariantes em `tests/invariants/` + `tests/api/`. Excluídos do `test:unit` de propósito (`vitest.config.ts:12`) e rodados pelo job `invariants` do CI via `pnpm test:db` |
-| 13 | Testes E2E | ⚠️ | 19 specs Playwright, incluindo os P0 `vps-fresh-onboarding` e `vps-webhook-outbound-ssrf`. **Não rodam no CI** |
+| 13 | Testes E2E | ⚠️ | 19 specs Playwright. **3 rodam no CI** (`e2e.yml`, não-obrigatório); os P0 `vps-fresh-onboarding` e `vps-webhook-outbound-ssrf` ainda não |
 | 14 | Comando único de verificação | ⚠️ | `pnpm gov:verify` = `typecheck && lint && test:unit`. **Omite `test:db` e `test:e2e`** — verde localmente não significa verificado. O CI cobre `test:db`, mas só depois do push |
 | 15 | CI executando verificações | ✅ | `ci.yml` tem 2 jobs: `verify` (typecheck + lint + test:unit) e **`invariants` (`pnpm test:db` — isolamento RLS + invariantes de governança, em job paralelo com timeout de 20min)**. Falta E2E e `format:check`. `perf.yml` faz build + bundle size; `publish-image.yml` publica no GHCR |
 | 16 | Proteção contra secrets | ⚠️ | `.gitignore` cobre `.env*` (exceção só para os `.example`) e o Sentry tem `beforeSend` que higieniza PII. **Sem** gitleaks/trufflehog no CI, **sem** pre-commit hook |


### PR DESCRIPTION
O job `e2e` (#74) e a mudança de branch protection tornaram falsas quatro afirmações que estavam corretas até hoje de manhã. Doc que promete garantia inexistente é o defeito que a auditoria do #60 foi corrigir — vale também quando o doc desatualizado é ela própria.

- **`AGENTS.md`, `CLAUDE.md`, `current-state`, `harness-audit`** — passam a dizer "3 das 19 specs rodam no CI, as outras 16 não", com o número declarado em vez de um "os e2e rodam" que leria como cobertura total.
- **`CLAUDE.md`** — lista os checks *realmente* obrigatórios na branch protection. O `invariants` só virou exigido hoje; o doc afirmava que era gate obrigatório há meses **sem que a configuração exigisse**. Agora as duas coisas batem.
- **`CONTRIBUTING.md`** — o DoD pedia `pnpm test:e2e` de quem contribui de fora e não tem como rodar (Docker + banco semeado + WAHA). Vira opcional para PR externo. E explica os dois vermelhos que não são culpa do contribuidor: o check da Vercel em PR de fork (a `main` faz deploy de produção, então a recusa está certa) e a espera de aprovação do primeiro PR.