### PR TITLE
fix(admin): painel de plataforma quebrava por falta de TooltipProvider

### DIFF
--- a/components/admin/AdminShell.tsx
+++ b/components/admin/AdminShell.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { PlatformModeBanner } from "./PlatformModeBanner";
 import { AdminSidebar } from "./AdminSidebar";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 interface AdminShellProps {
   userEmail: string;
@@ -10,15 +11,30 @@ interface AdminShellProps {
 /**
  * Server component shell for /admin/*. Renders the cross-tenant banner
  * (sticky top), platform sidebar, and main content area.
+ *
+ * O `TooltipProvider` mora aqui, e não em cada componente, porque o Radix exige
+ * um Provider ANCESTRAL de todo `Tooltip`: sem ele o componente lança
+ * "`Tooltip` must be used within `TooltipProvider`" no cliente, e o React
+ * derruba a árvore inteira — a tela vira a página de erro do Next, não um
+ * tooltip quebrado. Derrubava /admin/inbox (TenantBadge), /admin/usage
+ * (UsageCharts) e qualquer página que montasse UsageChart, num painel em que o
+ * dono só vê um "Digest: <hash>" sem pista nenhuma.
+ *
+ * No lado /app cada uso embrulha o seu (CredentialCard, MessageBubble), por
+ * isso lá nunca quebrou. Aqui, um Provider na casca cobre todas as telas de
+ * uma vez e novas telas nascem funcionando — é o padrão recomendado pelo Radix
+ * (Provider perto da raiz, compartilhando o delay entre os tooltips).
  */
 export function AdminShell({ userEmail, children }: AdminShellProps) {
   return (
-    <div className="flex min-h-screen w-full flex-col bg-background">
-      <PlatformModeBanner />
-      <div className="flex flex-1">
-        <AdminSidebar userEmail={userEmail} />
-        <main className="flex-1 overflow-auto p-6">{children}</main>
+    <TooltipProvider>
+      <div className="flex min-h-screen w-full flex-col bg-background">
+        <PlatformModeBanner />
+        <div className="flex flex-1">
+          <AdminSidebar userEmail={userEmail} />
+          <main className="flex-1 overflow-auto p-6">{children}</main>
+        </div>
       </div>
-    </div>
+    </TooltipProvider>
   );
 }

--- a/components/admin/AdminShell.tsx
+++ b/components/admin/AdminShell.tsx
@@ -16,14 +16,33 @@ interface AdminShellProps {
  * um Provider ANCESTRAL de todo `Tooltip`: sem ele o componente lança
  * "`Tooltip` must be used within `TooltipProvider`" no cliente, e o React
  * derruba a árvore inteira — a tela vira a página de erro do Next, não um
- * tooltip quebrado. Derrubava /admin/inbox (TenantBadge), /admin/usage
- * (UsageCharts) e qualquer página que montasse UsageChart, num painel em que o
- * dono só vê um "Digest: <hash>" sem pista nenhuma.
+ * tooltip quebrado. O dono não recebe pista nenhuma: vê "Algo deu errado" e um
+ * ID opaco (`app/error.tsx`), e no servidor não há rastro, porque o erro é do
+ * cliente.
  *
- * No lado /app cada uso embrulha o seu (CredentialCard, MessageBubble), por
- * isso lá nunca quebrou. Aqui, um Provider na casca cobre todas as telas de
- * uma vez e novas telas nascem funcionando — é o padrão recomendado pelo Radix
- * (Provider perto da raiz, compartilhando o delay entre os tooltips).
+ * QUEM É ATINGIDO, medido em vez de suposto: o único consumidor do Tooltip do
+ * Radix sem Provider próprio é o `TenantBadge`. Ele é montado em 4 telas —
+ * /admin/inbox, /admin/inbox/[conversationId], /admin/lgpd e
+ * /admin/lgpd/requests/[id]. Os outros três importadores de
+ * `components/ui/tooltip` (CredentialCard, MessageBubble, PlatformAdminsTable)
+ * embrulham o seu, por isso nunca quebraram.
+ *
+ * O que este Provider NÃO conserta, apesar de parecer: /admin/usage e
+ * /app/ai/usage. Os gráficos de lá (`UsageCharts`, `UsageChart`) importam um
+ * `Tooltip` de nome igual e origem diferente — o do **recharts**, que não usa
+ * Provider nenhum. Verificado abrindo /admin/usage com o defeito presente: a
+ * tela carrega normalmente. Fica escrito porque o nome colide e o próximo
+ * leitor vai procurar um Provider faltando ali e não vai encontrar.
+ *
+ * A quebra é CONDICIONAL A DADO: os mounts de `TenantBadge` estão atrás de
+ * guarda de organização resolvida, então uma instalação sem conversas (ou sem
+ * solicitação LGPD) abre as 4 telas normalmente mesmo com o defeito. Quem for
+ * reproduzir precisa de pelo menos uma linha com tenant; ver a tela abrir num
+ * banco vazio não significa que o defeito não existe.
+ *
+ * Um Provider na casca cobre as quatro telas de uma vez e faz tela nova nascer
+ * funcionando, em vez de repetir o erro a cada tela adicionada — é o padrão
+ * recomendado pelo Radix (Provider perto da raiz, compartilhando o delay).
  */
 export function AdminShell({ userEmail, children }: AdminShellProps) {
   return (


### PR DESCRIPTION
Várias telas de `/admin` caíam na página de erro do Next, mostrando só um `Digest: <hash>` — sem rastro no log do servidor, porque o erro é do cliente:

```
Error: `Tooltip` must be used within `TooltipProvider`
```

O Radix exige um Provider **ancestral** de todo `Tooltip`. Sem ele o componente lança, e o React derruba a árvore inteira: não é um tooltip que não abre, é **a página que some**.

Atingia:

| tela | componente |
|---|---|
| `/admin/inbox` | `components/admin/inbox/TenantBadge` |
| `/admin/usage` | `components/admin/usage/UsageCharts` |
| qualquer tela que monte | `components/ai/UsageChart` |

Nenhum dos layouts de `/admin` montava o Provider. No lado `/app` o problema não aparece porque cada uso embrulha o seu (`CredentialCard`, `MessageBubble`) — foi por isso que passou despercebido: **o app funciona, só o painel quebra.**

## A correção

O Provider entra no `AdminShell`, a casca comum de `/admin/*`, e não em cada componente. É o padrão recomendado pelo Radix (um Provider perto da raiz, compartilhando o `delayDuration` entre os tooltips) e faz telas novas nascerem funcionando, em vez de repetir o erro a cada tela adicionada.

## Verificação

Reproduzido e diagnosticado numa instalação real — o dono via só o digest e o painel inteiro inacessível. **Rodando em produção há 43 horas** na imagem publicada a partir deste código; `ci`, `e2e` e `perf` verdes no fork.

Um de sete PRs que estou abrindo em paralelo — todos independentes.
