### PR TITLE
docs(release): marca a 1.1.0 no changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Se você roda o DeskcommCRM numa VPS, **leia a seção da versão para a qual es
 
 ## [Não lançado]
 
+## [1.1.0] — 2026-07-30
+
 ### Adicionado
 
 - **Atualização pela própria tela.** O dono da instalação vê a versão instalada no rodapé do menu
@@ -97,5 +99,6 @@ Primeira versão marcada do DeskcommCRM. O projeto vinha sendo desenvolvido publ
 
 - **Node 22 é obrigatório para desenvolvimento.** A suíte de invariantes instancia o cliente do Supabase, que exige o `WebSocket` global — nativo apenas a partir do Node 22. Isso não afeta quem apenas hospeda: a VPS roda a imagem pronta.
 
-[Não lançado]: https://github.com/melgarafael/DeskcommCRM/compare/v1.0.0...HEAD
+[Não lançado]: https://github.com/melgarafael/DeskcommCRM/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/melgarafael/DeskcommCRM/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/melgarafael/DeskcommCRM/releases/tag/v1.0.0


### PR DESCRIPTION
Pré-requisito para cortar a tag `v1.1.0`.

O extrator de seções (`lib/system/changelog.ts`, entregue no #61) procura `## [1.1.0]` no CHANGELOG. Com a seção ainda como `[Não lançado]`, ele devolve `null` e a tela de atualização mostraria a versão nova **sem o bloco "⚠️ Requer atenção"** — que é exatamente onde está escrito que quem já tem o CRM instalado precisa rodar o `update.sh` duas vezes pelo terminal para ativar o botão.

Provado: `pnpm vitest run lib/system/changelog.test.ts` → 20/20, incluindo os dois casos que leem o `CHANGELOG.md` real do repositório.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ng41aCYobTn37KrN2V7BZf