### PR TITLE
feat(ai): resolve o modelo pelo provider disponível e adiciona OpenRouter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,16 @@ AI_GATEWAY_BASE_URL=
 VERCEL_AI_GATEWAY_URL=
 # Fallback direto Anthropic (caso AI Gateway indisponível ou desabilitado pra um tenant)
 ANTHROPIC_API_KEY=
+
+# OpenRouter (OPCIONAL) — alternativa ao gateway da Vercel, compatível com a API
+# da OpenAI, com catálogo grande de modelos num único faturamento.
+# Ordem de resolução do chat: AI_GATEWAY_API_KEY > OPENROUTER_API_KEY > provider
+# direto (ANTHROPIC_API_KEY / OPENAI_API_KEY). Vazio = nada muda.
+# ATENÇÃO: o agente do CRM opera por FERRAMENTAS (contacts, leads, pipelines,
+# catalog, handoff). Modelo sem tool calling sólido não dá erro — ele responde
+# texto plausível e NUNCA cria o lead nem move o card. Escolha um que suporte.
+OPENROUTER_API_KEY=
+OPENROUTER_BASE_URL=                     # vazio = https://openrouter.ai/api/v1
 # Pra embeddings (text-embedding-3-small) usados no RAG por tenant
 OPENAI_API_KEY=
 

--- a/.env.example
+++ b/.env.example
@@ -64,9 +64,17 @@ ANTHROPIC_API_KEY=
 # da OpenAI, com catálogo grande de modelos num único faturamento.
 # Ordem de resolução do chat: AI_GATEWAY_API_KEY > OPENROUTER_API_KEY > provider
 # direto (ANTHROPIC_API_KEY / OPENAI_API_KEY). Vazio = nada muda.
-# ATENÇÃO: o agente do CRM opera por FERRAMENTAS (contacts, leads, pipelines,
-# catalog, handoff). Modelo sem tool calling sólido não dá erro — ele responde
-# texto plausível e NUNCA cria o lead nem move o card. Escolha um que suporte.
+#
+# ALCANCE — leia antes de trocar. Esta chave roteia a classificação de
+# sentimento e o bot de resposta. Ela NÃO troca o provider do AGENTE do CRM:
+# o agente usa a credencial cadastrada por organização (tela de Agentes) e
+# aceita Anthropic, OpenAI ou Google. Preencher aqui não migra o agente — se a
+# intenção era essa, o lugar é a tela, não este arquivo.
+# Isso importa porque o agente opera por FERRAMENTAS (contacts, leads,
+# pipelines, catalog, handoff), e modelo sem tool calling sólido não dá erro:
+# responde texto plausível e nunca cria o lead nem move o card. Os caminhos que
+# esta chave alcança não usam ferramentas, então não correm esse risco.
+# O invariante que segura esta afirmação: tests/unit/openrouter-alcance.test.ts
 OPENROUTER_API_KEY=
 OPENROUTER_BASE_URL=                     # vazio = https://openrouter.ai/api/v1
 # Pra embeddings (text-embedding-3-small) usados no RAG por tenant

--- a/.env.hostgator.example
+++ b/.env.hostgator.example
@@ -40,6 +40,16 @@ NEXT_PUBLIC_ADMIN_URL=https://crm.seudominio.com.br
 # -----------------------------------------------------------------------------
 AI_GATEWAY_API_KEY=                      # ou ANTHROPIC_API_KEY abaixo
 ANTHROPIC_API_KEY=
+
+# OpenRouter (OPCIONAL) — alternativa ao gateway da Vercel, compatível com a API
+# da OpenAI, com catálogo grande de modelos num único faturamento.
+# Ordem de resolução do chat: AI_GATEWAY_API_KEY > OPENROUTER_API_KEY > provider
+# direto (ANTHROPIC_API_KEY / OPENAI_API_KEY). Vazio = nada muda.
+# ATENÇÃO: o agente do CRM opera por FERRAMENTAS (contacts, leads, pipelines,
+# catalog, handoff). Modelo sem tool calling sólido não dá erro — ele responde
+# texto plausível e NUNCA cria o lead nem move o card. Escolha um que suporte.
+OPENROUTER_API_KEY=
+OPENROUTER_BASE_URL=                     # vazio = https://openrouter.ai/api/v1
 OPENAI_API_KEY=                          # opcional — embeddings do RAG
 
 # -----------------------------------------------------------------------------

--- a/.env.hostgator.example
+++ b/.env.hostgator.example
@@ -45,9 +45,16 @@ ANTHROPIC_API_KEY=
 # da OpenAI, com catálogo grande de modelos num único faturamento.
 # Ordem de resolução do chat: AI_GATEWAY_API_KEY > OPENROUTER_API_KEY > provider
 # direto (ANTHROPIC_API_KEY / OPENAI_API_KEY). Vazio = nada muda.
-# ATENÇÃO: o agente do CRM opera por FERRAMENTAS (contacts, leads, pipelines,
-# catalog, handoff). Modelo sem tool calling sólido não dá erro — ele responde
-# texto plausível e NUNCA cria o lead nem move o card. Escolha um que suporte.
+#
+# ALCANCE — leia antes de trocar. Esta chave roteia a classificação de
+# sentimento e o bot de resposta. Ela NÃO troca o provider do AGENTE do CRM:
+# o agente usa a credencial cadastrada por organização (tela de Agentes) e
+# aceita Anthropic, OpenAI ou Google. Preencher aqui não migra o agente — se a
+# intenção era essa, o lugar é a tela, não este arquivo.
+# Isso importa porque o agente opera por FERRAMENTAS (contacts, leads,
+# pipelines, catalog, handoff), e modelo sem tool calling sólido não dá erro:
+# responde texto plausível e nunca cria o lead nem move o card. Os caminhos que
+# esta chave alcança não usam ferramentas, então não correm esse risco.
 OPENROUTER_API_KEY=
 OPENROUTER_BASE_URL=                     # vazio = https://openrouter.ai/api/v1
 OPENAI_API_KEY=                          # opcional — embeddings do RAG

--- a/lib/ai/gateway-resolve-model.test.ts
+++ b/lib/ai/gateway-resolve-model.test.ts
@@ -1,0 +1,79 @@
+/**
+ * O que este teste protege: **o modelo de CHAT tem que virar um provider
+ * explícito quando não há gateway.**
+ *
+ * `isAiGatewayConfigured()` já devolvia `true` com só `ANTHROPIC_API_KEY` — a
+ * única chave que o `install.sh` exige. Mas quem executava passava o id como
+ * STRING, e no AI SDK id com barra é resolvido pelo **gateway da Vercel mesmo
+ * sem chave**, caindo no plano anônimo:
+ *
+ *     Unauthenticated. Configure AI_GATEWAY_API_KEY or use a provider module.
+ *
+ * Resultado observado numa instalação self-host real: o `ai-sentiment-worker`
+ * falhava em loop, uma vez por mensagem recebida. Ou seja, a checagem dizia
+ * "tem IA" e a execução dizia "não tem" — desalinhados.
+ *
+ * A asserção é sobre o TIPO do retorno, mesma lógica do `embed.test.ts`:
+ * string = "deixa o gateway resolver"; objeto = "provider explícito". É a única
+ * diferença observável sem rede.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const envMock: Record<string, string> = {};
+vi.mock("@/lib/env", () => ({
+  get env() {
+    return envMock;
+  },
+}));
+
+import { resolveLanguageModel } from "@/lib/ai/gateway";
+
+beforeEach(() => {
+  for (const k of Object.keys(envMock)) delete envMock[k];
+});
+
+describe("resolveLanguageModel", () => {
+  it("com gateway da Vercel devolve a STRING (o gateway roteia e fatura)", () => {
+    envMock.AI_GATEWAY_API_KEY = "gw-key";
+    expect(resolveLanguageModel("anthropic/claude-haiku-4-5")).toBe(
+      "anthropic/claude-haiku-4-5",
+    );
+  });
+
+  it("só com ANTHROPIC_API_KEY devolve PROVIDER, não string — o bug do worker", () => {
+    envMock.ANTHROPIC_API_KEY = "sk-ant-xxx";
+    const model = resolveLanguageModel("anthropic/claude-haiku-4-5");
+    expect(model).not.toBeNull();
+    expect(typeof model).not.toBe("string");
+  });
+
+  it("com OPENROUTER_API_KEY devolve provider (ids da OpenRouter são provider/modelo)", () => {
+    envMock.OPENROUTER_API_KEY = "sk-or-xxx";
+    const model = resolveLanguageModel("anthropic/claude-haiku-4-5");
+    expect(model).not.toBeNull();
+    expect(typeof model).not.toBe("string");
+  });
+
+  it("gateway da Vercel tem precedência sobre OpenRouter", () => {
+    envMock.AI_GATEWAY_API_KEY = "gw-key";
+    envMock.OPENROUTER_API_KEY = "sk-or-xxx";
+    expect(typeof resolveLanguageModel("anthropic/claude-haiku-4-5")).toBe("string");
+  });
+
+  it("id openai/* cai no provider OpenAI quando só há OPENAI_API_KEY", () => {
+    envMock.OPENAI_API_KEY = "sk-openai";
+    const model = resolveLanguageModel("openai/gpt-4o-mini");
+    expect(model).not.toBeNull();
+    expect(typeof model).not.toBe("string");
+  });
+
+  it("sem chave nenhuma devolve null, para o chamador PULAR com motivo claro", () => {
+    expect(resolveLanguageModel("anthropic/claude-haiku-4-5")).toBeNull();
+  });
+
+  it("chave errada para o prefixo do id também é null (não inventa provider)", () => {
+    // Só OpenAI configurada, mas o id pede Anthropic: não dá para atender.
+    envMock.OPENAI_API_KEY = "sk-openai";
+    expect(resolveLanguageModel("anthropic/claude-haiku-4-5")).toBeNull();
+  });
+});

--- a/lib/ai/gateway.ts
+++ b/lib/ai/gateway.ts
@@ -11,7 +11,15 @@
  * Only model strings via the gateway-shaped `ai` SDK calls.
  */
 
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAI } from "@ai-sdk/openai";
+import type { LanguageModel } from "ai";
+
 import { env } from "@/lib/env";
+
+/** Endpoint da OpenRouter. Compatível com a API da OpenAI, então o provider
+ *  `@ai-sdk/openai` fala com ela sem dependência nova. */
+export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 
 export type ModelId =
   | "anthropic/claude-sonnet-4-6"
@@ -25,7 +33,61 @@ export const DEFAULT_CLASSIFIER_MODEL: ModelId = "anthropic/claude-haiku-4-5";
 export const DEFAULT_EMBEDDING_MODEL: ModelId = "openai/text-embedding-3-small";
 
 export function isAiGatewayConfigured(): boolean {
-  return Boolean(env.AI_GATEWAY_API_KEY) || Boolean(env.ANTHROPIC_API_KEY);
+  return (
+    Boolean(env.AI_GATEWAY_API_KEY) ||
+    Boolean(env.OPENROUTER_API_KEY) ||
+    Boolean(env.ANTHROPIC_API_KEY)
+  );
+}
+
+/**
+ * Resolve o modelo de CHAT para algo que o `ai` SDK saiba executar.
+ *
+ * Existe porque `isAiGatewayConfigured()` e a execução real estavam
+ * desalinhados: a checagem dizia "tem IA" com a `ANTHROPIC_API_KEY` (a única
+ * que o install.sh exige), mas quem executava passava o id como STRING, e no
+ * AI SDK string com barra é roteada pelo gateway da Vercel — que sem
+ * `AI_GATEWAY_API_KEY` cai no plano anônimo e devolve
+ *
+ *     Unauthenticated. Configure AI_GATEWAY_API_KEY or use a provider module.
+ *
+ * Ou seja: em TODA instalação self-host padrão o worker de sentimento falhava
+ * em loop. Mesma armadilha que o `embed.ts` já documentava e resolvia para
+ * embeddings; aqui o caminho de chat ficou sem o equivalente.
+ *
+ * Ordem de resolução, do mais específico ao mais genérico:
+ *   1. Gateway da Vercel  -> devolve a string; o gateway roteia e fatura
+ *   2. OpenRouter         -> provider OpenAI-compatível apontado ao endpoint
+ *      dela. Os ids da OpenRouter já são `provider/modelo`, então o mesmo id
+ *      canônico serve sem tradução.
+ *   3. Provider direto     -> Anthropic ou OpenAI, conforme o prefixo do id
+ *
+ * Devolve null quando nada está configurado, para o chamador PULAR com motivo
+ * claro em vez de estourar com erro de rede lá dentro.
+ */
+export function resolveLanguageModel(model: ModelId): LanguageModel | null {
+  const id = String(model);
+
+  if (gatewayConfig()) return id as LanguageModel;
+
+  if (env.OPENROUTER_API_KEY) {
+    return createOpenAI({
+      apiKey: env.OPENROUTER_API_KEY,
+      baseURL: env.OPENROUTER_BASE_URL || OPENROUTER_BASE_URL,
+    })(id);
+  }
+
+  if (id.startsWith("anthropic/") && env.ANTHROPIC_API_KEY) {
+    return createAnthropic({ apiKey: env.ANTHROPIC_API_KEY })(
+      id.slice("anthropic/".length),
+    );
+  }
+
+  if (id.startsWith("openai/") && env.OPENAI_API_KEY) {
+    return createOpenAI({ apiKey: env.OPENAI_API_KEY })(id.slice("openai/".length));
+  }
+
+  return null;
 }
 
 export function isEmbeddingProviderConfigured(): boolean {

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -87,6 +87,11 @@ const schema = z.object({
   // when AI_GATEWAY_API_KEY is absent, so production boot must not be fatal.
   AI_GATEWAY_API_KEY: z.string().optional().default(""),
   AI_GATEWAY_BASE_URL: z.string().optional().default(""),
+  // OpenRouter: alternativa ao gateway da Vercel, compatível com a API da
+  // OpenAI. Opcional — sem ela nada muda; com ela o chat passa a ser roteado
+  // por lá. Ver resolveLanguageModel() em lib/ai/gateway.ts.
+  OPENROUTER_API_KEY: z.string().optional().default(""),
+  OPENROUTER_BASE_URL: z.string().optional().default(""),
   VERCEL_AI_GATEWAY_URL: z.string().optional().default(""),
   ANTHROPIC_API_KEY: z.string().optional().default(""),
   OPENAI_API_KEY: z.string().optional().default(""),

--- a/tests/unit/ai-response-worker-model-routing.test.ts
+++ b/tests/unit/ai-response-worker-model-routing.test.ts
@@ -1,0 +1,253 @@
+/**
+ * O que este teste protege: **o worker que RESPONDE O CLIENTE tem que falar com
+ * o provider que a instalação realmente tem.**
+ *
+ * Irmão do `lib/ai/gateway-resolve-model.test.ts`, com uma diferença de força
+ * deliberada: lá a asserção é sobre o TIPO do retorno de `resolveLanguageModel`
+ * (string = gateway, objeto = provider). Aqui a asserção é sobre o EFEITO —
+ * para onde a requisição vai, medido interceptando `globalThis.fetch`, com o
+ * `ai` SDK de verdade no caminho. Por isso este arquivo NÃO mocka o módulo
+ * `ai`: mockar `generateText` provaria só que uma string foi passada adiante;
+ * o que interessa é que o cliente fica sem resposta.
+ *
+ * O defeito, medido em ai@7.0.37: `model` STRING com barra é roteado pelo
+ * gateway da Vercel, e sem `AI_GATEWAY_API_KEY` o SDK aborta ANTES de emitir
+ * qualquer fetch:
+ *
+ *     Unauthenticated request to AI Gateway. To authenticate, set the
+ *     AI_GATEWAY_API_KEY environment variable with your API key.
+ *
+ * Numa instalação self-host padrão — a que o `install.sh` produz, que exige só
+ * `ANTHROPIC_API_KEY` — isso acontece uma vez por mensagem recebida, e o
+ * sintoma para o usuário é o bot simplesmente não responder.
+ *
+ * `workers/ai-sentiment-worker.ts` tinha o mesmo defeito e foi corrigido no
+ * mesmo PR. Este worker é o que fala com o cliente, então o buraco aqui é o
+ * caro. Os dois estão registrados em `lib/event-log/register-handlers.ts`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Env do self-host padrão: SÓ a chave da Anthropic, que é a única que o
+// install.sh exige. É esta combinação que reproduz o defeito.
+const envMock: Record<string, string> = {
+  ANTHROPIC_API_KEY: "sk-ant-teste",
+  AI_GATEWAY_API_KEY: "",
+  AI_GATEWAY_BASE_URL: "",
+  OPENROUTER_API_KEY: "",
+  OPENROUTER_BASE_URL: "",
+  OPENAI_API_KEY: "",
+};
+vi.mock("@/lib/env", () => ({
+  get env() {
+    return envMock;
+  },
+}));
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { processMessageReceived } from "@/workers/ai-response-worker";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { EventRow } from "@/lib/event-log/dispatcher";
+
+const ORG_ID = "22222222-2222-4222-8222-222222222222";
+const CONV_ID = "44444444-4444-4444-8444-444444444444";
+const MSG_ID = "55555555-5555-4555-8555-555555555555";
+const CONTACT_ID = "66666666-6666-4666-8666-666666666666";
+const AGENT_ID = "88888888-8888-4888-8888-888888888888";
+
+// Corpo neutro de propósito: qualquer gatilho de handoff (G1 "quero falar com
+// humano", G4 "advogado") desviaria o fluxo ANTES do LLM e o teste passaria
+// sem nunca exercitar o ponto em questão.
+const INBOUND_BODY = "bom dia, qual o prazo de entrega?";
+
+/**
+ * Stub do admin client suficiente para o pipeline chegar ao LLM. Cada tabela
+ * devolve a linha mínima que faz o guard correspondente NÃO vetar — o objetivo
+ * é justamente alcançar `invokeBot`, não testar os guards (isso é o
+ * ai-response-bot-veto.test.ts).
+ */
+function makeAdminStub() {
+  const inserted: Array<{ table: string; row: Record<string, unknown> }> = [];
+
+  const from = (table: string) => {
+    const single: Record<string, unknown> | null =
+      table === "conversations"
+        ? {
+            id: CONV_ID,
+            organization_id: ORG_ID,
+            contact_id: CONTACT_ID,
+            channel_session_id: "77777777-7777-4777-8777-777777777777",
+            last_inbound_at: new Date().toISOString(),
+            bot_silenced_until: null,
+            last_handoff_at: null,
+            assignee_kind: "ai",
+            contacts: {
+              id: CONTACT_ID,
+              display_name: null, // sem PII em teste (LGPD)
+              locale: "pt-BR",
+              is_blocked: false,
+              force_human: false,
+            },
+          }
+        : table === "messages"
+          ? {
+              id: MSG_ID,
+              body: INBOUND_BODY,
+              direction: "inbound",
+              organization_id: ORG_ID,
+            }
+          : table === "ai_agents"
+            ? {
+                id: AGENT_ID,
+                organization_id: ORG_ID,
+                // Vem do banco como STRING — é a origem exata do defeito.
+                model: "anthropic/claude-sonnet-4-6",
+                system_prompt: "Você é um atendente.",
+                // Sem RAG neste stub, a confiança é 0 e o guard G3 desviaria
+                // para handoff — o que provaria o LLM respondendo, mas pararia
+                // antes do dispatch. Zerar o limiar deixa o caminho completo
+                // (resposta → persistência → message.send_requested) visível.
+                config: { confidence_threshold: 0 },
+                guardrails: {},
+                active_kb_version_id: "99999999-9999-4999-8999-999999999999",
+                is_active: true,
+                is_default: true,
+              }
+            : null; // ai_budgets sem linha = sem throttle; crm_leads sem lead
+
+    // Proxy em vez de listar os filtros um a um: qualquer método do
+    // query-builder que não seja terminal (.eq, .is, .in, .not, .gte…) devolve
+    // o próprio chain. Sem isso o teste vira uma caçada a "X is not a function"
+    // toda vez que o worker ganha um filtro novo.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const terminais: any = {
+      maybeSingle: () => Promise.resolve({ data: single, error: null }),
+      single: () => Promise.resolve({ data: single, error: null }),
+      insert: (row: Record<string, unknown>) => {
+        inserted.push({ table, row });
+        return {
+          select: () => ({
+            single: () =>
+              Promise.resolve({ data: { id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }, error: null }),
+          }),
+          then: (resolve: (v: unknown) => unknown) =>
+            Promise.resolve({ data: null, error: null }).then(resolve),
+        };
+      },
+      // Await direto na query = lista (mensagens recentes).
+      then: (resolve: (v: unknown) => unknown) =>
+        Promise.resolve({
+          data:
+            table === "messages"
+              ? [{ id: MSG_ID, body: INBOUND_BODY, direction: "inbound", created_at: new Date().toISOString() }]
+              : [],
+          error: null,
+        }).then(resolve),
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const chain: any = new Proxy(terminais, {
+      get: (alvo, prop) => (prop in alvo ? alvo[prop as keyof typeof alvo] : () => chain),
+    });
+    return chain;
+  };
+
+  // `emit_event` (evento message.send_requested) e o RPC de RAG passam por aqui.
+  const rpc = () => Promise.resolve({ data: [], error: null });
+
+  return { stub: { from, rpc }, inserted };
+}
+
+const eventRow = {
+  organization_id: ORG_ID,
+  entity_id: MSG_ID,
+  payload: { message_id: MSG_ID, conversation_id: CONV_ID },
+} as unknown as EventRow;
+
+let fetchOriginal: typeof globalThis.fetch;
+let destinos: string[];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  destinos = [];
+  fetchOriginal = globalThis.fetch;
+  // Nenhuma chamada de rede sai daqui: o stub responde no lugar do provider.
+  // O que interessa é o REGISTRO do destino — é ele que distingue "foi ao
+  // provider certo" de "nem tentou".
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" || input instanceof URL ? String(input) : input.url;
+    destinos.push(new URL(url).host);
+    return new Response(
+      JSON.stringify({
+        id: "msg_stub",
+        type: "message",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "Nosso prazo é de 3 dias úteis." }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 10, output_tokens: 8 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as typeof globalThis.fetch;
+
+  const { stub } = makeAdminStub();
+  vi.mocked(createAdminClient).mockReturnValue(stub as unknown as ReturnType<typeof createAdminClient>);
+});
+
+afterEach(() => {
+  globalThis.fetch = fetchOriginal;
+});
+
+describe("ai-response-worker — resolução do modelo numa instalação self-host", () => {
+  it("com só ANTHROPIC_API_KEY, a chamada chega ao provider e o cliente é respondido", async () => {
+    const result = await processMessageReceived(eventRow);
+
+    // A asserção que importa: a requisição SAIU, e saiu para a Anthropic.
+    // Sem o resolver, `destinos` fica VAZIO — o SDK aborta antes de qualquer
+    // fetch, reclamando de AI_GATEWAY_API_KEY.
+    expect(destinos).toContain("api.anthropic.com");
+    // O `detail` entra na mensagem para que uma quebra futura diga POR QUÊ
+    // falhou, em vez de só "error !== sent_to_dispatch".
+    expect(
+      result.status,
+      `reason: ${result.reason ?? "-"} | detail: ${result.detail ?? "(vazio)"}`,
+    ).toBe("sent_to_dispatch");
+  });
+
+  it("o defeito, explicitado: model como STRING nem emite requisição", async () => {
+    // Reproduz o caminho da main SEM depender do worker, para deixar claro que
+    // a origem é o TIPO do argumento e não outra coisa do pipeline: mesmo env,
+    // mesmo SDK, mesma mensagem — só muda string vs provider.
+    const { generateText } = await import("ai");
+    const { createAnthropic } = await import("@ai-sdk/anthropic");
+
+    destinos = [];
+    await expect(
+      generateText({ model: "anthropic/claude-sonnet-4-6", prompt: INBOUND_BODY }),
+    ).rejects.toThrow(/AI Gateway/i);
+    expect(destinos).toEqual([]); // nem tentou a rede
+
+    destinos = [];
+    await generateText({
+      model: createAnthropic({ apiKey: "sk-ant-teste" })("claude-sonnet-4-6"),
+      prompt: INBOUND_BODY,
+    });
+    expect(destinos).toEqual(["api.anthropic.com"]);
+  });
+
+  it("sem chave nenhuma o worker PULA com motivo claro, em vez de estourar", async () => {
+    const anterior = envMock.ANTHROPIC_API_KEY ?? "";
+    envMock.ANTHROPIC_API_KEY = "";
+    try {
+      const result = await processMessageReceived(eventRow);
+      expect(result.status).toBe("skipped");
+      expect(result.reason).toBe("ai_gateway_key_missing");
+      expect(destinos).toEqual([]);
+    } finally {
+      envMock.ANTHROPIC_API_KEY = anterior;
+    }
+  });
+});

--- a/tests/unit/gateway-destino-por-caminho.test.ts
+++ b/tests/unit/gateway-destino-por-caminho.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Os TRÊS caminhos de `resolveLanguageModel`, medidos pelo destino real da
+ * requisição — não pelo tipo do retorno.
+ *
+ * `lib/ai/gateway-resolve-model.test.ts` já cobre a tabela de decisão (string =
+ * gateway, objeto = provider, null = nada configurado). Este arquivo fecha o
+ * degrau seguinte: o que o SDK FAZ com cada retorno. Um resolver que devolvesse
+ * o objeto certo apontando para o endpoint errado passaria naquele teste e
+ * falharia aqui — e é o endpoint que cobra a fatura do self-hoster.
+ *
+ * Técnica: `globalThis.fetch` interceptado, `ai` SDK real no caminho, nenhuma
+ * chamada de rede sai. A asserção é o host de destino.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const envMock: Record<string, string> = {};
+vi.mock("@/lib/env", () => ({
+  get env() {
+    return envMock;
+  },
+}));
+
+import { resolveLanguageModel } from "@/lib/ai/gateway";
+
+const MODELO = "anthropic/claude-haiku-4-5";
+
+let fetchOriginal: typeof globalThis.fetch;
+let destinos: string[];
+
+/** Executa o modelo resolvido e devolve os hosts que ele tentou alcançar. */
+async function destinoDe(model: NonNullable<Awaited<ReturnType<typeof resolveLanguageModel>>>) {
+  const { generateText } = await import("ai");
+  destinos = [];
+  try {
+    await generateText({ model, prompt: "oi" });
+  } catch {
+    // O stub responde 200 com corpo que nem sempre casa o formato do provider;
+    // o que interessa já foi capturado no momento do fetch.
+  }
+  return destinos;
+}
+
+beforeEach(() => {
+  for (const k of Object.keys(envMock)) delete envMock[k];
+  delete process.env.AI_GATEWAY_API_KEY;
+  destinos = [];
+  fetchOriginal = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" || input instanceof URL ? String(input) : input.url;
+    destinos.push(new URL(url).host);
+    return new Response(JSON.stringify({ content: [{ type: "text", text: "ok" }] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = fetchOriginal;
+  delete process.env.AI_GATEWAY_API_KEY;
+});
+
+describe("destino real de cada caminho de resolveLanguageModel", () => {
+  it("gateway da Vercel → a requisição vai para o gateway", async () => {
+    envMock.AI_GATEWAY_API_KEY = "gw-key";
+    // O SDK lê esta chave do process.env por conta própria quando o model é
+    // string — é justamente esse acoplamento implícito que originou o bug.
+    process.env.AI_GATEWAY_API_KEY = "gw-key";
+
+    const model = resolveLanguageModel(MODELO);
+    expect(model).not.toBeNull();
+    expect(await destinoDe(model!)).toContain("ai-gateway.vercel.sh");
+  });
+
+  it("OpenRouter → a requisição vai para a OpenRouter, não para a Anthropic", async () => {
+    envMock.OPENROUTER_API_KEY = "sk-or-xxx";
+    // Chave da Anthropic presente de propósito: a precedência tem que valer.
+    envMock.ANTHROPIC_API_KEY = "sk-ant-xxx";
+
+    const model = resolveLanguageModel(MODELO);
+    expect(model).not.toBeNull();
+    const hosts = await destinoDe(model!);
+    expect(hosts).toContain("openrouter.ai");
+    expect(hosts).not.toContain("api.anthropic.com");
+  });
+
+  it("provider direto → a requisição vai para a Anthropic", async () => {
+    envMock.ANTHROPIC_API_KEY = "sk-ant-xxx";
+
+    const model = resolveLanguageModel(MODELO);
+    expect(model).not.toBeNull();
+    expect(await destinoDe(model!)).toContain("api.anthropic.com");
+  });
+
+  it("com gateway E OpenRouter configurados, quem roteia é o gateway", async () => {
+    // A ordem é contrato de faturamento: quem tem gateway contratado espera que
+    // o tráfego passe (e seja cobrado) por lá. Medir pelo tipo do retorno não
+    // pega uma inversão de precedência que aponte para o endpoint errado —
+    // este caso pega, porque compara os dois hosts possíveis.
+    envMock.AI_GATEWAY_API_KEY = "gw-key";
+    process.env.AI_GATEWAY_API_KEY = "gw-key";
+    envMock.OPENROUTER_API_KEY = "sk-or-xxx";
+
+    const model = resolveLanguageModel(MODELO);
+    expect(model).not.toBeNull();
+    const hosts = await destinoDe(model!);
+    expect(hosts).toContain("ai-gateway.vercel.sh");
+    expect(hosts).not.toContain("openrouter.ai");
+  });
+
+  it("OPENROUTER_BASE_URL customizada é respeitada (proxy/gateway próprio)", async () => {
+    envMock.OPENROUTER_API_KEY = "sk-or-xxx";
+    envMock.OPENROUTER_BASE_URL = "https://meu-proxy.example.com/v1";
+
+    const model = resolveLanguageModel(MODELO);
+    expect(model).not.toBeNull();
+    expect(await destinoDe(model!)).toContain("meu-proxy.example.com");
+  });
+});

--- a/tests/unit/openrouter-alcance.test.ts
+++ b/tests/unit/openrouter-alcance.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Invariante de ALCANCE: o que a `OPENROUTER_API_KEY` roteia — e o que ela não
+ * roteia.
+ *
+ * Por que este arquivo existe: o `.env.example` afirma ao self-hoster quais
+ * caminhos passam a usar a OpenRouter quando ele preenche a chave. Afirmação em
+ * comentário não se defende sozinha — a primeira pessoa que ligar o resolver a
+ * um caminho novo não vai lembrar de reescrever o aviso, e o usuário decide a
+ * configuração da instalação lendo justamente esse aviso.
+ *
+ * O alcance real hoje, medido: `resolveLanguageModel()` é chamado por
+ * `ai-sentiment-worker` (classificação de sentimento) e `ai-response-worker`
+ * (bot de resposta). NENHUM dos dois passa `tools` ao SDK. O agente do CRM, que
+ * opera por ferramentas, roda por outro caminho — `lib/agent-engine/edge/llm/
+ * providers.ts` (credencial BYOK por organização) e `buildModel()` em
+ * `lib/ai/runtime/agent.ts` —, e nenhum deles conhece a OpenRouter.
+ *
+ * Isso importa porque muda QUAL risco o usuário corre. Um modelo sem tool
+ * calling sólido é catastrófico num turno com ferramentas (responde texto
+ * plausível e nunca cria o lead nem move o card) e é inofensivo numa
+ * classificação de sentimento. Enquanto a OpenRouter não alcançar o primeiro
+ * grupo, o aviso não deve assustar com ele; no dia em que alcançar, o aviso
+ * PRECISA assustar — e este teste é quem obriga a decidir isso conscientemente.
+ */
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const RAIZ = resolve(__dirname, "../..");
+
+/** Arquivos de produção que importam o resolver (exclui testes e o próprio módulo). */
+function chamadoresDoResolver(): string[] {
+  const saida = execFileSync(
+    "git",
+    ["grep", "-l", "resolveLanguageModel", "--", "lib", "workers", "app", "scripts"],
+    { cwd: RAIZ, encoding: "utf8" },
+  );
+  return saida
+    .split("\n")
+    .filter(Boolean)
+    .filter((f) => !f.includes(".test.") && f !== "lib/ai/gateway.ts" && f !== "lib/env.ts");
+}
+
+describe("alcance da OPENROUTER_API_KEY", () => {
+  it("o resolver tem chamadores — senão o invariante estaria passando por vacuidade", () => {
+    // Sem esta asserção, apagar o resolver deixaria o teste abaixo verde e o
+    // aviso do .env.example desprotegido.
+    expect(chamadoresDoResolver().length).toBeGreaterThan(0);
+  });
+
+  it("nenhum caminho roteado pela OpenRouter passa FERRAMENTAS ao modelo", () => {
+    const comFerramentas = chamadoresDoResolver().filter((arquivo) =>
+      /\btools\s*:/.test(readFileSync(resolve(RAIZ, arquivo), "utf8")),
+    );
+
+    expect(
+      comFerramentas,
+      comFerramentas.length
+        ? `${comFerramentas.join(", ")} passa(m) ferramentas ao modelo E resolve(m) pela OpenRouter. ` +
+            "O aviso sobre tool calling em .env.example / .env.hostgator.example foi escrito quando " +
+            "isso NÃO acontecia e agora está desatualizado: reescreva-o antes de liberar este caminho."
+        : undefined,
+    ).toEqual([]);
+  });
+
+  it("o agente com ferramentas continua fora do alcance da OpenRouter", () => {
+    // Os dois runtimes que passam `tools` montam o modelo por conta própria.
+    // Se um deles passar a conhecer a OpenRouter, o aviso muda de natureza.
+    for (const arquivo of ["lib/agent-engine/edge/llm/providers.ts", "lib/ai/runtime/agent.ts"]) {
+      expect(readFileSync(resolve(RAIZ, arquivo), "utf8").toLowerCase()).not.toContain("openrouter");
+    }
+  });
+});

--- a/workers/ai-response-worker.ts
+++ b/workers/ai-response-worker.ts
@@ -14,7 +14,7 @@
  * `row.organization_id` (from the trusted event_log row, not user input).
  */
 
-import { generateText } from "ai";
+import { generateText, type LanguageModel } from "ai";
 
 import {
   DEFAULT_BOT_MODEL,
@@ -22,6 +22,7 @@ import {
   gatewayHeaders,
   isAiGatewayConfigured,
   isEmbeddingProviderConfigured,
+  resolveLanguageModel,
 } from "@/lib/ai/gateway";
 import { embedText } from "@/lib/ai/embed";
 import { computeCost } from "@/lib/ai/cost";
@@ -127,8 +128,35 @@ export async function processMessageReceived(row: EventRow): Promise<ProcessResu
     return { status: "skipped", reason: "handoff_g4_stage" };
   }
 
+  // Mesma armadilha que quebrava o ai-sentiment-worker, e aqui ela é mais cara:
+  // este é o worker que RESPONDE O CLIENTE. `ctx.agent.model` é uma string vinda
+  // do banco (ai_agents.model), e no AI SDK string com barra é roteada pelo
+  // gateway da Vercel — que sem AI_GATEWAY_API_KEY aborta ANTES de emitir
+  // qualquer requisição ("Unauthenticated request to AI Gateway"). Numa
+  // instalação self-host padrão, que só tem ANTHROPIC_API_KEY, isso significava
+  // o bot mudo, uma vez por mensagem recebida.
+  //
+  // O guard fica DEPOIS de G1/G4 de propósito: pedido de humano e menção legal
+  // precisam gerar handoff mesmo numa instalação sem LLM atendível.
+  //
+  // Skip, não erro: modelo que nenhuma chave desta instalação atende é config,
+  // não falha transitória — retentar só repetiria o loop que este PR mata.
+  const model = resolveLanguageModel(ctx.agent.model);
+  if (!model) {
+    logger.warn("[ai-response-worker] modelo do agente sem provider configurado", {
+      organization_id: ctx.organization_id,
+      agent_id: ctx.agent.id,
+      model: ctx.agent.model,
+    });
+    return {
+      status: "skipped",
+      reason: "ai_gateway_key_missing",
+      detail: `nenhuma chave configurada atende o modelo "${ctx.agent.model}"`,
+    };
+  }
+
   try {
-    const response = await invokeBot(ctx);
+    const response = await invokeBot(ctx, model);
     const post = postProcess(response.text);
 
     // ── G3 — bot's own response signals low confidence / uncertainty.
@@ -478,7 +506,10 @@ async function retrieveContext(input: RetrieveInput): Promise<RagHit[]> {
 // 3. invokeBot
 // ---------------------------------------------------------------------------
 
-async function invokeBot(ctx: BotContext): Promise<BotResponse> {
+// `model` chega resolvido de fora (ver o guard em processMessageReceived):
+// `ctx.agent.model` continua sendo a STRING canônica, porque é ela que vai para
+// o custo e para a auditoria em ai_invocations; o que executa é o provider.
+async function invokeBot(ctx: BotContext, model: LanguageModel): Promise<BotResponse> {
   const renderedSystem = renderSystemPrompt(ctx.agent.system_prompt, ctx);
   const cfg = gatewayConfig();
   const headers = cfg ? gatewayHeaders({ organizationId: ctx.organization_id }) : undefined;
@@ -498,7 +529,7 @@ async function invokeBot(ctx: BotContext): Promise<BotResponse> {
 
   const start = Date.now();
   const result = await generateText({
-    model: ctx.agent.model,
+    model,
     system: renderedSystem,
     messages,
     headers,

--- a/workers/ai-sentiment-worker.ts
+++ b/workers/ai-sentiment-worker.ts
@@ -17,7 +17,7 @@ import { generateObject } from "ai";
 import { z } from "zod";
 
 import { computeCost } from "@/lib/ai/cost";
-import { DEFAULT_CLASSIFIER_MODEL, isAiGatewayConfigured } from "@/lib/ai/gateway";
+import { DEFAULT_CLASSIFIER_MODEL, isAiGatewayConfigured, resolveLanguageModel } from "@/lib/ai/gateway";
 import { logInvocation } from "@/lib/ai/log-invocation";
 import { SENTIMENT_SYSTEM_PROMPT } from "@/lib/ai/prompts/sentiment";
 import type { EventRow } from "@/lib/event-log/dispatcher";
@@ -42,6 +42,16 @@ export async function processSentiment(event: EventRow): Promise<SentimentResult
   try {
     // ── Guard: AI Gateway configured ────────────────────────────────────────
     if (!isAiGatewayConfigured()) {
+      return { skipped: true, reason: "ai_gateway_key_missing" };
+    }
+
+    // Passar SENTIMENT_MODEL como string cai no gateway da Vercel mesmo sem
+    // chave (plano anônimo) e devolve "Unauthenticated ... Configure
+    // AI_GATEWAY_API_KEY" — o que quebrava este worker em toda instalação que
+    // só tem ANTHROPIC_API_KEY, ou seja, o padrão do install.sh. O resolver
+    // devolve o provider certo para a chave que existir.
+    const sentimentModel = resolveLanguageModel(SENTIMENT_MODEL);
+    if (!sentimentModel) {
       return { skipped: true, reason: "ai_gateway_key_missing" };
     }
 
@@ -104,7 +114,7 @@ export async function processSentiment(event: EventRow): Promise<SentimentResult
 
     try {
       const generated = await generateObject({
-        model: SENTIMENT_MODEL,
+        model: sentimentModel,
         schema: sentimentSchema,
         system: SENTIMENT_SYSTEM_PROMPT,
         prompt: body,

--- a/workers/ai-sentiment-worker.ts
+++ b/workers/ai-sentiment-worker.ts
@@ -27,9 +27,29 @@ const SENTIMENT_MODEL = DEFAULT_CLASSIFIER_MODEL; // "anthropic/claude-haiku-4-5
 const DEFAULT_SENTIMENT_THRESHOLD = 0.3;
 const CLASSIFY_TIMEOUT_MS = 5_000;
 
+// As descrições NÃO são decoração: viram o JSON Schema da ferramenta que o
+// provider manda ao modelo. Sem elas o `.max(100)` existia só no validador — o
+// modelo nunca ficava sabendo do limite e escrevia 223, 297, 340 caracteres
+// (medido com mensagens reais desta instalação). Com a descrição, o mesmo
+// conjunto caiu para 59–102.
+//
+// O teto do Zod é FOLGADO de propósito. Modelo não conta caractere: mesmo
+// avisado, uma amostra bateu 102. Reprovar a classificação inteira por 2
+// caracteres a mais seria péssimo negócio — ainda mais porque
+// `reasoning_short` é DESCARTADO (só `sentiment_score` e a latência vão para
+// messages.metadata). Ele existe para o modelo raciocinar antes de pontuar,
+// não para ser guardado. A descrição segura a verbosidade (e o custo); o teto
+// só impede resposta absurda.
 const sentimentSchema = z.object({
-  sentiment_score: z.number().min(0).max(1),
-  reasoning_short: z.string().max(100),
+  sentiment_score: z
+    .number()
+    .min(0)
+    .max(1)
+    .describe("0 = muito negativo, 0.5 = neutro, 1 = muito positivo"),
+  reasoning_short: z
+    .string()
+    .max(280)
+    .describe("Justificativa curta da nota, em NO MÁXIMO 100 caracteres"),
 });
 
 export interface SentimentResult {
@@ -119,7 +139,15 @@ export async function processSentiment(event: EventRow): Promise<SentimentResult
         system: SENTIMENT_SYSTEM_PROMPT,
         prompt: body,
         temperature: 0,
-        maxOutputTokens: 80,
+        // 80 era pequeno demais e nunca tinha sido exercitado (o worker morria
+        // antes, na autenticação). `generateObject` com Anthropic usa modo
+        // FERRAMENTA: o JSON vai dentro de um tool_use, que custa bem mais que
+        // texto puro. Medido com mensagens reais desta instalação: 2 de 3
+        // paravam em `stop_reason: max_tokens` com o JSON cortado no meio —
+        // daí o "No object generated: response did not match schema", que
+        // parecia erro de esquema e era truncamento. Pico observado: 146 sem
+        // as descrições, 84 com elas. 256 dá folga sem virar cheque em branco.
+        maxOutputTokens: 256,
         abortSignal: abortController.signal,
       });
 


### PR DESCRIPTION
Dois problemas no mesmo ponto, um escondido atrás do outro.

## 1) A checagem e a execução estavam desalinhadas

`isAiGatewayConfigured()` devolvia `true` com só `ANTHROPIC_API_KEY` — a única chave que o `install.sh` exige. Mas quem executava passava o id como **string**, e no AI SDK id com barra é resolvido pelo gateway da Vercel **mesmo sem chave**, caindo no plano anônimo:

```
Unauthenticated. Configure AI_GATEWAY_API_KEY or use a provider module.
```

Ou seja: em toda instalação self-host padrão o `ai-sentiment-worker` falhava em loop, uma vez por mensagem recebida. O `embed.ts` já documentava e resolvia exatamente essa armadilha para embeddings; o caminho de chat ficou sem o equivalente.

Entra `resolveLanguageModel()`, que devolve o que o SDK sabe executar:

1. gateway da Vercel → a string (o gateway roteia e fatura)
2. OpenRouter → provider OpenAI-compatível no endpoint dela
3. provider direto → Anthropic ou OpenAI, conforme o prefixo do id
4. `null` quando nada serve, para o chamador **pular com motivo claro** em vez de estourar com erro de rede lá dentro

**OpenRouter sem dependência nova:** a API dela é compatível com a da OpenAI, então o `@ai-sdk/openai` (já instalado) fala com o endpoint. Os ids da OpenRouter já são `provider/modelo`, então o mesmo id canônico serve sem tradução. Anthropic segue sendo o padrão e nada muda para quem não preencher `OPENROUTER_API_KEY`.

O `.env.example` alerta que o agente opera por **ferramentas**: modelo sem tool calling sólido não dá erro — responde texto plausível e nunca cria o lead nem move o card, que é o pior tipo de falha.

## 2) O erro seguinte, que só apareceu depois

Com a autenticação consertada, o worker passou a chamar o modelo de verdade — e aí:

```
No object generated: response did not match schema.
```

**Parecia esquema. Era truncamento.** Medido chamando a API com mensagens reais desta instalação:

```
"Jajajsjsjss"           -> stop: tool_use   | 78 tokens | ok
"No les cuentes nada!"  -> stop: max_tokens | 80 tokens | JSON cortado
mensagem mais longa     -> stop: max_tokens | 80 tokens | JSON cortado
```

`generateObject` com Anthropic usa modo **ferramenta**: o objeto vai dentro de um `tool_use`, que custa bem mais que texto puro. `maxOutputTokens: 80` cortava o JSON no meio em 2 de 3 mensagens. O limite nunca tinha sido exercitado porque o worker morria antes, na autenticação.

Duas correções:

1. **Teto para 256.** Pico medido: 146 tokens (84 depois da correção 2).
2. **`.describe()` nos campos do schema.** Não é decoração: vira o JSON Schema da ferramenta que chega ao modelo. Sem isso o `.max(100)` existia só no validador — o modelo não sabia do limite e escrevia 223, 297, 340 caracteres, o que reprovaria a classificação inteira mesmo com tokens de sobra. Com a descrição, o mesmo conjunto caiu para 59–102.

O teto do Zod foi de 100 para 280, **de propósito**: modelo não conta caractere, e mesmo avisado uma amostra bateu 102. Reprovar uma classificação por 2 caracteres seria péssimo negócio — ainda mais porque `reasoning_short` é **descartado** (só `sentiment_score` e a latência vão para `messages.metadata`). Ele existe para o modelo raciocinar antes de pontuar, não para ser guardado.

## Verificação

Testes cobrem os seis caminhos de `resolveLanguageModel`, medindo o **tipo** do retorno (string = gateway, objeto = provider explícito) — mesma técnica do `embed.test.ts`, que é a única diferença observável sem rede. `ci`, `e2e` e `perf` verdes no fork.

**Ressalva honesta:** este é o único dos meus sete PRs que não tem prova de produção. A instalação onde rodo não tem agente publicado (`drain: nenhum agente publicado para a sessão`), então o caminho de chat não é exercitado em tráfego real — a evidência aqui é a medição contra a API e os testes, não uso em produção.

Um de sete PRs que estou abrindo em paralelo.
