### PR TITLE
fix(kit): checagem de DNS considera todos os endereços (A e AAAA)

### DIFF
--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -502,8 +502,15 @@ c_grn "✓ .env escrito (permissão 600)"
 # ── 6. Checagem de DNS ──────────────────────────────────────────────────────
 step "Conferindo DNS de ${DOMAIN}"
 public_ip="$(curl -fsS --max-time 8 https://api.ipify.org 2>/dev/null || echo '')"
-resolved="$(getent hosts "$DOMAIN" 2>/dev/null | awk '{print $1}' | head -1 || echo '')"
-if [ -n "$public_ip" ] && [ -n "$resolved" ] && [ "$public_ip" = "$resolved" ]; then
+# Um domínio pode ter A (IPv4) e AAAA (IPv6) ao mesmo tempo, e o resolver não
+# garante ordem entre eles. Comparar só o PRIMEIRO endereço (o antigo `hosts`
+# + `head -1`) dava falso alarme sempre que o AAAA vinha antes do A: o DNS
+# estava correto, o SSL ia ser emitido normalmente, e mesmo assim o instalador
+# dizia que o domínio não apontava pra cá — assustando quem instala bem na hora
+# em que ela mais precisa de confiança. `ahosts` lista TODOS os endereços; basta
+# que UM deles seja o IP do VPS.
+resolved="$(getent ahosts "$DOMAIN" 2>/dev/null | awk '{print $1}' | sort -u | tr '\n' ' ' || echo '')"
+if [ -n "$public_ip" ] && case " $resolved " in *" $public_ip "*) true;; *) false;; esac; then
   c_grn "✓ ${DOMAIN} → ${public_ip} (aponta pra este VPS)"
 else
   c_ylw "⚠ ${DOMAIN} resolve para '${resolved:-nada}' e o IP deste VPS é '${public_ip:-desconhecido}'."


### PR DESCRIPTION
## O problema

A checagem de DNS do `install.sh` usava `getent hosts` + `head -1` e comparava **só o
primeiro** endereço resolvido com o IP público do VPS:

```bash
resolved="$(getent hosts "$DOMAIN" | awk '{print $1}' | head -1)"
if [ "$public_ip" = "$resolved" ]; then
```

Um domínio com **A (IPv4) e AAAA (IPv6) ao mesmo tempo** é comum, e o resolver não garante
ordem entre eles. Quando o AAAA vem primeiro, a comparação falha mesmo com o A-record
perfeitamente correto.

## O impacto

O instalador avisa:

```
⚠ crm.exemplo.com resolve para '2a02:4780:6e:ac81::1' e o IP deste VPS é '76.13.164.216'.
  O SSL (Let's Encrypt) só será emitido quando o A-record apontar pra cá.
```

...numa instalação em que o DNS está certo e o Let's Encrypt emite normalmente. Em modo
interativo isso ainda pede confirmação para continuar — ou seja, **um falso alarme pode
abortar uma instalação boa**, e logo no começo, quando quem instala mais precisa confiar no
que está lendo.

Reproduzido numa VPS Hostinger, cujo hostname do painel tem os dois registros:

```
crm.<srv>.hstgr.cloud → 2a02:4780:6e:ac81::1   (AAAA, vem primeiro)
                      → 76.13.164.216          (A, o IP do VPS)
```

## A correção

`getent ahosts` lista **todos** os endereços; basta que um deles seja o IP do VPS. A
comparação usa a lista com espaços nas bordas (`" $resolved "`) para não casar por prefixo
— `76.13.164.21` não pode dar match em `76.13.164.216`.

## Testes

Cinco casos, todos passando (incluindo o de prefixo parcial), e a suíte
`test-validators.sh` do kit segue verde:

| Caso | Esperado | Resultado |
|---|---|---|
| IPv6 primeiro, IPv4 depois (o bug) | ✓ OK | ✓ |
| DNS aponta pra outro servidor | ⚠ aviso | ✓ |
| Domínio não resolve | ⚠ aviso | ✓ |
| Sem internet (ipify falhou) | ⚠ aviso | ✓ |
| Prefixo parcial `.21` vs `.216` | ⚠ aviso | ✓ |

Comportamento inalterado quando o DNS realmente não aponta pro servidor: segue avisando e
pedindo confirmação.
