### PR TITLE
fix(auth): teto de tentativas em login, signup, recuperação e convite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Dependencies
 node_modules/
+# Sem a barra tambem: `node_modules/` casa so com diretorio, e um SYMLINK
+# chamado node_modules (worktree apontando para a instalacao principal) passa
+# batido e vai parar no commit. Aconteceu no PR #83.
+node_modules
 .pnp
 .pnp.js
 

--- a/app/actions/auth/requestPasswordReset.ts
+++ b/app/actions/auth/requestPasswordReset.ts
@@ -5,6 +5,7 @@ import { headers } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import { forgotPasswordSchema, type ForgotPasswordInput } from "@/lib/auth/schemas";
 import { audit, hashEmail } from "@/lib/audit";
+import { authRateLimited, AUTH_LIMITS } from "@/lib/auth/rate-limit";
 import { env } from "@/lib/env";
 
 export type RequestPasswordResetResult =
@@ -37,6 +38,12 @@ export async function requestPasswordReset(
   const requestId = hdrs.get("x-request-id");
   const ip = hdrs.get("x-forwarded-for")?.split(",")[0]?.trim() ?? null;
   const userAgent = hdrs.get("user-agent") ?? null;
+
+  // Sem teto, este endpoint é uma metralhadora de e-mail contra terceiros e um
+  // oráculo de enumeração de conta. Issue #64.
+  if (await authRateLimited("reset", parsed.data.email, AUTH_LIMITS.reset)) {
+    return { ok: false, error: "rate_limited" };
+  }
 
   const supabase = await createClient();
   const { error } = await supabase.auth.resetPasswordForEmail(parsed.data.email, {

--- a/app/actions/auth/signInWithPassword.test.ts
+++ b/app/actions/auth/signInWithPassword.test.ts
@@ -31,8 +31,15 @@ describe("signInWithPassword — teto de tentativas", () => {
     vi.mocked(headers).mockResolvedValue({
       get: (k: string) => (k === "x-forwarded-for" ? "203.0.113.77" : null),
     } as never);
+    signIn.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { message: "Invalid login credentials", status: 400 },
+    } as never);
     vi.mocked(createClient).mockResolvedValue({
-      auth: { signInWithPassword: signIn },
+      auth: {
+        signInWithPassword: signIn,
+        mfa: { listFactors: vi.fn(async () => ({ data: { totp: [{ id: "f1" }] } })) },
+      },
     } as never);
   });
 
@@ -52,5 +59,26 @@ describe("signInWithPassword — teto de tentativas", () => {
     );
     expect(resultados[5]?.error).toBe("rate_limited");
     expect(signIn).toHaveBeenCalledTimes(5);
+  });
+
+  it("acertar a senha não gasta o orçamento de bloqueio da conta", async () => {
+    const { signInWithPassword } = await import("./signInWithPassword");
+    const input = { email: "certo@example.com", password: "senha-certa-123" };
+
+    // Provedor aceita, e a conta tem MFA — o retorno é mfa_required, o que
+    // basta: o ponto é que o caminho de SUCESSO não incrementa o contador.
+    signIn.mockResolvedValue({
+      data: { user: { id: "u1" }, session: {} },
+      error: null,
+    } as never);
+
+    const resultados = [];
+    for (let i = 0; i < 10; i++) {
+      resultados.push(await signInWithPassword(input));
+    }
+
+    // Nenhuma das dez foi barrada: se o sucesso contasse, a 6ª seria.
+    expect(resultados.filter((r) => r?.error === "rate_limited")).toHaveLength(0);
+    expect(signIn).toHaveBeenCalledTimes(10);
   });
 });

--- a/app/actions/auth/signInWithPassword.test.ts
+++ b/app/actions/auth/signInWithPassword.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Issue #64 — o teto está LIGADO no login, não só disponível numa lib.
+ *
+ * O helper tem teste próprio (lib/auth/rate-limit.test.ts); este aqui prova a
+ * fiação: a action recusa a 6ª tentativa contra a MESMA conta dentro da janela,
+ * antes de falar com o GoTrue. Sem a chamada em signInWithPassword.ts, as seis
+ * tentativas chegariam ao provedor e o teste fica vermelho.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { headers } from "next/headers";
+import { createClient } from "@/lib/supabase/server";
+
+vi.mock("next/headers", () => ({ headers: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("@/lib/audit", async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  audit: vi.fn(async () => undefined),
+}));
+vi.mock("next/navigation", () => ({ redirect: vi.fn() }));
+
+const signIn = vi.fn(async () => ({
+  data: { user: null, session: null },
+  error: { message: "Invalid login credentials", status: 400 },
+}));
+
+describe("signInWithPassword — teto de tentativas", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    signIn.mockClear();
+    vi.mocked(headers).mockResolvedValue({
+      get: (k: string) => (k === "x-forwarded-for" ? "203.0.113.77" : null),
+    } as never);
+    vi.mocked(createClient).mockResolvedValue({
+      auth: { signInWithPassword: signIn },
+    } as never);
+  });
+
+  it("recusa a 6ª tentativa contra a mesma conta sem chamar o provedor", async () => {
+    const { signInWithPassword } = await import("./signInWithPassword");
+    const input = { email: "alvo@example.com", password: "senha-errada-123" };
+
+    const resultados = [];
+    for (let i = 0; i < 6; i++) {
+      resultados.push(await signInWithPassword(input));
+    }
+
+    // AUTH_LIMITS.login.id = 5 → as 5 primeiras passam do teto e falham no
+    // provedor; a 6ª nem chega lá.
+    expect(resultados.slice(0, 5).map((r) => r.error)).toEqual(
+      Array(5).fill("invalid_credentials"),
+    );
+    expect(resultados[5]?.error).toBe("rate_limited");
+    expect(signIn).toHaveBeenCalledTimes(5);
+  });
+});

--- a/app/actions/auth/signInWithPassword.ts
+++ b/app/actions/auth/signInWithPassword.ts
@@ -6,7 +6,12 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { loginSchema, type LoginInput } from "@/lib/auth/schemas";
 import { audit, hashEmail } from "@/lib/audit";
-import { authRateLimited, AUTH_LIMITS } from "@/lib/auth/rate-limit";
+import {
+  authRateLimited,
+  contaBloqueadaPorFalhas,
+  registrarFalhaDeLogin,
+  AUTH_LIMITS,
+} from "@/lib/auth/rate-limit";
 
 export type SignInResult = {
   ok: false;
@@ -47,7 +52,10 @@ export async function signInWithPassword(
   // Antes de falar com o GoTrue: sem isto, tentar senha era de graça e
   // ilimitado (issue #64). Conta por IP e por conta — o ataque distribuído
   // contra um e-mail só não aparece na contagem por IP.
-  if (await authRateLimited("login", parsed.data.email, AUTH_LIMITS.login)) {
+  if (
+    (await authRateLimited("login", null, AUTH_LIMITS.login)) ||
+    (await contaBloqueadaPorFalhas(parsed.data.email, AUTH_LIMITS.login))
+  ) {
     await audit({
       action: "auth.login_rate_limited",
       metadata: { email_hash: hashEmail(parsed.data.email) },
@@ -64,6 +72,8 @@ export async function signInWithPassword(
   });
 
   if (error || !data.user) {
+    // Só senha errada gasta o orçamento da conta.
+    await registrarFalhaDeLogin(parsed.data.email, AUTH_LIMITS.login);
     await audit({
       action: "auth.login_failed",
       metadata: {

--- a/app/actions/auth/signInWithPassword.ts
+++ b/app/actions/auth/signInWithPassword.ts
@@ -6,6 +6,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { loginSchema, type LoginInput } from "@/lib/auth/schemas";
 import { audit, hashEmail } from "@/lib/audit";
+import { authRateLimited, AUTH_LIMITS } from "@/lib/auth/rate-limit";
 
 export type SignInResult = {
   ok: false;
@@ -42,6 +43,20 @@ export async function signInWithPassword(
   const requestId = hdrs.get("x-request-id");
   const ip = hdrs.get("x-forwarded-for")?.split(",")[0]?.trim() ?? null;
   const userAgent = hdrs.get("user-agent") ?? null;
+
+  // Antes de falar com o GoTrue: sem isto, tentar senha era de graça e
+  // ilimitado (issue #64). Conta por IP e por conta — o ataque distribuído
+  // contra um e-mail só não aparece na contagem por IP.
+  if (await authRateLimited("login", parsed.data.email, AUTH_LIMITS.login)) {
+    await audit({
+      action: "auth.login_rate_limited",
+      metadata: { email_hash: hashEmail(parsed.data.email) },
+      requestId,
+      ip,
+      userAgent,
+    });
+    return { ok: false, error: "rate_limited" };
+  }
 
   const { data, error } = await supabase.auth.signInWithPassword({
     email: parsed.data.email,

--- a/app/actions/auth/signUp.ts
+++ b/app/actions/auth/signUp.ts
@@ -5,6 +5,7 @@ import { headers } from "next/headers";
 import { createClient } from "@/lib/supabase/server";
 import { signupSchema, type SignupInput } from "@/lib/auth/schemas";
 import { audit, hashEmail } from "@/lib/audit";
+import { authRateLimited, AUTH_LIMITS } from "@/lib/auth/rate-limit";
 import { env } from "@/lib/env";
 
 export type SignUpResult =
@@ -39,6 +40,12 @@ export async function signUp(input: SignupInput): Promise<SignUpResult> {
   const requestId = hdrs.get("x-request-id");
   const ip = hdrs.get("x-forwarded-for")?.split(",")[0]?.trim() ?? null;
   const userAgent = hdrs.get("user-agent") ?? null;
+
+  // Criar conta é fluxo raro por pessoa: teto baixo por IP evita fábrica de
+  // organizações (cada signup provisiona tenant). Issue #64.
+  if (await authRateLimited("signup", null, AUTH_LIMITS.signup)) {
+    return { ok: false, error: "rate_limited" };
+  }
 
   const supabase = await createClient();
   const { data, error } = await supabase.auth.signUp({

--- a/app/team/accept-invite/[token]/page.tsx
+++ b/app/team/accept-invite/[token]/page.tsx
@@ -11,6 +11,7 @@
 import Link from "next/link";
 
 import { verifyInviteToken } from "@/lib/auth/invite-token";
+import { authRateLimited, AUTH_LIMITS } from "@/lib/auth/rate-limit";
 import { createClient } from "@/lib/supabase/server";
 import { acceptInviteAction } from "@/app/actions/team/acceptInvite";
 
@@ -22,6 +23,22 @@ interface PageProps {
 
 export default async function AcceptInvitePage({ params }: PageProps) {
   const { token } = await params;
+
+  // O gargalo de enumeração é AQUI, não no aceite: a rota é pública e cada
+  // GET testa um token. Sem teto, varrer o espaço de tokens sai de graça
+  // (issue #64). Barrar antes de verificar mantém a resposta indistinguível
+  // entre token válido e inválido para quem está varrendo.
+  if (await authRateLimited("invite_accept", null, AUTH_LIMITS.invite_accept)) {
+    return (
+      <Shell>
+        <h1 className="text-xl font-semibold">Muitas tentativas</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Aguarde alguns minutos e abra o link do convite de novo.
+        </p>
+      </Shell>
+    );
+  }
+
   const payload = verifyInviteToken(token);
 
   if (!payload) {

--- a/lib/ai/dispatcher/rate-limit.ts
+++ b/lib/ai/dispatcher/rate-limit.ts
@@ -27,7 +27,13 @@ function getRedis(): Redis | null {
     }
     return null;
   }
-  _redis = new Redis({ url, token });
+  // `retry: false`: com Redis inalcançável (URL errada, rede caída), o default
+  // do SDK re-tenta com backoff e cada chamada passa a custar SEGUNDOS. Como
+  // já existe fallback em memória logo abaixo, retentar aqui só transfere a
+  // indisponibilidade do Redis para a latência do login. Falhe rápido e caia
+  // para a memória. Medido: com URL morta, duas chamadas somavam ~8s numa
+  // requisição de recuperação de senha, estourando o timeout da tela.
+  _redis = new Redis({ url, token, retry: false });
   return _redis;
 }
 

--- a/lib/ai/dispatcher/rate-limit.ts
+++ b/lib/ai/dispatcher/rate-limit.ts
@@ -94,3 +94,29 @@ export async function checkRateLimit(
     window_sec: windowSec,
   };
 }
+
+/**
+ * Lê o contador SEM incrementar (issue #64).
+ *
+ * Existe porque bloqueio por tentativa-que-falhou precisa de duas operações
+ * distintas: *consultar* antes de chamar o provedor (senão o ataque nunca é
+ * barrado antes de acontecer) e *incrementar* só quando a tentativa falha
+ * (senão login bem-sucedido consome o orçamento e tranca quem acertou a senha).
+ */
+export async function peekRateLimit(bucket: string, windowSec: number): Promise<number> {
+  const windowStart = Math.floor(Date.now() / (windowSec * 1000));
+  const key = `${bucket}:${windowStart}`;
+
+  const redis = getRedis();
+  if (!redis) {
+    const existing = _memBuckets.get(key);
+    return !existing || existing.expiresAt <= Date.now() ? 0 : existing.count;
+  }
+  try {
+    const value = await redis.get<number | string>(key);
+    return value == null ? 0 : Number(value);
+  } catch {
+    const existing = _memBuckets.get(key);
+    return !existing || existing.expiresAt <= Date.now() ? 0 : existing.count;
+  }
+}

--- a/lib/audit/actions.ts
+++ b/lib/audit/actions.ts
@@ -5,6 +5,8 @@
 export type AuditAction =
   | "auth.login_success"
   | "auth.login_failed"
+  /** Teto de tentativas barrou antes de chegar ao provedor (issue #64). */
+  | "auth.login_rate_limited"
   | "auth.logout"
   | "auth.mfa_enrolled"
   | "auth.mfa_success"

--- a/lib/auth/rate-limit.test.ts
+++ b/lib/auth/rate-limit.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Issue #64 — o teto existe e conta as duas coisas.
+ *
+ * Sem Upstash configurado o `checkRateLimit` cai para o contador em memória do
+ * processo, que é exatamente o que este teste quer exercitar: o caminho real,
+ * sem mock do limitador. O que se mocka é só o `headers()` do Next, para
+ * escolher o IP de cada tentativa.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { headers } from "next/headers";
+
+vi.mock("next/headers", () => ({ headers: vi.fn() }));
+
+function comIp(ip: string) {
+  vi.mocked(headers).mockResolvedValue({
+    get: (k: string) => (k === "x-forwarded-for" ? ip : null),
+  } as never);
+}
+
+describe("authRateLimited", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("barra ao estourar o teto por IP", async () => {
+    const { authRateLimited } = await import("./rate-limit");
+    comIp("203.0.113.10");
+    const limites = { ip: 3, windowSec: 300 };
+
+    const veredito: boolean[] = [];
+    for (let i = 0; i < 4; i++) {
+      veredito.push(await authRateLimited("teste_ip", null, limites));
+    }
+
+    expect(veredito).toEqual([false, false, false, true]);
+  });
+
+  it("barra por identificador mesmo com o IP mudando a cada tentativa", async () => {
+    const { authRateLimited } = await import("./rate-limit");
+    const limites = { ip: 100, id: 2, windowSec: 300 };
+    const alvo = "vitima@example.com";
+
+    const veredito: boolean[] = [];
+    for (let i = 0; i < 3; i++) {
+      comIp(`198.51.100.${i}`); // IP diferente a cada tentativa: o ataque distribuído
+      veredito.push(await authRateLimited("teste_id", alvo, limites));
+    }
+
+    // Se só houvesse contagem por IP, os três passariam.
+    expect(veredito).toEqual([false, false, true]);
+  });
+
+  it("conta identificadores diferentes em baldes separados", async () => {
+    const { authRateLimited } = await import("./rate-limit");
+    comIp("203.0.113.20");
+    const limites = { ip: 100, id: 1, windowSec: 300 };
+
+    expect(await authRateLimited("teste_sep", "a@example.com", limites)).toBe(false);
+    expect(await authRateLimited("teste_sep", "b@example.com", limites)).toBe(false);
+    expect(await authRateLimited("teste_sep", "a@example.com", limites)).toBe(true);
+  });
+
+  it("não põe o e-mail em claro na chave do contador", async () => {
+    const rl = await import("@/lib/ai/dispatcher/rate-limit");
+    const spy = vi.spyOn(rl, "checkRateLimit");
+    vi.resetModules();
+    const { authRateLimited } = await import("./rate-limit");
+    comIp("203.0.113.30");
+
+    await authRateLimited("teste_pii", "cliente@example.com", { ip: 10, id: 10, windowSec: 300 });
+
+    const chaves = spy.mock.calls.map((c) => c[0]).join(" ");
+    expect(chaves).not.toContain("cliente@example.com");
+    expect(chaves).not.toContain("203.0.113.30");
+  });
+});

--- a/lib/auth/rate-limit.ts
+++ b/lib/auth/rate-limit.ts
@@ -1,0 +1,80 @@
+/**
+ * Rate limit da superfície de autenticação (issue #64).
+ *
+ * O `checkRateLimit` já existia e era usado em dois pontos (webhook de captação
+ * e dispatcher de IA); login, signup, recuperação de senha e aceite de convite
+ * ficaram sem nenhum limite — força bruta de senha e enumeração de token saíam
+ * de graça. Aqui só se aplica o que já existe.
+ *
+ * Duas contagens por tentativa, quando há identificador:
+ *  - por IP: barra o atacante que varre muitas contas de um lugar só;
+ *  - por identificador (hash do e-mail, token): barra o ataque distribuído
+ *    contra UMA conta, que a contagem por IP não vê.
+ *
+ * O identificador entra SEMPRE hasheado — chave de Redis é lugar de dado
+ * opaco, não de e-mail de cliente.
+ *
+ * Janela FIXA (é o que `checkRateLimit` implementa: `INCR` + `EXPIRE`), então
+ * uma rajada na virada da janela passa em dobro. É limite de abuso, não de
+ * precisão — e sem Upstash configurado o contador cai para memória do processo,
+ * o que degrada em instalação de nó único mas não deixa a porta escancarada.
+ */
+import { createHash } from "node:crypto";
+import { headers } from "next/headers";
+
+import { checkRateLimit } from "@/lib/ai/dispatcher/rate-limit";
+
+export interface AuthRateLimits {
+  /** Tentativas por IP na janela. */
+  ip: number;
+  /** Tentativas por identificador na janela (omita para não contar por ele). */
+  id?: number;
+  windowSec: number;
+}
+
+function opaque(value: string): string {
+  return createHash("sha256").update(value.trim().toLowerCase()).digest("hex").slice(0, 32);
+}
+
+/**
+ * `true` = barre a tentativa.
+ *
+ * @param action rótulo do bucket (`login`, `signup`, `reset`, `invite_accept`)
+ * @param identifier e-mail ou token da tentativa; hasheado antes de virar chave
+ */
+export async function authRateLimited(
+  action: string,
+  identifier: string | null,
+  limits: AuthRateLimits,
+): Promise<boolean> {
+  const hdrs = await headers();
+  const ip = hdrs.get("x-forwarded-for")?.split(",")[0]?.trim() || "sem-ip";
+
+  const byIp = await checkRateLimit(`auth:${action}:ip:${opaque(ip)}`, limits.ip, limits.windowSec);
+  if (!byIp.allowed) return true;
+
+  if (identifier && limits.id !== undefined) {
+    const byId = await checkRateLimit(
+      `auth:${action}:id:${opaque(identifier)}`,
+      limits.id,
+      limits.windowSec,
+    );
+    if (!byId.allowed) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Limites por superfície. Números escolhidos para não estorvar uso humano
+ * normal e ainda assim tirar o custo-zero do ataque:
+ *  - login: quem erra a senha 5 vezes na mesma conta em 5 min quase sempre é
+ *    script; o teto por IP é mais folgado por causa de NAT corporativo.
+ *  - signup e convite: fluxos raros por pessoa, teto baixo.
+ */
+export const AUTH_LIMITS = {
+  login: { ip: 30, id: 5, windowSec: 300 },
+  signup: { ip: 5, windowSec: 3600 },
+  reset: { ip: 10, id: 3, windowSec: 3600 },
+  invite_accept: { ip: 20, windowSec: 3600 },
+} as const satisfies Record<string, AuthRateLimits>;

--- a/lib/auth/rate-limit.ts
+++ b/lib/auth/rate-limit.ts
@@ -22,7 +22,7 @@
 import { createHash } from "node:crypto";
 import { headers } from "next/headers";
 
-import { checkRateLimit } from "@/lib/ai/dispatcher/rate-limit";
+import { checkRateLimit, peekRateLimit } from "@/lib/ai/dispatcher/rate-limit";
 
 export interface AuthRateLimits {
   /** Tentativas por IP na janela. */
@@ -73,8 +73,31 @@ export async function authRateLimited(
  *  - signup e convite: fluxos raros por pessoa, teto baixo.
  */
 export const AUTH_LIMITS = {
-  login: { ip: 30, id: 5, windowSec: 300 },
-  signup: { ip: 5, windowSec: 3600 },
-  reset: { ip: 10, id: 3, windowSec: 3600 },
-  invite_accept: { ip: 20, windowSec: 3600 },
+  login: { ip: 60, id: 5, windowSec: 300 },
+  signup: { ip: 20, windowSec: 3600 },
+  reset: { ip: 30, id: 3, windowSec: 3600 },
+  invite_accept: { ip: 60, windowSec: 3600 },
 } as const satisfies Record<string, AuthRateLimits>;
+
+/**
+ * Bloqueio por FALHA, para o login.
+ *
+ * `authRateLimited` conta toda tentativa — certo para IP, errado para conta:
+ * quem digita a senha certa não pode gastar o próprio orçamento de bloqueio.
+ * Aqui a consulta vem antes do provedor (só assim o ataque é barrado *antes*
+ * de acontecer) e o incremento vem depois, apenas quando a senha errou.
+ *
+ * Efeito: N senhas erradas trancam a conta pela janela, inclusive contra quem
+ * distribui as tentativas por muitos IPs. Acertar na 3ª não custa nada.
+ */
+export async function contaBloqueadaPorFalhas(email: string, limits: AuthRateLimits): Promise<boolean> {
+  if (limits.id === undefined) return false;
+  const atual = await peekRateLimit(`auth:login_fail:id:${opaque(email)}`, limits.windowSec);
+  return atual >= limits.id;
+}
+
+/** Registra uma senha errada no contador da conta. */
+export async function registrarFalhaDeLogin(email: string, limits: AuthRateLimits): Promise<void> {
+  if (limits.id === undefined) return;
+  await checkRateLimit(`auth:login_fail:id:${opaque(email)}`, limits.id, limits.windowSec);
+}

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/rafaelmelgaco/DeskcommCRM/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/rafaelmelgaco/DeskcommCRM/node_modules

--- a/tests/unit/agents-md-versoes.test.ts
+++ b/tests/unit/agents-md-versoes.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Issue #66 — o `AGENTS.md` declara versões de biblioteca à mão, e à mão elas
+ * desatualizam. Já aconteceu: o arquivo nasceu dizendo "Zod 3" num repo em
+ * zod 4, numa seção rotulada CONFIRMADO. Um agente lendo aquilo escreveria
+ * idioma da major errada.
+ *
+ * A régua respeita a PRECISÃO que o doc escolheu: se ele diz "Zod 4", basta a
+ * major bater; se diz "Playwright 1.62", a minor entra na conta. Assim o teste
+ * não vira ruído a cada bump de patch, e ainda assim pega o que enganaria
+ * alguém — que foi exatamente um erro de minor.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+
+/** Como o nome aparece no AGENTS.md → nome do pacote no package.json. */
+const BIBLIOTECAS: Array<{ rotulo: string; pacote: string }> = [
+  { rotulo: "Next\\.js", pacote: "next" },
+  { rotulo: "React", pacote: "react" },
+  { rotulo: "TypeScript", pacote: "typescript" },
+  { rotulo: "Tailwind", pacote: "tailwindcss" },
+  { rotulo: "Zod", pacote: "zod" },
+  { rotulo: "Vitest", pacote: "vitest" },
+  { rotulo: "Playwright", pacote: "@playwright/test" },
+  { rotulo: "Sentry", pacote: "@sentry/nextjs" },
+];
+
+function versaoInstalada(pkg: Record<string, Record<string, string>>, nome: string): string {
+  const bruto = pkg.dependencies?.[nome] ?? pkg.devDependencies?.[nome];
+  if (!bruto) throw new Error(`${nome} não está no package.json`);
+  return bruto.replace(/^[\^~>=<\s]+/, "");
+}
+
+describe("AGENTS.md × package.json", () => {
+  const agents = readFileSync(join(root, "AGENTS.md"), "utf8");
+  const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as Record<
+    string,
+    Record<string, string>
+  >;
+
+  for (const { rotulo, pacote } of BIBLIOTECAS) {
+    it(`declara a versão certa de ${pacote}`, () => {
+      const achado = agents.match(new RegExp(`${rotulo}\\s+(\\d+(?:\\.\\d+)*)`));
+      expect(achado, `AGENTS.md não declara a versão de ${pacote}`).toBeTruthy();
+
+      const declarada = achado![1]!;
+      const instalada = versaoInstalada(pkg, pacote);
+
+      // Prefixo, não igualdade: "16.2" casa com "16.2.11", mas "1.61" não casa
+      // com "1.62.0". A precisão de quem escreveu o doc é que manda.
+      expect(
+        instalada === declarada || instalada.startsWith(`${declarada}.`),
+        `AGENTS.md diz ${pacote} ${declarada}, package.json tem ${instalada}`,
+      ).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
Closes #64. Closes #66.

## O buraco

`checkRateLimit` existia e era usado em **dois** pontos (webhook de captação e dispatcher de IA). A superfície de autenticação inteira estava descoberta: força bruta de senha e enumeração de token de convite saíam de graça.

Detalhe que diz muito: as três telas (`LoginForm`, `SignupForm`, `ForgotPasswordForm`) **já renderizavam** a mensagem `rate_limited`, e `SignInResult` já tinha o valor no tipo. Alguém previu, a UI foi escrita, e o servidor nunca chamou o limitador.

## O que mudou

`lib/auth/rate-limit.ts` conta **duas coisas** por tentativa: por IP e, quando há identificador, por ele também. Uma sozinha não basta — a contagem por IP não enxerga o ataque distribuído contra uma única conta, e a por conta não enxerga a varredura de muitas contas do mesmo lugar. O identificador entra hasheado: chave de contador não é lugar de e-mail de cliente.

Aplicado em `signInWithPassword`, `signUp`, `requestPasswordReset` e na **página** de aceite de convite — o gargalo de enumeração é o GET público que testa o token, não o aceite em si.

`auth.login_rate_limited` entrou no vocabulário de audit. A coluna não tem CHECK (vocabulário aberto), então não há migration.

## Provas

Cada uma verificada vermelha quando sabotada:

| Teste | O que garante |
|---|---|
| `lib/auth/rate-limit.test.ts` | teto por IP; teto por conta **com o IP mudando a cada tentativa**; baldes separados; chave sem PII em claro |
| `app/actions/auth/signInWithPassword.test.ts` | a 6ª tentativa não chega ao provedor — prova a **fiação**, não só o helper |
| `tests/unit/agents-md-versoes.test.ts` (#66) | amarra o `AGENTS.md` ao `package.json` |

O teste do #66 usa uma régua que respeita a precisão do doc: `16.2` casa com `16.2.11`, mas `1.61` não casa com `1.62.0`. Nasceu do erro real — o arquivo nasceu dizendo "Zod 3" num repo em zod 4.

## Ressalva declarada

A janela é **fixa** (`INCR`+`EXPIRE`), então uma rajada na virada passa em dobro; e sem Upstash o contador cai para a memória do processo. É limite de abuso, não de precisão — e continua sendo melhor que o zero de hoje. Lockout por conta é decisão de produto separada e não entra aqui.