### PR TITLE
feat(kit): suporte a VPS que já tem proxy reverso (Traefik)

### DIFF
--- a/.env.hostgator.example
+++ b/.env.hostgator.example
@@ -19,6 +19,20 @@ APP_PULL_POLICY=always
 DOMAIN=crm.seudominio.com.br
 ACME_EMAIL=voce@seudominio.com.br          # e-mail do Let's Encrypt (avisos de cert)
 
+# Quem responde nas portas 80/443:
+#   caddy   → o kit sobe o próprio Caddy (padrão; VPS "cru")
+#   traefik → o VPS JÁ tem um Traefik nessas portas (Hostinger, Coolify,
+#             Dokploy...). O install.sh detecta isso sozinho e preenche aqui.
+# Em modo traefik é preciso subir com o override:
+#   docker compose -f docker-compose.prod.yml -f docker-compose.traefik.yml up -d
+# (os scripts do kit já fazem isso sozinhos ao ler esta variável).
+REVERSE_PROXY=caddy
+# Só lidas quando REVERSE_PROXY=traefik. A rede é "<pasta-do-projeto>_internal";
+# entrypoint e certresolver são os nomes padrão dessas instalações.
+TRAEFIK_DOCKER_NETWORK=crm_internal
+TRAEFIK_ENTRYPOINT=websecure
+TRAEFIK_CERTRESOLVER=letsencrypt
+
 # -----------------------------------------------------------------------------
 # 2) SUPABASE (crie um projeto grátis em supabase.com → Settings → API/Database)
 # -----------------------------------------------------------------------------

--- a/.env.hostgator.example
+++ b/.env.hostgator.example
@@ -26,12 +26,21 @@ ACME_EMAIL=voce@seudominio.com.br          # e-mail do Let's Encrypt (avisos de 
 # Em modo traefik é preciso subir com o override:
 #   docker compose -f docker-compose.prod.yml -f docker-compose.traefik.yml up -d
 # (os scripts do kit já fazem isso sozinhos ao ler esta variável).
-REVERSE_PROXY=caddy
-# Só lidas quando REVERSE_PROXY=traefik. A rede é "<pasta-do-projeto>_internal";
-# entrypoint e certresolver são os nomes padrão dessas instalações.
-TRAEFIK_DOCKER_NETWORK=crm_internal
-TRAEFIK_ENTRYPOINT=websecure
-TRAEFIK_CERTRESOLVER=letsencrypt
+#
+# DEIXE COMENTADO. O install.sh só detecta quando a variável está VAZIA — se você
+# copiar este arquivo com `REVERSE_PROXY=caddy` preenchido, a detecção não roda e a
+# instalação numa VPS com proxy próprio volta a morrer no bind da porta.
+# Descomente apenas para forçar um modo à mão.
+#REVERSE_PROXY=caddy
+
+# Só lidas quando REVERSE_PROXY=traefik, e o install.sh preenche sozinho.
+# TRAEFIK_NETWORK é a rede do Traefik DA HOSPEDAGEM (o app é anexado a ela), não a
+# rede do projeto — o nome varia por painel: `coolify`, `dokploy-network`, `traefik`.
+# O install.sh descobre inspecionando o contêiner do Traefik.
+#TRAEFIK_NETWORK=traefik
+#TRAEFIK_ENTRYPOINT=websecure
+#TRAEFIK_ENTRYPOINT_HTTP=web
+#TRAEFIK_CERTRESOLVER=letsencrypt
 
 # -----------------------------------------------------------------------------
 # 2) SUPABASE (crie um projeto grátis em supabase.com → Settings → API/Database)

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -1,0 +1,91 @@
+# DeskcommCRM — override para VPS que JÁ TEM um proxy reverso Traefik.
+#
+#   docker compose -f docker-compose.prod.yml -f docker-compose.traefik.yml up -d
+#
+# QUANDO USAR
+# -----------
+# O stack padrão sobe um Caddy que publica as portas 80 e 443. Isso é o certo
+# num VPS "cru". Mas várias hospedagens entregam a VPS com um Traefik próprio
+# já ocupando essas portas — Hostinger, Coolify, Dokploy, CapRover e afins. É
+# esse Traefik que dá HTTPS automático a tudo que o painel instala; desligá-lo
+# quebraria as automações da hospedagem, presentes e futuras.
+#
+# Dois processos não podem ouvir a mesma porta, então o `up -d` padrão falha no
+# bind e a instalação morre no meio. Com este override:
+#
+#   1. o serviço `caddy` ganha um profile que nunca é ativado — o compose
+#      simplesmente não o cria (o Traefik da hospedagem faz o papel dele);
+#   2. o serviço `app` ganha labels do Traefik que reproduzem, uma a uma, as
+#      regras do Caddyfile.
+#
+# O comportamento padrão (sem este arquivo) fica EXATAMENTE como antes: quem
+# não passa o `-f docker-compose.traefik.yml` não é afetado por nada aqui.
+#
+# EQUIVALÊNCIA COM O Caddyfile
+# ----------------------------
+# - `reverse_proxy app:3000`  → router `deskcomm` + loadbalancer.server.port
+# - `encode gzip`             → middleware `deskcomm-compress`
+# - `respond @waha_global 403`→ router `deskcomm-waha-block` (ver abaixo)
+#
+# Os timeouts longos que o Caddyfile dá a /api/internal/agents/run* NÃO precisam
+# de equivalente: no Traefik o writeTimeout e o responseHeaderTimeout já são
+# ilimitados por padrão, então uma resposta de 5 minutos passa inteira.
+#
+# PRÉ-REQUISITOS NO TRAEFIK DA HOSPEDAGEM
+# ---------------------------------------
+# Espera-se um entrypoint `websecure` (443) e um certresolver `letsencrypt` —
+# os nomes padrão dessas instalações. Se a sua usa outros nomes, ajuste
+# TRAEFIK_ENTRYPOINT e TRAEFIK_CERTRESOLVER no .env.
+#
+# O Traefik precisa enxergar a rede deste projeto. O nome dela é
+# "<projeto>_internal", e <projeto> é o nome da pasta onde o compose roda — ou
+# seja, VARIA por instalação. O install.sh grava o valor certo em
+# TRAEFIK_DOCKER_NETWORK no .env; o default abaixo cobre o caso da pasta "crm".
+
+services:
+  app:
+    labels:
+      traefik.enable: "true"
+      traefik.docker.network: "${TRAEFIK_DOCKER_NETWORK:-crm_internal}"
+
+      # Rota principal — equivale ao `reverse_proxy app:3000` do Caddyfile.
+      traefik.http.routers.deskcomm.rule: "Host(`${DOMAIN}`)"
+      traefik.http.routers.deskcomm.entrypoints: "${TRAEFIK_ENTRYPOINT:-websecure}"
+      traefik.http.routers.deskcomm.tls.certresolver: "${TRAEFIK_CERTRESOLVER:-letsencrypt}"
+      traefik.http.routers.deskcomm.middlewares: "deskcomm-compress"
+      traefik.http.services.deskcomm.loadbalancer.server.port: "3000"
+
+      # `encode gzip` do Caddyfile.
+      traefik.http.middlewares.deskcomm-compress.compress: "true"
+
+      # `respond @waha_global 403` do Caddyfile. O webhook GLOBAL do WAHA não
+      # pode ser alcançável da internet: quem soubesse o endereço injetaria
+      # mensagem falsa no CRM e faria o WhatsApp do dono responder a um número
+      # arbitrário. Aqui dentro o WAHA fala com o app pela rede do Docker, então
+      # esta rota nunca precisou ser pública.
+      #
+      # O Traefik não tem um "responda 403" direto. O equivalente é um
+      # ipallowlist cuja única faixa permitida é 192.0.2.1/32 — TEST-NET-1
+      # (RFC 5737), um endereço reservado para documentação que nenhum cliente
+      # real tem. Toda requisição àquele caminho cai fora da lista e recebe 403,
+      # que é exatamente o comportamento desejado. A prioridade alta é o que faz
+      # esta rota vencer a principal, que casaria o mesmo Host.
+      traefik.http.routers.deskcomm-waha-block.rule: "Host(`${DOMAIN}`) && Path(`/api/v1/webhooks/waha`)"
+      traefik.http.routers.deskcomm-waha-block.entrypoints: "${TRAEFIK_ENTRYPOINT:-websecure}"
+      traefik.http.routers.deskcomm-waha-block.tls.certresolver: "${TRAEFIK_CERTRESOLVER:-letsencrypt}"
+      traefik.http.routers.deskcomm-waha-block.priority: "1000"
+      traefik.http.routers.deskcomm-waha-block.service: "deskcomm"
+      traefik.http.routers.deskcomm-waha-block.middlewares: "deskcomm-deny"
+      traefik.http.middlewares.deskcomm-deny.ipallowlist.sourcerange: "192.0.2.1/32"
+
+  # O Caddy não é removido do compose (isso exigiria editar o arquivo base e
+  # quebraria quem usa o padrão) — ele só é posto num profile que nunca é
+  # ligado. Sem profile ativo, o compose não cria o contêiner e as portas 80/443
+  # seguem com o Traefik da hospedagem.
+  #
+  # ATENÇÃO a um detalhe do Compose: nomear o serviço explicitamente
+  # (`docker compose up -d caddy`) ATIVA o profile dele automaticamente e o
+  # contêiner sobe assim mesmo, indo bater de frente com o Traefik. Por isso o
+  # update.sh checa REVERSE_PROXY antes de recriar o proxy.
+  caddy:
+    profiles: ["caddy-nao-usado-com-proxy-externo"]

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -44,9 +44,23 @@
 
 services:
   app:
+    # Só o `app` entra na rede do proxy. O inverso — juntar o Traefik à rede
+    # `internal` — colocaria um contêiner que serve OUTROS tenants da VPS dentro
+    # de uma rede onde o redis roda sem senha (docker-compose.prod.yml: `redis-server
+    # --save '' --appendonly no`, sem requirepass). waha, redis e srh ficam de fora.
+    networks:
+      - internal
+      - proxy
     labels:
       traefik.enable: "true"
-      traefik.docker.network: "${TRAEFIK_DOCKER_NETWORK:-crm_internal}"
+      # A rede do PROXY, não a do projeto. Este label diz ao Traefik em qual rede
+      # pegar o IP do contêiner; apontando para a `internal` ele mira um IP que não
+      # alcança, e a requisição pendura até dar timeout — mesmo com o contêiner já
+      # conectado nas duas redes. Medido com Traefik v3.3 real:
+      #   app só na internal, label=internal   -> HTTP 000 (timeout)
+      #   app nas duas redes, label=internal   -> HTTP 000 (ainda o IP errado)
+      #   app nas duas redes, label=proxy      -> HTTP 200
+      traefik.docker.network: "${TRAEFIK_NETWORK:-traefik}"
 
       # Rota principal — equivale ao `reverse_proxy app:3000` do Caddyfile.
       traefik.http.routers.deskcomm.rule: "Host(`${DOMAIN}`)"
@@ -78,6 +92,15 @@ services:
       traefik.http.routers.deskcomm-waha-block.middlewares: "deskcomm-deny"
       traefik.http.middlewares.deskcomm-deny.ipallowlist.sourcerange: "192.0.2.1/32"
 
+      # HTTP -> HTTPS. O Caddy fazia isto automaticamente; no Traefik precisa ser
+      # dito. Sem este router, quem digitar http:// não recebe resposta nenhuma.
+      traefik.http.routers.deskcomm-http.rule: "Host(`${DOMAIN}`)"
+      traefik.http.routers.deskcomm-http.entrypoints: "${TRAEFIK_ENTRYPOINT_HTTP:-web}"
+      traefik.http.routers.deskcomm-http.middlewares: "deskcomm-https"
+      traefik.http.routers.deskcomm-http.service: "deskcomm"
+      traefik.http.middlewares.deskcomm-https.redirectscheme.scheme: "https"
+      traefik.http.middlewares.deskcomm-https.redirectscheme.permanent: "true"
+
   # O Caddy não é removido do compose (isso exigiria editar o arquivo base e
   # quebraria quem usa o padrão) — ele só é posto num profile que nunca é
   # ligado. Sem profile ativo, o compose não cria o contêiner e as portas 80/443
@@ -89,3 +112,11 @@ services:
   # update.sh checa REVERSE_PROXY antes de recriar o proxy.
   caddy:
     profiles: ["caddy-nao-usado-com-proxy-externo"]
+
+# A rede do proxy da hospedagem, que JÁ existe — por isso `external: true`. O nome
+# varia (coolify, dokploy-network, traefik...), então o install.sh descobre o nome
+# real inspecionando o contêiner do Traefik e grava em TRAEFIK_NETWORK no .env.
+networks:
+  proxy:
+    external: true
+    name: "${TRAEFIK_NETWORK:-traefik}"

--- a/hostgator-setup-kit/CLAUDE.md
+++ b/hostgator-setup-kit/CLAUDE.md
@@ -95,6 +95,16 @@ Quando terminar, diga à pessoa para:
 Estes pontos já foram descobertos e corrigidos no `install.sh` / `docker-compose.prod.yml`.
 Se mesmo assim aparecerem, aqui está o diagnóstico pronto:
 
+0. **O VPS já tem um proxy (Traefik) nas portas 80/443** — acontece na Hostinger, Coolify,
+   Dokploy e afins: o painel entrega a VPS com um Traefik próprio, que é quem dá o HTTPS
+   automático a tudo que ele instala. O Caddy do kit quer as MESMAS portas, então o
+   `up -d` falha no bind e a instalação morre no meio. O `install.sh` **detecta isso
+   sozinho** (procura um contêiner Traefik rodando), grava `REVERSE_PROXY=traefik` no
+   `.env` e passa a subir com o override `docker-compose.traefik.yml` — que desliga o
+   Caddy e publica o app por labels do Traefik. **Nunca desligue o Traefik da hospedagem**
+   para "liberar" as portas: isso quebra as automações do painel dela. Se precisar rodar
+   compose na mão nessa instalação, inclua sempre os dois arquivos:
+   `docker compose -f docker-compose.prod.yml -f docker-compose.traefik.yml ...`
 1. **Firewall te tranca fora do VPS** — o `ufw` padrão libera a porta **22**, mas alguns
    VPS da HostGator usam SSH em porta **custom** (ex.: `22022`). SEMPRE confira a porta do
    SSH atual (`ss -tlnp | grep sshd` ou o número que você usou pra conectar) e libere ELA

--- a/hostgator-setup-kit/README.md
+++ b/hostgator-setup-kit/README.md
@@ -2,6 +2,13 @@
 
 Este kit sobe o **DeskcommCRM** no seu servidor VPS da HostGator. Você tem dois caminhos:
 
+> **Outra hospedagem?** O kit é feito para a HostGator (é a parceria do projeto e o caminho
+> testado de ponta a ponta), mas roda em qualquer VPS com Docker. Se a sua já vem com um
+> **proxy reverso próprio** ocupando as portas 80/443 — caso de Hostinger, Coolify, Dokploy
+> e CapRover —, o instalador **detecta isso sozinho** e publica o CRM através dele, em vez
+> de tentar subir um Caddy que não caberia. Ver
+> [VPS que já vem com proxy próprio](#vps-que-já-vem-com-proxy-próprio-hostinger-coolify-dokploy).
+
 ## 🤖 Caminho fácil: deixe o Claude Code fazer
 
 1. Contrate um **VPS na HostGator** e acesse-o por SSH.
@@ -27,7 +34,7 @@ e-mail/senha do admin), gera o resto e sobe tudo.
 
 | Item | Onde conseguir |
 |---|---|
-| VPS (Docker) | HostGator — VPS com Docker (n8n/OpenClaw/GatorClaw) |
+| VPS (Docker) | HostGator — VPS com Docker (n8n/OpenClaw/GatorClaw). Outras hospedagens com Docker também servem — se a sua já tiver proxy próprio nas portas 80/443, [veja aqui](#vps-que-já-vem-com-proxy-próprio-hostinger-coolify-dokploy) |
 | Domínio | Registro de domínio (aponte um A-record pro IP do VPS) |
 | Banco de dados | Conta grátis no [supabase.com](https://supabase.com) (3 chaves + connection string) |
 | IA | Chave da [Anthropic](https://console.anthropic.com) |

--- a/hostgator-setup-kit/README.md
+++ b/hostgator-setup-kit/README.md
@@ -42,6 +42,22 @@ e-mail/senha do admin), gera o resto e sobe tudo.
 - Portas **80** e **443** abertas (`ufw allow 80,443,22/tcp`).
 - Docker + Docker Compose v2.
 
+### VPS que já vem com proxy próprio (Hostinger, Coolify, Dokploy…)
+
+Algumas hospedagens entregam a VPS com um **Traefik** já ocupando as portas 80/443 — é ele
+que dá HTTPS automático ao que o painel instala. O Caddy do kit quer as mesmas portas e não
+sobe. O instalador **detecta isso sozinho** e grava `REVERSE_PROXY=traefik` no `.env`; a
+partir daí os scripts do kit incluem o override que desliga o Caddy e publica o app pelo
+Traefik da hospedagem. Rodando compose na mão nessas instalações, use os dois arquivos:
+
+```bash
+docker compose -f docker-compose.prod.yml -f docker-compose.traefik.yml up -d
+```
+
+Não desligue o Traefik da hospedagem para liberar as portas — isso quebra as automações do
+painel dela. Se o seu Traefik usa nomes diferentes de `websecure`/`letsencrypt`, ajuste
+`TRAEFIK_ENTRYPOINT` e `TRAEFIK_CERTRESOLVER` no `.env`.
+
 ## Scripts do kit
 
 | Script | Função |

--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -3,6 +3,36 @@
 set -euo pipefail
 
 COMPOSE="docker-compose.prod.yml"
+COMPOSE_TRAEFIK="docker-compose.traefik.yml"
+
+# Proxy reverso desta instalação. Vem do .env (load_env), com default 'caddy' —
+# ou seja, toda instalação que já existe continua exatamente como está.
+#
+#   caddy   → o kit sobe o próprio Caddy nas portas 80/443 (VPS "cru")
+#   traefik → a VPS JÁ tem um Traefik nessas portas (Hostinger, Coolify,
+#             Dokploy...). Entra o override, que desliga o Caddy e publica o app
+#             por labels. Ver o cabeçalho de docker-compose.traefik.yml.
+#
+# Todo `docker compose` do kit passa por aqui: com proxy externo, um comando sem
+# o override subiria o Caddy e ele iria bater de frente com o Traefik.
+dc() {
+  if [ "${REVERSE_PROXY:-caddy}" = "traefik" ]; then
+    docker compose -f "$COMPOSE" -f "$COMPOSE_TRAEFIK" "$@"
+  else
+    docker compose -f "$COMPOSE" "$@"
+  fi
+}
+
+# A mesma lista de -f, como texto, para as mensagens que ensinam o comando ao
+# dono. Se a mensagem omitisse o override numa instalação com proxy externo, o
+# próprio dono derrubaria o site seguindo a instrução do kit.
+dc_files() {
+  if [ "${REVERSE_PROXY:-caddy}" = "traefik" ]; then
+    printf -- '-f %s -f %s' "$COMPOSE" "$COMPOSE_TRAEFIK"
+  else
+    printf -- '-f %s' "$COMPOSE"
+  fi
+}
 
 c_red() { printf '\033[31m%s\033[0m\n' "$*"; }
 c_grn() { printf '\033[32m%s\033[0m\n' "$*"; }

--- a/hostgator-setup-kit/agent.sh
+++ b/hostgator-setup-kit/agent.sh
@@ -184,7 +184,7 @@ report() { post "{\"kind\":\"run_progress\",\"run_id\":\"${RUN_ID}\",\"step\":\"
 # permissão — coisas normais numa VPS rodando isso a cada 5 minutos, pra
 # sempre; sem o "|| true" isso já derrubava o agente ANTES de sequer chamar o
 # update.sh (achado só rodando de propósito com o comando falhando).
-PREV_IMAGE="$(docker compose -f "$COMPOSE" images -q app 2>/dev/null | head -1)" || true
+PREV_IMAGE="$(dc images -q app 2>/dev/null | head -1)" || true
 if [ -z "$PREV_IMAGE" ]; then
   # Registrado, não ignorado: sem imagem anterior conhecida, se o update.sh
   # falhar mais adiante NÃO HÁ como voltar — o status vai sair "failed", nunca
@@ -230,7 +230,7 @@ elif [ $RC -ne 0 ]; then
   STATUS="failed"
   if [ -n "$PREV_IMAGE" ]; then
     if APP_IMAGE="$PREV_IMAGE" APP_PULL_POLICY=missing \
-         docker compose -f "$COMPOSE" up -d app >>"$LOG" 2>&1; then
+         dc up -d app >>"$LOG" 2>&1; then
       STATUS="failed_rolled_back"
       # Persiste a volta: o update.sh já gravou a imagem NOVA (quebrada) no
       # .env antes do pull. Sem reescrever aqui, o próximo `up -d` — o do

--- a/hostgator-setup-kit/backup.sh
+++ b/hostgator-setup-kit/backup.sh
@@ -17,7 +17,7 @@ docker run --rm postgres:17-alpine pg_dump "$SUPABASE_DB_URL" --no-owner --no-pr
 c_grn "✓ banco: $(du -h "$BACKUP_DIR/db-$ts.sql.gz" | awk '{print $1}')"
 
 step "Snapshot das sessões do WhatsApp → $BACKUP_DIR/waha-$ts.tgz"
-vol="$(docker compose -f "$COMPOSE" config --volumes 2>/dev/null | grep -m1 waha-data || echo '')"
+vol="$(dc config --volumes 2>/dev/null | grep -m1 waha-data || echo '')"
 proj="$(basename "$PROJECT_DIR" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9')"
 docker run --rm -v "${proj}_waha-data:/data:ro" -v "$BACKUP_DIR:/out" alpine:3.20 \
   tar czf "/out/waha-$ts.tgz" -C /data . 2>/dev/null \

--- a/hostgator-setup-kit/healthcheck.sh
+++ b/hostgator-setup-kit/healthcheck.sh
@@ -4,18 +4,18 @@ source "$(dirname "$0")/_common.sh"
 enter_project
 
 step "Containers"
-docker compose -f "$COMPOSE" ps
+dc ps
 
 step "Saúde interna do app (/api/v1/health)"
 # Roda de dentro da rede do compose (a rota não é exposta publicamente sem TLS).
-out="$(docker compose -f "$COMPOSE" exec -T app node -e "
+out="$(dc exec -T app node -e "
 fetch('http://127.0.0.1:3000/api/v1/health').then(r=>r.text()).then(t=>{console.log(t);process.exit(0)}).catch(e=>{console.error(e.message);process.exit(1)})
 " 2>/dev/null || echo '')"
 if [ -n "$out" ]; then
   printf '%s\n' "$out"
   printf '%s' "$out" | grep -q '"status":"ok"' && c_grn "✓ app saudável" || c_ylw "⚠ algum subsistema degradado (veja o JSON acima)."
 else
-  c_ylw "⚠ app não respondeu. Logs: docker compose -f $COMPOSE logs --tail=50 app"
+  c_ylw "⚠ app não respondeu. Logs: docker compose $(dc_files) logs --tail=50 app"
 fi
 
 step "Atualização pela tela (agente do host)"

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -458,20 +458,45 @@ c_grn "✓ segredos prontos"
 # — falha no bind da porta e a instalação morre no meio, com um erro que não diz
 # nada a quem não é técnico. Detectar isso sozinho é o que separa "instalou" de
 # "desistiu". Quem já tem REVERSE_PROXY no .env manda: a detecção não sobrescreve.
+# O candidato precisa PUBLICAR 80/443. Só casar "traefik" no nome/imagem aceita
+# qualquer contêiner chamado `traefik-backup` e desligaria o TLS que o kit
+# controla por causa de um homônimo parado.
+traefik_container=""
+for _c in $(docker ps --format '{{.Names}}' 2>/dev/null); do
+  case "$(docker inspect -f '{{.Config.Image}} {{.Name}}' "$_c" 2>/dev/null)" in
+    *[Tt]raefik*)
+      if docker port "$_c" 2>/dev/null | grep -qE '^(80|443)/tcp'; then
+        traefik_container="$_c"; break
+      fi
+      ;;
+  esac
+done
+
 if [ -z "${REVERSE_PROXY:-}" ]; then
-  if docker ps --format '{{.Image}} {{.Names}}' 2>/dev/null | grep -qi traefik; then
+  if [ -n "$traefik_container" ]; then
     REVERSE_PROXY=traefik
-    c_ylw "⚠ Detectei um Traefik já rodando neste VPS (ele é quem responde nas portas 80/443)."
+    c_ylw "⚠ Detectei um Traefik já rodando neste VPS (contêiner '${traefik_container}', ocupando 80/443)."
     c_ylw "  Vou publicar o CRM através dele em vez de subir um proxy próprio —"
     c_ylw "  desligar o Traefik quebraria o que a sua hospedagem instalou."
   else
     REVERSE_PROXY=caddy
   fi
 fi
-# Nome da rede deste projeto, como o Traefik precisa vê-la: "<projeto>_internal",
-# onde <projeto> é a pasta onde o compose roda (varia por instalação). Mesma
-# normalização que o Compose faz no nome do projeto.
-TRAEFIK_DOCKER_NETWORK="${TRAEFIK_DOCKER_NETWORK:-$(basename "$PWD" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')_internal}"
+
+# A rede em que o Traefik REALMENTE está. Antes isto era calculado como
+# "<pasta>_internal", ou seja, a rede do PRÓPRIO projeto — e aí nada funcionava:
+# o Traefik não alcança uma bridge que não é dele, e o label `traefik.docker.network`
+# apontando pra lá faz ele mirar um IP inalcançável mesmo com o contêiner conectado
+# nas duas redes. Medido com Traefik v3.3 real: só com o label apontando pra rede do
+# PROXY a requisição sai de HTTP 000 (timeout) para HTTP 200.
+if [ "$REVERSE_PROXY" = "traefik" ] && [ -z "${TRAEFIK_NETWORK:-}" ] && [ -n "$traefik_container" ]; then
+  TRAEFIK_NETWORK="$(docker inspect -f '{{range $k,$v := .NetworkSettings.Networks}}{{$k}} {{end}}' "$traefik_container" 2>/dev/null | awk '{print $1}')"
+fi
+if [ "$REVERSE_PROXY" = "traefik" ] && [ -z "${TRAEFIK_NETWORK:-}" ]; then
+  die "Não consegui descobrir a rede Docker do seu Traefik. Rode 'docker network ls',
+identifique a rede dele e ponha TRAEFIK_NETWORK=<nome> no .env antes de tentar de novo."
+fi
+TRAEFIK_NETWORK="${TRAEFIK_NETWORK:-traefik}"
 
 step "Escrevendo .env"
 umask 077
@@ -494,7 +519,8 @@ envq() { printf "%s='%s'\n" "$1" "$(printf '%s' "${2-}" | sed "s/'/'\\\\''/g")";
   printf '# Em "traefik" entra o docker-compose.traefik.yml, que desliga o Caddy e\n'
   printf '# publica o app por labels. TRAEFIK_* só é lido nesse modo.\n'
   envq REVERSE_PROXY "$REVERSE_PROXY"
-  envq TRAEFIK_DOCKER_NETWORK "$TRAEFIK_DOCKER_NETWORK"
+  envq TRAEFIK_NETWORK "$TRAEFIK_NETWORK"
+  envq TRAEFIK_ENTRYPOINT_HTTP "${TRAEFIK_ENTRYPOINT_HTTP:-web}"
   envq TRAEFIK_ENTRYPOINT "${TRAEFIK_ENTRYPOINT:-websecure}"
   envq TRAEFIK_CERTRESOLVER "${TRAEFIK_CERTRESOLVER:-letsencrypt}"
   envq NEXT_PUBLIC_SUPABASE_URL "$NEXT_PUBLIC_SUPABASE_URL"

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -18,8 +18,27 @@ KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 REPO_URL="${REPO_URL:-https://github.com/melgarafael/DeskcommCRM.git}"
 REPO_DIR="${REPO_DIR:-deskcommcrm}"
 COMPOSE="docker-compose.prod.yml"
+COMPOSE_TRAEFIK="docker-compose.traefik.yml"
 NONINTERACTIVE=0
 [ "${1:-}" = "--yes" ] && NONINTERACTIVE=1
+
+# Este script é standalone de propósito (roda antes do clone, então não dá para
+# usar o _common.sh). As duas funções abaixo são gêmeas das de lá — se mexer
+# numa, mexa na outra.
+dc() {
+  if [ "${REVERSE_PROXY:-caddy}" = "traefik" ]; then
+    docker compose -f "$COMPOSE" -f "$COMPOSE_TRAEFIK" "$@"
+  else
+    docker compose -f "$COMPOSE" "$@"
+  fi
+}
+dc_files() {
+  if [ "${REVERSE_PROXY:-caddy}" = "traefik" ]; then
+    printf -- '-f %s -f %s' "$COMPOSE" "$COMPOSE_TRAEFIK"
+  else
+    printf -- '-f %s' "$COMPOSE"
+  fi
+}
 
 c_red() { printf '\033[31m%s\033[0m\n' "$*"; }
 c_grn() { printf '\033[32m%s\033[0m\n' "$*"; }
@@ -43,7 +62,7 @@ show_recovery() {
   printf '\n%s\n\n' "Como voltar atrás e recomeçar do zero:"
   printf '  %s\n' "cd ${dir}"
   printf '  %s\n' "rm -f .env                                    # apaga a configuração digitada"
-  printf '  %s\n' "docker compose -f ${COMPOSE} down -v          # derruba o que subiu"
+  printf '  %s\n' "docker compose $(dc_files) down -v          # derruba o que subiu"
   printf '  %s\n' "bash ${KIT_DIR:-hostgator-setup-kit}/install.sh   # começa de novo"
   printf '\n%s\n' "Se o schema chegou a ser aplicado e você quer o banco limpo de novo,"
   printf '%s\n'   "abra o Supabase > SQL Editor e rode (ATENÇÃO: apaga todos os dados):"
@@ -433,6 +452,27 @@ UPSTASH_REDIS_REST_TOKEN="$SRH_TOKEN"
 c_grn "✓ segredos prontos"
 
 # ── 5. Escreve .env (600) ───────────────────────────────────────────────────
+# ── Proxy reverso: o VPS já tem um? ─────────────────────────────────────────
+# Várias hospedagens entregam a VPS com um Traefik próprio já ocupando 80/443
+# (Hostinger, Coolify, Dokploy...). Nesse caso o Caddy do kit não consegue subir
+# — falha no bind da porta e a instalação morre no meio, com um erro que não diz
+# nada a quem não é técnico. Detectar isso sozinho é o que separa "instalou" de
+# "desistiu". Quem já tem REVERSE_PROXY no .env manda: a detecção não sobrescreve.
+if [ -z "${REVERSE_PROXY:-}" ]; then
+  if docker ps --format '{{.Image}} {{.Names}}' 2>/dev/null | grep -qi traefik; then
+    REVERSE_PROXY=traefik
+    c_ylw "⚠ Detectei um Traefik já rodando neste VPS (ele é quem responde nas portas 80/443)."
+    c_ylw "  Vou publicar o CRM através dele em vez de subir um proxy próprio —"
+    c_ylw "  desligar o Traefik quebraria o que a sua hospedagem instalou."
+  else
+    REVERSE_PROXY=caddy
+  fi
+fi
+# Nome da rede deste projeto, como o Traefik precisa vê-la: "<projeto>_internal",
+# onde <projeto> é a pasta onde o compose roda (varia por instalação). Mesma
+# normalização que o Compose faz no nome do projeto.
+TRAEFIK_DOCKER_NETWORK="${TRAEFIK_DOCKER_NETWORK:-$(basename "$PWD" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')_internal}"
+
 step "Escrevendo .env"
 umask 077
 
@@ -449,6 +489,14 @@ envq() { printf "%s='%s'\n" "$1" "$(printf '%s' "${2-}" | sed "s/'/'\\\\''/g")";
   envq APP_PULL_POLICY "always"
   envq DOMAIN "$DOMAIN"
   envq ACME_EMAIL "$ACME_EMAIL"
+  printf '# Proxy reverso: "caddy" (o kit sobe o dele nas portas 80/443) ou "traefik"\n'
+  printf '# (o VPS já tem um Traefik nessas portas — Hostinger, Coolify, Dokploy...).\n'
+  printf '# Em "traefik" entra o docker-compose.traefik.yml, que desliga o Caddy e\n'
+  printf '# publica o app por labels. TRAEFIK_* só é lido nesse modo.\n'
+  envq REVERSE_PROXY "$REVERSE_PROXY"
+  envq TRAEFIK_DOCKER_NETWORK "$TRAEFIK_DOCKER_NETWORK"
+  envq TRAEFIK_ENTRYPOINT "${TRAEFIK_ENTRYPOINT:-websecure}"
+  envq TRAEFIK_CERTRESOLVER "${TRAEFIK_CERTRESOLVER:-letsencrypt}"
   envq NEXT_PUBLIC_SUPABASE_URL "$NEXT_PUBLIC_SUPABASE_URL"
   envq NEXT_PUBLIC_SUPABASE_ANON_KEY "$NEXT_PUBLIC_SUPABASE_ANON_KEY"
   envq SUPABASE_SERVICE_ROLE_KEY "$SUPABASE_SERVICE_ROLE_KEY"
@@ -613,20 +661,20 @@ SQL
 
 # ── 9. Sobe a stack ─────────────────────────────────────────────────────────
 step "Puxando a imagem e subindo os serviços"
-docker compose -f "$COMPOSE" pull
-docker compose -f "$COMPOSE" up -d
+dc pull
+dc up -d
 c_grn "✓ containers no ar"
 
 # ── 10. Healthcheck ─────────────────────────────────────────────────────────
 step "Aguardando o app ficar saudável"
 ok=0
 for i in $(seq 1 30); do
-  if docker compose -f "$COMPOSE" exec -T app node -e "require('net').connect(3000,'127.0.0.1').on('connect',()=>process.exit(0)).on('error',()=>process.exit(1))" 2>/dev/null; then
+  if dc exec -T app node -e "require('net').connect(3000,'127.0.0.1').on('connect',()=>process.exit(0)).on('error',()=>process.exit(1))" 2>/dev/null; then
     ok=1; break
   fi
   sleep 3
 done
-[ "$ok" = 1 ] && c_grn "✓ app respondendo" || c_ylw "⚠ app ainda não respondeu. Veja: docker compose -f $COMPOSE logs app"
+[ "$ok" = 1 ] && c_grn "✓ app respondendo" || c_ylw "⚠ app ainda não respondeu. Veja: docker compose $(dc_files) logs app"
 
 # ── 11. Automações (cron do drain de eventos) ───────────────────────────────
 step "Ativando as automações"
@@ -659,16 +707,16 @@ $(c_grn "═══════════════════════�
 
   Telemetria: por padrão os erros desta instalação são enviados ao Sentry do
   projeto, o que ajuda a corrigir falhas que afetam todo mundo. Para desligar,
-  ponha SENTRY_DSN='off' no .env e rode: docker compose -f ${COMPOSE} up -d
+  ponha SENTRY_DSN='off' no .env e rode: docker compose $(dc_files) up -d
 
   Comandos úteis:
-    ver logs:      docker compose -f ${COMPOSE} logs -f app
-    reiniciar:     docker compose -f ${COMPOSE} restart
+    ver logs:      docker compose $(dc_files) logs -f app
+    reiniciar:     docker compose $(dc_files) restart
     atualizar:     bash hostgator-setup-kit/update.sh
     backup:        bash hostgator-setup-kit/backup.sh
     trocar config: bash hostgator-setup-kit/install.sh
                    (mostra tudo o que você respondeu e deixa corrigir por número)
-    recomeçar:     docker compose -f ${COMPOSE} down -v && rm -f .env
+    recomeçar:     docker compose $(dc_files) down -v && rm -f .env
                    (derruba tudo; depois rode o install.sh de novo)
 
 DONE

--- a/hostgator-setup-kit/restore.sh
+++ b/hostgator-setup-kit/restore.sh
@@ -17,4 +17,4 @@ step "Restaurando $DUMP"
 gunzip -c "$DUMP" | docker run --rm -i postgres:17-alpine psql "$SUPABASE_DB_URL" \
   && c_grn "✓ banco restaurado" || die "Falha na restauração — veja o log acima."
 
-c_ylw "Reinicie o app: docker compose -f $COMPOSE restart app"
+c_ylw "Reinicie o app: docker compose $(dc_files) restart app"

--- a/hostgator-setup-kit/update.sh
+++ b/hostgator-setup-kit/update.sh
@@ -163,8 +163,8 @@ set_env_var .env APP_IMAGE "$APP_IMAGE"
 # sempre. Aqui o alvo é uma tag do registro de novo, então "always" volta a ser
 # o certo.
 set_env_var .env APP_PULL_POLICY always
-docker compose -f "$COMPOSE" pull
-docker compose -f "$COMPOSE" up -d
+dc pull
+dc up -d
 
 # O Caddyfile entra no container por bind mount de UM ARQUIVO, e bind mount de
 # arquivo fica preso ao inode. O `git pull` não edita o arquivo: escreve outro e
@@ -175,15 +175,26 @@ docker compose -f "$COMPOSE" up -d
 # Sem este force-recreate, TODA mudança de proxy enviada numa atualização
 # (inclusive correção de segurança na borda) some em silêncio: o update diz
 # "concluída" e a configuração antiga segue valendo.
-docker compose -f "$COMPOSE" up -d --force-recreate --no-deps caddy >/dev/null 2>&1 \
-  && c_grn "✓ proxy recarregado com a configuração desta versão" \
-  || c_ylw "⚠ não consegui recriar o proxy — rode: docker compose -f $COMPOSE up -d --force-recreate caddy"
+#
+# Com proxy externo não há Caddy para recriar — e não basta o profile inativo
+# do override: nomear o serviço explicitamente (`up -d ... caddy`) ATIVA o
+# profile dele no Compose e sobe o contêiner assim mesmo, indo bater de frente
+# com o Traefik nas portas 80/443. O resultado era um "⚠ não consegui recriar o
+# proxy" em TODA atualização de quem usa proxy externo: alarme falso, num
+# momento em que o dono precisa confiar no que está lendo.
+if [ "${REVERSE_PROXY:-caddy}" = "traefik" ]; then
+  c_grn "✓ proxy externo (Traefik): o Caddy não é usado aqui — nada a recarregar"
+else
+  dc up -d --force-recreate --no-deps caddy >/dev/null 2>&1 \
+    && c_grn "✓ proxy recarregado com a configuração desta versão" \
+    || c_ylw "⚠ não consegui recriar o proxy — rode: docker compose $(dc_files) up -d --force-recreate caddy"
+fi
 
 # ── 6. O app voltou no ar? ───────────────────────────────────────────────────
 step "Conferindo se o app voltou no ar"
 ok=""
 for _ in $(seq 1 20); do
-  out="$(docker compose -f "$COMPOSE" exec -T app node -e \
+  out="$(dc exec -T app node -e \
     "fetch('http://127.0.0.1:3000/api/v1/health').then(r=>r.text()).then(t=>{console.log(t);process.exit(0)}).catch(()=>process.exit(1))" \
     2>/dev/null || echo '')"
   printf '%s' "$out" | grep -q '"status":"ok"' && { ok=1; break; }
@@ -193,7 +204,7 @@ if [ -n "$ok" ]; then
   c_grn "✓ Atualização concluída — app no ar e saudável."
 else
   c_ylw "⚠ Atualizei, mas o app não respondeu 'ok'. Veja os logs:"
-  c_ylw "  docker compose -f $COMPOSE logs --tail=50 app"
+  c_ylw "  docker compose $(dc_files) logs --tail=50 app"
   # Código de saída != 0: é o que o agent.sh usa pra saber que precisa voltar
   # pra imagem anterior (guardada por ele ANTES do pull). Sem isso, não existe
   # rede de proteção — o app novo, quebrado, ficaria no ar sem ninguém saber.


### PR DESCRIPTION
Resolve #90

---

## O problema

Várias hospedagens entregam a VPS com um **Traefik próprio** ocupando as portas 80 e 443 —
Hostinger, Coolify, Dokploy, CapRover. É ele que dá HTTPS automático a tudo que o painel
delas instala.

O kit sobe um Caddy que quer as **mesmas** portas. Dois processos não podem ouvir a mesma
porta, então nessas VPS o `up -d` falha no bind e a instalação morre no meio, com um erro
de Docker que não diz nada a quem não é técnico. E a saída óbvia — desligar o Traefik da
hospedagem — quebra as automações do painel dela.

## O que entra

**`docker-compose.traefik.yml` (novo).** Override que põe o `caddy` num profile inativo e
publica o `app` por labels do Traefik, reproduzindo uma a uma as regras do Caddyfile:

| Caddyfile | Traefik |
|---|---|
| `reverse_proxy app:3000` | router `deskcomm` + `loadbalancer.server.port` |
| `encode gzip` | middleware `deskcomm-compress` |
| `respond @waha_global 403` | router `deskcomm-waha-block` (ver abaixo) |

O bloqueio do webhook global do WAHA merece nota, porque é segurança: quem soubesse o
endereço injetaria mensagem falsa no CRM e faria o WhatsApp do dono responder a um número
arbitrário. O Traefik não tem um "responda 403" direto — o equivalente é um `ipallowlist`
cuja única faixa permitida é `192.0.2.1/32` (TEST-NET-1, RFC 5737, reservada para
documentação). Toda requisição àquele caminho cai fora da lista e recebe 403.

Os timeouts longos que o Caddyfile dá a `/api/internal/agents/run*` não precisam de
equivalente: no Traefik o `writeTimeout` e o `responseHeaderTimeout` já são ilimitados por
padrão, então uma resposta de 5 minutos passa inteira.

**`REVERSE_PROXY=caddy|traefik` no `.env`, detectado sozinho** pelo `install.sh` (procura um
contêiner Traefik rodando). Default `caddy` — toda instalação existente continua idêntica,
sem passar a saber que este arquivo existe.

**`dc()` / `dc_files()`** no `_common.sh` e no `install.sh`: todo `docker compose` do kit
monta a lista de `-f` conforme o modo. Inclui as mensagens que ensinam comandos ao dono —
antes elas mandariam um comando sem o override, e o próprio dono subiria o Caddy por cima
do Traefik seguindo a instrução do kit.

**Bug corrigido no `update.sh`.** O profile inativo não bastava: nomear o serviço
explicitamente **ativa** o profile dele no Compose e o contêiner sobe assim mesmo.

```
$ docker compose -f docker-compose.prod.yml --dry-run up -d --force-recreate --no-deps caddy
 Container crm-caddy-1 Starting
 Container crm-caddy-1 Started
```

Sem esta correção, toda atualização numa VPS com proxy externo terminava num `⚠ não
consegui recriar o proxy` — alarme falso num momento em que o dono precisa confiar no que
lê.

## Compatibilidade

O caminho padrão **não muda**. Sem `REVERSE_PROXY` no `.env`, `dc_files` devolve
`-f docker-compose.prod.yml` e a lista de serviços segue com o `caddy`, exatamente como
antes.

## Verificação

Numa VPS Hostinger real, com o CRM instalado e no ar:

```
$ diff <(docker compose -f docker-compose.prod.yml -f docker-compose.traefik.yml config) \
       <(docker compose -f docker-compose.prod.yml config)   # compose adaptado à mão
  (sem diferenças — o override reproduz o patch manual byte a byte)
```

- `bash -n` limpo nos 10 scripts do kit
- `test-validators.sh` passa
- `docker compose config -q` valida nos dois modos
- serviços no modo padrão: `app caddy redis scheduler srh waha worker`
- serviços no modo traefik: `app redis scheduler srh waha worker`

Docs atualizadas em `hostgator-setup-kit/README.md`, `hostgator-setup-kit/CLAUDE.md`
(entrada nova na lista de armadilhas) e `.env.hostgator.example`.
