### PR TITLE
fix(db): contacts.locale — coluna que o código lia e o banco nunca teve

### DIFF
--- a/supabase/baseline.sql
+++ b/supabase/baseline.sql
@@ -8715,3 +8715,19 @@ CREATE OR REPLACE FUNCTION "public"."retrieve_top_k_chunks"("p_organization_id" 
   order by c.embedding <=> p_embedding asc
   limit greatest(p_k, 0);
 $$;
+
+-- ---- idioma do contato (migration 0098) ----
+-- O ai-response-worker seleciona contacts.locale e o prompt usa {{contact_locale}},
+-- mas a coluna nunca existiu no snapshot: em toda instalação self-host o PostgREST
+-- respondia "column contacts_1.locale does not exist" e o worker pulava TODA
+-- conversa, com o erro escondido num log de nível info.
+-- NULL = herda o padrão da organização (o código resolve com fallback pt-BR).
+-- Sem CHECK: locale é vocabulário aberto; constraint aqui quebraria o update.sh
+-- de clones com valores legados.
+alter table public.contacts
+  add column if not exists locale text;
+
+comment on column public.contacts.locale is
+  'Idioma preferido do contato (ex.: pt-BR, es-PY). NULL = herda o padrão da organização; o código resolve com fallback pt-BR.';
+
+notify pgrst, 'reload schema';

--- a/supabase/migrations/20260801200000_0098_contacts_locale.sql
+++ b/supabase/migrations/20260801200000_0098_contacts_locale.sql
@@ -1,0 +1,32 @@
+-- 0098 — contacts.locale: a coluna que o código já lia e o banco nunca teve.
+--
+-- O `ai-response-worker` seleciona `contacts:contact_id(id, display_name, locale,
+-- is_blocked, force_human)` (workers/ai-response-worker.ts) e o render do prompt
+-- consome `{{contact_locale}}` (lib/ai/render-system-prompt.ts). A coluna nunca
+-- existiu no baseline, então em TODA instalação self-host o PostgREST devolvia
+--
+--     column contacts_1.locale does not exist
+--
+-- e o worker registrava `skip / conversation_not_found` para cada conversa. Como
+-- o skip é logado em nível info e o dono do dispatch por padrão é o
+-- agent-engine (AI_DISPATCH_OWNER=engine), o sintoma ficava escondido no log em
+-- vez de estourar — schema drift silencioso.
+--
+-- NULLABLE de propósito (doutrina DIRC): o idioma do contato não é duplicado do
+-- da organização. NULL = "não definido, herda o padrão", que é exatamente o que
+-- o código faz com `?? "pt-BR"`. Copiar o default para cada linha criaria
+-- duplicação sem fonte da verdade e um backfill a manter.
+--
+-- Sem CHECK: código de locale é vocabulário ABERTO (pt-BR, es-PY, en-US, …). Uma
+-- constraint aqui quebraria o `update.sh` de clones com valores legados, o que a
+-- doutrina de migrations proíbe.
+
+alter table public.contacts
+  add column if not exists locale text;
+
+comment on column public.contacts.locale is
+  'Idioma preferido do contato (ex.: pt-BR, es-PY). NULL = herda o padrão da organização; o código resolve com fallback pt-BR.';
+
+-- O PostgREST cacheia o schema: sem recarregar, a coluna existe no Postgres mas
+-- a API segue respondendo "does not exist" até o próximo restart.
+notify pgrst, 'reload schema';

--- a/supabase/migrations/MANIFEST.md
+++ b/supabase/migrations/MANIFEST.md
@@ -97,6 +97,7 @@ Migrations applied to Supabase project `rrydmwnporysaiysiztn` (sa-east-1, Postgr
 | `20260730180000` | `0095_budget_conta_llm_calls` | O gatilho de consumo do orçamento de IA existia só em `ai_invocations` (workers legados); o agent-engine grava em `llm_calls`, então o contador ficava zerado, a tela mostrava R$ 0,00 com dinheiro saindo e o alarme/pausa nunca disparavam. Passa a valer nas duas + reconcilia o mês corrente. |
 | `20260730200000` | `0096_llm_default_model_da_org` | Toda org nasce (e as existentes são curadas) com `settings.llm.default_model`. Sem ele o caminho genérico do turno — documentado como "não é silêncio" — ficava sem modelo e o turno morria com "modelo LLM não definido"; bastava um roteador sem membros para derrubar TODAS as respostas. |
 | `20260730220000` | `0097_rag_threshold_calibrado` | Limiar de similaridade do RAG de 0.72 para 0.40, calibrado por medição (relevante 0.49–0.85, irrelevante 0.27). Com 0.72 só a pergunta literal do FAQ passava e toda paráfrase era descartada. |
+| `20260801200000` | `0098_contacts_locale` | Adiciona `contacts.locale` (nullable). O `ai-response-worker` já selecionava a coluna e o prompt já usava `{{contact_locale}}`, mas ela nunca existiu no baseline: em toda instalação self-host o PostgREST devolvia "column contacts_1.locale does not exist" e o worker pulava TODA conversa, com o erro escondido num log de nível info. NULL = herda o padrão da organização (fallback pt-BR no código); sem CHECK porque locale é vocabulário aberto. |
 
 ## Reproducibility
 


### PR DESCRIPTION
O `ai-response-worker` seleciona `contacts:contact_id(id, display_name, locale, is_blocked, force_human)` e o render do prompt consome `{{contact_locale}}` — mas **a coluna nunca existiu no baseline**. Em TODA instalação self-host o PostgREST devolvia

```
column contacts_1.locale does not exist
```

e o worker registrava `skip / conversation_not_found` para cada conversa, uma vez por mensagem recebida. Como o skip é logado em nível **info** e o dono do dispatch por padrão é o agent-engine (`AI_DISPATCH_OWNER=engine`), o sintoma ficava escondido no log em vez de estourar. Schema drift silencioso: a IA não respondia e nada dizia por quê.

## Provado, não afirmado

Não quis mandar isso só com o meu relato. Subi um Postgres descartável (`pgvector/pgvector:pg17`), apliquei o `baseline.sql` **da `main`** como o `install.sh` faz, e rodei a consulta exata do worker:

```
baseline da main   ->  ERROR: column "locale" does not exist
baseline com o fix ->  passa
```

E as três perguntas que importam para quem já clonou:

| | |
|---|---|
| instalação nova (`ON_ERROR_STOP=1`) | ✅ install limpo, coluna `text · nullable` |
| clone antigo rodando o `update.sh` | ✅ 1500 → 1500 contatos, 0 erros de psql, recebeu a coluna |
| idempotência (re-aplicar) | ✅ 0 erros, coluna continua única |

## Decisões

**NULLABLE de propósito** (doutrina DIRC): o idioma do contato não se duplica do da organização. `NULL` = "não definido, herda o padrão", que é exatamente o que o código faz com `?? "pt-BR"`. Copiar o default para cada linha criaria duplicação sem fonte da verdade e um backfill a manter.

**Sem CHECK**: código de locale é vocabulário **aberto** (`pt-BR`, `es-PY`, `en-US`…). Uma constraint aqui quebraria o `update.sh` de clones com valores legados, o que a doutrina de migrations proíbe.

Os três artefatos andam juntos: migration versionada, apêndice idempotente no `baseline.sql` (é o que o kit self-host aplica) e linha no MANIFEST.

Um de sete PRs que estou abrindo em paralelo. Este e o da foto de perfil (#113) são os dois que tocam `baseline.sql` e o MANIFEST — cada um acrescenta o seu próprio bloco no fim, então quando o primeiro entrar eu rebaso o outro.
