### PR TITLE
fix(inbox): eco do envio duplicava a mensagem numa janela de corrida

### DIFF
--- a/app/api/v1/messages/_handler.ts
+++ b/app/api/v1/messages/_handler.ts
@@ -26,6 +26,67 @@ import type { Message } from "@/lib/types/messaging";
 
 type SB = SupabaseClient;
 
+/**
+ * Remove a linha que o WEBHOOK criou para a mensagem que ESTE envio acabou de
+ * mandar — o "eco do próprio envio".
+ *
+ * A janela: a linha do envio nasce antes de falar com o canal (`queued`,
+ * `external_id` NULL) e só recebe o id depois que o adapter volta. Todo envio
+ * retorna pelo webhook como `fromMe=true`; o eco que chega nesse intervalo não
+ * acha nada para casar e vira uma segunda linha com a mesma frase.
+ *
+ * POR QUE AQUI E NÃO NO WEBHOOK. Lá, a única coisa disponível para casar seria a
+ * própria linha `queued` — e ela não carrega nada que a identifique como sendo
+ * daquela mensagem. Casar por ela é casar por "existe um envio em voo nesta
+ * conversa", o que vale para o eco e também para uma mensagem legítima que o
+ * atendente digitou no celular enquanto o envio estava em voo: medido, esperado
+ * 2 mensagens e obtido 1, com a do celular descartada. Seria o defeito do #108
+ * de volta — e permanente, porque nada tira uma linha de `queued` (o cron
+ * `recover-stuck-messages` do CLAUDE.md:93 não existe no código).
+ *
+ * Aqui não há ambiguidade: o canal acabou de devolver o id EXATO da mensagem que
+ * mandamos. Casa por id, nunca por proximidade.
+ *
+ * QUAIS formas o mesmo id pode ter é conhecimento do CANAL, não de quem envia —
+ * então os candidatos chegam prontos, de `adapter.echoExternalIds`. Um canal
+ * simétrico não implementa o método e o chamador cai no próprio `externalId`.
+ *
+ * O escopo é deliberadamente estreito — mesma conversa e só o que nasceu de
+ * `external_device`. O bare pode colidir entre mensagens diferentes (garantia do
+ * WhatsApp, não nossa); restringir mantém o estrago de uma colisão dentro do
+ * único lugar onde ela seria de fato a nossa mensagem, e impede de apagar linha
+ * do próprio CRM.
+ */
+async function removerEcoDoProprioEnvio(
+  supabase: SB,
+  organizationId: string,
+  conversationId: string,
+  minhaLinhaId: string,
+  externalId: string | null,
+  candidatos: string[],
+): Promise<void> {
+  if (!externalId || candidatos.length === 0) return;
+
+  // BLINDADO DE PROPÓSITO. Esta chamada roda dentro do `try` do envio, e a
+  // mensagem JÁ SAIU quando chegamos aqui: deixar uma exceção subir faria o
+  // `catch` de baixo marcar como `failed` uma mensagem que o cliente recebeu —
+  // trocar uma duplicata visível por um status mentiroso. O pior caso aceitável
+  // é não conseguir remover, que é exatamente o mundo de antes desta função.
+  try {
+    const { error } = await supabase
+      .from("messages")
+      .delete()
+      .eq("organization_id", organizationId)
+      .eq("conversation_id", conversationId)
+      .eq("sent_via", "external_device")
+      .in("external_id", candidatos)
+      .neq("id", minhaLinhaId);
+    if (error) console.error("[messages.send] não consegui remover o eco do próprio envio", error.message);
+  } catch (err) {
+    console.error("[messages.send] a remoção do eco lançou", err instanceof Error ? err.message : err);
+  }
+}
+
 const MSG_COLS =
   "id, organization_id, conversation_id, channel_session_id, contact_id, external_id, type, direction, status, ack, error_code, error_message, body, media_url, media_mime, media_size_bytes, media_storage_path, sent_via, sent_by_user_id, sent_at, delivered_at, read_at, metadata, created_at";
 
@@ -338,6 +399,14 @@ export async function sendMessageHandler(
           body: input.body ?? "",
         }));
       }
+      await removerEcoDoProprioEnvio(
+        supabase,
+        ctx.organization_id,
+        c.id,
+        message.id,
+        externalId,
+        externalId ? (adapter.echoExternalIds?.({ externalId, recipient: chatId }) ?? [externalId]) : [],
+      );
       const { data: updated } = await supabase
         .from("messages")
         .update({

--- a/app/api/v1/messages/_handler.ts
+++ b/app/api/v1/messages/_handler.ts
@@ -80,6 +80,13 @@ async function removerEcoDoProprioEnvio(
       .eq("conversation_id", conversationId)
       .eq("sent_via", "external_device")
       .in("external_id", candidatos)
+      // ⚠️ SEGUNDA CAMADA, SEM COBERTURA POSSÍVEL — escrito porque medi: trocar
+      // este `neq` por um que nunca casa deixa a suíte VERDE. O filtro de
+      // `sent_via` acima já exclui a linha deste envio (que nasce `user`/`ai`,
+      // nunca `external_device`), então nenhum teste alcança esta cláusula.
+      // Fica porque o desfecho que ela impede é o pior que esta função poderia
+      // produzir: apagar a própria mensagem que acabou de ser entregue. Quem
+      // mexer no filtro de cima não vai ser avisado por teste nenhum.
       .neq("id", minhaLinhaId);
     if (error) console.error("[messages.send] não consegui remover o eco do próprio envio", error.message);
   } catch (err) {

--- a/lib/channels/adapters/waha.ts
+++ b/lib/channels/adapters/waha.ts
@@ -7,7 +7,7 @@
  */
 import { getWahaClient } from "@/lib/waha/client";
 import { wahaSendPlanFor } from "@/lib/waha/media-send";
-import { parseWahaMessageId } from "@/lib/waha/message-id";
+import { bareWaMessageId, parseWahaMessageId } from "@/lib/waha/message-id";
 import { resolveWahaChatId } from "@/lib/waha/send";
 import type { ChannelAdapter, OutboundEnvelope, RecipientInput } from "../types";
 
@@ -16,6 +16,23 @@ export const wahaAdapter: ChannelAdapter = {
 
   resolveRecipient(input: RecipientInput): string | null {
     return resolveWahaChatId(input);
+  },
+
+  /**
+   * As duas pontas do mesmo id, porque os engines gravam lados opostos:
+   *   NOWEB — o envio devolve o id cru (`3EB0…`) e o webhook manda o composto
+   *           `true_<chatId>_3EB0…`
+   *   WEBJS — os dois lados usam o `_serialized` completo
+   *
+   * Reduzir ao bare cobre o segundo caso; para o primeiro é preciso CONSTRUIR o
+   * composto a partir do destinatário — daí o `recipient`. Sem ele o par nunca
+   * contém a forma que o webhook realmente gravou.
+   *
+   * `true_` porque o eco de um envio nosso é sempre `fromMe`.
+   */
+  echoExternalIds(input: { externalId: string; recipient: string }): string[] {
+    const bare = bareWaMessageId(input.externalId);
+    return [...new Set([input.externalId, bare, `true_${input.recipient}_${bare}`])];
   },
 
   // Mesmo pre-check que o handler já fazia com `getWahaClient() !== null`,

--- a/lib/channels/types.ts
+++ b/lib/channels/types.ts
@@ -96,4 +96,20 @@ export interface ChannelAdapter {
     sessionRef: string;
     recipient: string;
   }): Promise<string | null>;
+
+  /**
+   * Todas as formas sob as quais ESTE canal pode ter registrado a MESMA mensagem
+   * que acabou de ser enviada — para reconhecer o eco do próprio envio quando ele
+   * volta pelo webhook.
+   *
+   * Existe porque alguns canais são assimétricos: a resposta do envio e o
+   * webhook do eco trazem pontas diferentes do mesmo identificador, e comparar
+   * as duas strings direto nunca casa. Que formas são essas é conhecimento do
+   * canal, não de quem envia — por isso mora aqui e não no handler, que é
+   * justamente o que o lint de canal impede.
+   *
+   * OPCIONAL: um canal simétrico (mesmo id nos dois lados) não implementa, e
+   * quem chama cai no próprio `externalId`.
+   */
+  echoExternalIds?(input: { externalId: string; recipient: string }): string[];
 }

--- a/tests/unit/messages-handler-eco-duplicado.test.ts
+++ b/tests/unit/messages-handler-eco-duplicado.test.ts
@@ -1,0 +1,273 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { sendMessageHandler } from '@/app/api/v1/messages/_handler';
+import type { HandlerCtx } from '@/lib/api/handlers/types';
+import type { SendMessageInput } from '@/lib/schemas';
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: () => ({ storage: { from: () => ({ createSignedUrl: vi.fn() }) } }),
+}));
+vi.mock('@/lib/audit', () => ({ audit: vi.fn(async () => {}) }));
+
+/**
+ * A MESMA FRASE NÃO PODE APARECER DUAS VEZES NA CONVERSA.
+ *
+ * O envio grava a linha ANTES de falar com o canal (`status: "queued"`,
+ * `external_id` NULL) e só carimba o id num UPDATE depois que o adapter volta.
+ * Todo envio volta pelo webhook como `fromMe=true`; o eco que chega DENTRO desse
+ * intervalo não encontra nada para casar — nem pelo id completo, nem pelo bare —
+ * e nasce uma segunda linha.
+ *
+ * No NOWEB (engine padrão do kit) isso é comportamento NOVO desde o PR #108:
+ * antes, o eco era descartado junto com as mensagens legítimas do celular, e o
+ * defeito maior escondia o menor. Medido na época: pré-PR/NOWEB dava 1 linha,
+ * pós-PR/NOWEB dá 2.
+ *
+ * ⚠️ POR QUE A CORREÇÃO É AQUI E NÃO NO INGEST. A tentação é o webhook casar a
+ * linha `queued` da conversa. Isso foi medido e REPROVADO: a linha `queued` não
+ * carrega nada que a identifique como sendo daquela mensagem, então casar por
+ * ela é casar por "existe um envio em voo nesta conversa" — o que vale para o
+ * eco E para uma mensagem legítima que o atendente digitou no celular enquanto o
+ * envio estava em voo. O falso positivo seria o próprio defeito do #108 de volta,
+ * e permanente: nada no sistema tira uma linha de `queued` (o cron
+ * `recover-stuck-messages` do CLAUDE.md:93 não existe no código).
+ *
+ * O lado do ENVIO não tem essa ambiguidade: ele sabe qual linha é dele e acabou
+ * de receber do canal o id exato da mensagem que mandou. Casa por ID.
+ */
+
+const ORG = '11111111-1111-4111-8111-111111111111';
+const CONV = '22222222-2222-4222-8222-222222222222';
+const OUTRA_CONV = '99999999-9999-4999-8999-999999999999';
+const CONTACT = '33333333-3333-4333-8333-333333333333';
+const SESSION = '44444444-4444-4444-8444-444444444444';
+const USER = '55555555-5555-4555-8555-555555555555';
+
+/** O que o WAHA/NOWEB devolve no envio: o id BARE, sem o chat. */
+const BARE = '3EB0ABCDEF0123456789';
+/** O mesmo id como o webhook o entrega de volta: composto. */
+const COMPOSTO = `true_5531999998888@c.us_${BARE}`;
+
+type Row = Record<string, unknown>;
+
+function conversationRow(): Row {
+  return {
+    id: CONV,
+    organization_id: ORG,
+    contact_id: CONTACT,
+    channel_session_id: SESSION,
+    is_group: false,
+    group_chat_id: null,
+    contacts: { phone_number: '+5531999998888', wa_identity: null, is_blocked: false },
+    channel_sessions: { provider: 'waha', waha_session_name: 'default', status: 'WORKING' },
+  };
+}
+
+/**
+ * Fake com uma TABELA (não uma linha só): o desfecho deste caso é "quantas
+ * linhas sobraram", então um fake de linha única responderia sempre 1 e o teste
+ * passaria sem tocar no defeito.
+ */
+function makeSupabase(preexistentes: Row[] = []) {
+  const messages: Row[] = [...preexistentes];
+
+  const filtrar = (filtros: Array<(r: Row) => boolean>) => messages.filter((r) => filtros.every((f) => f(r)));
+
+  const from = (table: string) => {
+    if (table === 'conversations') {
+      return {
+        select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: conversationRow(), error: null }) }) }),
+        update: () => ({ eq: async () => ({ error: null }) }),
+      };
+    }
+    if (table !== 'messages') throw new Error(`fake: tabela inesperada '${table}'`);
+
+    return {
+      insert: (row: Row) => {
+        const nova: Row = { id: `msg-${messages.length + 1}`, external_id: null, ack: null, error_code: null, error_message: null, ...row };
+        messages.push(nova);
+        return { select: () => ({ single: async () => ({ data: { ...nova }, error: null }) }) };
+      },
+      update: (patch: Row) => {
+        const filtros: Array<(r: Row) => boolean> = [];
+        const q = {
+          eq(col: string, val: unknown) {
+            filtros.push((r) => r[col] === val);
+            return q;
+          },
+          select: () => ({
+            maybeSingle: async () => {
+              const alvos = filtrar(filtros);
+              // O unique (organization_id, external_id) é a regra de banco de que
+              // este desfecho depende: sem ela, gravar o id numa linha quando
+              // outra já o tem passaria batido.
+              const externo = patch.external_id as string | undefined;
+              if (externo) {
+                const colide = messages.some(
+                  (r) => r.organization_id === ORG && r.external_id === externo && !alvos.includes(r),
+                );
+                if (colide) {
+                  return { data: null, error: { code: '23505', message: 'duplicate key value violates "messages_org_external_id_unique"' } };
+                }
+              }
+              alvos.forEach((r) => Object.assign(r, patch));
+              return { data: alvos[0] ? { ...alvos[0] } : null, error: null };
+            },
+          }),
+        };
+        return q;
+      },
+      delete: () => {
+        const filtros: Array<(r: Row) => boolean> = [];
+        const q = {
+          eq(col: string, val: unknown) {
+            filtros.push((r) => r[col] === val);
+            return q;
+          },
+          neq(col: string, val: unknown) {
+            filtros.push((r) => r[col] !== val);
+            return q;
+          },
+          in(col: string, vals: unknown[]) {
+            filtros.push((r) => vals.includes(r[col]));
+            return q;
+          },
+          then(resolve: (v: { error: null }) => unknown) {
+            for (const alvo of filtrar(filtros)) messages.splice(messages.indexOf(alvo), 1);
+            return Promise.resolve({ error: null }).then(resolve);
+          },
+        };
+        return q;
+      },
+    };
+  };
+
+  const client = { from, rpc: async () => ({ error: null }) };
+  return { supabase: client as unknown as SupabaseClient, messages };
+}
+
+/** A linha que o webhook cria quando o eco chega antes do envio terminar. */
+function ecoDoWebhook(over: Row = {}): Row {
+  return {
+    id: 'eco-1',
+    organization_id: ORG,
+    conversation_id: CONV,
+    contact_id: CONTACT,
+    channel_session_id: SESSION,
+    external_id: COMPOSTO,
+    direction: 'outbound',
+    status: 'sent',
+    body: 'oi',
+    sent_via: 'external_device',
+    ...over,
+  };
+}
+
+const ctx: HandlerCtx = { organization_id: ORG, actor: { type: 'user', id: USER }, requestId: 'req-1' };
+const input = { conversation_id: CONV, type: 'text', body: 'oi' } as SendMessageInput;
+
+function wahaRespondendo(idBare: string) {
+  vi.stubEnv('WAHA_API_BASE_URL', 'http://localhost:3030');
+  vi.stubEnv('WAHA_API_KEY', 'hash123');
+  // NOWEB devolve o id interno cru — é daí que sai o `external_id` do envio.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response(JSON.stringify({ id: { id: idBare } }), { status: 200 })),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe('eco do próprio envio na janela em que a linha ainda não tem external_id', () => {
+  it('o eco que chegou primeiro não deixa a frase duplicada', async () => {
+    wahaRespondendo(BARE);
+    const { supabase, messages } = makeSupabase([ecoDoWebhook()]);
+
+    await sendMessageHandler(supabase, ctx, input);
+
+    const daMensagem = messages.filter((m) => m.external_id === BARE || m.external_id === COMPOSTO);
+    expect(daMensagem, 'a mesma frase ficou duas vezes na conversa').toHaveLength(1);
+  });
+
+  it('a linha que sobra é a do ENVIO, com autoria — não a do webhook', async () => {
+    // Qual das duas sobrevive importa: a do envio carrega `sent_by_user_id` e
+    // `sent_via`, que é o que a tela usa para dizer quem falou. Ficar com a do
+    // webhook apagaria a autoria.
+    wahaRespondendo(BARE);
+    const { supabase, messages } = makeSupabase([ecoDoWebhook()]);
+
+    await sendMessageHandler(supabase, ctx, input);
+
+    const sobrou = messages.find((m) => m.external_id === BARE || m.external_id === COMPOSTO)!;
+    expect(sobrou.sent_by_user_id).toBe(USER);
+    expect(sobrou.sent_via).toBe('user');
+    expect(sobrou.status).toBe('sent');
+  });
+
+  it('sem eco nenhum, nada é removido e o envio segue normal', async () => {
+    // Guarda de vacuidade: se a correção apagasse indiscriminadamente, este caso
+    // ainda daria 1 linha — por isso ele também confere que a linha é a do envio
+    // e que ela recebeu o id.
+    wahaRespondendo(BARE);
+    const { supabase, messages } = makeSupabase();
+
+    await sendMessageHandler(supabase, ctx, input);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.external_id).toBe(BARE);
+    expect(messages[0]!.status).toBe('sent');
+  });
+});
+
+describe('o que a correção NÃO pode apagar', () => {
+  it('mensagem que o dono digitou no celular na MESMA conversa continua lá', async () => {
+    // ESTE é o caso que reprovou a correção pelo lado do webhook. Uma mensagem
+    // legítima de dispositivo externo, na mesma conversa, durante o envio — ela
+    // só não é o eco porque o id é OUTRO. Casar por id preserva; casar por
+    // "envio em voo" apagaria.
+    wahaRespondendo(BARE);
+    const outraMensagem = ecoDoWebhook({
+      id: 'celular-1',
+      external_id: 'true_5531999998888@c.us_3EB0OUTRAMENSAGEM99',
+      body: 'vou verificar e ja te falo',
+    });
+    const { supabase, messages } = makeSupabase([outraMensagem]);
+
+    await sendMessageHandler(supabase, ctx, input);
+
+    expect(
+      messages.find((m) => m.body === 'vou verificar e ja te falo'),
+      'apagou uma mensagem legítima do celular',
+    ).toBeDefined();
+    expect(messages).toHaveLength(2);
+  });
+
+  it('eco com o mesmo id em OUTRA conversa não é tocado', async () => {
+    // O bare pode colidir entre mensagens diferentes (não há garantia nossa, só
+    // a do WhatsApp). Restringir à conversa do envio mantém o estrago de uma
+    // colisão dentro do único lugar onde ela seria mesmo a nossa mensagem.
+    wahaRespondendo(BARE);
+    const deOutraConversa = ecoDoWebhook({ id: 'outro-1', conversation_id: OUTRA_CONV });
+    const { supabase, messages } = makeSupabase([deOutraConversa]);
+
+    await sendMessageHandler(supabase, ctx, input);
+
+    expect(messages.find((m) => m.id === 'outro-1'), 'apagou linha de outra conversa').toBeDefined();
+  });
+
+  it('linha do CRM (não-webhook) com o mesmo id não é tocada', async () => {
+    // Só o eco nasce com `sent_via: external_device`. Uma linha nossa com o
+    // mesmo id seria outra coisa — e apagá-la seria perder envio de verdade.
+    wahaRespondendo(BARE);
+    const doCrm = ecoDoWebhook({ id: 'crm-1', sent_via: 'ai' });
+    const { supabase, messages } = makeSupabase([doCrm]);
+
+    await sendMessageHandler(supabase, ctx, input);
+
+    expect(messages.find((m) => m.id === 'crm-1'), 'apagou uma linha que não era eco de dispositivo').toBeDefined();
+  });
+});


### PR DESCRIPTION
Follow-up do #108. O #108 consertou o descarte silencioso da mensagem digitada no celular e, ao consertar, **expôs** uma duplicação que o defeito maior mascarava — o trade ficou registrado no PR, não escondido. Isto fecha a dívida.

## O bug

`app/api/v1/messages/_handler.ts` insere a linha do envio com `status: "queued"` e `external_id` NULL; o id só chega num UPDATE **depois** que o adapter volta. O eco que chegar nesse intervalo não acha nada para casar, e nasce uma segunda linha com a mesma frase.

| cenário | linhas |
|---|---|
| pré-#108 / NOWEB | 1 — não duplicava porque descartava tudo |
| pós-#108 / NOWEB | **2** |

## Por que a correção é do lado do ENVIO

Já foi medida e descartada a alternativa de casar a linha `queued` no dedup do ingest: numa conversa em que o atendente manda pelo CRM e responde pelo celular, **esperado 2 mensagens, medido 1** — a do celular era descartada. A `queued` não carrega nada que a identifique, então casar por ela é casar por "existe um envio em voo", e o falso positivo é o próprio defeito que o #108 conserta.

O lado do envio **sabe qual linha é dele**. Casa por id, não por heurística.

Agravante que torna o erro caro: **ninguém tira linha de `queued`**. O `CLAUDE.md:93` promete o cron `recover-stuck-messages`, mas a string só existe num README e não há implementação; o índice de recuperação cobre `sending` e `failed`. Órfã ali é permanente.

## O que o caminho revelou

- O `lint:channels` reprovou porque o handler passou a nomear provider. Virou **`echoExternalIds` no `ChannelAdapter`**, opcional como o `fetchProfilePictureUrl` — a catraca voltou a zero, sem exceção pedida.
- A **direção do id** estava errada: no NOWEB o `externalId` já *é* o bare, então derivar nunca produzia o composto que o webhook gravou. Precisa **construir**.
- A rede de caracterização existente pegou um defeito da própria correção: a remoção estava dentro do `try` do envio, e qualquer erro ali marcaria como `failed` uma mensagem **já entregue**. Agora tem `try/catch` próprio.

## Verificação

Sabotando a limpeza do eco, **2 testes ficam vermelhos**. `typecheck` 0 · `lint` 0 · `lint:channels` 0 · `test:unit` 0.

Uma linha sem cobertura possível (o `neq` da própria linha) está marcada **no código**, com o resultado da sabotagem escrito ao lado: sabotada, a suíte fica verde, porque o filtro de `sent_via` já a torna inalcançável. Fica porque impede o pior desfecho.

**Não medido, e declarado:** o `DELETE` contra banco real com RLS. A policy `messages_delete` existe e autoriza membro da org, mas isso é leitura de schema, não comportamento medido — o teste usa fake, que não tem RLS. O filtro de `organization_id` está explícito na query, que é o que a doutrina exige.

Medição e implementação: **@QAVivo**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4NxbuaBH2rNizak9HkDpd