### PR TITLE
fix(rag): traduz a falta do binário nativo do canvas em instrução acionável

### DIFF
--- a/lib/ai/rag/extractors/pdf.ts
+++ b/lib/ai/rag/extractors/pdf.ts
@@ -69,6 +69,25 @@ export async function extractPdfText(buffer: Buffer): Promise<string> {
     return combined;
   } catch (err) {
     if (err instanceof PdfExtractError) throw err;
+
+    // O pdfjs 6 faz `new DOMMatrix()` no topo do módulo e depende do
+    // `@napi-rs/canvas` (optionalDependency) para o polyfill. Sem esse binário —
+    // plataforma sem binding publicado, registry corporativo sem os artefatos, ou
+    // instalação com optional deps podadas — ele estoura no IMPORT, antes de ler o
+    // arquivo. A versão 4 só avisava e extraía o texto assim mesmo.
+    //
+    // Sem esta mensagem, quem instalou vê "DOMMatrix is not defined" e não tem como
+    // ligar isso a uma dependência que ele nem sabe que existe. O diagnóstico custa
+    // 4 linhas; a caçada custa uma tarde.
+    if (err instanceof Error && /DOMMatrix|@napi-rs\/canvas/.test(err.message)) {
+      throw new PdfExtractError(
+        "Extração de PDF indisponível: o binário nativo @napi-rs/canvas não foi instalado " +
+          "nesta plataforma. Reinstale as dependências SEM podar as opcionais " +
+          "(`pnpm install`, não `--no-optional`). Até lá, PDFs não são lidos.",
+        err,
+      );
+    }
+
     throw new PdfExtractError("Both pdf-parse and pdfjs-dist failed to extract text", err);
   }
 }

--- a/tests/unit/pdf-extractor.test.ts
+++ b/tests/unit/pdf-extractor.test.ts
@@ -43,6 +43,32 @@ describe("extractPdfText", () => {
     expect(texto).toContain(TEXTO_ESPERADO);
   });
 
+  it("diz o que fazer quando o binário nativo do canvas falta", async () => {
+    // O pdfjs 6 estoura no import sem @napi-rs/canvas. Sem esta tradução o
+    // self-hoster vê "DOMMatrix is not defined" e não tem como ligar isso a uma
+    // dependência opcional que ele nem sabe que existe.
+    vi.doMock("pdf-parse", () => ({
+      default: () => {
+        throw new Error("pdf-parse sabotado de propósito");
+      },
+    }));
+    // Na VPS o erro nasce no IMPORT do módulo. Aqui ele nasce no getDocument, e é
+    // fiel ao que importa: o branch decide pela MENSAGEM, não pelo ponto de origem.
+    // (Mockar o factory para lançar não serve — o vitest reembrulha e a mensagem some.)
+    vi.doMock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+      GlobalWorkerOptions: {},
+      getDocument: () => {
+        throw new Error("DOMMatrix is not defined");
+      },
+    }));
+    vi.resetModules();
+
+    const { extractPdfText, PdfExtractError } = await import("@/lib/ai/rag/extractors/pdf");
+    await expect(extractPdfText(readFileSync(FIXTURE))).rejects.toThrow(PdfExtractError);
+    await expect(extractPdfText(readFileSync(FIXTURE))).rejects.toThrow(/@napi-rs\/canvas/);
+    vi.doUnmock("pdfjs-dist/legacy/build/pdf.mjs");
+  });
+
   it("lança PdfExtractError quando o buffer não é PDF", async () => {
     const { extractPdfText, PdfExtractError } = await import("@/lib/ai/rag/extractors/pdf");
     await expect(extractPdfText(Buffer.from("isto não é um pdf"))).rejects.toBeInstanceOf(


### PR DESCRIPTION
Ponta solta que eu **descrevi na revisão do #98 e não fechei** — o Rafael perguntou se os insights viraram código ou só relatório, e este era o que tinha ficado só como relatório.

O pdfjs 6 depende do `@napi-rs/canvas` para o polyfill de `DOMMatrix` e estoura no import sem ele. A v4 só avisava e extraía assim mesmo.

Medido em `node:22-alpine` com `--omit=optional`:

```
antes → message: Both pdf-parse and pdfjs-dist failed to extract text
        cause  : DOMMatrix is not defined
depois → Extração de PDF indisponível: o binário nativo @napi-rs/canvas não foi
         instalado nesta plataforma. Reinstale as dependências SEM podar as
         opcionais (`pnpm install`, não `--no-optional`).
```

O processo nunca morria — o `catch` segurava. O que faltava era o diagnóstico.

Teste verificado **vermelho sem a correção** e verde com ela. `typecheck`/`lint` exit 0, 204 arquivos / 1713 testes.

O caminho padrão continua coberto (lockfile com os 11 bindings + `--frozen-lockfile` no Dockerfile). Isto é rede para o caso de borda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4NxbuaBH2rNizak9HkDpd