### PR TITLE
fix(waha): chatId que não sabemos ler deixa de virar 'grupo' e sumir calado

### DIFF
--- a/lib/waha/ingest-celular.test.ts
+++ b/lib/waha/ingest-celular.test.ts
@@ -167,12 +167,17 @@ describe("mensagem digitada no celular do dono (fromMe)", () => {
     expect(messages).toHaveLength(1);
   });
 
-  it("o descarte era silencioso porque chatId vazio cai na classificação de grupo", async () => {
-    // `p.to ?? ""` produzia "" e `parseChatId("")` não casa nenhum sufixo
-    // conhecido → devolve `group`. O `return` executado era o do filtro de
-    // grupo, uma linha ANTES da guarda `if (!p.id || !chatId)`. Mesmo desfecho,
-    // e é por isso que não havia sequer um log: grupo é descarte esperado.
-    expect(parseChatId("")).toEqual({ kind: "group", phone: null, lid: null });
+  it("o descarte era silencioso porque chatId vazio caía na classificação de grupo", async () => {
+    // COMO ERA, e por que o defeito não deixava rastro: `p.to ?? ""` produzia ""
+    // e `parseChatId("")` não casava nenhum sufixo conhecido → devolvia `group`.
+    // O `return` executado era o do filtro de grupo, uma linha ANTES da guarda
+    // que a descrição do PR apontava. Grupo é descarte esperado, então ninguém
+    // jamais pensaria em instrumentar ali — daí o silêncio total.
+    //
+    // COMO É AGORA: string vazia é `unknown`, não `group`. A ausência de dado
+    // parou de se disfarçar de decisão de produto, e o descarte emite
+    // `whatsapp.chat_id_not_recognized`. Ver ingest-chat-desconhecido.test.ts.
+    expect(parseChatId("")).toEqual({ kind: "unknown", phone: null, lid: null });
   });
 });
 

--- a/lib/waha/ingest-chat-desconhecido.test.ts
+++ b/lib/waha/ingest-chat-desconhecido.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/audit", () => ({ audit: vi.fn() }));
+
+import { dispatchWahaEvent, parseChatId, type WahaEnvelope, type WahaPayload } from "@/lib/waha/ingest";
+
+/**
+ * UM CHAT QUE NÃO SABEMOS LER TEM QUE APARECER EM ALGUM LUGAR.
+ *
+ * `parseChatId` jogava QUALQUER sufixo desconhecido no balde `group`, e o ingest
+ * descarta grupo — então "não sei ler isto" virava "descarta calado", que é a
+ * mesma família do defeito do PR #108 (a mensagem do celular sumia sem erro,
+ * webhook devolvendo 200). O WhatsApp já tem `@newsletter` e `@broadcast` em
+ * produção; o próximo formato reproduz o sintoma inteiro.
+ *
+ * A correção separa as duas coisas: grupo é descarte ESPERADO (silencioso, por
+ * doutrina); desconhecido é descarte que precisa deixar rastro.
+ *
+ * ⚠️ O RISCO DE INTRODUZIR ALGO PIOR mora no upsert de contato, e é por isso que
+ * o caso de vazamento existe aqui. `fn_upsert_wa_contact` NÃO valida `p_kind`, e
+ * `contacts.wa_identity` é coluna GERADA que só vira `phone:`/`lid:` — qualquer
+ * outro kind produz `wa_identity` NULL. Como o `on conflict` da RPC é
+ * `(organization_id, wa_identity) WHERE wa_identity is not null`, uma linha NULL
+ * nunca conflita: cada webhook criaria um CONTATO ÓRFÃO NOVO. É exatamente o
+ * anti-pattern que a migration 0027 veio matar.
+ */
+
+interface Duplo {
+  admin: unknown;
+  rpcs: Array<{ fn: string; args: Record<string, unknown> }>;
+  messages: Array<Record<string, unknown>>;
+}
+
+function bancoDeMentira(): Duplo {
+  const rpcs: Array<{ fn: string; args: Record<string, unknown> }> = [];
+  const messages: Array<Record<string, unknown>> = [];
+  const consulta = () => {
+    const q = {
+      eq: () => q,
+      in: () => q,
+      limit: () => q,
+      maybeSingle: async () => ({ data: null, error: null }),
+    };
+    return q;
+  };
+  const admin = {
+    from: () => ({
+      select: () => consulta(),
+      insert: (linha: Record<string, unknown>) => ({
+        select: () => ({
+          maybeSingle: async () => {
+            messages.push(linha);
+            return { data: { id: `msg-${messages.length}` }, error: null };
+          },
+        }),
+      }),
+    }),
+    rpc: async (fn: string, args: Record<string, unknown>) => {
+      rpcs.push({ fn, args });
+      if (fn === "fn_upsert_wa_contact") return { data: "contato-1", error: null };
+      if (fn === "fn_upsert_wa_conversation") return { data: "conversa-1", error: null };
+      return { data: null, error: null };
+    },
+  };
+  return { admin, rpcs, messages };
+}
+
+const SESSION = { id: "sessao-1", organization_id: "org-1" };
+
+function inbound(from: string): WahaEnvelope {
+  const payload: WahaPayload = { id: `false_${from}_3EB0ABC`, from, fromMe: false, body: "oi" };
+  return { event: "message.any", session: "default", payload };
+}
+
+describe("parseChatId separa desconhecido de grupo", () => {
+  it("os formatos que sabemos ler continuam iguais", async () => {
+    // Guarda de vacuidade: sem isto, um parseChatId que devolvesse "unknown"
+    // para tudo passaria nos casos abaixo.
+    expect(parseChatId("5511999999999@c.us")).toEqual({ kind: "phone", phone: "+5511999999999", lid: null });
+    expect(parseChatId("250302204792918@lid")).toEqual({ kind: "lid", phone: null, lid: "250302204792918" });
+    expect(parseChatId("120363000000000000@g.us")).toEqual({ kind: "group", phone: null, lid: null });
+    expect(parseChatId("5511999999999@s.whatsapp.net")).toEqual({
+      kind: "phone",
+      phone: "+5511999999999",
+      lid: null,
+    });
+  });
+
+  it("sufixo que não conhecemos NÃO é grupo", async () => {
+    // O WhatsApp já usa os dois em produção; nenhum é grupo.
+    expect(parseChatId("11111111111@newsletter").kind).toBe("unknown");
+    expect(parseChatId("status@broadcast").kind).toBe("unknown");
+    // E o caso que originou o #108: string vazia não é grupo, é ausência de dado.
+    expect(parseChatId("").kind).toBe("unknown");
+  });
+});
+
+describe("o chat não reconhecido deixa rastro", () => {
+  it("emite whatsapp.chat_id_not_recognized em vez de sumir calado", async () => {
+    const { admin, rpcs } = bancoDeMentira();
+
+    await dispatchWahaEvent(admin as never, SESSION as never, inbound("11111111111@newsletter"), "req-1");
+
+    const aviso = rpcs.find(
+      (c) => c.fn === "emit_event" && c.args.p_event_type === "whatsapp.chat_id_not_recognized",
+    );
+    expect(aviso, "o chat desconhecido foi descartado sem deixar rastro nenhum").toBeDefined();
+    expect(aviso!.args.p_organization_id).toBe("org-1");
+  });
+
+  it("registra o SUFIXO, não o identificador do contato", async () => {
+    // O que responde "que formato novo é este?" é o sufixo. O identificador
+    // inteiro é dado de uma pessoa e não tem propósito no log operacional —
+    // mesma doutrina de whatsapp.conversation_mark_failed, que não copia o texto.
+    const { admin, rpcs } = bancoDeMentira();
+
+    await dispatchWahaEvent(admin as never, SESSION as never, inbound("11111111111@newsletter"), "req-1");
+
+    const aviso = rpcs.find(
+      (c) => c.fn === "emit_event" && c.args.p_event_type === "whatsapp.chat_id_not_recognized",
+    )!;
+    expect(JSON.stringify(aviso.args)).toContain("@newsletter");
+    expect(JSON.stringify(aviso.args), "vazou o identificador do contato para o log").not.toContain(
+      "11111111111",
+    );
+  });
+
+  it("grupo continua descartado EM SILÊNCIO — descarte esperado não vira ruído", async () => {
+    // O controle que impede o teste de passar por acidente: se o aviso saísse em
+    // todo descarte, as asserções acima passariam sem provar nada sobre o
+    // desconhecido. Grupo é skip por doutrina (CLAUDE.md), não anomalia.
+    const { admin, rpcs } = bancoDeMentira();
+
+    await dispatchWahaEvent(admin as never, SESSION as never, inbound("120363000000000000@g.us"), "req-1");
+
+    const avisos = rpcs.filter(
+      (c) => c.fn === "emit_event" && c.args.p_event_type === "whatsapp.chat_id_not_recognized",
+    );
+    expect(avisos).toHaveLength(0);
+  });
+});
+
+describe("o chat não reconhecido NÃO vira contato", () => {
+  it("nunca chama fn_upsert_wa_contact com kind fora de phone|lid", async () => {
+    // Esta é a asserção que impede a correção de introduzir algo pior que o
+    // defeito. `wa_identity` é gerada e fica NULL para qualquer outro kind; como
+    // o `on conflict` da RPC exige `wa_identity is not null`, a linha nunca
+    // conflita e NASCE UM CONTATO NOVO A CADA WEBHOOK.
+    const { admin, rpcs, messages } = bancoDeMentira();
+
+    for (const chat of ["11111111111@newsletter", "status@broadcast", "120363000000000000@g.us"]) {
+      await dispatchWahaEvent(admin as never, SESSION as never, inbound(chat), "req-1");
+    }
+
+    const kinds = rpcs.filter((c) => c.fn === "fn_upsert_wa_contact").map((c) => c.args.p_kind);
+    expect(kinds, "vazou um kind não-endereçável para o upsert de contato").toEqual([]);
+    expect(messages, "chat não endereçável não vira mensagem").toHaveLength(0);
+  });
+
+  it("controle: chat endereçável continua virando contato", async () => {
+    const { admin, rpcs, messages } = bancoDeMentira();
+
+    await dispatchWahaEvent(admin as never, SESSION as never, inbound("5511999999999@c.us"), "req-1");
+
+    const kinds = rpcs.filter((c) => c.fn === "fn_upsert_wa_contact").map((c) => c.args.p_kind);
+    expect(kinds).toEqual(["phone"]);
+    expect(messages).toHaveLength(1);
+  });
+});

--- a/lib/waha/ingest.ts
+++ b/lib/waha/ingest.ts
@@ -58,13 +58,26 @@ export interface WahaEnvelope {
 export type ChatIdentity =
   | { kind: "phone"; phone: string; lid: null }
   | { kind: "lid"; phone: null; lid: string } // lid = somente dígitos
-  | { kind: "group"; phone: null; lid: null };
+  | { kind: "group"; phone: null; lid: null }
+  | { kind: "unknown"; phone: null; lid: null };
 
 /**
  * Resolve um chatId WAHA em identidade canônica:
  *  - `{number}@c.us` | `@s.whatsapp.net` -> phone E.164 ("+55...")
  *  - `{lid}@lid` -> lid (somente dígitos; número protegido pelo WhatsApp)
- *  - `@g.us` | formato desconhecido -> group (skip binding CRM)
+ *  - `@g.us` -> group (skip binding CRM — descarte ESPERADO, por doutrina)
+ *  - qualquer outra coisa -> unknown (descarte que DEIXA RASTRO)
+ *
+ * A quarta variante existe porque este `return` final classificava tudo o que
+ * não reconhecia como "grupo", e o ingest descarta grupo: "não sei ler isto"
+ * virava "descarta calado" — a mesma família do defeito que sumia com a mensagem
+ * digitada no celular (PR #108), inclusive o mesmo sintoma de webhook devolvendo
+ * 200 sem erro. `@newsletter` e `@broadcast` já existem em produção e caíam
+ * aqui; o próximo formato do WhatsApp reproduziria o caso inteiro.
+ *
+ * Grupo e desconhecido têm o MESMO desfecho (não viram contato) e naturezas
+ * opostas: um é decisão de produto, o outro é buraco de conhecimento. Só o
+ * segundo é anomalia, então só ele emite evento.
  */
 export function parseChatId(chatId: string): ChatIdentity {
   if (chatId.endsWith("@g.us")) return { kind: "group", phone: null, lid: null };
@@ -75,7 +88,52 @@ export function parseChatId(chatId: string): ChatIdentity {
     const digits = chatId.replace(/@.*$/, "").replace(/^\+/, "");
     return { kind: "phone", phone: "+" + digits, lid: null };
   }
-  return { kind: "group", phone: null, lid: null };
+  return { kind: "unknown", phone: null, lid: null };
+}
+
+/** Só estes dois viram contato no CRM — ver a guarda de `upsertContact`. */
+function ehEnderecavel(parsed: ChatIdentity): boolean {
+  return parsed.kind === "phone" || parsed.kind === "lid";
+}
+
+/**
+ * O SUFIXO responde "que formato é este?"; o resto identifica uma pessoa.
+ *
+ * Registro operacional não é cópia de dado de contato — mesma linha de
+ * `markConversation`, que deliberadamente não copia o texto da mensagem. Sem
+ * isso, o log de diagnóstico vira depósito de número de telefone.
+ */
+function sufixoDeChatId(chatId: string): string {
+  const at = chatId.lastIndexOf("@");
+  if (at !== -1) return chatId.slice(at);
+  return chatId === "" ? "(vazio)" : "(sem @)";
+}
+
+/**
+ * Um chatId que não sabemos endereçar é ANOMALIA — tem que ser contável.
+ *
+ * `select count(*) from event_log where event_type = 'whatsapp.chat_id_not_recognized'`
+ * responde "o WhatsApp mudou de formato e estamos perdendo mensagem?", que antes
+ * não tinha como ser respondido: o descarte não deixava nada para trás.
+ */
+async function avisarChatNaoReconhecido(
+  admin: Admin,
+  organizationId: string,
+  sessionId: string,
+  chatId: string,
+  direction: "inbound" | "outbound",
+): Promise<void> {
+  const { error } = await admin.rpc("emit_event" as never, {
+    p_event_type: "whatsapp.chat_id_not_recognized",
+    p_entity_kind: "channel_session",
+    p_entity_id: sessionId,
+    p_payload: { sufixo: sufixoDeChatId(chatId), direction },
+    p_metadata: { severity: "warn" },
+    p_organization_id: organizationId,
+  } as never);
+  if (error) {
+    console.error("[waha.ingest] o aviso de chat não reconhecido também falhou", error.message);
+  }
 }
 
 const STOP_RX = /\b(STOP|PARAR|SAIR|UNSUBSCRIBE)\b/i;
@@ -190,7 +248,18 @@ async function upsertContact(
   chatId: string,
   notifyName: string | null,
 ): Promise<string | null> {
-  if (parsed.kind === "group") return null;
+  // ALLOWLIST, não denylist — e a diferença aqui não é estilo.
+  //
+  // `fn_upsert_wa_contact` NÃO valida `p_kind`, e `contacts.wa_identity` é coluna
+  // GERADA que só produz `phone:`/`lid:`; qualquer outro kind a deixa NULL. Como
+  // o `on conflict` da RPC é `(organization_id, wa_identity) where wa_identity is
+  // not null`, uma linha NULL nunca conflita — nasceria UM CONTATO NOVO A CADA
+  // WEBHOOK, que é exatamente o anti-pattern que a migration 0027 veio matar.
+  //
+  // Com `kind === "group"` (a forma antiga), acrescentar uma variante à união
+  // abria esse buraco em silêncio: o TS não reclama de um `===` que deixou de
+  // cobrir todos os casos. Perguntar quem PODE passar falha fechado sozinho.
+  if (!ehEnderecavel(parsed)) return null;
   const { data, error } = await admin.rpc("fn_upsert_wa_contact" as never, {
     p_org: orgId,
     p_kind: parsed.kind,
@@ -294,9 +363,17 @@ async function handleInbound(
   const chatId = p.from ?? "";
   const parsed = parseChatId(chatId);
   if (parsed.kind === "group") return; // grupos não fazem binding CRM
-  if (!p.id || !chatId) return;
+  if (!p.id) return;
   // WAHA emite eventos vazios p/ status/read-receipt/presence — não viram mensagem.
   if (!p.body && !mediaUrlOf(p) && !p.hasMedia) return;
+  // Daqui para baixo era para ser uma mensagem de verdade: se o chat não é
+  // endereçável, PERDEMOS uma — e isso precisa ser contável. O aviso fica depois
+  // das guardas acima de propósito; antes delas, todo evento de presença viraria
+  // um registro, e log que enche sozinho é log que ninguém lê.
+  if (!ehEnderecavel(parsed)) {
+    await avisarChatNaoReconhecido(admin, session.organization_id, session.id, chatId, "inbound");
+    return;
+  }
 
   const contactId = await upsertContact(admin, session.organization_id, parsed, chatId, notifyNameOf(p));
   if (!contactId) return;
@@ -441,8 +518,21 @@ async function handleOutboundFromUserPhone(
   const chatId = p.to ?? chatIdFromWaMessageId(p.id ?? "") ?? p.from ?? "";
   const parsed = parseChatId(chatId);
   if (parsed.kind === "group") return;
-  if (!p.id || !chatId) return;
+  if (!p.id) return;
   if (!p.body && !mediaUrlOf(p) && !p.hasMedia) return;
+  // Idem inbound. Aqui o caso que mais dói é o chatId vazio: é literalmente o
+  // defeito do #108 — mensagem que o dono digitou no celular sem `to`, sem id
+  // composto e sem `from`. Se voltar a acontecer por um formato novo, agora sai
+  // um evento em vez de silêncio.
+  //
+  // A metade `!chatId` da guarda anterior sai daqui junto: ela era condição
+  // MORTA (varri 12 valores de `to` e nenhum a disparava, porque o único falsy
+  // já era classificado como grupo uma linha acima) e voltaria a viver como
+  // duplicata desta guarda, descartando calado justamente o caso que se quer ver.
+  if (!ehEnderecavel(parsed)) {
+    await avisarChatNaoReconhecido(admin, session.organization_id, session.id, chatId, "outbound");
+    return;
+  }
 
   // ECO DO PRÓPRIO ENVIO — não duplicar.
   //

--- a/lib/waha/ingest.ts
+++ b/lib/waha/ingest.ts
@@ -259,6 +259,13 @@ async function upsertContact(
   // Com `kind === "group"` (a forma antiga), acrescentar uma variante à união
   // abria esse buraco em silêncio: o TS não reclama de um `===` que deixou de
   // cobrir todos os casos. Perguntar quem PODE passar falha fechado sozinho.
+  //
+  // ⚠️ SEGUNDA CAMADA, SEM COBERTURA POSSÍVEL — e isto está escrito porque medi:
+  // trocar esta linha de volta pela denylist deixa a suíte inteira VERDE (35/35,
+  // typecheck 0). Os dois chamadores já barram o não-endereçável antes de chegar
+  // aqui, então nenhum teste consegue alcançá-la; é defesa em profundidade na
+  // fronteira com uma RPC que não valida nada. Quem mexer aqui não vai ser
+  // avisado por teste nenhum — só por este comentário.
   if (!ehEnderecavel(parsed)) return null;
   const { data, error } = await admin.rpc("fn_upsert_wa_contact" as never, {
     p_org: orgId,


### PR DESCRIPTION
Follow-up do #108, mesma família de defeito.

## O bug

`lib/waha/ingest.ts`, o `return` final do `parseChatId` devolvia `{ kind: "group" }` para **qualquer** sufixo desconhecido. Como o ingest descarta grupo, *"não sei ler isto"* virava *"descarta calado"* — inclusive com o mesmo sintoma do #108: webhook devolvendo 200, sem erro em log.

E não é hipotético: **`@newsletter` e `@broadcast` já existem em produção** e caíam nesse ramo. O próximo formato que o WhatsApp lançar reproduziria o caso inteiro.

## Por que virou allowlist, e não só "mais um caso"

A medição pedida antes do desenho — quantos consumidores leem `ChatIdentity.kind` e o que fazem com um valor novo — mostrou **3 consumidores, todos internos, todos denylist** (`kind === "group"`). E o desfecho de um valor novo vazar por eles é pior que o defeito original:

- `fn_upsert_wa_contact` **não valida** `p_kind`;
- `contacts.wa_identity` é coluna **gerada** que só produz `phone:`/`lid:` e fica NULL em qualquer outro caso;
- o `on conflict` exige `wa_identity not null`.

Logo a linha **nunca conflita** e nasce **um contato órfão a cada webhook** — o anti-pattern que a migration 0027 matou, voltando pela porta dos fundos. Denylist aqui não é questão de estilo, é bug.

## O critério do evento

Grupo e desconhecido têm o **mesmo desfecho** (não viram contato) e naturezas opostas: um é decisão de produto, o outro é buraco de conhecimento. Só o segundo é anomalia, então só ele emite `whatsapp.chat_id_not_recognized`. O evento registra o **sufixo**, não o identificador do contato.

## Verificação

Revertendo o catch-all para `"group"`, **3 testes ficam vermelhos**, incluindo *"emite ... em vez de sumir calado"*. `typecheck` 0 · `lint` 0 · `lint:channels` 0 · `test:unit` 0. Não toca schema, então `test:db` não foi rodado — declarado.

A allowlist do `upsertContact` é a segunda camada e **não tem cobertura possível**: sabotada, a suíte fica verde, porque a primeira camada a torna inalcançável. Está marcada no código com o resultado da sabotagem ao lado, em vez de fingir cobertura.

Medição e implementação: **@QAVivo**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4NxbuaBH2rNizak9HkDpd