### PR TITLE
test(admin): a casca do /admin provia o TooltipProvider sem nada que o guardasse

### DIFF
--- a/tests/unit/admin-shell-tooltip.test.tsx
+++ b/tests/unit/admin-shell-tooltip.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * A casca do /admin provê o `TooltipProvider`. O que estes testes protegem:
+ *
+ *  - tela nova renderizada DENTRO da casca nasce funcionando, sem precisar
+ *    lembrar do Provider — e nos dois valores de `userEmail` que o call site
+ *    real pode entregar, porque ele passa `user.email ?? ""`;
+ *  - o segundo caso prova que a exigência é do Radix, não do teste: sem ele o
+ *    primeiro passaria mesmo que nada estivesse sendo exigido.
+ *
+ * Por que merece catraca: sem um Provider ANCESTRAL o `Tooltip` do Radix lança
+ * no cliente e o React derruba a árvore inteira — não é um tooltip sem estilo,
+ * é a tela inteira sumindo. Como não existe `app/admin/error.tsx`, quem captura
+ * é o boundary da RAIZ (`app/error.tsx` → `components/feedback/SegmentError.tsx`),
+ * então some junto a casca: o dono vê "Algo deu errado" e um ID. Rastro existe,
+ * mas não onde se procura primeiro — o throw é do cliente, então não há linha no
+ * log do servidor Next; quem recebe é o Sentry, que numa instalação padrão é o
+ * da comunidade (`SENTRY_DSN` vazio no `.env.example` cai no `DEFAULT_SENTRY_DSN`).
+ * Com `SENTRY_DSN=off` não sobra rastro nenhum.
+ *
+ * Quem é atingido, e quem não é — está medido em `components/admin/AdminShell.tsx`
+ * e não é repetido aqui. Dois pontos de lá que mudam como se lê um vermelho:
+ * o consumidor sem Provider próprio é o `TenantBadge`, montado em /admin/inbox,
+ * /admin/inbox/[conversationId], /admin/lgpd e /admin/lgpd/requests/[id]; e
+ * /admin/usage NÃO está na lista, apesar do nome colidir, porque os gráficos de
+ * lá importam um `Tooltip` do recharts, que não usa Provider nenhum.
+ *
+ * LIMITE DECLARADO — o que estes testes NÃO guardam: o elo entre a casca e as
+ * telas. Quem monta a casca é `app/admin/(protected)/layout.tsx`, e se ele
+ * deixar de usar o `AdminShell` as 4 telas quebram de novo com estes casos
+ * verdes. Pelo mesmo motivo, "tela nova" acima quer dizer tela sob
+ * `app/admin/(protected)`: o `app/admin/layout.tsx` é passthrough deliberado, e
+ * `app/admin/forbidden` já renderiza fora da casca hoje. Guardar esse elo
+ * exigiria montar um layout async que chama `requirePlatformAdmin`; o teste
+ * frágil que sairia daí vale menos que esta frase precisa.
+ *
+ * Sabotagem que confirma que a guarda vigia: remover o `<TooltipProvider>` de
+ * `AdminShell.tsx` deixa o primeiro caso vermelho, nos dois valores de e-mail.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { AdminShell } from "@/components/admin/AdminShell";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+// Único mock: o `AdminSidebar` é client component e chama `usePathname`. O
+// banner e o sidebar continuam reais — a casca sob teste é a casca de verdade,
+// não uma maquete dela. Mesmo padrão de `tests/unit/sidebar-grupos.test.tsx`.
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/admin/inbox",
+}));
+
+/** Consumidor sem Provider próprio, como o `TenantBadge`. */
+function UsaTooltipSemProviderProprio() {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button type="button">gatilho</button>
+      </TooltipTrigger>
+      <TooltipContent>dica</TooltipContent>
+    </Tooltip>
+  );
+}
+
+afterEach(cleanup);
+
+describe("AdminShell", () => {
+  // Os dois valores que `app/admin/(protected)/layout.tsx:7` pode passar:
+  // `user.email ?? ""`. Sem o caso vazio, uma casca que condicionasse o
+  // Provider ao e-mail passaria verde e quebraria para quem não tem e-mail.
+  it.each([
+    ["e-mail preenchido", "dono@exemplo.com"],
+    ["e-mail vazio, como em user.email ?? ''", ""],
+  ])(
+    "provê o TooltipProvider aos filhos com %s — tela nova nasce funcionando",
+    (_rotulo, userEmail) => {
+      expect(() =>
+        render(
+          <AdminShell userEmail={userEmail}>
+            <UsaTooltipSemProviderProprio />
+          </AdminShell>,
+        ),
+      ).not.toThrow();
+
+      expect(screen.getByRole("button", { name: "gatilho" })).toBeInTheDocument();
+    },
+  );
+
+  it("o mesmo filho SEM a casca lança — prova que a guarda vem do AdminShell", () => {
+    // Com a mensagem fixada: `.toThrow()` sozinho aceita QUALQUER lançamento, e
+    // aí um import quebrado no stand-in manteria o verde enquanto o caso
+    // deixaria de provar que a exigência é do Radix.
+    expect(() => render(<UsaTooltipSemProviderProprio />)).toThrow(
+      /must be used within `TooltipProvider`/,
+    );
+  });
+});


### PR DESCRIPTION
A `main` descreve um defeito em **33 linhas de comentário** e não tem nenhum teste que o reprove. Isto fecha a lacuna.

## A lacuna

```
$ git grep -l TooltipProvider origin/main -- tests/   # vazio, exit 1
$ git grep -l AdminShell      origin/main -- tests/   # vazio, exit 1
$ git grep -l TenantBadge     origin/main -- tests/   # vazio, exit 1
```

Controle positivo, porque três vazios seguidos são indistinguíveis de instrumento morto: os mesmos termos **sem** pathspec acham 7, 3 e 20 arquivos, e `tests/` tem 198 arquivos com `describe`. O grep estava vivo — a cobertura é que não existia. Também não há spec e2e que navegue para `/admin` (24 specs, nenhuma).

## Por que merece catraca

Sem Provider ancestral o `Tooltip` do Radix **lança no cliente**, o React derruba a árvore e — como não existe `app/admin/error.tsx` — quem captura é o boundary da **raiz** (`app/error.tsx` → `SegmentError`). Some a casca inteira: o dono vê "Algo deu errado" e um ID. Não é um tooltip sem estilo, é a tela.

O rastro existe, mas não onde se procura primeiro: o throw é do cliente, então não há linha no log do servidor Next. Quem recebe é o Sentry — numa instalação padrão, o **da comunidade** (`SENTRY_DSN` vazio no `.env.example:92` cai no `DEFAULT_SENTRY_DSN`). Com `SENTRY_DSN=off`, nada.

## Discriminância — 3 sabotagens, 3 vermelhos distintos

| sabotagem | resultado |
|---|---|
| remover o `<TooltipProvider>` do `AdminShell` | **2 casos vermelhos**, erro `` `Tooltip` must be used within `TooltipProvider` `` |
| Provider condicional a `userEmail` | **1 vermelho — só o de e-mail vazio** |
| Radix deixar de exigir Provider (stand-in trivial) | **o caso de vacuidade vermelho** |

A do meio é o motivo do `it.each`. O call site é `<AdminShell userEmail={user.email ?? ""}>` — string vazia é **valor de produção**. Com um único e-mail preenchido, essa variante passava verde enquanto quebrava a tela para todo usuário sem e-mail. A terceira mostra que o caso de vacuidade não é decorativo: ele reprova quando sua própria premissa cai. O `.toThrow()` ganhou matcher da mensagem, senão qualquer lançamento o manteria verde.

## Limite declarado, escrito no cabeçalho

Os casos guardam a **casca**, não o elo entre ela e as telas. Se `app/admin/(protected)/layout.tsx` deixar de usar o `AdminShell`, as 4 telas quebram de novo com este PR verde — medido, não suposto. Pelo mesmo motivo, "tela nova" quer dizer tela sob `(protected)`: `app/admin/layout.tsx` é passthrough deliberado e `app/admin/forbidden` já renderiza fora da casca. Guardar o elo exigiria montar um layout async que chama `requirePlatformAdmin`; o teste frágil que sairia daí vale menos que a frase precisa.

Uma afirmação portada foi **corrigida antes de entrar**: a versão original dizia que o defeito derrubava `/admin/usage`. Não derruba — `UsageCharts` importa um `Tooltip` do **recharts**, que não usa Provider. Já estava refutado por medição no comentário do `AdminShell`; a prosa é que tinha ficado para trás.

## Gates

`typecheck` 0 · `lint` 0 erros · `lint:channels` 0 · `test:unit` exit 0, **223 arquivos / 1890 testes** (base sem o arquivo: 222 / 1887 — medido movendo o arquivo para fora e rodando de novo, porque o reporter não imprime arquivo que passa e "verde" não prova que ele rodou).

`test:db` não rodado e declarado: não toca schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4NxbuaBH2rNizak9HkDpd