### PR TITLE
fix(waha): mensagem digitada no celular sumia do CRM (NOWEB não manda `to`)

### DIFF
--- a/lib/waha/ingest-celular.test.ts
+++ b/lib/waha/ingest-celular.test.ts
@@ -274,6 +274,28 @@ describe("eco do próprio envio", () => {
     expect(messages).toHaveLength(2);
   });
 
+  it("JANELA CONHECIDA: enquanto o envio está `queued` sem external_id, o eco duplica", async () => {
+    // ⚠️ Documenta um defeito conhecido, não o aprova. Se alguém fechar a
+    // janela, este caso fica vermelho — e é para ficar: o número certo passa a
+    // ser 1, e quem consertar atualiza aqui.
+    //
+    // O envio (app/api/v1/messages/_handler.ts) grava a linha ANTES de falar com
+    // o canal (status `queued`, `external_id` NULL) e só carimba o external_id
+    // num UPDATE depois que o adapter responde. O eco que chegar nesse intervalo
+    // não encontra nada para casar — nem por id completo, nem por bare.
+    //
+    // Antes do PR isso não aparecia no NOWEB porque o eco era descartado junto
+    // com as mensagens legítimas do celular. É o preço de consertar aquilo: no
+    // engine padrão do kit, esta duplicação em corrida é comportamento NOVO.
+    const { admin, messages } = bancoDeMentira([
+      { organization_id: "org-1", external_id: null, direction: "outbound", body: "respondi por aqui mesmo" },
+    ]);
+
+    await dispatchWahaEvent(admin as never, SESSION as never, envelope(CELULAR_NOWEB), "req-1");
+
+    expect(messages, "se virou 1, a janela foi fechada — atualize este caso").toHaveLength(2);
+  });
+
   it("o dedup é por organização — o eco de outro tenant não bloqueia o meu", async () => {
     // Service role bypassa RLS: sem o filtro explícito de organization_id, uma
     // linha de OUTRO tenant com o mesmo id faria a mensagem desta org sumir.
@@ -287,30 +309,51 @@ describe("eco do próprio envio", () => {
   });
 });
 
-describe("WEBJS — o número do operador nunca vira contato", () => {
+describe("precedência dos três candidatos a chat", () => {
+  // `from` = OPERADOR é o cenário WEBJS (no NOWEB, `from` é o próprio chat).
   const WEBJS: WahaPayload = {
     id: "true_5511999999999@c.us_3EB0ABCDEF",
-    from: "5599888888888@c.us", // no WEBJS, `from` é o OPERADOR
+    from: "5599888888888@c.us",
     to: "5511999999999@c.us",
     fromMe: true,
     body: "resposta pelo WhatsApp Web",
   };
 
-  it("com `to` presente, o contato é o destinatário", async () => {
+  it("`to` vence: com ele presente, o contato é o destinatário", async () => {
     const { admin, rpcs } = bancoDeMentira();
     await dispatchWahaEvent(admin as never, SESSION as never, envelope(WEBJS), "req-1");
-    const contato = rpcs.find((c) => c.fn === "fn_upsert_wa_contact")!;
-    expect(contato.args.p_chat_id).toBe("5511999999999@c.us");
+    expect(rpcs.find((c) => c.fn === "fn_upsert_wa_contact")!.args.p_chat_id).toBe("5511999999999@c.us");
   });
 
-  it("sem `to`, o id composto resolve o chat ANTES de `from` — o operador não vira contato", async () => {
-    // Este é o risco do terceiro fallback: no WEBJS `from` é o operador, então
-    // usá-lo criaria um contato com o próprio número da empresa. O id composto
-    // (2º fallback) resolve primeiro, e o WEBJS sempre manda id composto.
+  it("sem `to`, o id composto vence `from` — mesmo com `from` sendo outro número", async () => {
+    // Guarda de vacuidade: o `from` aqui é DIFERENTE do chat do id, senão o caso
+    // passaria mesmo que a precedência estivesse invertida.
     const { admin, rpcs } = bancoDeMentira();
     await dispatchWahaEvent(admin as never, SESSION as never, envelope({ ...WEBJS, to: undefined }), "req-1");
-    const contato = rpcs.find((c) => c.fn === "fn_upsert_wa_contact")!;
-    expect(contato.args.p_chat_id).toBe("5511999999999@c.us");
-    expect(contato.args.p_chat_id).not.toBe("5599888888888@c.us");
+    const chat = rpcs.find((c) => c.fn === "fn_upsert_wa_contact")!.args.p_chat_id;
+    expect(chat).toBe("5511999999999@c.us");
+    expect(chat).not.toBe("5599888888888@c.us");
+  });
+
+  it("sem `to` E com id sem chat embutido, `from` VIRA o contato — inclusive no WEBJS", async () => {
+    // ⚠️ Este caso documenta um comportamento, não o aprova.
+    //
+    // No NOWEB está certo: `from` de uma mensagem fromMe É o chat. No WEBJS
+    // seria errado — `from` é o número do operador, e o CRM criaria um contato
+    // com o próprio número da empresa.
+    //
+    // O ingest NÃO sabe qual engine falou com ele. O que impede o dano hoje é o
+    // WAHA nunca produzir a combinação (sem `to` + id bare) no WEBJS — garantia
+    // EXTERNA, não uma proteção do nosso código. Se algum dia produzir, o
+    // sintoma é contato fantasma com o número da empresa. Escrito aqui para que
+    // isso seja uma decisão consciente e não uma surpresa.
+    const { admin, rpcs } = bancoDeMentira();
+    await dispatchWahaEvent(
+      admin as never,
+      SESSION as never,
+      envelope({ id: "3EB0ABCDEF", from: "5599888888888@c.us", fromMe: true, body: "oi" }),
+      "req-1",
+    );
+    expect(rpcs.find((c) => c.fn === "fn_upsert_wa_contact")!.args.p_chat_id).toBe("5599888888888@c.us");
   });
 });

--- a/lib/waha/ingest-celular.test.ts
+++ b/lib/waha/ingest-celular.test.ts
@@ -195,6 +195,33 @@ describe("controles — o que tem que continuar sendo descartado", () => {
     expect(messages, "grupo não faz binding CRM").toHaveLength(0);
   });
 
+  it("id de 4 segmentos (grupo, formato documentado do WAHA) não cria contato", async () => {
+    // A doc do WAHA declara `{fromMe}_{chatId}_{messageId}[_{participant}]` — o
+    // 4º segmento existe em GRUPO. Com ele, `chatIdFromWaMessageId` devolve
+    // "…@g.us_4CC5…": lixo NÃO-nulo, que por ser não-nulo atropela o `?? p.from`.
+    //
+    // Hoje o desfecho ainda é o certo, mas por ACIDENTE: `parseChatId` joga
+    // qualquer sufixo desconhecido no balde `group`, e grupo é descartado. A
+    // segurança mora em ingest.ts, não no parser — então quem mexer no
+    // `parseChatId` quebra isto aqui, e é para isso que este caso existe.
+    const { admin, messages, rpcs } = bancoDeMentira();
+
+    await dispatchWahaEvent(
+      admin as never,
+      SESSION as never,
+      envelope({
+        id: "true_11111111111@g.us_4CC5EDD64BC22EBA6D639F2AF571346C_9999@lid",
+        from: "11111111111@g.us",
+        fromMe: true,
+        body: "mensagem de grupo com participant no id",
+      }),
+      "req-1",
+    );
+
+    expect(messages).toHaveLength(0);
+    expect(rpcs.some((c) => c.fn === "fn_upsert_wa_contact"), "criou contato a partir do id de grupo").toBe(false);
+  });
+
   it("evento sem corpo e sem mídia continua descartado", async () => {
     // WAHA emite eventos vazios para status/read-receipt/presence.
     const { admin, messages } = bancoDeMentira();

--- a/lib/waha/ingest-celular.test.ts
+++ b/lib/waha/ingest-celular.test.ts
@@ -141,10 +141,10 @@ describe("mensagem digitada no celular do dono (fromMe)", () => {
     await dispatchWahaEvent(admin as never, SESSION as never, envelope(CELULAR_NOWEB), "req-1");
 
     expect(messages, "a mensagem do celular sumiu — o webhook devolveu 200 e nada foi gravado").toHaveLength(1);
-    expect(messages[0].external_id).toBe(CELULAR_NOWEB.id);
-    expect(messages[0].direction).toBe("outbound");
-    expect(messages[0].body).toBe("respondi por aqui mesmo");
-    expect(messages[0].sent_via).toBe("external_device");
+    expect(messages[0]!.external_id).toBe(CELULAR_NOWEB.id);
+    expect(messages[0]!.direction).toBe("outbound");
+    expect(messages[0]!.body).toBe("respondi por aqui mesmo");
+    expect(messages[0]!.sent_via).toBe("external_device");
 
     // O contato tem que ser o CHAT (o cliente), com a identidade @lid preservada.
     const contato = rpcs.find((c) => c.fn === "fn_upsert_wa_contact");
@@ -232,7 +232,7 @@ describe("eco do próprio envio", () => {
     await dispatchWahaEvent(admin as never, SESSION as never, envelope(CELULAR_NOWEB), "req-1");
 
     expect(messages, "a mesma frase apareceu duas vezes na conversa").toHaveLength(1);
-    expect(messages[0].external_id).toBe("2A1B890FB8AA87730CBC");
+    expect(messages[0]!.external_id).toBe("2A1B890FB8AA87730CBC");
   });
 
   it("controle: mensagem DIFERENTE no mesmo chat continua entrando", async () => {

--- a/lib/waha/ingest-celular.test.ts
+++ b/lib/waha/ingest-celular.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it, vi } from "vitest";
+
+// ingest.ts importa @/lib/audit (→ supabase/server → validação de env);
+// o mock corta a cadeia sem tocar no que está sob teste.
+vi.mock("@/lib/audit", () => ({ audit: vi.fn() }));
+
+import { dispatchWahaEvent, parseChatId, type WahaEnvelope, type WahaPayload } from "@/lib/waha/ingest";
+
+/**
+ * A MENSAGEM QUE O DONO DIGITA NO CELULAR TEM QUE CHEGAR NO CRM.
+ *
+ * Sintoma relatado numa instalação real: o atendente responde pelo WhatsApp do
+ * próprio celular e a conversa no CRM não mostra nada — sem erro em lugar
+ * nenhum, porque o webhook devolve 200. As mensagens enviadas pelo composer e
+ * pela IA apareciam (essas nascem no banco ANTES do webhook), o que fazia o
+ * defeito parecer "às vezes some".
+ *
+ * ⚠️ O TESTE ENTRA PELO CAMINHO DE PRODUÇÃO (`dispatchWahaEvent`). O handler do
+ * caso, `handleOutboundFromUserPhone`, é privado: chamá-lo direto provaria a
+ * função e mentiria sobre o roteamento — é o roteador que os dois route
+ * handlers de webhook chamam, e é onde `fromMe` decide o ramo.
+ *
+ * O duplo de admin implementa a ÚNICA regra de banco que o desfecho depende: o
+ * unique (organization_id, external_id). Sem ela, o teste do eco passaria por
+ * não ter constraint nenhuma para violar.
+ */
+
+interface LinhaMessage {
+  id: string;
+  organization_id: string;
+  external_id: string | null;
+  direction?: string;
+  body?: string | null;
+  sent_via?: string;
+  [k: string]: unknown;
+}
+
+interface Duplo {
+  admin: unknown;
+  messages: LinhaMessage[];
+  rpcs: Array<{ fn: string; args: Record<string, unknown> }>;
+}
+
+/** Admin de mentira com um "banco" em memória só de `messages`. */
+function bancoDeMentira(preexistentes: Array<Partial<LinhaMessage>> = []): Duplo {
+  const messages: LinhaMessage[] = preexistentes.map((m, i) => ({
+    id: `pre-${i + 1}`,
+    organization_id: "org-1",
+    external_id: null,
+    ...m,
+  }));
+  const rpcs: Array<{ fn: string; args: Record<string, unknown> }> = [];
+
+  const consulta = () => {
+    let org: string | null = null;
+    let externos: string[] = [];
+    const q = {
+      eq(coluna: string, valor: string) {
+        if (coluna === "organization_id") org = valor;
+        return q;
+      },
+      in(coluna: string, valores: string[]) {
+        if (coluna === "external_id") externos = valores;
+        return q;
+      },
+      limit() {
+        return q;
+      },
+      async maybeSingle() {
+        const achou = messages.find(
+          (m) => m.organization_id === org && m.external_id !== null && externos.includes(m.external_id),
+        );
+        return { data: achou ? { id: achou.id } : null, error: null };
+      },
+    };
+    return q;
+  };
+
+  const tabela = (nome: string) => ({
+    select: () => consulta(),
+    insert: (linha: Record<string, unknown>) => ({
+      select: () => ({
+        async maybeSingle() {
+          if (nome !== "messages") return { data: { id: "x" }, error: null };
+          const externo = linha.external_id as string | null;
+          const colide =
+            externo !== null &&
+            messages.some((m) => m.organization_id === linha.organization_id && m.external_id === externo);
+          if (colide) {
+            return {
+              data: null,
+              error: { code: "23505", message: 'duplicate key value violates "messages_org_external_id_unique"' },
+            };
+          }
+          const nova = { id: `msg-${messages.length + 1}`, ...linha } as LinhaMessage;
+          messages.push(nova);
+          return { data: { id: nova.id }, error: null };
+        },
+      }),
+    }),
+    update: () => ({ eq: () => ({ in: async () => ({ error: null }) }) }),
+  });
+
+  const admin = {
+    from: (nome: string) => tabela(nome),
+    rpc: async (fn: string, args: Record<string, unknown>) => {
+      rpcs.push({ fn, args });
+      // Sem os ids de retorno o ingest desiste antes do insert e o teste
+      // passaria por não ter exercitado nada.
+      if (fn === "fn_upsert_wa_contact") return { data: "contato-1", error: null };
+      if (fn === "fn_upsert_wa_conversation") return { data: "conversa-1", error: null };
+      return { data: null, error: null };
+    },
+  };
+
+  return { admin, messages, rpcs };
+}
+
+const SESSION = { id: "sessao-1", organization_id: "org-1" };
+
+function envelope(payload: WahaPayload): WahaEnvelope {
+  return { event: "message.any", session: "default", payload };
+}
+
+/**
+ * Payload REAL capturado numa instalação com o engine NOWEB (o padrão do kit),
+ * quando o dono digita no celular. Note o que NÃO existe aqui: `to`.
+ */
+const CELULAR_NOWEB: WahaPayload = {
+  id: "true_250302204792918@lid_2A1B890FB8AA87730CBC",
+  from: "250302204792918@lid",
+  fromMe: true,
+  body: "respondi por aqui mesmo",
+  timestamp: 1_760_000_000,
+};
+
+describe("mensagem digitada no celular do dono (fromMe)", () => {
+  it("NOWEB sem `to`: a mensagem é gravada como outbound", async () => {
+    const { admin, messages, rpcs } = bancoDeMentira();
+
+    await dispatchWahaEvent(admin as never, SESSION as never, envelope(CELULAR_NOWEB), "req-1");
+
+    expect(messages, "a mensagem do celular sumiu — o webhook devolveu 200 e nada foi gravado").toHaveLength(1);
+    expect(messages[0].external_id).toBe(CELULAR_NOWEB.id);
+    expect(messages[0].direction).toBe("outbound");
+    expect(messages[0].body).toBe("respondi por aqui mesmo");
+    expect(messages[0].sent_via).toBe("external_device");
+
+    // O contato tem que ser o CHAT (o cliente), com a identidade @lid preservada.
+    const contato = rpcs.find((c) => c.fn === "fn_upsert_wa_contact");
+    expect(contato!.args.p_chat_id).toBe("250302204792918@lid");
+    expect(contato!.args.p_lid).toBe("250302204792918");
+  });
+
+  it("controle: o MESMO payload COM `to` sempre gravou — a única variável é a ausência de `to`", async () => {
+    // Isola a causa. Se este caso também falhasse, o defeito estaria em outro
+    // lugar (guarda de conteúdo, filtro de grupo, dedup) e não em `p.to ?? ""`.
+    const { admin, messages } = bancoDeMentira();
+
+    await dispatchWahaEvent(
+      admin as never,
+      SESSION as never,
+      envelope({ ...CELULAR_NOWEB, to: "250302204792918@lid" }),
+      "req-1",
+    );
+
+    expect(messages).toHaveLength(1);
+  });
+
+  it("o descarte era silencioso porque chatId vazio cai na classificação de grupo", async () => {
+    // `p.to ?? ""` produzia "" e `parseChatId("")` não casa nenhum sufixo
+    // conhecido → devolve `group`. O `return` executado era o do filtro de
+    // grupo, uma linha ANTES da guarda `if (!p.id || !chatId)`. Mesmo desfecho,
+    // e é por isso que não havia sequer um log: grupo é descarte esperado.
+    expect(parseChatId("")).toEqual({ kind: "group", phone: null, lid: null });
+  });
+});
+
+describe("controles — o que tem que continuar sendo descartado", () => {
+  it("grupo continua fora do CRM mesmo quando o chat vem do id", async () => {
+    const { admin, messages } = bancoDeMentira();
+
+    await dispatchWahaEvent(
+      admin as never,
+      SESSION as never,
+      envelope({
+        id: "true_120363000000000000@g.us_2A1B890FB8AA87730CBC",
+        from: "120363000000000000@g.us",
+        fromMe: true,
+        body: "mensagem no grupo",
+      }),
+      "req-1",
+    );
+
+    expect(messages, "grupo não faz binding CRM").toHaveLength(0);
+  });
+
+  it("evento sem corpo e sem mídia continua descartado", async () => {
+    // WAHA emite eventos vazios para status/read-receipt/presence.
+    const { admin, messages } = bancoDeMentira();
+
+    await dispatchWahaEvent(admin as never, SESSION as never, envelope({ ...CELULAR_NOWEB, body: undefined }), "req-1");
+
+    expect(messages).toHaveLength(0);
+  });
+
+  it("id sem chat embutido e sem `to` não inventa contato a partir de lixo", async () => {
+    const { admin, messages, rpcs } = bancoDeMentira();
+
+    await dispatchWahaEvent(
+      admin as never,
+      SESSION as never,
+      envelope({ id: "true_naoehchat_2A1B890", fromMe: true, body: "oi" }),
+      "req-1",
+    );
+
+    expect(messages).toHaveLength(0);
+    expect(rpcs.some((c) => c.fn === "fn_upsert_wa_contact")).toBe(false);
+  });
+});
+
+describe("eco do próprio envio", () => {
+  it("linha já gravada com o id bare não vira segunda mensagem", async () => {
+    // O envio (composer/IA) grava `external_id` = id bare devolvido pelo WAHA
+    // NOWEB (`2A1B…`); o mesmo envio volta pelo webhook com o id COMPOSTO
+    // (`true_<chat>_2A1B…`). São strings diferentes: o unique não dispara e
+    // nasceria uma segunda linha com a mesma frase.
+    const { admin, messages } = bancoDeMentira([
+      { organization_id: "org-1", external_id: "2A1B890FB8AA87730CBC", direction: "outbound", body: "respondi por aqui mesmo" },
+    ]);
+
+    await dispatchWahaEvent(admin as never, SESSION as never, envelope(CELULAR_NOWEB), "req-1");
+
+    expect(messages, "a mesma frase apareceu duas vezes na conversa").toHaveLength(1);
+    expect(messages[0].external_id).toBe("2A1B890FB8AA87730CBC");
+  });
+
+  it("controle: mensagem DIFERENTE no mesmo chat continua entrando", async () => {
+    // Sem este controle, um dedup largo demais (que casasse por chat, por
+    // exemplo) passaria nas asserções acima engolindo mensagens legítimas.
+    const { admin, messages } = bancoDeMentira([
+      { organization_id: "org-1", external_id: "OUTRAMENSAGEM111", direction: "outbound" },
+    ]);
+
+    await dispatchWahaEvent(admin as never, SESSION as never, envelope(CELULAR_NOWEB), "req-1");
+
+    expect(messages).toHaveLength(2);
+  });
+
+  it("o dedup é por organização — o eco de outro tenant não bloqueia o meu", async () => {
+    // Service role bypassa RLS: sem o filtro explícito de organization_id, uma
+    // linha de OUTRO tenant com o mesmo id faria a mensagem desta org sumir.
+    const { admin, messages } = bancoDeMentira([
+      { organization_id: "org-2", external_id: "2A1B890FB8AA87730CBC", direction: "outbound" },
+    ]);
+
+    await dispatchWahaEvent(admin as never, SESSION as never, envelope(CELULAR_NOWEB), "req-1");
+
+    expect(messages, "vazamento entre tenants: o dedup olhou fora da organização").toHaveLength(2);
+  });
+});
+
+describe("WEBJS — o número do operador nunca vira contato", () => {
+  const WEBJS: WahaPayload = {
+    id: "true_5511999999999@c.us_3EB0ABCDEF",
+    from: "5599888888888@c.us", // no WEBJS, `from` é o OPERADOR
+    to: "5511999999999@c.us",
+    fromMe: true,
+    body: "resposta pelo WhatsApp Web",
+  };
+
+  it("com `to` presente, o contato é o destinatário", async () => {
+    const { admin, rpcs } = bancoDeMentira();
+    await dispatchWahaEvent(admin as never, SESSION as never, envelope(WEBJS), "req-1");
+    const contato = rpcs.find((c) => c.fn === "fn_upsert_wa_contact")!;
+    expect(contato.args.p_chat_id).toBe("5511999999999@c.us");
+  });
+
+  it("sem `to`, o id composto resolve o chat ANTES de `from` — o operador não vira contato", async () => {
+    // Este é o risco do terceiro fallback: no WEBJS `from` é o operador, então
+    // usá-lo criaria um contato com o próprio número da empresa. O id composto
+    // (2º fallback) resolve primeiro, e o WEBJS sempre manda id composto.
+    const { admin, rpcs } = bancoDeMentira();
+    await dispatchWahaEvent(admin as never, SESSION as never, envelope({ ...WEBJS, to: undefined }), "req-1");
+    const contato = rpcs.find((c) => c.fn === "fn_upsert_wa_contact")!;
+    expect(contato.args.p_chat_id).toBe("5511999999999@c.us");
+    expect(contato.args.p_chat_id).not.toBe("5599888888888@c.us");
+  });
+});

--- a/lib/waha/ingest.ts
+++ b/lib/waha/ingest.ts
@@ -14,7 +14,7 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { audit } from "@/lib/audit";
 import type { createAdminClient } from "@/lib/supabase/admin";
 import { ackToStatus } from "@/lib/types/messaging";
-import { bareWaMessageId } from "@/lib/waha/message-id";
+import { bareWaMessageId, chatIdFromWaMessageId } from "@/lib/waha/message-id";
 
 type Admin = ReturnType<typeof createAdminClient>;
 
@@ -426,7 +426,19 @@ async function handleOutboundFromUserPhone(
   p: WahaPayload,
   requestId: string,
 ): Promise<void> {
-  const chatId = p.to ?? "";
+  // De onde sai o chat, em ordem de confiança:
+  //   1. `to`  — o WEBJS manda; é o destinatário explícito.
+  //   2. o id  — `{fromMe}_{chatId}_{bareId}` carrega o chat em qualquer engine.
+  //   3. `from`— no NOWEB, mensagem fromMe traz o CHAT em `from` (não o número
+  //              do operador, como acontece no WEBJS).
+  //
+  // O NOWEB (engine padrão do kit) **não manda `to`** aqui. Com `p.to ?? ""` o
+  // chatId ficava vazio e a guarda abaixo descartava a mensagem em silêncio —
+  // toda mensagem que o dono digitava no celular sumia do CRM, enquanto as
+  // enviadas pelo composer e pela IA apareciam (essas nascem no banco antes do
+  // webhook, então não dependiam deste caminho). O sintoma era "respondi pelo
+  // celular e o CRM não mostra", sem nenhum erro em log: o webhook devolvia 200.
+  const chatId = p.to ?? chatIdFromWaMessageId(p.id ?? "") ?? p.from ?? "";
   const parsed = parseChatId(chatId);
   if (parsed.kind === "group") return;
   if (!p.id || !chatId) return;

--- a/lib/waha/ingest.ts
+++ b/lib/waha/ingest.ts
@@ -444,6 +444,32 @@ async function handleOutboundFromUserPhone(
   if (!p.id || !chatId) return;
   if (!p.body && !mediaUrlOf(p) && !p.hasMedia) return;
 
+  // ECO DO PRÓPRIO ENVIO — não duplicar.
+  //
+  // Toda mensagem que o CRM manda (composer ou IA) volta pelo webhook como
+  // `fromMe=true`. O dedup por `external_id` NÃO pega esse caso, porque os dois
+  // lados gravam formas diferentes do mesmo id: o envio grava o id "bare"
+  // (`3EB0…`) e o webhook chega com o composto (`true_<chat>_3EB0…`). São
+  // strings distintas, então o unique não dispara e nasce uma segunda linha —
+  // a mesma frase aparecendo duas vezes na conversa.
+  //
+  // Antes isto não aparecia por acidente: sem `to`, esta função voltava cedo e
+  // o eco era descartado junto com as mensagens legítimas do celular. Ao
+  // consertar aquele caminho, a duplicação ficou exposta.
+  //
+  // Mesmo par de candidatos que o `handleAck` usa — cobre NOWEB (bare) e WEBJS
+  // (full) sem depender do engine.
+  const bare = bareWaMessageId(p.id);
+  const idCandidates = bare === p.id ? [p.id] : [p.id, bare];
+  const { data: jaRegistrada } = await admin
+    .from("messages")
+    .select("id")
+    .eq("organization_id", session.organization_id)
+    .in("external_id", idCandidates)
+    .limit(1)
+    .maybeSingle();
+  if (jaRegistrada) return; // nasceu no envio; quem atualiza o status é o ack
+
   const contactId = await upsertContact(admin, session.organization_id, parsed, chatId, notifyNameOf(p));
   if (!contactId) return;
   const conversationId = await upsertConversation(admin, session.organization_id, contactId, session.id);

--- a/lib/waha/message-id.ts
+++ b/lib/waha/message-id.ts
@@ -37,3 +37,29 @@ export function bareWaMessageId(id: string): string {
   const cut = id.lastIndexOf('_');
   return cut === -1 ? id : id.slice(cut + 1);
 }
+
+/**
+ * Extrai o chatId do id composto do WAHA (`{fromMe}_{chatId}_{bareId}`).
+ *
+ * Existe porque o NOWEB **não manda `to`** no payload de mensagem `fromMe=true`
+ * (a que o dono digitou no celular): o chat vai em `from`, e `to` simplesmente
+ * não vem. Payload real capturado numa instalação:
+ *
+ *   { "id": "true_250302204792918@lid_2A1B890FB8AA87730CBC",
+ *     "from": "250302204792918@lid", "fromMe": true, "source": "app" }
+ *
+ * Como o id JÁ carrega o chatId, dá para recuperá-lo sem depender do engine.
+ * Mesmo raciocínio de `bareWaMessageId`: chatId (`@c.us`/`@lid`) e o serializado
+ * WA não contêm `_`, então as fatias entre o primeiro e o último `_` são o chat.
+ *
+ * Devolve null quando o id não é composto (id "bare" do envio) ou quando o
+ * miolo não parece um chatId — assim quem chama cai no próximo fallback em vez
+ * de inventar um contato a partir de lixo.
+ */
+export function chatIdFromWaMessageId(id: string): string | null {
+  const first = id.indexOf('_');
+  const last = id.lastIndexOf('_');
+  if (first === -1 || last === first) return null;
+  const chat = id.slice(first + 1, last);
+  return chat.includes('@') ? chat : null;
+}

--- a/tests/unit/waha-message-id.test.ts
+++ b/tests/unit/waha-message-id.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { bareWaMessageId, parseWahaMessageId } from "@/lib/waha/message-id";
+import { bareWaMessageId, chatIdFromWaMessageId, parseWahaMessageId } from "@/lib/waha/message-id";
 
 describe("parseWahaMessageId", () => {
   it("string plana não é uma shape reconhecida (guard exige objeto) → null", () => {
@@ -51,5 +51,35 @@ describe("bareWaMessageId", () => {
     const candidates = [ackFull, bareWaMessageId(ackFull)];
     expect(candidates).toContain(webjsStored); // WEBJS: casa pela forma full
     expect(candidates).toContain("3EB0ABC"); // NOWEB: casa pela cauda
+  });
+});
+
+describe("chatIdFromWaMessageId", () => {
+  it("recupera o chat de uma mensagem fromMe do NOWEB (payload real)", () => {
+    // Capturado numa instalação Hostinger: o dono digitou no celular e o CRM
+    // não mostrou. O payload NÃO tem `to` — sem este helper o chatId ficava
+    // vazio e a mensagem era descartada em silêncio (webhook devolvia 200).
+    expect(chatIdFromWaMessageId("true_250302204792918@lid_2A1B890FB8AA87730CBC")).toBe(
+      "250302204792918@lid",
+    );
+  });
+
+  it("funciona com @c.us (numero classico) e com inbound (false_)", () => {
+    expect(chatIdFromWaMessageId("true_5511999999999@c.us_3EB0ABC")).toBe("5511999999999@c.us");
+    expect(chatIdFromWaMessageId("false_5511999999999@c.us_3EB0ABC")).toBe("5511999999999@c.us");
+  });
+
+  it("id já-bare (do envio) não tem chat embutido → null, não lixo", () => {
+    expect(chatIdFromWaMessageId("3EB02714A82A56A80702CE")).toBeNull();
+  });
+
+  it("miolo sem @ não é chatId → null (não inventa contato)", () => {
+    expect(chatIdFromWaMessageId("true_naoehchat_3EB0ABC")).toBeNull();
+  });
+
+  it("convive com bareWaMessageId: um pega o chat, o outro o id", () => {
+    const id = "true_250302204792918@lid_2A1B890FB8AA87730CBC";
+    expect(chatIdFromWaMessageId(id)).toBe("250302204792918@lid");
+    expect(bareWaMessageId(id)).toBe("2A1B890FB8AA87730CBC");
   });
 });


### PR DESCRIPTION
Quem responde o cliente pelo WhatsApp do **próprio celular** não via essa mensagem aparecer no CRM. As enviadas pelo composer e pela IA apareciam normalmente — o que fazia parecer problema de tela, e não de ingestão.

## A causa

`handleOutboundFromUserPhone` tirava o chat de `p.to`:

```ts
const chatId = p.to ?? "";
if (!p.id || !chatId) return;      // <- saía aqui, calado
```

O **NOWEB** (engine padrão do kit) não manda `to` em mensagem `fromMe=true`: o chat vem em `from`. Payload real capturado numa instalação Hostinger, via `webhook_events_log`:

```json
{ "id": "true_250302204792918@lid_2A1B890FB8AA87730CBC",
  "from": "250302204792918@lid", "fromMe": true, "source": "app",
  "body": "Javi jajaja perdon ahi le estaba probando a una ia" }
```

Sem `to`, o chatId ficava vazio, a guarda descartava e a função voltava sem erro. O webhook respondia **200** e o WAHA registrava entrega bem-sucedida — não havia sinal nenhum de que a mensagem tinha sido perdida, nem em log nem em métrica. As mensagens do composer/IA escapavam porque nascem no banco no momento do envio: não dependem deste caminho.

## A correção (commit 1)

O chat passa a ser resolvido em três degraus, do mais confiável ao menos:

1. `to` — o WEBJS manda; destinatário explícito
2. o `id` — `{fromMe}_{chatId}_{bareId}` carrega o chat em qualquer engine
3. `from` — no NOWEB é o chat (no WEBJS seria o operador, mas aí o passo 1 já resolveu)

O passo 2 entra como `chatIdFromWaMessageId()`, irmão de `bareWaMessageId()` e com o mesmo raciocínio: chatId e serializado WA não contêm `_`. Devolve `null` quando o id não é composto ou o miolo não tem `@`, para cair no próximo fallback em vez de inventar contato a partir de lixo.

## A regressão que isso expôs (commit 2)

Consertar o caminho `fromMe` fez o eco das mensagens que o **próprio CRM** manda ser inserido de novo — a mesma frase duas vezes na conversa. O dedup não pegava porque os dois lados gravam formas diferentes do mesmo id:

```
envio (composer/IA) -> external_id = "3EB034D151D540591832DF"                        (bare)
eco do webhook      -> external_id = "true_267851...@lid_3EB034D151D540591832DF"     (composto)
```

O unique é `(organization_id, external_id)`; como as strings diferem, não dispara. Observado em produção:

```
18:34:45 | outbound | external_device | true_2678...@lid_3EB0...DF | "jaja enserio"
18:34:45 | outbound | user            | 3EB0...DF                  | "jaja enserio"
```

Antes do commit 1 isso não aparecia **por acidente**: sem `to`, a função voltava cedo e o eco era descartado junto com as mensagens legítimas do celular.

Agora, antes de inserir, procura por `external_id in (composto, bare)` — o mesmo par de candidatos que o `handleAck` já usa para casar os dois engines. Se achar, a mensagem nasceu no envio e o eco não tem nada a fazer: quem atualiza o status dela é o `message.ack`. Mensagem digitada no celular continua entrando normalmente (não tem linha prévia, nenhum candidato casa).

## Verificação

- Testes unitários cobrem o payload real capturado, `@c.us`, inbound (`false_`), id bare e miolo inválido.
- **Rodando em produção há 43 horas** numa VPS Hostinger com clientes reais, na imagem publicada a partir deste código.
- `ci` (typecheck + lint + unit), `e2e` e `perf` verdes no fork.

Um de sete PRs que estou abrindo em paralelo — todos independentes, sem sobreposição de arquivos entre eles.
