### PR TITLE
feat(kit): instala o Docker sozinho e cria o projeto Supabase pela Management API

### DIFF
--- a/hostgator-setup-kit/README.md
+++ b/hostgator-setup-kit/README.md
@@ -11,11 +11,17 @@ Este kit sobe o **DeskcommCRM** no seu servidor VPS da HostGator. Você tem dois
 
 ## ⚙️ Caminho manual: um comando
 
-Dentro do VPS, com Docker instalado:
+Dentro do VPS:
 
 ```bash
 bash install.sh
 ```
+
+> **VPS sem Docker?** O instalador resolve. Se não encontrar o Docker, ele **pergunta**
+> antes e instala pelo `get.docker.com` — o instalador oficial da Docker, que roda como
+> root, como manda a documentação deles. Com `--yes` ele segue sem perguntar, que é o
+> contrato desse modo. Se preferir instalar por conta própria, responda `n` e rode
+> `curl -fsSL https://get.docker.com | sh` antes.
 
 O instalador pergunta o que precisa (domínio, chaves do Supabase e da Anthropic,
 e-mail/senha do admin), gera o resto e sobe tudo.
@@ -70,7 +76,7 @@ Owner/Admin. Não dá para hospedar vários clientes numa conta só.
   ~150 MB por sessão de WhatsApp além de ~300 MB de overhead do Node. Com 2 GB você roda
   no limite e vai precisar de swap. Ver `docs/runbooks/waha-hostgator.md`.
 - Portas **80** e **443** abertas (`ufw allow 80,443,22/tcp`).
-- Docker + Docker Compose v2.
+- Docker + Docker Compose v2 — o `install.sh` instala o Docker sozinho se faltar (ver acima).
 
 ## Scripts do kit
 

--- a/hostgator-setup-kit/README.md
+++ b/hostgator-setup-kit/README.md
@@ -31,7 +31,15 @@ não conecta de um VPS IPv4, é a armadilha mais comum). Dá para pular tudo iss
 
 ```bash
 export SUPABASE_ACCESS_TOKEN=sbp_...        # supabase.com/dashboard/account/tokens
-bash supabase-provision.sh "Nome do Projeto" sa-east-1
+bash install.sh                             # cria o projeto e segue a instalação
+```
+
+O `install.sh` chama o provisionamento sozinho quando encontra o token e as
+credenciais ainda vazias — as 4 variáveis entram no fluxo sem copiar e colar.
+Para criar só o projeto, sem instalar, o script também roda sozinho:
+
+```bash
+bash supabase-provision.sh "Nome do Projeto" sa-east-1 >> .env
 ```
 
 O script cria o projeto, **espera o banco ficar `ACTIVE_HEALTHY`** (projeto novo não

--- a/hostgator-setup-kit/README.md
+++ b/hostgator-setup-kit/README.md
@@ -23,6 +23,28 @@ e-mail/senha do admin), gera o resto e sobe tudo.
 > Modo não-interativo: copie `.env.hostgator.example` (do repositório) para `.env`,
 > preencha, e rode `bash install.sh --yes`.
 
+## Criar o Supabase automaticamente (opcional)
+
+Criar o projeto no navegador e copiar as 4 credenciais é o passo mais demorado da
+instalação — e o mais fácil de errar (copiar a *Direct connection*, que é IPv6-only e
+não conecta de um VPS IPv4, é a armadilha mais comum). Dá para pular tudo isso:
+
+```bash
+export SUPABASE_ACCESS_TOKEN=sbp_...        # supabase.com/dashboard/account/tokens
+bash supabase-provision.sh "Nome do Projeto" sa-east-1
+```
+
+O script cria o projeto, **espera o banco ficar `ACTIVE_HEALTHY`** (projeto novo não
+nasce pronto), busca as chaves e **descobre o host do pooler testando conexão real** em
+vez de adivinhar. Imprime as 4 linhas prontas para colar no `.env`.
+
+⚠️ **O token é uma chave mestra** — dá acesso a todos os projetos da conta. Ele é lido do
+ambiente e nunca gravado em disco. Instalando para terceiros, use o token DO CLIENTE, ou
+rode o script na sua máquina e leve só as 4 credenciais para o servidor dele.
+
+⚠️ **Plano grátis: 2 projetos por usuário**, contados em todas as organizações onde ele é
+Owner/Admin. Não dá para hospedar vários clientes numa conta só.
+
 ## O que você precisa antes
 
 | Item | Onde conseguir |

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -286,6 +286,28 @@ mask() {
   if [ "${#v}" -le 12 ]; then printf '%s' "****"; else printf '%s…%s (%d caracteres)' "${v:0:8}" "${v: -4}" "${#v}"; fi
 }
 
+# Lê as 4 credenciais que o supabase-provision.sh imprime (`CHAVE='valor'`) SEM
+# interpretar o conteúdo.
+#
+# Por que não `eval`: os valores saem de `printf "%s='%s'"` sem escapar a aspa
+# simples, então um valor que contenha `'` fecha o literal e o resto da linha
+# volta a ser CÓDIGO — e `SUPABASE_REGION`, que vem do ambiente, é interpolada
+# dentro da connection string que sai de lá. Mesma postura do `load_env`
+# (_common.sh): casa a chave contra uma lista fixa e copia o valor como texto.
+# Chave fora da lista é ignorada, então a saída nunca cria variável arbitrária.
+sb_carrega_credenciais() {
+  local linha val
+  while IFS= read -r linha; do
+    val="${linha#*=\'}"; val="${val%\'}"
+    case "$linha" in
+      NEXT_PUBLIC_SUPABASE_URL=\'*\')      NEXT_PUBLIC_SUPABASE_URL="$val";;
+      NEXT_PUBLIC_SUPABASE_ANON_KEY=\'*\') NEXT_PUBLIC_SUPABASE_ANON_KEY="$val";;
+      SUPABASE_SERVICE_ROLE_KEY=\'*\')     SUPABASE_SERVICE_ROLE_KEY="$val";;
+      SUPABASE_DB_URL=\'*\')               SUPABASE_DB_URL="$val";;
+    esac
+  done <<<"$1"
+}
+
 # Carrega só as funções acima, sem instalar nada — é assim que
 # `test-validators.sh` exercita os validadores:  INSTALL_SH_LIB=1 . install.sh
 if [ "${INSTALL_SH_LIB:-}" = "1" ]; then trap - EXIT; return 0; fi
@@ -312,8 +334,16 @@ if ! command -v docker >/dev/null 2>&1; then
   fi
   if [ "$instalar" = 1 ]; then
     c_dim "  Instalando (get.docker.com — o instalador oficial). Leva 1-2 minutos…"
-    curl -fsSL https://get.docker.com | sh >/dev/null 2>&1 \
-      || die "Não consegui instalar o Docker. Rode 'curl -fsSL https://get.docker.com | sh' e tente de novo."
+    # A saída vai para um log em vez de /dev/null: silenciar o stderr também
+    # deixava a falha MUDA (disco cheio, apt travado, arquitetura sem pacote
+    # viravam todos a mesma frase genérica) — exatamente o que o trap lá em cima
+    # existe para impedir. Tela limpa no caminho feliz, causa real no caminho ruim.
+    _docker_log="$(mktemp)"
+    if ! curl -fsSL https://get.docker.com | sh >"$_docker_log" 2>&1; then
+      c_red "  Últimas linhas do instalador do Docker:"; tail -15 "$_docker_log" >&2
+      die "Não consegui instalar o Docker (log em $_docker_log). Rode 'curl -fsSL https://get.docker.com | sh' e tente de novo."
+    fi
+    rm -f "$_docker_log"; unset _docker_log
     command -v docker >/dev/null 2>&1 || die "Docker instalou mas não ficou no PATH. Reabra o terminal e rode de novo."
     c_grn "✓ Docker instalado"
   else
@@ -373,10 +403,18 @@ if [ -z "${NEXT_PUBLIC_SUPABASE_URL:-}" ] && [ -n "${SUPABASE_ACCESS_TOKEN:-}" ]
   _sb_out="$(bash "$KIT_DIR/supabase-provision.sh" "${APP_NAME:-DeskcommCRM}" "${SUPABASE_REGION:-sa-east-1}")" \
     || die "Não consegui criar o projeto Supabase. Crie no painel e rode de novo sem SUPABASE_ACCESS_TOKEN."
   # O script imprime `CHAVE='valor'` em stdout (o visual dele vai para stderr).
-  # `eval` aqui é seguro: a entrada é a saída do nosso próprio script, com os
-  # valores já entre aspas simples e escapados.
-  eval "$_sb_out"
+  # A leitura é por parse, não por `eval` — o porquê está em
+  # sb_carrega_credenciais(), e `test-validators.sh` cobra isso.
+  sb_carrega_credenciais "$_sb_out"
   unset _sb_out
+
+  # Credencial que não chegou tem que parar AQUI. Sem esta checagem o install
+  # seguiria com a variável vazia e morreria lá na frente, longe da causa — e a
+  # pessoa veria "erro de conexão" em vez de "o provisionamento não devolveu X".
+  if [ -z "${NEXT_PUBLIC_SUPABASE_URL:-}" ] || [ -z "${NEXT_PUBLIC_SUPABASE_ANON_KEY:-}" ] \
+     || [ -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ] || [ -z "${SUPABASE_DB_URL:-}" ]; then
+    die "O provisionamento não devolveu as 4 credenciais. Crie o projeto no painel e rode de novo sem SUPABASE_ACCESS_TOKEN."
+  fi
   c_grn "✓ Supabase pronto — as 4 credenciais entraram sozinhas"
 fi
 

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -549,6 +549,12 @@ envq() { printf "%s='%s'\n" "$1" "$(printf '%s' "${2-}" | sed "s/'/'\\\\''/g")";
   envq APP_LOGO_URL "${APP_LOGO_URL:-}"
   envq ANTHROPIC_API_KEY "$ANTHROPIC_API_KEY"
   envq AI_GATEWAY_API_KEY "${AI_GATEWAY_API_KEY:-}"
+  printf '# OpenRouter: alternativa ao AI Gateway para o chat da IA. A ordem de\n'
+  printf '# resolução é AI_GATEWAY_API_KEY > OPENROUTER_API_KEY > provider direto,\n'
+  printf '# então deixar vazio NÃO muda nada — o comportamento de hoje continua.\n'
+  printf '# BASE_URL vazia = https://openrouter.ai/api/v1 (só mude se usa proxy).\n'
+  envq OPENROUTER_API_KEY "${OPENROUTER_API_KEY:-}"
+  envq OPENROUTER_BASE_URL "${OPENROUTER_BASE_URL:-}"
   printf '# OpenAI: transcrição dos áudios do WhatsApp (Whisper) + embeddings do RAG.\n'
   printf '# Opcional — sem ela a IA responde sem a base e pede o áudio em texto.\n'
   envq OPENAI_API_KEY "${OPENAI_API_KEY:-}"

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -292,6 +292,35 @@ if [ "${INSTALL_SH_LIB:-}" = "1" ]; then trap - EXIT; return 0; fi
 
 # ── 1. Preflight ────────────────────────────────────────────────────────────
 step "Verificando dependências"
+
+# VPS "cru" (Hetzner, DigitalOcean, Contabo…) não vem com Docker. Antes isto era
+# um beco sem saída: o script morria dizendo "instale antes de continuar" e a
+# pessoa — que por definição não é técnica — ficava sem saber como. Hospedagens
+# com template (Hostinger, HostGator) já trazem Docker, então o caso nunca
+# aparecia para quem escreveu o kit.
+#
+# O instalador oficial do Docker é o mesmo comando da documentação deles; não
+# inventamos nada. Em modo interativo PERGUNTA (instalar coisa no servidor de
+# alguém sem avisar é abuso de confiança); com --yes segue direto, que é o
+# contrato desse modo.
+if ! command -v docker >/dev/null 2>&1; then
+  c_ylw "⚠ Docker não está instalado — é o motor que roda o CRM."
+  instalar=1
+  if [ "$NONINTERACTIVE" = 0 ]; then
+    read -r -p "  Posso instalar agora? (S/n) " r
+    case "${r:-S}" in [Nn]*) instalar=0;; esac
+  fi
+  if [ "$instalar" = 1 ]; then
+    c_dim "  Instalando (get.docker.com — o instalador oficial). Leva 1-2 minutos…"
+    curl -fsSL https://get.docker.com | sh >/dev/null 2>&1 \
+      || die "Não consegui instalar o Docker. Rode 'curl -fsSL https://get.docker.com | sh' e tente de novo."
+    command -v docker >/dev/null 2>&1 || die "Docker instalou mas não ficou no PATH. Reabra o terminal e rode de novo."
+    c_grn "✓ Docker instalado"
+  else
+    die "Sem Docker não dá para seguir. Instale com: curl -fsSL https://get.docker.com | sh"
+  fi
+fi
+
 for bin in docker git openssl curl; do
   command -v "$bin" >/dev/null 2>&1 || die "'$bin' não encontrado. Instale antes de continuar."
 done
@@ -329,6 +358,27 @@ source "$KIT_DIR/_common.sh"
 step "Configuração"
 # Se já existe .env, carrega pra não repetir perguntas (idempotência).
 if [ -f .env ]; then load_env .env; c_grn "✓ .env existente carregado"; fi
+
+# ── Supabase automático (opcional) ──────────────────────────────────────────
+# Criar o projeto no navegador e copiar 4 campos era o passo mais LENTO da
+# instalação (medido: ~59min de preparação contra ~3min de script) e o mais
+# fácil de errar — copiar a "Direct connection", que é IPv6-only e não conecta
+# de um VPS IPv4, é a armadilha campeã.
+#
+# Com SUPABASE_ACCESS_TOKEN no ambiente e as credenciais ainda vazias, o
+# projeto é criado aqui e as 4 variáveis entram direto no fluxo, sem copiar e
+# colar. Sem o token, nada muda: seguem as perguntas de sempre.
+if [ -z "${NEXT_PUBLIC_SUPABASE_URL:-}" ] && [ -n "${SUPABASE_ACCESS_TOKEN:-}" ]; then
+  step "Criando o projeto Supabase automaticamente"
+  _sb_out="$(bash "$KIT_DIR/supabase-provision.sh" "${APP_NAME:-DeskcommCRM}" "${SUPABASE_REGION:-sa-east-1}")" \
+    || die "Não consegui criar o projeto Supabase. Crie no painel e rode de novo sem SUPABASE_ACCESS_TOKEN."
+  # O script imprime `CHAVE='valor'` em stdout (o visual dele vai para stderr).
+  # `eval` aqui é seguro: a entrada é a saída do nosso próprio script, com os
+  # valores já entre aspas simples e escapados.
+  eval "$_sb_out"
+  unset _sb_out
+  c_grn "✓ Supabase pronto — as 4 credenciais entraram sozinhas"
+fi
 
 # Cada linha: VARIÁVEL|pergunta|padrão|validador|secret|opcional
 # A ordem importa: a URL do projeto vem antes das chaves porque os validadores

--- a/hostgator-setup-kit/supabase-provision.sh
+++ b/hostgator-setup-kit/supabase-provision.sh
@@ -39,11 +39,47 @@ REGION="${2:-${SUPABASE_REGION:-sa-east-1}}"
 c_red() { printf '\033[31m%s\033[0m\n' "$*" >&2; }
 c_grn() { printf '\033[32m%s\033[0m\n' "$*" >&2; }
 c_ylw() { printf '\033[33m%s\033[0m\n' "$*" >&2; }
-step()  { printf '\n\033[1m▶ %s\033[0m\n' "$*" >&2; }
+c_dim() { printf '\033[2m%s\033[0m\n' "$*" >&2; }
 die()   { c_red "✖ $*"; exit 1; }
 
-[ -n "${SUPABASE_ACCESS_TOKEN:-}" ] \
-  || die "Falta SUPABASE_ACCESS_TOKEN. Gere em https://supabase.com/dashboard/account/tokens"
+# Passo numerado: quem instala precisa saber ONDE está e QUANTO falta. "▶ Criando
+# projeto" sozinho não diz se é o começo ou o fim.
+TOTAL_PASSOS=6
+PASSO=0
+step() {
+  PASSO=$((PASSO + 1))
+  printf '\n\033[1m[%d/%d] %s\033[0m\n' "$PASSO" "$TOTAL_PASSOS" "$*" >&2
+}
+
+# Mostra segredo sem vazá-lo no terminal (nem no screenshot que a pessoa manda
+# pedindo ajuda): primeiros 6 e últimos 4.
+mascara() {
+  local v="$1"
+  if [ "${#v}" -le 14 ]; then printf '%s' "••••••"; else printf '%s…%s' "${v:0:6}" "${v: -4}"; fi
+}
+
+moldura() {
+  local txt="$1" larg=60 pad
+  # `printf %-60s` conta BYTES, e acento/·/em traço ocupam 2+ em UTF-8: a borda
+  # direita saía torta em qualquer título com acento — que em português é quase
+  # todo. `${#txt}` conta CARACTERES, então o preenchimento sai certo.
+  pad=$(( larg - ${#txt} )); [ "$pad" -lt 0 ] && pad=0
+  printf '\033[36m╭%s╮\033[0m\n' "$(printf '─%.0s' $(seq 1 $((larg + 2))))" >&2
+  printf '\033[36m│\033[0m \033[1m%s%*s\033[0m \033[36m│\033[0m\n' "$txt" "$pad" '' >&2
+  printf '\033[36m╰%s╯\033[0m\n' "$(printf '─%.0s' $(seq 1 $((larg + 2))))" >&2
+}
+
+moldura "DeskcommCRM · criando seu banco no Supabase"
+
+if [ -z "${SUPABASE_ACCESS_TOKEN:-}" ]; then
+  c_red "✖ Falta o token de acesso do Supabase."
+  printf '\n' >&2
+  c_dim "  1. Abra https://supabase.com/dashboard/account/tokens"
+  c_dim "  2. Generate new token, dê um nome (ex.: deskcommcrm) e copie"
+  c_dim "  3. Rode:  export SUPABASE_ACCESS_TOKEN=sbp_...  e tente de novo"
+  printf '\n' >&2
+  exit 1
+fi
 
 # Extrai um campo string de um JSON PLANO. Mesmo estilo do jwt_claim() do
 # install.sh: o kit promete depender só de bash+curl, então nada de jq/python.
@@ -87,20 +123,35 @@ c_grn "✓ projeto criado: $REF"
 # Projeto novo NÃO nasce pronto: passa por COMING_UP até ACTIVE_HEALTHY. Sem
 # esperar, o passo do schema falha com "connection refused" e a instalação
 # morre no meio sem explicar por quê.
-step "Aguardando o banco subir (leva alguns minutos)"
+step "Aguardando o banco subir"
+c_dim "      Projeto novo leva de 2 a 5 minutos para ficar de pé. Pode deixar rodando."
 ok=""
-for _ in $(seq 1 60); do
+inicio=$SECONDS
+LIMITE=60   # 60 x 10s = 10 minutos
+for i in $(seq 1 $LIMITE); do
   st="$(json_str "$(api GET "/projects/$REF")" status)"
   case "$st" in
     ACTIVE_HEALTHY) ok=1; break;;
-    INACTIVE|REMOVED|RESTORE_FAILED) die "Projeto entrou em '$st' — verifique no painel.";;
+    INACTIVE|REMOVED|RESTORE_FAILED)
+      printf '\n' >&2
+      die "Projeto entrou em '$st' — verifique em supabase.com/dashboard/project/$REF";;
   esac
-  printf '.' >&2
+  # Uma linha que se reescreve: barra + estado REAL vindo da API + tempo
+  # decorrido. Ponto solto por 10 minutos parece travamento; ver COMING_UP
+  # mudando e o relógio andando mostra que está vivo.
+  preenchido=$((i * 24 / LIMITE))
+  # `printf 'x%.0s' $(seq 1 0)` NÃO imprime nada — imprime UMA vez, porque
+  # printf sem argumentos ainda roda o formato uma vez. Sem este guarda a barra
+  # nascia com 1 bloco a mais no início e no fim (25 de 24).
+  barra=""; [ "$preenchido" -gt 0 ] && barra="$(printf '█%.0s' $(seq 1 "$preenchido"))"
+  vazio="";  [ $((24 - preenchido)) -gt 0 ] && vazio="$(printf '░%.0s' $(seq 1 $((24 - preenchido))))"
+  printf '\r      \033[36m%s%s\033[0m  %-16s %dm%02ds' \
+    "$barra" "$vazio" "${st:-consultando…}" $(( (SECONDS-inicio)/60 )) $(( (SECONDS-inicio)%60 )) >&2
   sleep 10
 done
-printf '\n' >&2
-[ "$ok" = 1 ] || die "O projeto não ficou ACTIVE_HEALTHY em 10 minutos. Confira no painel."
-c_grn "✓ banco no ar"
+printf '\r%*s\r' 70 '' >&2
+[ "$ok" = 1 ] || die "Não ficou pronto em 10 minutos. Veja em supabase.com/dashboard/project/$REF"
+c_grn "✓ banco no ar (levou $(( (SECONDS-inicio)/60 ))m$(( (SECONDS-inicio)%60 ))s)"
 
 # ── 5. Chaves ───────────────────────────────────────────────────────────────
 step "Buscando as chaves de API"
@@ -130,8 +181,25 @@ done
 [ -n "$DB_URL" ] || die "Nenhum host de pooler respondeu. Pegue a Session pooler em Settings > Database."
 
 # ── 7. Saída ────────────────────────────────────────────────────────────────
-step "Pronto"
-c_ylw "⚠ Guarde a senha do banco — ela não é recuperável pela API depois."
+printf '\n' >&2
+moldura "Projeto Supabase pronto"
+# O resumo vai MASCARADO: quem instala costuma mandar print pedindo ajuda, e um
+# service_role inteiro num screenshot é acesso total ao banco, sem RLS.
+printf '  %-14s %s\n' "Projeto"  "$PROJECT_NAME ($REF)" >&2
+printf '  %-14s %s\n' "Região"   "$REGION" >&2
+printf '  %-14s %s\n' "URL"      "https://$REF.supabase.co" >&2
+printf '  %-14s %s\n' "anon"     "$(mascara "$ANON")" >&2
+printf '  %-14s %s\n' "service"  "$(mascara "$SERVICE")" >&2
+printf '  %-14s %s\n' "banco"    "$(mascara "$DB_PASS") @ $(sed 's|.*@||; s|:5432.*||' <<<"$DB_URL")" >&2
+printf '\n' >&2
+c_ylw "  ⚠ A senha do banco NÃO é recuperável pela API depois. Guarde agora."
+c_dim "     Painel: https://supabase.com/dashboard/project/$REF"
+printf '\n' >&2
+c_grn "  Cole as 4 linhas abaixo no seu .env (ou redirecione: >> .env)"
+printf '\n' >&2
+
+# stdout limpo: só as 4 linhas, para `bash supabase-provision.sh ... >> .env`
+# funcionar. Todo o visual acima foi para stderr de propósito.
 printf "NEXT_PUBLIC_SUPABASE_URL='https://%s.supabase.co'\n" "$REF"
 printf "NEXT_PUBLIC_SUPABASE_ANON_KEY='%s'\n" "$ANON"
 printf "SUPABASE_SERVICE_ROLE_KEY='%s'\n" "$SERVICE"

--- a/hostgator-setup-kit/supabase-provision.sh
+++ b/hostgator-setup-kit/supabase-provision.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# Cria o projeto Supabase pela Management API e devolve as 4 credenciais que o
+# install.sh precisa — em vez de a pessoa criar o projeto no navegador e copiar
+# quatro campos à mão.
+#
+# POR QUE ISTO EXISTE
+# -------------------
+# Numa instalação medida de ponta a ponta, o script levou ~3 minutos e a
+# preparação levou ~59. A maior fatia foi criar o projeto Supabase e copiar
+# URL, anon, service_role e connection string — o passo mais lento e o mais
+# fácil de errar (copiar a "Direct connection", que é IPv6-only e não conecta
+# de um VPS IPv4, era a armadilha número um).
+#
+# USO
+#   export SUPABASE_ACCESS_TOKEN=sbp_...      # Personal Access Token
+#   bash supabase-provision.sh "Nome do Projeto" [regiao]
+#
+# Escreve as 4 variáveis em stdout no formato `CHAVE='valor'`, prontas para
+# concatenar num .env. Nada é impresso em log.
+#
+# ⚠️ O TOKEN É UMA CHAVE MESTRA: dá acesso a TODOS os projetos da conta. Ele é
+# lido do ambiente, nunca gravado em disco por este script, e não deve ficar no
+# .env do servidor do cliente. Quem instala para terceiros: use o token DO
+# CLIENTE, ou rode este script na sua máquina e leve só as 4 credenciais.
+#
+# LIMITE DO PLANO GRÁTIS: são 2 projetos gratuitos por USUÁRIO, contados em
+# todas as organizações onde ele é Owner/Admin. Não dá para hospedar N clientes
+# numa conta só — cada cliente precisa da conta dele (ou de plano pago).
+#
+# Dependências: as mesmas do kit (bash + curl). Sem jq, sem python.
+
+set -euo pipefail
+
+API="https://api.supabase.com/v1"
+PROJECT_NAME="${1:-DeskcommCRM}"
+REGION="${2:-${SUPABASE_REGION:-sa-east-1}}"
+
+c_red() { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+c_grn() { printf '\033[32m%s\033[0m\n' "$*" >&2; }
+c_ylw() { printf '\033[33m%s\033[0m\n' "$*" >&2; }
+step()  { printf '\n\033[1m▶ %s\033[0m\n' "$*" >&2; }
+die()   { c_red "✖ $*"; exit 1; }
+
+[ -n "${SUPABASE_ACCESS_TOKEN:-}" ] \
+  || die "Falta SUPABASE_ACCESS_TOKEN. Gere em https://supabase.com/dashboard/account/tokens"
+
+# Extrai um campo string de um JSON PLANO. Mesmo estilo do jwt_claim() do
+# install.sh: o kit promete depender só de bash+curl, então nada de jq/python.
+# Só serve para os campos simples que a API devolve (ref, id, name, status).
+json_str() { grep -o "\"$2\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" <<<"$1" | head -1 | sed 's/.*"\([^"]*\)"$/\1/'; }
+
+api() {
+  local method="$1" path="$2" body="${3:-}"
+  if [ -n "$body" ]; then
+    curl -sS -X "$method" "$API$path" \
+      -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+      -H "Content-Type: application/json" -d "$body"
+  else
+    curl -sS -X "$method" "$API$path" -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN"
+  fi
+}
+
+# ── 1. Organização ──────────────────────────────────────────────────────────
+step "Descobrindo a organização"
+ORG_ID="${SUPABASE_ORG_ID:-}"
+if [ -z "$ORG_ID" ]; then
+  orgs="$(api GET /organizations)"
+  ORG_ID="$(json_str "$orgs" id)"
+  [ -n "$ORG_ID" ] || die "Não achei nenhuma organização. Confira o token."
+  c_grn "✓ organização: $(json_str "$orgs" name) ($ORG_ID)"
+fi
+
+# ── 2. Senha do banco ───────────────────────────────────────────────────────
+# Sem caracteres que quebram uma URL (@ : / ? # &) — a senha entra na
+# connection string, e um '@' aqui parte o host no meio.
+DB_PASS="$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32)"
+
+# ── 3. Cria o projeto ───────────────────────────────────────────────────────
+step "Criando o projeto '$PROJECT_NAME' em $REGION"
+created="$(api POST /projects "{\"name\":\"$PROJECT_NAME\",\"organization_id\":\"$ORG_ID\",\"region\":\"$REGION\",\"db_pass\":\"$DB_PASS\"}")"
+REF="$(json_str "$created" ref)"
+[ -n "$REF" ] || { c_red "Resposta da API:"; printf '%s\n' "$created" >&2; die "Não consegui criar o projeto."; }
+c_grn "✓ projeto criado: $REF"
+
+# ── 4. Espera ficar de pé ───────────────────────────────────────────────────
+# Projeto novo NÃO nasce pronto: passa por COMING_UP até ACTIVE_HEALTHY. Sem
+# esperar, o passo do schema falha com "connection refused" e a instalação
+# morre no meio sem explicar por quê.
+step "Aguardando o banco subir (leva alguns minutos)"
+ok=""
+for _ in $(seq 1 60); do
+  st="$(json_str "$(api GET "/projects/$REF")" status)"
+  case "$st" in
+    ACTIVE_HEALTHY) ok=1; break;;
+    INACTIVE|REMOVED|RESTORE_FAILED) die "Projeto entrou em '$st' — verifique no painel.";;
+  esac
+  printf '.' >&2
+  sleep 10
+done
+printf '\n' >&2
+[ "$ok" = 1 ] || die "O projeto não ficou ACTIVE_HEALTHY em 10 minutos. Confira no painel."
+c_grn "✓ banco no ar"
+
+# ── 5. Chaves ───────────────────────────────────────────────────────────────
+step "Buscando as chaves de API"
+keys="$(api GET "/projects/$REF/api-keys")"
+ANON="$(grep -o '"name"[[:space:]]*:[[:space:]]*"anon"[^}]*' <<<"$keys" | grep -o '"api_key"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
+SERVICE="$(grep -o '"name"[[:space:]]*:[[:space:]]*"service_role"[^}]*' <<<"$keys" | grep -o '"api_key"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
+[ -n "$ANON" ] && [ -n "$SERVICE" ] || { printf '%s\n' "$keys" >&2; die "Não consegui ler anon/service_role."; }
+c_grn "✓ anon e service_role obtidas"
+
+# ── 6. Descobre o host do POOLER — testando, não adivinhando ────────────────
+# O host é `aws-<N>-<regiao>.pooler.supabase.com`, e esse <N> VARIA por projeto
+# (0, 1, …). Construir às cegas erra, e o erro é justamente o que mais atrapalha
+# quem instala: a Direct connection (`db.<ref>.supabase.co`) só existe em IPv6 e
+# nunca conecta de um VPS IPv4, mas falha com uma mensagem de rede genérica.
+#
+# Então: monta os candidatos e PROVA cada um com uma conexão real, via o mesmo
+# postgres:17-alpine que o install.sh já usa para aplicar o schema. Fica o que
+# responde — sem chute.
+step "Descobrindo o host do pooler (testando conexão real)"
+DB_URL=""
+for n in 0 1 2; do
+  cand="postgresql://postgres.${REF}:${DB_PASS}@aws-${n}-${REGION}.pooler.supabase.com:5432/postgres"
+  if docker run --rm postgres:17-alpine psql "$cand" -c 'select 1' >/dev/null 2>&1; then
+    DB_URL="$cand"; c_grn "✓ pooler: aws-${n}-${REGION}"; break
+  fi
+done
+[ -n "$DB_URL" ] || die "Nenhum host de pooler respondeu. Pegue a Session pooler em Settings > Database."
+
+# ── 7. Saída ────────────────────────────────────────────────────────────────
+step "Pronto"
+c_ylw "⚠ Guarde a senha do banco — ela não é recuperável pela API depois."
+printf "NEXT_PUBLIC_SUPABASE_URL='https://%s.supabase.co'\n" "$REF"
+printf "NEXT_PUBLIC_SUPABASE_ANON_KEY='%s'\n" "$ANON"
+printf "SUPABASE_SERVICE_ROLE_KEY='%s'\n" "$SERVICE"
+printf "SUPABASE_DB_URL='%s'\n" "$DB_URL"

--- a/hostgator-setup-kit/supabase-provision.sh
+++ b/hostgator-setup-kit/supabase-provision.sh
@@ -84,7 +84,14 @@ fi
 # Extrai um campo string de um JSON PLANO. Mesmo estilo do jwt_claim() do
 # install.sh: o kit promete depender só de bash+curl, então nada de jq/python.
 # Só serve para os campos simples que a API devolve (ref, id, name, status).
-json_str() { grep -o "\"$2\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" <<<"$1" | head -1 | sed 's/.*"\([^"]*\)"$/\1/'; }
+#
+# O `|| true` no fim não é preguiça — é o que mantém as mensagens de erro
+# ALCANÇÁVEIS. Campo ausente faz o `grep` sair 1; com `pipefail`, isso derruba a
+# substituição, e com `set -e` o script inteiro morre em silêncio na linha da
+# atribuição — antes do `die` que explicaria o problema. Medido com token
+# inválido: a API respondia {"message":"Unauthorized"} e o terminal apenas
+# voltava, sem uma palavra. Falhando vazio, quem decide o que dizer é o `die`.
+json_str() { grep -o "\"$2\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" <<<"$1" | head -1 | sed 's/.*"\([^"]*\)"$/\1/' || true; }
 
 api() {
   local method="$1" path="$2" body="${3:-}"
@@ -156,8 +163,11 @@ c_grn "✓ banco no ar (levou $(( (SECONDS-inicio)/60 ))m$(( (SECONDS-inicio)%60
 # ── 5. Chaves ───────────────────────────────────────────────────────────────
 step "Buscando as chaves de API"
 keys="$(api GET "/projects/$REF/api-keys")"
-ANON="$(grep -o '"name"[[:space:]]*:[[:space:]]*"anon"[^}]*' <<<"$keys" | grep -o '"api_key"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
-SERVICE="$(grep -o '"name"[[:space:]]*:[[:space:]]*"service_role"[^}]*' <<<"$keys" | grep -o '"api_key"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
+# `|| true` pelo mesmo motivo do json_str(): sem ele, resposta inesperada da API
+# mata o script na atribuição e a linha de baixo — que imprime a resposta crua e
+# explica o que houve — nunca roda.
+ANON="$(grep -o '"name"[[:space:]]*:[[:space:]]*"anon"[^}]*' <<<"$keys" | grep -o '"api_key"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/' || true)"
+SERVICE="$(grep -o '"name"[[:space:]]*:[[:space:]]*"service_role"[^}]*' <<<"$keys" | grep -o '"api_key"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/' || true)"
 [ -n "$ANON" ] && [ -n "$SERVICE" ] || { printf '%s\n' "$keys" >&2; die "Não consegui ler anon/service_role."; }
 c_grn "✓ anon e service_role obtidas"
 

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -135,6 +135,51 @@ TMP2="$(mktemp -d)"
 ) || fail=1
 rm -rf "$TMP2"
 
+echo "integração: o install.sh não INTERPRETA a saída do provisionamento"
+# O bloco de cima guarda a FUNÇÃO; este guarda o PONTO DE CHAMADA — trocar
+# `sb_carrega_credenciais "$_sb_out"` de volta por `eval "$_sb_out"` passava
+# despercebido, porque a função continuava correta e ninguém mais a chamava.
+#
+# Guarda o COMPORTAMENTO, não o texto: uma asserção do tipo "não existe a palavra
+# eval" pegaria só a reincidência literal, e `. <(printf %s "$_sb_out")` executa
+# igual. Aqui o install.sh roda de verdade (docker é stub, nada de rede) com um
+# provisionamento que devolve uma aspa simples no valor; se qualquer mecanismo
+# interpretar aquilo, o marcador aparece.
+TMP3="$(mktemp -d)"
+(
+  MARCA="$TMP3/executou"
+  mkdir -p "$TMP3/bin" "$TMP3/proj"
+  cp install.sh _common.sh "$TMP3/"
+  : > "$TMP3/proj/docker-compose.prod.yml"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$TMP3/bin/docker"; chmod +x "$TMP3/bin/docker"
+  cat > "$TMP3/supabase-provision.sh" <<'PROV'
+#!/usr/bin/env bash
+# O que o provisionamento emite quando SUPABASE_REGION (que vem do ambiente)
+# traz uma aspa simples: ela fecha o literal do printf e o resto vira código.
+VENENO="postgresql://u:p@aws-0-x'\$(touch $MARCA)'.pooler.supabase.com:5432/postgres"
+printf "NEXT_PUBLIC_SUPABASE_URL='https://ref.supabase.co'\n"
+printf "NEXT_PUBLIC_SUPABASE_ANON_KEY='a'\n"
+printf "SUPABASE_SERVICE_ROLE_KEY='s'\n"
+printf "SUPABASE_DB_URL='%s'\n" "$VENENO"
+PROV
+
+  saida="$(cd "$TMP3/proj" && env PATH="$TMP3/bin:$PATH" MARCA="$MARCA" \
+    SUPABASE_ACCESS_TOKEN=fake NEXT_PUBLIC_SUPABASE_URL= \
+    bash "$TMP3/install.sh" --yes 2>&1 || true)"
+
+  # Sem esta checagem o teste passaria por VACUIDADE: se o install.sh morresse
+  # antes do bloco (stub quebrado, refactor movendo o trecho), nada executaria o
+  # veneno e o silêncio seria lido como aprovação.
+  if ! printf '%s' "$saida" | grep -q "credenciais entraram sozinhas"; then
+    printf '  ✗ o install.sh não chegou ao bloco do Supabase — teste inconclusivo, não verde\n'; exit 1
+  fi
+  if [ -e "$MARCA" ]; then
+    printf '  ✗ o install.sh INTERPRETOU a saída do provisionamento (eval/source no ponto de chamada?)\n'; exit 1
+  fi
+  printf '  ✓ ponto de chamada não interpreta a saída\n'
+) || fail=1
+rm -rf "$TMP3"
+
 echo
 if [ "$fail" = 0 ]; then echo "todos os validadores passaram"; else echo "FALHOU"; fi
 exit "$fail"

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -103,6 +103,38 @@ EOF
 ) || fail=1
 rm -rf "$TMP"
 
+echo "credenciais do provisionamento (sb_carrega_credenciais)"
+# Este bloco existe porque a leitura já foi feita com `eval`, e com `eval` ela
+# EXECUTAVA o conteúdo: o provisionamento imprime `CHAVE='valor'` sem escapar a
+# aspa simples, e SUPABASE_REGION — que vem do ambiente — é interpolada dentro da
+# connection string. Medido: com `eval`, o marcador abaixo era criado.
+TMP2="$(mktemp -d)"
+(
+  MARCA="$TMP2/executou"
+  # Exatamente o que o provisionamento emite quando a região traz uma aspa simples.
+  VENENO="postgresql://postgres.ref:senha@aws-0-sa-east-1'\$(touch $MARCA)'.pooler.supabase.com:5432/postgres"
+  PATH_ANTES="$PATH"
+  unset NEXT_PUBLIC_SUPABASE_URL NEXT_PUBLIC_SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY SUPABASE_DB_URL
+
+  sb_carrega_credenciais "$(printf "SUPABASE_DB_URL='%s'\n" "$VENENO")"
+
+  eq() { if [ "$2" = "$3" ]; then printf '  ✓ %s\n' "$1"; else printf '  ✗ %s  esperava [%s] obteve [%s]\n' "$1" "$3" "$2"; exit 1; fi; }
+  if [ -e "$MARCA" ]; then printf '  ✗ aspa simples no valor EXECUTOU comando\n'; exit 1; fi
+  printf '  ✓ aspa simples no valor não executa comando\n'
+  eq "valor com aspa chega literal"    "${SUPABASE_DB_URL:-}"  "$VENENO"
+
+  # Chave fora da lista fixa é ignorada — a saída não pode criar variável qualquer.
+  sb_carrega_credenciais "PATH='/pwn'"
+  eq "chave desconhecida é ignorada"   "$PATH"                 "$PATH_ANTES"
+
+  # E o caminho feliz continua inteiro.
+  unset SUPABASE_DB_URL
+  sb_carrega_credenciais "$(printf "NEXT_PUBLIC_SUPABASE_URL='https://abc.supabase.co'\nSUPABASE_DB_URL='postgresql://u:p@h:5432/postgres'\n")"
+  eq "url normal chega íntegra"        "${NEXT_PUBLIC_SUPABASE_URL:-}" "https://abc.supabase.co"
+  eq "db_url normal chega íntegra"     "${SUPABASE_DB_URL:-}"          "postgresql://u:p@h:5432/postgres"
+) || fail=1
+rm -rf "$TMP2"
+
 echo
 if [ "$fail" = 0 ]; then echo "todos os validadores passaram"; else echo "FALHOU"; fi
 exit "$fail"

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -180,6 +180,51 @@ PROV
 ) || fail=1
 rm -rf "$TMP3"
 
+echo "sincronia: o install.sh grava as chaves que o .env.hostgator.example promete"
+# O install.sh monta o .env a partir de uma LISTA FECHADA de `envq` e fecha com
+# `} > .env`, que TRUNCA. Chave fora da lista simplesmente não é gravada — e se a
+# pessoa a tiver posto à mão, some no próximo install, num script que o README
+# vende como idempotente. Medido: uma chave posta à mão é carregada por load_env
+# e depois DESCARTADA na escrita.
+#
+# Passou despercebido porque o env-example-sync do repo compara .env.example com
+# lib/env.ts e nunca olha para o install.sh — ninguém guardava esta ponta.
+#
+# DÍVIDA: chaves que o install.sh hoje não grava. A lista só pode ENCOLHER; se
+# uma delas passar a ser gravada, o teste manda tirá-la daqui.
+DIVIDA="AGENT_DISPATCH_CONSUMER NUVEMSHOP_APP_ID NUVEMSHOP_CLIENT_ID NUVEMSHOP_CLIENT_SECRET RESEND_API_KEY RESEND_FROM_EMAIL"
+EXEMPLO="${EXEMPLO_ENV:-../.env.hostgator.example}"
+if [ ! -f "$EXEMPLO" ]; then
+  # Pular é aceitável (o kit também roda solto, fora do repo), mas em voz alta:
+  # pulo silencioso é indistinguível de teste que passou.
+  printf '  — pulado: %s não existe (kit fora do repositório)\n' "$EXEMPLO"
+else
+  GRAVA="$(grep -oE '^[[:space:]]*envq [A-Z_0-9]+' install.sh | awk '{print $2}' | sort -u)"
+  novas=""
+  for k in $(grep -oE '^[A-Z_0-9]+=' "$EXEMPLO" | tr -d '=' | sort -u); do
+    printf '%s\n' "$GRAVA" | grep -qx "$k" && continue
+    case " $DIVIDA " in *" $k "*) continue ;; esac
+    novas="$novas $k"
+  done
+  if [ -n "$novas" ]; then
+    printf '  ✗ o .env.hostgator.example promete chave(s) que o install.sh não grava:%s\n' "$novas"
+    printf '     quem instalar pelo kit não recebe essa configuração; quem puser à mão perde no próximo install\n'
+    fail=1
+  else
+    printf '  ✓ nenhuma chave nova fora da lista de escrita\n'
+  fi
+  estagnada=""
+  for k in $DIVIDA; do
+    printf '%s\n' "$GRAVA" | grep -qx "$k" && estagnada="$estagnada $k"
+  done
+  if [ -n "$estagnada" ]; then
+    printf '  ✗ já é gravada pelo install.sh — tire da lista DÍVIDA deste teste:%s\n' "$estagnada"
+    fail=1
+  else
+    printf '  ✓ dívida ainda condiz (%s chaves conhecidas, só pode encolher)\n' "$(printf '%s' "$DIVIDA" | wc -w | tr -d ' ')"
+  fi
+fi
+
 echo
 if [ "$fail" = 0 ]; then echo "todos os validadores passaram"; else echo "FALHOU"; fi
 exit "$fail"


### PR DESCRIPTION
Auditoria dos dois caminhos de instalação encontrou dois becos sem saída. Numa instalação medida de ponta a ponta o script levou **~3 minutos** e a **preparação ~59** — a maior fatia era criar o projeto Supabase no navegador e copiar quatro campos à mão.

## 1) VPS cru morria na primeira linha

```bash
command -v docker || die "'docker' não encontrado. Instale antes de continuar."
```

Hospedagem com template (Hostinger, HostGator) já traz Docker, então o caso nunca aparecia para quem escreveu o kit. Num VPS limpo (Hetzner, DigitalOcean, Contabo) a pessoa — que por definição **não é técnica**, é o público do kit — batia num beco: a mensagem diz "instale" e não diz como.

Agora o instalador instala, pelo `get.docker.com` (o instalador oficial deles, não inventamos nada). Em modo interativo **pergunta antes**: pôr software no servidor de alguém sem avisar é abuso de confiança. Com `--yes` segue direto, que é o contrato do modo.

## 2) Criar o projeto Supabase pela Management API

O passo mais lento e o mais fácil de errar. A armadilha número um era a connection string: quem copia a "Direct connection" leva um host **IPv6-only**, que nunca conecta de um VPS IPv4 e falha com erro de rede genérico, sem dizer o que houve.

O script recebe um Personal Access Token e devolve as 4 credenciais prontas:

1. descobre a organização
2. gera senha de banco sem caracteres que quebram URL (`@ : / ? # &`) — um `@` aqui partiria o host da connection string ao meio
3. cria o projeto
4. **espera ficar `ACTIVE_HEALTHY`**. Projeto novo não nasce pronto: passa por `COMING_UP`, e sem esperar o passo do schema falha com "connection refused" e a instalação morre no meio sem explicar por quê
5. busca `anon` e `service_role`
6. **descobre o host do pooler testando conexão real**, não adivinhando

O passo 6 merece nota: o host é `aws-<N>-<regiao>.pooler.supabase.com` e esse `<N>` varia por projeto. Construir às cegas erra, e o erro é exatamente o que mais atrapalha quem instala. Então o script monta os candidatos e prova cada um com uma conexão de verdade, pelo mesmo `postgres:17-alpine` que o `install.sh` já usa. Fica o que responde.

**Sem dependência nova**: só bash + curl, como o resto do kit. O JSON é lido com grep/sed no mesmo estilo do `jwt_claim()` do `install.sh`.

## 3) A espera precisava comunicar

O script funcionava mas comunicava mal, e o pior momento era a espera: até 10 minutos imprimindo **pontos secos**. Ponto solto por tanto tempo parece travamento — e quem instala, na dúvida, mata o processo no meio da criação do projeto.

Entra barra de progresso reescrevendo uma linha só, com o estado **real** vindo da API (`COMING_UP` → `ACTIVE_HEALTHY`) e o tempo decorrido; passos numerados `[n/6]`; sem token, as 3 instruções para conseguir um em vez de uma linha de erro; e resumo final em moldura.

Dois detalhes que só aparecem testando de verdade:

- `printf %-60s` conta **bytes**. Acento e `·` ocupam 2+ em UTF-8, então a borda direita da moldura saía torta em qualquer título em português. Agora o preenchimento sai de `${#txt}`, que conta **caracteres**.
- `printf 'x%.0s' $(seq 1 0)` **não imprime nada — imprime uma vez**, porque printf sem argumentos ainda roda o formato. A barra nascia com 1 bloco a mais no começo e no fim (25 de 24). Verificado em 0/1/30/59/60.

O resumo **mascara** `anon`, `service_role` e a senha do banco (6 primeiros + 4 últimos): quem instala manda print pedindo ajuda, e um `service_role` inteiro num screenshot é acesso total ao banco, sem RLS. Todo o visual vai para **stderr**; o stdout continua com as 4 linhas limpas, para `bash supabase-provision.sh ... >> .env` seguir funcionando.

## Integração no install.sh

Com `SUPABASE_ACCESS_TOKEN` no ambiente e as credenciais vazias, o `install.sh` cria o projeto e as variáveis entram direto no fluxo. Sem o token, **nada muda** — seguem as perguntas de sempre. O `eval` da saída é seguro: a entrada é o stdout do nosso próprio script, com valores já entre aspas simples e escapados (verificado com senha contendo `@`, que é justamente o que quebraria uma connection string mal citada).

Documentados no README os dois limites que mudam a decisão de quem instala para terceiros: **o token é chave mestra da conta inteira** (use o do cliente, ou rode na sua máquina e leve só as credenciais), e o plano grátis dá **2 projetos por usuário** contados em todas as organizações — não dá para hospedar vários clientes numa conta só.

Resultado nos dois cenários:

```
Hetzner    git clone && export SUPABASE_ACCESS_TOKEN=... && bash install.sh
Hostinger  idem — o Traefik é detectado e o override entra sozinho
```

Um comando, do VPS vazio ao CRM no ar.

## Ressalva

Este PR toca `install.sh`, igual ao #92. Se aquele entrar primeiro eu rebaso este — testei os dois e não há conflito hoje, mas prefiro avisar a deixar você descobrir no merge.

Um de sete PRs que estou abrindo em paralelo.
