### PR TITLE
fix(kit): healthcheck denuncia o agente de atualizacao mudo

### DIFF
--- a/hostgator-setup-kit/healthcheck.sh
+++ b/hostgator-setup-kit/healthcheck.sh
@@ -17,3 +17,29 @@ if [ -n "$out" ]; then
 else
   c_ylw "⚠ app não respondeu. Logs: docker compose -f $COMPOSE logs --tail=50 app"
 fi
+
+step "Atualização pela tela (agente do host)"
+# Achado numa VPS real: o cron do agente é instalado no TOPO do update.sh, de
+# propósito (para sobreviver a uma saída antecipada) — e isso cria uma janela em
+# que o agente existe e o schema do banco ainda não. Ele então bate 500 a cada 5
+# minutos, com o erro indo só para o .update-agent.log e o `>/dev/null` do cron.
+# Para o dono, o sintoma é "o botão nunca apareceu": nenhuma pista, nenhum alarme.
+# Este bloco é a pista.
+if crontab -l 2>/dev/null | grep -q 'hostgator-setup-kit/agent.sh'; then
+  c_grn "✓ agente instalado no cron (a cada 5 minutos)"
+  log="$PROJECT_DIR/.update-agent.log"
+  # Recência pela MTIME do arquivo, não parseando a data de dentro: `date -d` é
+  # sintaxe GNU e falha calado no BSD/macOS, devolvendo "sem falhas" para um
+  # agente que está falhando agora. `find -mmin` é portátil.
+  if [ -s "$log" ] && [ -n "$(find "$log" -mmin -120 2>/dev/null)" ]; then
+    c_ylw "⚠ o agente falhou recentemente ao falar com o app:"
+    c_ylw "  $(tail -2 "$log" | head -1)"
+    c_ylw "  Se o botão de atualizar não aparece na tela, é por isto."
+    c_ylw "  Quase sempre resolve rodando: bash hostgator-setup-kit/update.sh"
+  else
+    c_grn "✓ sem falhas recentes do agente"
+  fi
+else
+  c_ylw "⚠ o agente NÃO está no cron — o botão de atualizar não vai aparecer na tela."
+  c_ylw "  Ative rodando: bash hostgator-setup-kit/update.sh"
+fi


### PR DESCRIPTION
Achado **numa VPS real**, não em teste: o cron do agente estava instalado e batendo **500 a cada 5 minutos** havia pelo menos 15 minutos, porque o banco ainda não tinha o schema da feature. O cron manda tudo para `/dev/null` e o erro só vive no `.update-agent.log`. Para o dono, o sintoma é **"o botão de atualizar nunca apareceu"** — sem nenhuma pista.

É consequência direta de uma decisão deliberada: o `setup_update_agent_cron` roda no **topo** do `update.sh` para sobreviver a uma saída antecipada, e isso cria uma janela em que o agente existe e o schema não.

O `healthcheck.sh` passa a responder três perguntas: o agente está no cron? ele falhou recentemente? e o que fazer a respeito.

**Detalhe que o próprio teste pegou:** a primeira versão media a recência parseando a data de dentro do log com `date -d`, que é sintaxe GNU — funcionaria na VPS e devolveria "sem falhas" no macOS para um agente falhando naquele instante. Trocado por `find -mmin`, portátil. Mesma família do bug de locale que matava o agente calado.

Provado nas quatro saídas: sem cron (avisa) · cron + erro recente (avisa e explica) · cron + erro de 3h (não avisa) · cron sem log (não avisa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ng41aCYobTn37KrN2V7BZf