### PR TITLE
fix(agents): toggle de split de mensagens some da tela por drift de coluna

### DIFF
--- a/app/api/v1/ai/agents/[id]/duplicate/route.ts
+++ b/app/api/v1/ai/agents/[id]/duplicate/route.ts
@@ -22,7 +22,7 @@ const UUID_RX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 const AGENT_COLUMNS =
   "id, organization_id, name, description, model, system_prompt, is_active, is_default, kind, priority, published_version_id, archived_at, config, guardrails, active_kb_version_id, created_at, updated_at";
 const VERSION_COLUMNS =
-  "id, organization_id, agent_id, version_number, system_prompt, provider, model, credential_id, tool_ids, trigger_config, channel_session_id, max_steps, token_budget, cost_budget_cents, history_message_window, history_token_window, handoff_keywords, handoff_tool_enabled, cases_enabled, followup, status, published_at, superseded_at, created_at, created_by";
+  "id, organization_id, agent_id, version_number, system_prompt, provider, model, credential_id, tool_ids, trigger_config, channel_session_id, max_steps, token_budget, cost_budget_cents, history_message_window, history_token_window, handoff_keywords, handoff_tool_enabled, cases_enabled, split_messages, split_max_chars, followup, status, published_at, superseded_at, created_at, created_by";
 
 type Ctx = { params: Promise<{ id: string }> };
 
@@ -115,6 +115,8 @@ export async function POST(_req: NextRequest, ctx: Ctx): Promise<Response> {
       handoff_keywords: srcVersion.handoff_keywords,
       handoff_tool_enabled: srcVersion.handoff_tool_enabled,
       cases_enabled: srcVersion.cases_enabled,
+      split_messages: srcVersion.split_messages,
+      split_max_chars: srcVersion.split_max_chars,
       followup: srcVersion.followup,
       status: "draft",
       created_by: authUser.id,

--- a/app/api/v1/ai/agents/[id]/versions/[vid]/route.ts
+++ b/app/api/v1/ai/agents/[id]/versions/[vid]/route.ts
@@ -17,7 +17,7 @@ import { versionPatchSchema } from "@/lib/ai/agents/validation";
 export const dynamic = "force-dynamic";
 
 const VERSION_COLUMNS =
-  "id, organization_id, agent_id, version_number, system_prompt, provider, model, credential_id, tool_ids, trigger_config, channel_session_id, max_steps, token_budget, cost_budget_cents, history_message_window, history_token_window, handoff_keywords, handoff_tool_enabled, cases_enabled, followup, status, published_at, superseded_at, created_at, created_by";
+  "id, organization_id, agent_id, version_number, system_prompt, provider, model, credential_id, tool_ids, trigger_config, channel_session_id, max_steps, token_budget, cost_budget_cents, history_message_window, history_token_window, handoff_keywords, handoff_tool_enabled, cases_enabled, split_messages, split_max_chars, followup, status, published_at, superseded_at, created_at, created_by";
 
 const UUID_RX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -113,6 +113,8 @@ export async function PATCH(req: NextRequest, ctx: Ctx): Promise<Response> {
   if (patch.handoff_tool_enabled !== undefined)
     update.handoff_tool_enabled = patch.handoff_tool_enabled;
   if (patch.cases_enabled !== undefined) update.cases_enabled = patch.cases_enabled;
+  if (patch.split_messages !== undefined) update.split_messages = patch.split_messages;
+  if (patch.split_max_chars !== undefined) update.split_max_chars = patch.split_max_chars;
   if (patch.followup !== undefined) update.followup = patch.followup;
 
   const { data, error } = await admin

--- a/app/api/v1/ai/agents/[id]/versions/route.ts
+++ b/app/api/v1/ai/agents/[id]/versions/route.ts
@@ -19,7 +19,7 @@ import { versionCreateSchema } from "@/lib/ai/agents/validation";
 export const dynamic = "force-dynamic";
 
 const VERSION_COLUMNS =
-  "id, organization_id, agent_id, version_number, system_prompt, provider, model, credential_id, tool_ids, trigger_config, channel_session_id, max_steps, token_budget, cost_budget_cents, history_message_window, history_token_window, handoff_keywords, handoff_tool_enabled, cases_enabled, followup, status, published_at, superseded_at, created_at, created_by";
+  "id, organization_id, agent_id, version_number, system_prompt, provider, model, credential_id, tool_ids, trigger_config, channel_session_id, max_steps, token_budget, cost_budget_cents, history_message_window, history_token_window, handoff_keywords, handoff_tool_enabled, cases_enabled, split_messages, split_max_chars, followup, status, published_at, superseded_at, created_at, created_by";
 
 const UUID_RX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -127,6 +127,8 @@ export async function POST(req: NextRequest, ctx: Ctx): Promise<Response> {
         handoff_keywords: v.handoff_keywords,
         handoff_tool_enabled: v.handoff_tool_enabled,
         cases_enabled: v.cases_enabled,
+        split_messages: v.split_messages,
+        split_max_chars: v.split_max_chars,
         followup: v.followup,
         status: "draft",
         created_by: authUser.id,

--- a/app/api/v1/ai/agents/route.ts
+++ b/app/api/v1/ai/agents/route.ts
@@ -27,7 +27,7 @@ const AGENT_COLUMNS =
   "id, organization_id, name, description, model, system_prompt, is_active, is_default, kind, priority, published_version_id, archived_at, config, guardrails, active_kb_version_id, created_at, updated_at";
 
 const VERSION_COLUMNS =
-  "id, organization_id, agent_id, version_number, system_prompt, provider, model, credential_id, tool_ids, trigger_config, channel_session_id, max_steps, token_budget, cost_budget_cents, history_message_window, history_token_window, handoff_keywords, handoff_tool_enabled, cases_enabled, followup, status, published_at, superseded_at, created_at, created_by";
+  "id, organization_id, agent_id, version_number, system_prompt, provider, model, credential_id, tool_ids, trigger_config, channel_session_id, max_steps, token_budget, cost_budget_cents, history_message_window, history_token_window, handoff_keywords, handoff_tool_enabled, cases_enabled, split_messages, split_max_chars, followup, status, published_at, superseded_at, created_at, created_by";
 
 // ---------------------------------------------------------------------------
 // GET — list
@@ -136,6 +136,8 @@ export async function POST(req: NextRequest): Promise<Response> {
         handoff_keywords: v.handoff_keywords,
         handoff_tool_enabled: v.handoff_tool_enabled,
         cases_enabled: v.cases_enabled,
+        split_messages: v.split_messages,
+        split_max_chars: v.split_max_chars,
         followup: v.followup,
         status: "draft",
         created_by: authUser.id,

--- a/app/app/ai/agents/[id]/_actions.ts
+++ b/app/app/ai/agents/[id]/_actions.ts
@@ -35,7 +35,7 @@ import { VALID_TOOL_IDS } from "@/lib/mcp/tools";
 const UUID_RX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const VERSION_COLUMNS =
-  "id, organization_id, agent_id, version_number, system_prompt, provider, model, credential_id, tool_ids, trigger_config, channel_session_id, max_steps, token_budget, cost_budget_cents, history_message_window, history_token_window, handoff_keywords, handoff_tool_enabled, cases_enabled, followup, status, published_at, superseded_at, created_at, created_by";
+  "id, organization_id, agent_id, version_number, system_prompt, provider, model, credential_id, tool_ids, trigger_config, channel_session_id, max_steps, token_budget, cost_budget_cents, history_message_window, history_token_window, handoff_keywords, handoff_tool_enabled, cases_enabled, split_messages, split_max_chars, followup, status, published_at, superseded_at, created_at, created_by";
 
 type ActionResult<T = void> =
   | { ok: true; data?: T }
@@ -170,6 +170,8 @@ export async function saveAgentDraftAction(
         handoff_keywords: v.handoff_keywords,
         handoff_tool_enabled: v.handoff_tool_enabled,
         cases_enabled: v.cases_enabled,
+        split_messages: v.split_messages,
+        split_max_chars: v.split_max_chars,
         followup: v.followup,
         status: "draft",
         created_by: authUser.id,
@@ -351,6 +353,8 @@ export async function revertToVersionAction(
     handoff_keywords: string[];
     handoff_tool_enabled: boolean;
     cases_enabled: boolean;
+    split_messages: boolean;
+    split_max_chars: number;
   };
   const src = source as unknown as SourceRow;
 
@@ -388,6 +392,8 @@ export async function revertToVersionAction(
         handoff_keywords: src.handoff_keywords,
         handoff_tool_enabled: src.handoff_tool_enabled,
         cases_enabled: src.cases_enabled,
+        split_messages: src.split_messages,
+        split_max_chars: src.split_max_chars,
         status: "draft",
         created_by: authUser.id,
       })
@@ -531,6 +537,8 @@ export async function createMcpAgentAction(
     handoff_keywords: v.handoff_keywords,
     handoff_tool_enabled: v.handoff_tool_enabled,
     cases_enabled: v.cases_enabled,
+    split_messages: v.split_messages,
+    split_max_chars: v.split_max_chars,
     status: "draft",
     created_by: authUser.id,
   });

--- a/app/app/ai/agents/[id]/_components/AgentForm.tsx
+++ b/app/app/ai/agents/[id]/_components/AgentForm.tsx
@@ -99,6 +99,8 @@ interface FormState {
   handoff_keywords: string[];
   handoff_tool_enabled: boolean;
   cases_enabled: boolean;
+  split_messages: boolean;
+  split_max_chars: number;
   followup: FollowupValue;
 }
 
@@ -150,6 +152,8 @@ function buildState(args: {
     ],
     handoff_tool_enabled: version?.handoff_tool_enabled ?? true,
     cases_enabled: version?.cases_enabled ?? false,
+    split_messages: version?.split_messages ?? false,
+    split_max_chars: version?.split_max_chars ?? 600,
     followup: version?.followup ?? DEFAULT_FOLLOWUP,
   };
 }
@@ -171,6 +175,8 @@ function toVersionPayload(s: FormState) {
     handoff_keywords: s.handoff_keywords,
     handoff_tool_enabled: s.handoff_tool_enabled,
     cases_enabled: s.cases_enabled,
+    split_messages: s.split_messages,
+    split_max_chars: s.split_max_chars,
     followup: s.followup,
   };
 }
@@ -632,6 +638,46 @@ export function AgentForm(props: Props) {
             />
             {validation.system_prompt ? (
               <p className="text-xs text-destructive">{validation.system_prompt}</p>
+            ) : null}
+          </Card>
+
+          {/* Estilo de resposta (split de mensagens — Onda 4) */}
+          <Card className="space-y-3 p-4">
+            <h3 className="text-sm font-medium">Estilo de resposta</h3>
+            <div className="flex items-center gap-2">
+              <Switch
+                id="split_messages"
+                checked={form.split_messages}
+                onCheckedChange={(v) => patch({ split_messages: v })}
+                disabled={disabled}
+              />
+              <Label htmlFor="split_messages">
+                Responder em várias mensagens curtas (como uma pessoa digita)
+              </Label>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Em vez de um bloco único, a resposta sai em bolhas separadas, espaçadas pelo
+              mesmo ritmo anti-banimento do envio. O agente também é instruído a escrever
+              em parágrafos curtos.
+            </p>
+            {form.split_messages ? (
+              <div className="space-y-1">
+                <Label htmlFor="split_max_chars">Tamanho máximo por bolha (80–4000)</Label>
+                <Input
+                  id="split_max_chars"
+                  type="number"
+                  min={80}
+                  max={4000}
+                  step={20}
+                  value={form.split_max_chars}
+                  onChange={(e) => patch({ split_max_chars: Number(e.target.value) })}
+                  disabled={disabled}
+                  aria-invalid={!!validation.split_max_chars}
+                />
+                {validation.split_max_chars ? (
+                  <p className="text-xs text-destructive">{validation.split_max_chars}</p>
+                ) : null}
+              </div>
             ) : null}
           </Card>
 

--- a/app/app/ai/agents/[id]/_components/VersionDiff.tsx
+++ b/app/app/ai/agents/[id]/_components/VersionDiff.tsx
@@ -87,6 +87,8 @@ function buildFieldChanges(a: AgentVersionRow, b: AgentVersionRow): FieldChange[
     ["history_token_window", "history_token_window"],
     ["handoff_tool_enabled", "handoff_tool_enabled"],
     ["cases_enabled", "cases_enabled"],
+    ["split_messages", "split_messages"],
+    ["split_max_chars", "split_max_chars"],
   ];
   return fields
     .filter(([k]) => a[k] !== b[k])

--- a/app/app/ai/agents/[id]/page.tsx
+++ b/app/app/ai/agents/[id]/page.tsx
@@ -17,7 +17,7 @@ const AGENT_COLUMNS =
   "id, organization_id, name, description, model, system_prompt, is_active, is_default, kind, priority, published_version_id, archived_at, config, guardrails, active_kb_version_id, created_at, updated_at";
 
 const VERSION_COLUMNS =
-  "id, organization_id, agent_id, version_number, system_prompt, provider, model, credential_id, tool_ids, trigger_config, channel_session_id, max_steps, token_budget, cost_budget_cents, history_message_window, history_token_window, handoff_keywords, handoff_tool_enabled, cases_enabled, followup, status, published_at, superseded_at, created_at, created_by";
+  "id, organization_id, agent_id, version_number, system_prompt, provider, model, credential_id, tool_ids, trigger_config, channel_session_id, max_steps, token_budget, cost_budget_cents, history_message_window, history_token_window, handoff_keywords, handoff_tool_enabled, cases_enabled, split_messages, split_max_chars, followup, status, published_at, superseded_at, created_at, created_by";
 
 const CREDENTIAL_COLUMNS =
   "id, organization_id, provider, label, api_key_last4, validated_at, validation_error, models_available, is_active, created_by, created_at, updated_at";

--- a/hooks/ai/useAgentVersions.ts
+++ b/hooks/ai/useAgentVersions.ts
@@ -24,6 +24,8 @@ export interface AgentVersionRow {
   handoff_keywords: string[];
   handoff_tool_enabled: boolean;
   cases_enabled: boolean;
+  split_messages: boolean;
+  split_max_chars: number;
   followup: { enabled: boolean; flow_pointer_ids: string[] };
   status: "draft" | "published" | "superseded" | "archived";
   published_at: string | null;

--- a/lib/ai/agents/validation.ts
+++ b/lib/ai/agents/validation.ts
@@ -84,6 +84,10 @@ const versionShapeSchema = z
       .default(["falar com humano", "atendente", "pessoa real"]),
     handoff_tool_enabled: z.boolean().default(true),
     cases_enabled: z.boolean().default(false),
+    // Onda 4 — quebra a resposta em bolhas curtas (splitIntoBubbles) espaçadas
+    // pelo pacing anti-ban. Defaults espelham a migration 0059.
+    split_messages: z.boolean().default(false),
+    split_max_chars: z.number().int().min(80).max(4000).default(600),
     followup: followupConfigSchema,
   })
   .strict();

--- a/tests/sonda-split-na-tela.ts
+++ b/tests/sonda-split-na-tela.ts
@@ -1,0 +1,86 @@
+/**
+ * PROVA DE TELA do toggle de split de mensagens na configuração do agente.
+ *
+ * O defeito era mudo: a coluna existia no banco e o runtime a lia, mas a tela
+ * não tinha o campo — e mesmo se tivesse, o Zod `.strict()` rejeitaria o save.
+ * A prova precisa fechar o ciclo do usuário: LIGA na tela → SALVA → RECARREGA →
+ * continua ligado (é aqui que o bug de drift de coluna se manifesta, o campo
+ * "desmarcando sozinho") → e o valor está na linha da draft no banco.
+ *
+ * Roda com: E2E_PORT=3000 npx tsx tests/sonda-split-na-tela.ts
+ */
+import * as fs from "node:fs";
+
+import { chromium } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+
+import { BASE, login } from "./qa-helpers";
+
+const env = Object.fromEntries(
+  fs.readFileSync(".env.local", "utf8").split("\n")
+    .filter((l) => l.includes("=") && !l.trimStart().startsWith("#"))
+    .map((l) => [l.slice(0, l.indexOf("=")), l.slice(l.indexOf("=") + 1).replace(/^"|"$/g, "")]),
+);
+const admin = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!, {
+  auth: { persistSession: false },
+});
+
+const ORG = "6e567068-fd1c-4f94-ae1f-40e0334be190";
+const AGENT = "69d04579-169d-40ac-bd43-ca5869598ace"; // Lia — AgendaPlus
+const MAX_CHARS = 240;
+
+async function main(): Promise<void> {
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+  await login(page, "admin");
+
+  await page.goto(`${BASE}/app/ai/agents/${AGENT}`, { waitUntil: "networkidle" });
+
+  const toggle = page.locator("#split_messages");
+  await toggle.waitFor({ state: "visible", timeout: 15_000 });
+  const antes = await toggle.getAttribute("data-state");
+  console.log(`[1] campo existe na tela — estado inicial: ${antes}`);
+  if (antes === "checked") throw new Error("já estava ligado: a prova precisa partir de desligado");
+
+  await toggle.click();
+  const campoChars = page.locator("#split_max_chars");
+  await campoChars.waitFor({ state: "visible", timeout: 5_000 });
+  await campoChars.fill(String(MAX_CHARS));
+  await page.screenshot({ path: "evidence/split-toggle-ligado.png", fullPage: false });
+
+  await page.getByRole("button", { name: /Salvar rascunho/i }).click();
+  await page.getByText(/Rascunho v\d+ salvo/i).waitFor({ timeout: 15_000 });
+  console.log("[2] save aceito pelo servidor (toast de rascunho salvo)");
+
+  await page.reload({ waitUntil: "networkidle" });
+  const depois = await page.locator("#split_messages").getAttribute("data-state");
+  const charsDepois = await page.locator("#split_max_chars").inputValue();
+  console.log(`[3] após reload — toggle: ${depois}, max_chars: ${charsDepois}`);
+  if (depois !== "checked") throw new Error("REGREDIU: o toggle se desmarcou depois do reload");
+  if (charsDepois !== String(MAX_CHARS)) {
+    throw new Error(`REGREDIU: max_chars voltou para ${charsDepois}`);
+  }
+  await page.screenshot({ path: "evidence/split-persistiu-apos-reload.png", fullPage: false });
+
+  const { data: draft } = await admin
+    .from("ai_agent_versions")
+    .select("version_number, status, split_messages, split_max_chars")
+    .eq("organization_id", ORG)
+    .eq("agent_id", AGENT)
+    .eq("status", "draft")
+    .order("version_number", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  console.log("[4] linha da draft no banco:", draft);
+  if (draft?.split_messages !== true || draft?.split_max_chars !== MAX_CHARS) {
+    throw new Error("banco não recebeu os valores da tela");
+  }
+
+  console.log("\nPASS — tela grava, servidor persiste, reload devolve.");
+  await browser.close();
+}
+
+main().catch((e) => {
+  console.error("FAIL:", e.message);
+  process.exit(1);
+});

--- a/tests/unit/agent-version-columns-drift.test.ts
+++ b/tests/unit/agent-version-columns-drift.test.ts
@@ -14,6 +14,8 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { versionCreateSchema } from "@/lib/ai/agents/validation";
+
 const ROOT = process.cwd();
 
 /** Todo arquivo que carrega uma cópia da lista de colunas de versão. */
@@ -60,6 +62,42 @@ describe("VERSION_COLUMNS de ai_agent_versions", () => {
       const columns = versionColumnsOf(file);
       expect(columns).toContain("handoff_tool_enabled");
       expect(columns).toContain("cases_enabled");
+      expect(columns).toContain("split_messages");
+      expect(columns).toContain("split_max_chars");
     }
+  });
+});
+
+/**
+ * O SELECT idêntico não basta: o payload do form passa por `versionCreateSchema`,
+ * que é `.strict()`. Coluna ausente do schema faz o parse REJEITAR o save inteiro
+ * (ou, se fosse não-strict, silenciosamente descartar o campo). Foi o segundo elo
+ * quebrado do split de mensagens: a coluna existia no banco e no runtime, mas o
+ * schema não a conhecia, então a tela nunca conseguiria gravá-la.
+ */
+describe("versionCreateSchema aceita as flags por-agente que a tela edita", () => {
+  const base = {
+    system_prompt: "Você é um atendente de testes.",
+    provider: "anthropic" as const,
+    model: "claude-sonnet-4-6",
+    credential_id: "11111111-1111-4111-8111-111111111111",
+    channel_session_id: "22222222-2222-4222-8222-222222222222",
+  };
+
+  it("preserva split_messages/split_max_chars no parse", () => {
+    const parsed = versionCreateSchema.safeParse({
+      ...base,
+      split_messages: true,
+      split_max_chars: 240,
+    });
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data.split_messages).toBe(true);
+    expect(parsed.success && parsed.data.split_max_chars).toBe(240);
+  });
+
+  it("cai nos defaults da migration 0059 quando omitido", () => {
+    const parsed = versionCreateSchema.safeParse(base);
+    expect(parsed.success && parsed.data.split_messages).toBe(false);
+    expect(parsed.success && parsed.data.split_max_chars).toBe(600);
   });
 });


### PR DESCRIPTION
## O que estava quebrado

O split de mensagens (Onda 4) já estava completo no runtime desde `f60caf7` — `splitIntoBubbles`, `sendInBubbles`, migration `0059` e o apêndice do `baseline.sql`. Mas **não havia caminho algum para gravar `split_messages = true`**: a coluna existia no banco, o runtime a lia, e a tela não tinha o campo.

Dois elos faltavam entre a intenção do usuário e a linha da versão:

1. **`versionCreateSchema` é `.strict()`** e não conhecia `split_messages` / `split_max_chars` — um save com esses campos seria rejeitado inteiro.
2. **`VERSION_COLUMNS`, copiada em 7 arquivos**, não tinha as colunas. É o mesmo defeito que `cases_enabled` teve na Wave 5 e que `agent-version-columns-drift.test.ts` passou a vigiar — a rota `duplicate` estava fora, e o teste a apontou.

## O que mudou

| Camada | Arquivos |
|---|---|
| Schema Zod | `lib/ai/agents/validation.ts` |
| Selects + inserts + PATCH | `_actions.ts`, `page.tsx`, 4 rotas em `app/api/v1/ai/agents/` |
| Tipo do hook + diff de versões | `useAgentVersions.ts`, `VersionDiff.tsx` |
| UI | `AgentForm.tsx` — card **"Estilo de resposta"** |

O card fica no topo da coluna de comportamento, logo abaixo do System prompt e antes de Tools/Gatilhos/Handoff. O campo de tamanho máximo por bolha só aparece com o toggle ligado.

## Prova

`tests/sonda-split-na-tela.ts` dirige a tela como usuário, contra `next build` + `next start`:

```
[1] campo existe na tela — estado inicial: unchecked
[2] save aceito pelo servidor (toast de rascunho salvo)
[3] após reload — toggle: checked, max_chars: 240
[4] linha da draft no banco: { split_messages: true, split_max_chars: 240 }
PASS
```

O passo 3 é o que importa: era ali que o drift de coluna se manifestava, com o campo se desmarcando sozinho depois do refresh.

O teste de drift ganhou o elo que ele não cobria (o schema Zod). Sabotado de propósito, ele vermelha — 2 falhas, restaurado em seguida.

Validado **sobre esta base** (worktree em `origin/main`, não na branch de origem): typecheck limpo, lint 0 erros, 1695 testes unitários em 201 arquivos, `next build` OK.

## Fora de escopo

O cap diário do anti-banimento conta 1 por turno, não 1 por bolha. É decisão consciente já documentada em `split-message.ts` — não mexi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eDYqCWr7Zrs99vLjqGj8r