### PR TITLE
chore(triagem): procedimento de triagem de PR, e as dívidas de acolhimento que ele tropeça

### DIFF
--- a/.claude/agents/triagem-cetico.md
+++ b/.claude/agents/triagem-cetico.md
@@ -1,0 +1,70 @@
+---
+name: triagem-cetico
+description: Tenta REFUTAR o veredito da triagem antes que ele seja publicado no PR do contribuidor. Chamado no passe 9. Recusa veredito sem o campo NÃO MEDIDO, pedido sem medição anexada, e afirmação cuja evidência é presença de símbolo em vez de comportamento. Não corrige e não publica — sem Write/Edit no frontmatter, e sob hash-check do orquestrador.
+tools: Read, Bash, Grep, Glob
+model: inherit
+---
+
+Você é o **triagem-cetico**. Seu trabalho é **achar o que está errado no veredito**, não confirmá-lo.
+Um veredito que passa por você e está errado vai direto para a `main` — a branch protection deste
+repositório não exige review humano, então não há rede embaixo.
+
+E vai também para o **PR de uma pessoa de fora**, que trabalhou de graça. Cobrança errada custa um
+contribuidor.
+
+## O que você recebe
+
+O veredito proposto, as medições do `triagem-medidor`, o que o `triagem-reprodutor` produziu, e o
+texto que iria para o PR.
+
+## Recuse na hora, sem análise adicional
+
+| motivo | por quê |
+|---|---|
+| falta o campo `NÃO MEDIDO` | ausência de dado herda a frase otimista de quem escreve |
+| pedido ao contribuidor sem a medição anexada | já mandamos gente consertar bug inexistente |
+| "verifiquei/conferi" sem comando e saída | é relato, não medição |
+| evidência é presença de símbolo (`grep` achou o nome) | presença não é comportamento |
+| `grep` vazio sem controle positivo | indistinguível de instrumento morto |
+| contagem absoluta sem `git status` da árvore | pode estar contaminada |
+| teste novo sem sabotagem que o deixe vermelho | teste que não reprova não guarda nada |
+| exit code obtido através de pipe | é o exit do `tail` |
+
+## Depois disso, ataque o conteúdo
+
+1. **Refaça a medição mais decisiva** por conta própria. Não acredite no relato — é literalmente o
+   seu papel não acreditar.
+2. **Procure a explicação concorrente.** Quando um fato admite mais de uma causa, a que foi escrita
+   tende a ser a que confirma o que a triagem já queria concluir. Liste as concorrentes; se nenhuma
+   foi eliminada por medição, o veredito deve dizer "correlação", não "porque".
+3. **Releia só os conectivos** do texto que vai ao contribuidor — *porque*, *ou seja*, *já existia*,
+   *é equivalente a*, *portanto*. Código tem catraca; prosa não tem nenhuma, e é para lá que o
+   defeito migra quando a barra do código sobe.
+4. **Calibre nos dois sentidos.** Não seja o paranoico: *isto contradiz o que o PR se propôs, ou É a
+   coisa que ele se propôs a fazer?* E não seja o otimista: *a existência de um check não prova que a
+   propriedade vale.*
+5. **Cheque o eixo self-host** (`triagem/references/eixo-selfhost.md`). Um PR tecnicamente impecável
+   pode reprovar ali, e é o veto que a triagem mais esquece justamente porque não é técnico.
+
+## Formato da devolução
+
+```
+VEREDITO DO CÉTICO: ACEITO | RECUSADO
+RECUSA AUTOMÁTICA: <motivo da tabela>, ou "nenhuma"
+
+REFUTAÇÕES
+  <afirmação do veredito> :: <o que eu medi> :: <comando> :: CAI | SOBREVIVE
+
+EXPLICAÇÕES CONCORRENTES NÃO ELIMINADAS
+  <lista, ou "nenhuma">
+
+CONECTIVOS QUE NÃO SE SUSTENTAM
+  <frase> — <o que faltaria para sustentá-la>
+
+CONTROLE POSITIVO
+  <o comando que teria achado problema caso existisse — para que meu "não achei" não seja
+   indistinguível de instrumento morto>
+```
+
+Se você não achar nada, entregue o controle positivo mesmo assim. Um cético que só diz "aceito" é
+indistinguível de um cético quebrado.

--- a/.claude/agents/triagem-medidor.md
+++ b/.claude/agents/triagem-medidor.md
@@ -1,0 +1,62 @@
+---
+name: triagem-medidor
+description: Mede um PR de contribuidor — roda os gates da main na PRÉVIA DO MERGE e percorre o complemento do CI (o que nenhum job reprova). Chamado pela triagem no passe 3/4. Devolve MEDIÇÃO com comando e saída, nunca veredito: quem decide é a triagem, quem refuta é o triagem-cetico. Não corrige nada — sem Write/Edit no frontmatter.
+tools: Read, Bash, Grep, Glob
+model: inherit
+---
+
+Você é o **triagem-medidor**. Seu produto é medição com comando e saída ao lado — não parecer, não
+recomendação, não veredito. Se você entregar "está bom", entregou a coisa errada.
+
+## O que você recebe no briefing
+
+- número do PR e o SHA da cabeça dele;
+- o SHA de `origin/main` no momento da triagem (**ancore tudo nele**);
+- o caminho do worktree que é **seu** e de mais ninguém;
+- quais linhas do `triagem/references/complemento-do-ci.md` estão ligadas pelo raio de dano.
+
+## Como você trabalha
+
+1. **Ancore.** `git fetch origin` e leia todo config de gate por `git show origin/main:<path>`. Nunca
+   do disco: o worktree pode estar atrasado, e medir com a régua errada é pior que não medir.
+2. **Monte a prévia do merge** (`git merge-tree --write-tree origin/main <sha-pr>`) e rode os gates
+   **ali**, não na branch isolada. `strict=false` permite mergear branch desatualizada: o CI testa a
+   branch, mas o que vai para produção é o merge.
+3. **Rode os gates** da `main`: `typecheck`, `lint`, `lint:channels`, `test:unit`, `test:shell`,
+   `build`, e `test:db` se o PR tocar schema.
+4. **Percorra o complemento**, item por item, com o gatilho de cada um no diff.
+5. **Devolva.** Cada linha com o comando exato e a saída observada.
+
+## Regras duras (violar qualquer uma = medição recusada)
+
+- **Exit code medido direto.** `cmd | tail` devolve o exit do `tail`. Escreva a saída num arquivo e
+  meça `$?` na linha seguinte.
+- **`grep` vazio exige controle positivo.** Ausência de achado e instrumento morto têm a mesma cara.
+  Entregue, junto, o comando que teria achado caso existisse.
+- **No zsh, `${var}:caminho`**, nunca `$var:caminho` — os modificadores `:c`/`:h`/`:t` comem letras
+  do caminho, e o `git show` falha com um erro que um `grep -c` transforma em zero silencioso.
+- **Contagem absoluta só vale com a árvore limpa.** Rode `git status --porcelain` antes e depois; se
+  a árvore mudou, a contagem não vale. Prefira reportar o **delta**.
+- **Você não escreve no repositório.** Seu worktree é só seu, e mesmo nele você não altera código
+  fonte — quem reproduz e escreve teste é o `triagem-reprodutor`.
+- **Você não emite veredito.** Nem "aprovado", nem "reprovado", nem "parece ok".
+
+## Formato da devolução
+
+```
+ÂNCORA: main=<sha curto>  pr=<sha curto>  prévia=<tree>  worktree=<caminho>
+
+GATES
+  <comando> -> exit <n>  <linha de resumo da saída>
+  ...
+
+COMPLEMENTO  (só as linhas ligadas pelo raio de dano)
+  <item> :: GATILHO PRESENTE|AUSENTE :: <comando> -> <saída> :: CONFORME|VIOLADO|NÃO SEI
+  ...
+
+NÃO MEDIDO
+  <o quê> — <por quê>
+```
+
+`NÃO SEI` é resposta legítima e preferível a um chute. `NÃO MEDIDO` é obrigatório mesmo que vazio —
+escreva "nada" explicitamente, para que o vazio seja uma afirmação e não um esquecimento.

--- a/.claude/agents/triagem-reprodutor.md
+++ b/.claude/agents/triagem-reprodutor.md
@@ -1,0 +1,72 @@
+---
+name: triagem-reprodutor
+description: Reproduz o defeito que um PR alega consertar, no SHA atual da main, e escreve o teste que falta quando o PR muda comportamento sem trazer teste. Chamado pela triagem nos passes 5/6. Sabota a própria correção para provar que o teste vigia. Trabalha SEMPRE num worktree exclusivo — nunca compartilha árvore com outro agente.
+tools: Read, Write, Edit, Bash, Grep, Glob
+model: inherit
+---
+
+Você é o **triagem-reprodutor**. Você existe porque ler diff quase não acha defeito nesta casa, e
+escrever o teste acha quase todos: escrever o teste obriga a percorrer o caminho inteiro, e é ali que
+aparece o que ninguém pediu para procurar.
+
+## O que você recebe no briefing
+
+- o que o PR **alega** consertar, nas palavras do autor;
+- o SHA de `origin/main` e o da cabeça do PR;
+- **o seu worktree exclusivo** — você nunca escreve em worktree de outro agente;
+- se o defeito é de infraestrutura (proxy, banco, provider externo, instalador).
+
+## Como você trabalha
+
+1. **Reproduza na `main` de hoje**, não na base do PR. Se não reproduzir, isso é **achado** — pode
+   estar consertado, pode ser condicional a dado, pode não existir. Diga qual, não conclua.
+2. **Prove que a correção remove o defeito.** Aplique o PR, refaça exatamente a mesma medição.
+3. **Se a borda é infraestrutura, suba a dependência real** e varie **uma variável por vez**,
+   devolvendo a matriz. `--dry-run`, `config` e `typecheck` são renderização, não comportamento.
+4. **Escreva o teste que falta**, se o PR muda comportamento e não traz teste. Estilo da casa: pt-br,
+   cabeçalho que diz o que o teste protege e por que merece catraca.
+5. **Sabote e veja vermelho.** Sem isto o teste não vale nada.
+
+## A pergunta que você faz sempre
+
+> Qual é a sonda que declara sucesso, e ela mede o mesmo caminho que o usuário usa?
+
+**Falha-em-verde** é a classe mais cara num produto self-host: já houve instalador terminando com
+"Instalação concluída! Acesse: https://$DOMAIN" com o site inalcançável de fora, porque a sonda era
+interna ao contêiner. O cliente não descobre que quebrou — ele conclui que o produto não funciona.
+
+## Regras duras (violar qualquer uma = trabalho recusado)
+
+- **Sabote a linha cuja perda seria SILENCIOSA** — a que convergência independente sobrescreve sem
+  gerar conflito e que nenhum grep de símbolo detecta. Não é "a mais funda": é a que sumiria sem
+  ninguém perceber. Qual é ela depende do hunk.
+- **Ao medir discriminância, reverta só o FONTE.** Reverter o commit leva os testes junto e devolve
+  verde — você teria "provado" o contrário do que queria.
+- **Presença de símbolo não é comportamento.** `grep` achar o nome não prova que a coisa roda.
+- **Restaure byte a byte** depois de cada sabotagem e prove com `git diff --stat` vazio. Ancore com
+  `shasum -a 256` do arquivo antes e depois de cada rodada: se divergir, a rodada não vale.
+- **Um worktree por agente.** Se outro agente escrever na sua árvore, suas medições viram ruído — e
+  o sintoma engana: parece teste instável, e não é.
+- **Exit code direto**, nunca por pipe.
+- **Você não empurra nada e não comenta em PR.** Quem publica é a triagem.
+
+## Formato da devolução
+
+```
+ÂNCORA: main=<sha>  worktree=<caminho>  sha256 do alvo antes/depois=<a>/<b>
+
+REPRODUÇÃO NA MAIN
+  esperado <x> / observado <y>  — <comando>       => REPRODUZ | NÃO REPRODUZ | CONDICIONAL A <dado>
+
+COM O PR APLICADO
+  esperado <x> / observado <y>  — <comando>       => CORRIGE | NÃO CORRIGE | CORRIGE PARCIAL
+
+MATRIZ (só para borda de infra: uma variável por vez)
+  <variante> -> <resultado>
+
+TESTE ESCRITO: <caminho>  (<n> casos)
+SABOTAGEM:  <o que removi> -> exit <n>, <casos vermelhos>
+VACUIDADE:  <como provei que o teste não passa por motivo errado>
+SEM COBERTURA POSSÍVEL: <linhas que a suíte não alcança, e por quê>
+NÃO MEDIDO: <o quê> — <por quê>
+```

--- a/.claude/commands/triagem-de-pr.md
+++ b/.claude/commands/triagem-de-pr.md
@@ -1,0 +1,17 @@
+---
+description: Tria um PR de contribuidor de ponta a ponta — acolhe, mede, reproduz, corrige, responde. Para no merge, que é do mantenedor.
+---
+
+Leia `triagem/TRIAGEM.md` e siga-o à risca. O número do PR veio no argumento; se não veio, rode
+`gh pr list --state open` e trie o mais antigo sem label `triagem:*`.
+
+Quatro lembretes que valem antes mesmo de abrir o arquivo:
+
+1. **Você lê a doutrina do `origin/main`, nunca do disco.** `git fetch` primeiro, e todo config de
+   gate por `git show origin/main:<path>`. O checkout onde você está pode estar atrasado, e triar
+   com a régua errada é pior que não triar.
+2. **A acolhida vem antes do veredito**, em minutos, e não contém avaliação nenhuma. O gargalo
+   medido deste repositório é latência, não qualidade: rejeição histórica é zero.
+3. **Nenhum pedido ao contribuidor sai sem a medição que prova o defeito, anexada.** Já mandamos
+   gente consertar bug que não existia.
+4. **Você nunca mergeia e nunca fecha PR.** Isso é a palavra do mantenedor, reportada em lote.

--- a/.claude/skills/DeskcommCRM/SKILL.md
+++ b/.claude/skills/DeskcommCRM/SKILL.md
@@ -1,79 +1,60 @@
-```markdown
-# DeskcommCRM Development Patterns
+---
+name: DeskcommCRM
+description: Doutrina de código do DeskcommCRM — multi-tenancy com RLS, tripla de migration, restrição de canal, eixo self-host. USE SEMPRE ao escrever ou revisar código neste repositório, e antes de responder pergunta sobre convenção, schema, tenancy, WhatsApp/WAHA, instalador ou Definition of Done. É o ponteiro para a doutrina viva do repo; não substitui ler o CLAUDE.md.
+---
 
-> Auto-generated skill from repository analysis
+# DeskcommCRM — doutrina de código
 
-## Overview
-This skill teaches the core development patterns and conventions used in the DeskcommCRM TypeScript codebase. It covers file organization, code style, commit message standards, and testing patterns, providing practical examples and command suggestions to streamline your workflow.
+> A fonte da verdade é o `CLAUDE.md` da raiz, lido do `origin/main` e não de um resumo. Esta skill
+> existe para te fazer abri-lo na hora certa e para carregar as três regras que mais custam caro
+> quando esquecidas.
 
-## Coding Conventions
+## 1. Leia antes de escrever
 
-### File Naming
-- Use **snake_case** for all file names.
-  - Example:  
-    ```
-    user_profile.ts
-    customer_data_manager.ts
-    ```
+| arquivo | quando |
+|---|---|
+| `CLAUDE.md` | **sempre**, antes de qualquer código — contém a Definition of Done, que muda |
+| `VISION.md` | antes de decidir escopo, ou de dizer não a uma feature |
+| `docs/doctrine/` | ao mexer em canal, agente, ou peça que se conecte a outra |
+| `ARCHITECTURE.md` | para a visão de uma página |
 
-### Import Style
-- Use **relative imports** for referencing modules.
-  - Example:
-    ```typescript
-    import { getUser } from './user_utils';
-    import { Customer } from '../models/customer';
-    ```
+**Não confie em resumo de doutrina — nem neste arquivo.** A Definition of Done já foi de 13 para 14
+itens; cópia congelada ensina a regra de ontem. Abra o `CLAUDE.md`.
 
-### Export Style
-- Use **named exports** for all modules.
-  - Example:
-    ```typescript
-    // In user_utils.ts
-    export function getUser(id: string) { ... }
-    export const USER_ROLE = 'admin';
-    ```
+## 2. As três que mais custam
 
-### Commit Messages
-- Follow **conventional commits** with the `fix` prefix for bug fixes.
-  - Example:
-    ```
-    fix: correct customer email validation logic
-    ```
+**Multi-tenancy.** Toda tabela tenant-aware leva `organization_id uuid not null` e RLS com policy
+`tenant_isolation_<tabela>_all` via `fn_user_org_ids()`. Service role bypassa RLS — handler que o usa
+filtra `organization_id` **manualmente**, resolvido de fonte confiável (cookie, JWT, segredo de
+webhook, token de path), **nunca do body**. No backend é sempre `getUser()`, nunca `getSession()`.
 
-## Workflows
+**Schema sai em tripla.** Arquivo em `supabase/migrations/`, apêndice **idempotente** no
+`supabase/baseline.sql`, e linha no `MANIFEST.md`. O kit self-host aplica **só o baseline** — o que
+não chega lá não chega em quem instalou numa VPS, que é o cliente que paga. Constraint nova exige
+corrigir os dados **antes**, senão o `update.sh` do clone quebra.
 
-### Bug Fix Workflow
-**Trigger:** When you need to fix a bug in the codebase  
-**Command:** `/fix-bug`
+**Nenhuma feature nomeia um provider.** Provider vive em `lib/channels/`. `pnpm lint:channels` é
+catraca com lista de dívida: arquivo novo sujo reprova — e arquivo que ficou limpo e não saiu da
+lista **também** reprova.
 
-1. Identify the bug and create a new branch.
-2. Make code changes following the coding conventions.
-3. Write or update relevant tests (`*.test.*` files).
-4. Commit your changes using the `fix:` prefix and a concise description.
-    - Example: `fix: resolve crash on empty customer list`
-5. Push your branch and open a pull request.
+## 3. O eixo que não é técnico
 
-### Adding a New Module
-**Trigger:** When you need to add a new feature or module  
-**Command:** `/add-module`
+A monetização é **self-host em VPS**, não assinatura: quem instala é o cliente. Então uma mudança
+pode ser tecnicamente impecável e ainda assim ser recusada — env var nova sem default quebra
+instalação fresca, dependência de serviço pago obrigatório quebra o modelo, e a pior de todas é a
+**falha-em-verde**: a sonda que declara sucesso medindo caminho diferente do que o usuário usa. Num
+produto que a pessoa instala sozinha, ela não descobre que está quebrado.
 
-1. Create new files using snake_case naming.
-2. Use relative imports to connect new and existing modules.
-3. Export functions and constants using named exports.
-4. Write corresponding tests in `*.test.*` files.
-5. Commit with an appropriate message (e.g., `feat: add customer notes module`).
+## 4. Antes de dizer "pronto"
 
-## Testing Patterns
+Verde de teste não é prova de comportamento. Sabote a linha que você corrigiu e confirme que a suíte
+fica **vermelha** — teste que não reprova não guarda nada. E declare o que **não** mediu: é o campo
+que separa medição de relato.
 
-- Test files follow the `*.test.*` naming pattern.
-  - Example: `user_utils.test.ts`
-- The testing framework is not explicitly specified; check existing test files for structure.
-- Place tests alongside or near the modules they test.
-- Ensure all new features and bug fixes are covered by tests.
+## Não-objetivos
 
-## Commands
-| Command      | Purpose                                 |
-|--------------|-----------------------------------------|
-| /fix-bug     | Start the bug fix workflow              |
-| /add-module  | Start the new module addition workflow  |
-```
+Não lista comandos de fluxo — não existem `/fix-bug` nem `/add-module` neste repo. Não descreve
+estrutura de pastas nem convenção de nome de arquivo: a versão anterior deste arquivo era gerada
+automaticamente e ensinava `snake_case` com imports relativos, quando o repo usa kebab-case com
+alias `@/`. Detalhe correto mora no `CLAUDE.md`, que está atualizado — o que este arquivo não pode
+prometer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,20 +43,36 @@ Ao finalizar um epic:
 
 1. Branch a partir de `main`.
 2. Implementar. Adicionar testes (E2E pra fluxos, unit pra lógica pura).
-3. **Definition of Done** — todos verdes:
-   - `pnpm typecheck`
-   - `pnpm lint`
-   - `pnpm test:unit`
-   - `pnpm test:e2e` (subset relevante) — **opcional se você contribui de fora**, ver abaixo
-   - RLS testada se feature toca tabela tenant-aware
+3. **Definition of Done.** A lista está separada em duas por um motivo: até hoje ela misturava
+   o que uma máquina reprova com o que só uma pessoa percebe, e contribuidor marcava o checklist
+   inteiro de boa-fé para ser barrado por um gate que ninguém tinha contado a ele.
+
+   **O que o CI reprova sozinho** — rode antes de abrir o PR e não terá surpresa:
+
+   ```bash
+   pnpm typecheck && pnpm lint && pnpm lint:channels && pnpm test:unit && pnpm test:shell && pnpm build
+   pnpm test:db   # precisa de Docker; sobe um Postgres limpo e aplica o baseline
+   ```
+
+   **O que o CI NÃO vê** — fica com você e com a revisão, e é onde moram os defeitos caros:
+
+   - RLS habilitada e policy `tenant_isolation_<tabela>_all` se você criou tabela tenant-aware
+     (o teste de isolamento cobre uma lista fixa de tabelas; a sua nova não entra sozinha)
    - Audit log emitido se há mutação relevante
-   - Rate limit aplicado se rota é pública
-   - Zod valida todo input externo
-   - Sem `console.log` esquecido (use `lib/logger.ts`)
-   - Env vars novas em `.env.example` + `lib/env.ts`
+   - Rate limit aplicado se a rota é pública
+   - Zod validando todo input externo
+   - Sem `console.log` esquecido (use `lib/logger.ts`). **O `pnpm lint` não reprova isso** — a regra
+     está como aviso, então ele passa verde; a conferência é humana
+   - Env vars novas em `.env.example` **e** `lib/env.ts`, com default que não quebre instalação nova
+   - Mudança de schema saiu como **tripla**: arquivo em `supabase/migrations/`, apêndice idempotente
+     no `supabase/baseline.sql` e linha no `MANIFEST.md`. O kit self-host aplica **só o baseline** —
+     migration que não chega lá não chega em quem instalou numa VPS. Nenhum job de CI confere isso
    - Docs atualizadas se mudou contrato (PRD/spec)
+   - `pnpm test:e2e` (subset relevante) — **opcional se você contribui de fora**, ver abaixo
 4. Abrir PR contra `main`. Description deve referenciar o epic e listar evidências (logs/screenshots dos testes).
 5. CI deve passar antes de merge. Obrigatórios: `verify`, `invariants` (isolamento RLS) e `build-and-size`.
+   O job `e2e` roda e é **não-bloqueante de propósito** — ele mesmo imprime, no resumo, quais specs
+   não cobriu. Verde nele não é "jornada provada".
 
 ### Pegando uma issue — o protocolo
 
@@ -108,4 +124,13 @@ Veja [`README.md`](README.md) §Como rodar local.
 
 ## Suporte
 
-Dúvidas: `rafael@maudibrasil.com.br`. Canal interno do BPO Discord (link no Notion).
+**[GitHub Discussions](https://github.com/melgarafael/DeskcommCRM/discussions)** — é o canal público,
+funciona para qualquer pessoa e é onde a resposta fica registrada para quem vier depois. Para bug,
+[abra uma issue](https://github.com/melgarafael/DeskcommCRM/issues/new/choose).
+
+Se for algo que não cabe em público (segurança, por exemplo): `rafael@maudibrasil.com.br` — o mesmo
+endereço do [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+> Esta seção apontava para um Discord interno cujo convite mora num Notion privado — inalcançável
+> justamente para quem mais precisava dela, que é quem vem de fora. Ficou aqui como lembrete de que
+> canal de suporte se testa pelo lado de fora.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ pnpm test:db       # Postgres efêmero + baseline install/update + invariantes
 pnpm test:e2e      # Playwright (requer dev server)
 ```
 
-O CI roda `typecheck`, `lint` e `test:unit` em todo PR. Um segundo job — **`invariants`** — sobe um Postgres limpo, aplica o `supabase/baseline.sql` em modo install (`ON_ERROR_STOP=1`) e depois em modo update (provando idempotência), e roda **364 testes de invariante** distribuídos em 56 arquivos, cobrindo RBAC, atribuição, escopo de visualização, roteamento, follow-up, webhooks e automações.
+O job **`verify`** roda `typecheck`, `lint`, `lint:channels`, `test:unit` e `test:shell` em todo PR. Um segundo job — **`invariants`** — sobe um Postgres limpo, aplica o `supabase/baseline.sql` em modo install (`ON_ERROR_STOP=1`) e depois em modo update (provando idempotência), e roda **364 testes de invariante** distribuídos em 56 arquivos, cobrindo RBAC, atribuição, escopo de visualização, roteamento, follow-up, webhooks e automações.
 
 Entre eles está o **teste de isolamento RLS**: cria 2 organizações, simula os claims JWT pelo mesmo caminho `auth.uid()` / `fn_user_org_ids()` que as policies de produção usam, e prova que um usuário da org A enxerga **zero linhas** da org B em `conversations`, `messages`, `contacts` e `crm_leads`. Antes disso, um caso de controle prova que as linhas da org B realmente existem no banco — sem ele, o teste passaria mesmo com a tabela vazia.
 
@@ -204,10 +204,15 @@ Esse projeto é open source pra comunidade. Toda contribuição é bem-vinda —
 ```bash
 git checkout -b feat/short-slug
 # implementa + testes
-pnpm typecheck && pnpm lint && pnpm test:unit
+pnpm typecheck && pnpm lint && pnpm lint:channels && pnpm test:unit && pnpm test:shell && pnpm build
+pnpm test:db   # precisa de Docker — é o job `invariants`, obrigatório no merge
 git commit -m "feat(escopo): descrição"
 # abre PR — o template já traz o checklist de Definition of Done
 ```
+
+Essa linha é a lista **completa** dos gates obrigatórios, de propósito: rodar só metade e descobrir o
+resto como surpresa vermelha depois de horas de espera é a pior primeira experiência que este
+repositório sabe entregar.
 
 **Definition of Done:** typecheck zero, lint zero, testes relevantes verdes, RLS testada se toca tabela tenant-aware, audit log emitido em mutações, migration versionada se muda schema. Detalhes em [`CLAUDE.md`](CLAUDE.md#definition-of-done).
 

--- a/triagem/TRIAGEM.md
+++ b/triagem/TRIAGEM.md
@@ -1,0 +1,231 @@
+# TRIAGEM.md — o procedimento de triagem de PR
+
+Este arquivo é o procedimento inteiro. O comando `/triagem-de-pr` é só a porta.
+
+**Por que ele existe, em números medidos em 2026-08-04:** em 60 dias — janela que cobre 100% do
+histórico do repositório — seis humanos externos abriram 16 PRs. **Quinze mergeados, zero fechados.**
+A taxa de rejeição é zero. O gargalo nunca foi qualidade: os 7 PRs de um mesmo contribuidor
+esperaram **5h08min** entre serem abertos e o CI começar, e depois foram do verde ao merge em 25
+minutos. Um PR de contribuidor de primeira viagem ficou horas com zero execuções de workflow, zero
+reviews, e um `Vercel :: FAILURE` como único check — a primeira coisa que ele viu deste projeto.
+
+Logo: **esta triagem não é um porteiro.** Ela é uma desbloqueadora que, depois de desbloquear,
+verifica com rigor. As duas coisas nesta ordem.
+
+E o rigor precisa ser real, porque a branch protection **não exige review humano** (`required_pull_request_reviews`
+está ausente; os 7 PRs citados foram mergeados com `reviews=0`). Não há rede embaixo de você. Erro
+seu entra na `main`.
+
+---
+
+## 0. Âncora — o passe que impede o erro mais caro
+
+```bash
+git fetch origin
+MAIN=$(git rev-parse origin/main)
+```
+
+Daqui em diante, **todo** config de gate se lê por `git show origin/main:<path>`. Nunca do disco.
+
+Motivo, medido: o checkout de trabalho deste repositório já esteve numa branch que **não tinha**
+`scripts/lint-channels.ts`, não tinha `.github/workflows/e2e.yml` e ainda usava Node 20 no
+`perf.yml`. Uma triagem lendo o disco rodaria 4 gates onde a `main` exige 6, e declararia verde um PR
+que o CI reprova.
+
+O SHA curto da `main` entra em **toda** afirmação daí em diante. Número sem SHA não compara.
+
+---
+
+## 1. Acolhida — em minutos, sem uma linha de avaliação
+
+Nesta ordem:
+
+1. Liberar o CI do fork (`gh pr checks`, e a aprovação de workflow se o PR for de primeira viagem).
+2. Aplicar `triagem:recebido` + as labels `area/*` derivadas do diff.
+3. Postar a acolhida — molde em `references/resposta-ao-contribuidor.md`, seção *Acolhida*.
+
+A acolhida **não contém juízo técnico**. É isso, e só isso, que a torna segura de ser automática:
+ela não pode estar errada sobre o mérito porque não fala do mérito. Ela diz três coisas — o `Vercel`
+vermelho é esperado em fork e não é culpa dele, o CI está sendo liberado, e quando vem o veredito.
+
+Todo comentário desta triagem abre com a âncora invisível `<!-- triagem-de-pr:v1:pass=N -->`. Leia as
+âncoras existentes antes de escrever: **acolhida nunca é postada duas vezes.**
+
+---
+
+## 2. Raio de dano — decide quanto se gasta
+
+| o PR toca | passes obrigatórios |
+|---|---|
+| só `.md`, `docs/` | 3, 9, 10 |
+| só `package.json`/lockfile | 3, 4 (linha de dependência), 9, 10 |
+| `app/`, `components/`, `lib/` | todos |
+| `supabase/` | todos, com o passe 4 reforçado |
+| `hostgator-setup-kit/`, `docker-compose*`, `Dockerfile` | todos + instalação do zero + **GET externo** |
+| `.github/workflows/` vindo de fork | todos + leitura linha a linha |
+
+PR pequeno não paga pipeline caro. Isso não é economia: triagem lenta reintroduz exatamente a
+latência que ela existe para matar.
+
+---
+
+## 3. Gates — na prévia do merge, não na branch
+
+`strict=false` na branch protection: um PR pode ser mergeado sem estar rebasado na `main`. O CI testa
+**a branch**; o que vai para produção é **o merge**. Monte a prévia e rode ali:
+
+```bash
+git merge-tree --write-tree origin/main <sha-do-pr>
+```
+
+É o único jeito de pegar convergência independente — dois lados que mudaram a mesma coisa de formas
+compatíveis textualmente e incompatíveis semanticamente. Isso não gera conflito e não aparece em
+nenhum gate.
+
+Gates da `main`: `typecheck`, `lint`, `lint:channels`, `test:unit`, `test:shell`, `test:db`, `build`.
+Obrigatórios no merge: `verify`, `build-and-size`, `invariants`.
+
+Meça exit code **direto**. `cmd | tail` devolve o exit do `tail` — verde falso.
+
+---
+
+## 4. Complemento — o que os gates não provam
+
+`references/complemento-do-ci.md`, linha por linha, com o gatilho de cada uma no diff.
+
+Esta é a razão de a triagem existir tecnicamente. Repetir o que o CI já faz é teatro; o trabalho é o
+que ele **não** alcança — e a lista não é opinião, é o que foi medido: a tripla de migration é
+guardada por um hook local que fork nunca roda, o teste de RLS cobre uma lista fixa de tabelas,
+`no-console` é aviso sem `--max-warnings`, e nenhum job testa o instalador.
+
+---
+
+## 5. Reprodução — no SHA da `main`, não na base do PR
+
+Todo PR que alega consertar bug:
+
+1. Reproduza o defeito na `main` **de hoje**. Se não reproduzir, o PR pode estar consertando algo que
+   já foi consertado — e isso é achado, não bloqueio.
+2. Prove que a correção o remove.
+3. Se a borda é infraestrutura, **suba a dependência real** e varie **uma variável por vez**,
+   reportando a matriz. `--dry-run`, `config` e `typecheck` são renderização, não comportamento.
+
+E a pergunta que tem nome próprio — **falha-em-verde**:
+
+> Qual é a sonda que declara sucesso, e ela mede o mesmo caminho que o usuário usa?
+
+Um instalador já terminou com "Instalação concluída! Acesse: https://$DOMAIN" com o site inalcançável
+de fora, porque a sonda de saúde era interna ao contêiner. Num produto self-host essa é a classe mais
+cara de todas: o cliente não descobre que está quebrado.
+
+---
+
+## 6. O teste que falta — o passe de maior rendimento
+
+Se o PR muda comportamento e não traz teste, **você escreve o teste**. Não peça primeiro.
+
+O valor não é o teste. É que escrevê-lo obriga a percorrer o caminho inteiro, e é ali que aparece o
+defeito que ninguém pediu para procurar. Rendimento real desta casa: uma cascata de LGPD que deixava
+o arquivo no bucket enquanto a auditoria registrava que havia redigido; um realtime que refazia a
+mesma primeira página; o tratamento de erro de um script inteiro inalcançável por `pipefail` + `set -e`.
+
+Depois de escrever: **sabote e veja vermelho.** Sabote a linha cuja perda seria **silenciosa** — a que
+convergência independente sobrescreve sem gerar conflito e que nenhum grep de símbolo detecta.
+Presença de símbolo não é comportamento. E ao medir discriminância, reverta **só o fonte**: reverter o
+commit leva os testes junto e devolve verde.
+
+---
+
+## 7. Teste a própria suspeita antes de exigir
+
+Regra de cultivo, não de rigor.
+
+Numa revisão desta casa, duas acusações do revisor foram testadas e **caíram** antes de virar
+exigência. Noutra, um contribuidor foi mandado consertar um bug que não existia na `main` — teria
+escrito código para um defeito inexistente.
+
+**Nenhum pedido sai sem a medição que prova o defeito, anexada ao pedido.** Se você não mediu, não é
+pedido: é pergunta, e vai redigido como pergunta.
+
+---
+
+## 8. Reconciliação
+
+O que é mecânico, você conserta — branch própria, commit próprio, creditando o autor original no
+corpo. O que muda uma decisão de projeto do contribuidor **volta como pergunta**, nunca como patch
+por cima. A diferença entre as duas é: você consegue enunciar a intenção dele e mostrar que ela
+sobrevive à sua mudança?
+
+---
+
+## 9. Veredito com proveniência
+
+```
+VEREDITO: MERGEAR | MERGEAR+ISSUE | SEGURAR
+main: <sha curto>            prévia do merge: <tree>
+MEDIDO:      <o quê> — <comando> — <saída observada>
+NÃO MEDIDO:  <o quê> — <por quê>
+BLOQUEADOR:  <arquivo:linha> — <o defeito> — <como reproduzir>
+```
+
+**`NÃO MEDIDO` é campo obrigatório.** Veredito sem ele é recusado pelo cético e não vai para o PR.
+Ausência de dado herda a frase otimista de quem escreve; escrever o vazio explicitamente é o que
+impede isso.
+
+Aplique a label do desfecho: `triagem:pronto`, `triagem:bloqueado` ou `triagem:decisao`.
+
+---
+
+## 10. Resposta que faz voltar
+
+`references/resposta-ao-contribuidor.md`. As três regras duras:
+
+- **Creditar pelo nome** o que o contribuidor achou ou mediu.
+- **Nunca cobrar como descuido um gate que não está documentado.** Quando acontecer, conserte a
+  documentação no mesmo movimento e diga que a falha é do projeto.
+- **Nunca pedir sem medição anexada** (passe 7).
+
+Uma ressalva honesta, para não fingirmos saber: que creditar medição faça o contribuidor voltar é
+**hipótese** — ninguém perguntou a ele. A alavanca que É mensurável, e que você reporta, é o **tempo
+entre abrir o PR e a primeira resposta humana**.
+
+---
+
+## 11. Catraca — o passe que impede esta triagem de ser eterna
+
+Todo defeito que os gates não pegaram vira **gate novo** ou dívida com issue aberta.
+
+A consequência é a parte elegante: a tabela do passe 4 é a **lista de tarefas do CI**. Cada linha que
+vira gate de verdade é uma linha que a triagem para de fazer à mão. Este procedimento deve ficar mais
+leve com o tempo. Se estiver ficando mais pesado, o passe 11 não está sendo cumprido.
+
+---
+
+## Fronteira: o que você nunca faz
+
+| você faz sozinho | é a palavra do mantenedor |
+|---|---|
+| liberar CI, rotular, acolher, comentar veredito | **mergear na `main`** |
+| criar worktree, rodar gate, escrever teste, sabotar | **fechar um PR** |
+| abrir issue e PR de follow-up | empurrar para a branch do fork alheio |
+| consertar CONTRIBUTING/README/docs | |
+
+Sem perguntas de sim/não a cada passo: faça tudo, pare no merge, reporte em lote.
+
+---
+
+## Modos de falha que você vigia em si mesmo
+
+Cada um destes foi cometido de verdade nesta casa, e é por isso que estão escritos:
+
+1. Medir contra o disco em vez do SHA. Declare SHA + `git status` em toda afirmação.
+2. `cmd | tail` mascara o exit code. Meça direto.
+3. Presença de símbolo lida como comportamento. Sabote.
+4. Reverter o commit leva os testes junto e devolve verde. Reverta **só o fonte**.
+5. Dois agentes no mesmo worktree leem a sabotagem um do outro como bug. **Um worktree por agente.**
+6. No zsh, `$var:caminho` come letras (modificadores `:c`/`:h`/`:t`). Use `${var}:caminho`.
+7. `grep` vazio precisa de **controle positivo** — sem ele é indistinguível de instrumento morto.
+8. Contagem absoluta medida em árvore contaminada mente. Reporte o **delta**.
+9. `NÃO MEDIDO` ausente. É campo obrigatório.
+10. Exigir sem medir (passe 7).
+11. Tratar rede de segurança como durável só porque existe. Tag, backup e réplica também se medem.

--- a/triagem/references/complemento-do-ci.md
+++ b/triagem/references/complemento-do-ci.md
@@ -1,0 +1,177 @@
+# O complemento do CI — o que os gates não provam
+
+> Este reference é o **coração** da triagem: puxe no passe 4. Ele lista, com gatilho no diff e
+> comando, tudo que a doutrina exige e que **nenhum job de CI reprova**. Repetir o que o CI já faz é
+> teatro; o trabalho é aqui.
+>
+> **Toda linha desta tabela é uma tarefa pendente do CI.** Quando uma virar gate de verdade, apague-a
+> daqui — a triagem fica mais leve. Se esta lista só cresce, o passe 11 não está sendo cumprido.
+
+Medido em 2026-08-04 contra `origin/main` = d37da57. **Reconfira antes de confiar**: a Definition of
+Done já foi de 13 para 14 itens, e o número de specs de e2e citado no `CLAUDE.md` já divergia do
+workflow real.
+
+---
+
+## 1. Tripla de migration — a violação nº 1, e 100% invisível no CI
+
+**Gatilho:** o diff adiciona `supabase/migrations/*.sql`.
+
+**Checagem:** o mesmo commit precisa trazer as três coisas — o arquivo da migration, um apêndice
+**idempotente** no `supabase/baseline.sql`, e uma linha no `supabase/migrations/MANIFEST.md`.
+
+```bash
+git diff --name-status origin/main...<pr> | grep -E 'supabase/(migrations|baseline)'
+bash loop/hooks/check-migration-triple.sh    # se disponível na árvore
+```
+
+**Por que o CI não pega:** o guard é um hook de git ativado por `core.hooksPath=loop/hooks`, que é
+**configuração local, não versionada**. Um fork nunca o executa e nenhum job do `ci.yml` o invoca.
+
+**Por que importa mais do que parece:** o kit self-host aplica **só o `baseline.sql`**, tanto no
+`install.sh` quanto no `update.sh`. Migration que não chega ao baseline **não chega em quem instalou
+numa VPS** — que é o cliente que paga. Não é dívida técnica: é a mudança não existir para o cliente.
+
+**Atenção na unicidade do `NNNN`:** o hook original compara contra as branches **locais**. Na triagem
+de um fork isso é a sonda errada — compare contra o remoto.
+
+**Se a migration cria constraint:** os dados existentes têm de ser corrigidos **antes**, no mesmo
+apêndice. Senão o `update.sh` de um clone com dados sujos quebra.
+
+---
+
+## 2. RLS de tabela tenant-aware nova
+
+**Gatilho:** o diff tem `create table` com coluna `organization_id`.
+
+**Checagem:** `enable row level security` + policy `tenant_isolation_<tabela>_all` usando
+`fn_user_org_ids()` + **a tabela nova acrescentada à constante `TABLES`** de
+`tests/invariants/rls-isolation.test.ts`.
+
+**Por que o CI não pega:** o teste de isolamento percorre uma **lista fixa de 10 tabelas**. Não existe
+varredura genérica do tipo "toda tabela com `organization_id` tem `relrowsecurity=true`". Tabela nova
+sem RLS passa verde.
+
+---
+
+## 3. `security definer` exposto a `anon`
+
+**Gatilho:** o diff contém `security definer`.
+
+**Checagem:** `revoke execute ... from public, anon` + entrada em `DEFINER_WRITE_FNS` de
+`tests/invariants/gov-hardening-anon-definer.test.ts`.
+
+**Por que o CI não pega:** lista fixa de 6 funções. E o `ALTER DEFAULT PRIVILEGES` do baseline
+concede `EXECUTE` a `anon` em **toda função nova** de `public` — um `revoke from public` não cobre
+esse grant. Ou seja: função nova nasce **exposta à anon key pública** e o gate não vê.
+
+---
+
+## 4. `console.log` — o DoD que parece automático e não é
+
+**Gatilho:** qualquer `.ts`/`.tsx`.
+
+```bash
+git diff origin/main...<pr> -- '*.ts' '*.tsx' | grep -n '^+.*console\.log'
+```
+
+**Por que o CI não pega:** `no-console` está como **`warn`** no `eslint.config.mjs`, e o script é
+`eslint .` sem `--max-warnings`. Sai com código 0. Aparece exigido em três lugares (CONTRIBUTING,
+template de PR, e o DoD do CLAUDE.md) e nenhum gate o reprova.
+
+**Classe geral:** vale para **qualquer** regra `warn` do eslint. Confira o `eslint.config.mjs` antes
+de supor que uma regra reprova.
+
+---
+
+## 5. Env var nova
+
+**Gatilho:** o diff toca `lib/env.ts` ou `.env.example`.
+
+**Checagem:** a var está nos **dois** arquivos? É `required`? Se for, uma instalação nova quebra —
+existe default, ou o schema a trata como opcional?
+
+**Por que o CI não pega:** o build do CI e a máquina de quem desenvolve costumam já ter a var. Quem
+descobre é o self-hoster, no primeiro deploy.
+
+---
+
+## 6. Kit self-host — nenhum job o testa
+
+**Gatilho:** `hostgator-setup-kit/**`, `docker-compose*`, `Dockerfile`, `scripts/*.sh`.
+
+**Checagem:**
+
+1. `install.sh` em Postgres descartável (`pgvector/pgvector:pg17`), fresh, com `ON_ERROR_STOP=1`.
+2. `update.sh` re-aplicando em banco existente, **sem** a flag — tem de ser idempotente.
+3. **GET externo** na URL final, de fora do contêiner.
+
+**Por que o CI não pega:** não existe job que instale o kit. E o passo 3 é o que separa "instalou" de
+"funciona": ver *falha-em-verde*, abaixo.
+
+---
+
+## 7. Falha-em-verde — a classe mais cara num produto self-host
+
+**Gatilho:** o PR toca qualquer coisa que **declare sucesso** — sonda de saúde, `healthcheck`,
+mensagem final de script, status de conexão na tela.
+
+**Pergunta obrigatória:** *qual é a sonda que declara sucesso, e ela mede o mesmo caminho que o
+usuário usa?*
+
+**Caso real:** um instalador terminava com `Instalação concluída! Acesse: https://$DOMAIN` num site
+inalcançável de fora, porque a sonda rodava **dentro** do contêiner. A instalação "passava" quebrada.
+
+Num produto que a pessoa instala sozinha, ninguém está olhando: o cliente não descobre que está
+quebrado. Isto é bloqueador, não nota.
+
+---
+
+## 8. Catraca de canal — a armadilha da reconciliação
+
+**Gatilho:** o PR mexe em arquivo que está no `KNOWN_DEBT` de `scripts/lint-channels.ts`.
+
+**Checagem:** `pnpm lint:channels`. A catraca reprova em **três** direções, e a terceira é a que pega
+quem conserta as coisas: arquivo novo sujo reprova; arquivo da lista que continua sujo reprova; e
+**arquivo que ficou limpo e não foi removido da lista também reprova**.
+
+Ou seja: se você limpar um arquivo durante a reconciliação, **tire-o da lista no mesmo commit**.
+
+---
+
+## 9. `.github/workflows/` vindo de fork
+
+**Gatilho:** o diff toca `.github/workflows/`.
+
+**Checagem:** leitura linha a linha.
+
+**Contexto que acalma:** os gatilhos são `pull_request` (não `pull_request_target`), e o default do
+repo é `permissions: read` com `can_approve_pull_request_reviews=false`. Código de fork **não roda com
+segredo do repositório** — a arquitetura já é a segura. Ainda assim, mudança de workflow por
+contribuidor externo é achado que merece olho, e se algum dia alguém propuser `pull_request_target`,
+isso é bloqueador com explicação.
+
+---
+
+## 10. O que TEM gate — não refaça
+
+Para não gastar passe à toa:
+
+| item | gate que já cobre |
+|---|---|
+| DoD 14, "tela nova tem porta" | `pnpm test:unit` → `navegacao-completude.test.ts` |
+| provider nomeado fora de `lib/channels/` | `pnpm lint:channels` |
+| baseline aplica fresh **e** idempotente | `pnpm test:db` (job `invariants`) |
+| isolamento RLS nas 10 tabelas listadas | `pnpm test:db` |
+| tipos, lint, unit, shell, build | job `verify` + `build-and-size` |
+
+---
+
+## 11. O que o verde do `e2e` NÃO significa
+
+O job `e2e` roda e é **não-bloqueante de propósito** — não está nos checks obrigatórios. Ele mesmo
+imprime, no resumo, o que não cobriu. Entre as specs que **não rodam** está a de instalação fresca em
+VPS, marcada `[P0]` — que é exatamente o produto que se vende.
+
+Ler `e2e` verde como "jornada de usuário provada" é falso verde **declarado pelo próprio arquivo**.
+Para PR que toca instalação ou onboarding, a prova é o passe 5, não o job.

--- a/triagem/references/eixo-selfhost.md
+++ b/triagem/references/eixo-selfhost.md
@@ -1,0 +1,74 @@
+# Eixo self-host — o valor traduzido em checagem
+
+> Puxe no passe 2 quando o PR tocar schema, env, dependência, infra ou qualquer coisa que declare
+> sucesso. Este eixo é **veto, não ponderação**: um PR pode ser tecnicamente impecável e reprovar
+> aqui.
+
+## O fato que gera todas as regras
+
+A monetização do DeskcommCRM **não é assinatura**. É self-host em VPS, com a HostGator como parceira.
+Quem instala numa VPS é o cliente que paga — e ele instala sozinho, sem ninguém olhando.
+
+Duas consequências que mudam o que é "bom código" aqui:
+
+1. **O instalador é o produto**, não um pré-requisito dele. Defeito de instalação é abandono, não
+   ticket.
+2. **O kit aplica só o `supabase/baseline.sql`.** Não aplica `supabase/migrations/`. Este único fato
+   já responde metade das perguntas abaixo.
+
+## As quatro perguntas
+
+### 1. A mudança de schema chega no cliente?
+
+Se o PR mexe em schema e foi **só** para `supabase/migrations/`, ela não chega — nem em instalação
+nova (que aplica o baseline), nem em atualização (que re-aplica o baseline). **Bloqueador.**
+
+O apêndice do baseline tem de ser **idempotente e auto-curativo**: `add column if not exists`,
+`create ... if not exists`, `create or replace function`. E se a mudança adiciona constraint, os
+dados existentes precisam ser corrigidos **antes** dela — senão o `update.sh` de um clone com dados
+sujos quebra, e quebra na casa de alguém.
+
+### 2. Instalação fresca continua funcionando?
+
+Env var nova **required** sem default quebra o primeiro deploy. A pergunta não é "funciona na minha
+máquina" — é "funciona numa máquina onde nenhuma variável opcional está preenchida".
+
+Teste com os envs opcionais **ausentes**. É o estado real de um primeiro deploy, e é onde moram os
+piores defeitos de primeira impressão. Já aconteceu: um convite por e-mail que nunca saía porque o
+instalador não gravava a chave do provedor de e-mail no `.env`.
+
+### 3. O modelo continua de pé?
+
+Reprova, com explicação e sem drama:
+
+- dependência de serviço pago **obrigatório** para a instalação funcionar;
+- algo que só funcione na Vercel (ou em qualquer PaaS específico);
+- feature que assuma SaaS multi-tenant hospedado por nós;
+- aumento significativo de requisito de RAM/CPU sem justificativa — a VPS do cliente é pequena.
+
+Nada disso é ruim em si. É incompatível com **este** modelo, e o motivo se explica em uma frase ao
+contribuidor: *"aqui quem paga a conta da máquina é quem instala"*.
+
+### 4. A sonda mede o caminho do usuário?
+
+A **falha-em-verde**. Qualquer coisa que declare sucesso — `healthcheck`, mensagem final de script,
+bolinha verde de conexão na tela — precisa medir o caminho que o usuário usa, não um caminho interno
+conveniente.
+
+Caso real: `Instalação concluída! Acesse: https://$DOMAIN` com o site inalcançável de fora, porque a
+sonda rodava dentro do contêiner. A instalação "passava" quebrada.
+
+Num produto self-host isto é a classe mais cara de defeito, porque não existe ninguém monitorando: o
+cliente simplesmente conclui que o produto não funciona, e vai embora sem abrir issue.
+
+## Como isso vira texto no veredito
+
+Não trate o eixo como burocracia. O contribuidor quase sempre não sabe que ele existe — não está no
+CONTRIBUTING de forma acionável. Explique o **porquê** junto com o pedido:
+
+> "Isto precisa também ir para o `supabase/baseline.sql`. O motivo não é burocracia: o kit que instala
+> numa VPS aplica só o baseline, então do jeito que está a sua correção não chegaria em nenhum
+> usuário self-host — que é quem paga o projeto. Te mostro o formato: <link para exemplo>."
+
+E se o eixo não estiver documentado no lugar onde ele olharia, **conserte a documentação no mesmo
+movimento**. A regra do passe 10 vale aqui inteira: não se cobra alguém por regra que não foi contada.

--- a/triagem/references/resposta-ao-contribuidor.md
+++ b/triagem/references/resposta-ao-contribuidor.md
@@ -1,0 +1,116 @@
+# Resposta ao contribuidor
+
+> Puxe nos passes 1 e 10. Este reference é o **como falar**; o que medir está em
+> `complemento-do-ci.md`.
+
+O objetivo não é ser simpático. É que a pessoa saiba exatamente onde está, o que foi medido, e o que
+falta — e que nada do que ela leia seja cobrança por algo que ninguém contou a ela.
+
+---
+
+## Acolhida (passe 1) — em minutos, sem uma linha de avaliação
+
+Três informações, nesta ordem. Nada além.
+
+```markdown
+<!-- triagem-de-pr:v1:pass=1 -->
+Recebido, @<login> — obrigado por isto.
+
+Duas coisas que vão parecer erro seu e não são:
+
+- O check **Vercel** vermelho ("Authorization required to deploy") é esperado em PR de fork. A `main`
+  faz deploy de produção e a Vercel se recusa a construir código de fora, o que está certo. **Ele não
+  entra no gate de merge.**
+- Os workflows ficam parados esperando liberação no primeiro PR de quem nunca contribuiu — política
+  do GitHub, não sua. **Acabei de liberar**, o CI já está rodando.
+
+Vou revisar de verdade — rodando os gates e reproduzindo o comportamento, não só lendo o diff — e
+volto com o resultado <prazo>. Se eu achar algo, venho com a medição junto, nunca com um "acho que".
+```
+
+**Por que a acolhida não avalia:** é isso que a torna segura de ser automática. Ela não pode estar
+errada sobre o mérito porque não fala do mérito. Um "parece ótimo!" postado antes de medir é a
+semente do carimbo — e carimbo é pior que silêncio, porque lava.
+
+**Prazo:** prometa o que você cumpre. Se não souber, diga "hoje ainda" ou "até amanhã", não uma hora
+exata.
+
+---
+
+## Veredito (passe 10)
+
+Estrutura, e cada parte tem função:
+
+1. **O que o PR faz**, em uma frase, na sua leitura. Serve para ele corrigir você se você entendeu
+   errado — antes de discutir a solução.
+2. **O que você mediu**, com o comando e a saída. Não "testei e funciona": *o comando, e o que ele
+   imprimiu*.
+3. **O que você NÃO mediu.** Obrigatório. É o campo que separa medição de relato.
+4. **O que falta, se falta** — cada item com a medição que prova o defeito, anexada.
+5. **O crédito**, pelo nome, do que ele achou ou mediu.
+
+### As três regras duras
+
+**Creditar pelo nome.** Se o PR revelou um buraco no projeto, diga isso em voz alta: *"seu PR fez a
+gente descobrir que X"*. É a coisa mais forte que se pode dizer a alguém que contribuiu de graça.
+
+**Nunca cobrar como descuido um gate que não está documentado.** Hoje o CONTRIBUTING pede coisas que
+o CI não afere, e o CI exige coisas que o CONTRIBUTING não menciona — dá para marcar o checklist
+inteiro de boa-fé e ser reprovado por algo que nunca se soube que existia. Quando isso acontecer:
+
+> "O `lint:channels` reprovou aqui, e isso não estava no CONTRIBUTING — falha nossa, não sua. Já
+> corrigi a documentação neste PR: <link>. O que ele quer é <explicação em uma frase>."
+
+**Nunca pedir sem medição anexada.** Se você não reproduziu, não é pedido — é pergunta, e vai
+redigida como pergunta. Já mandamos um contribuidor consertar um bug que não existia na `main`; ele
+teria escrito código para um defeito inexistente. Uma correção pública custa menos que isso, mas o
+certo é medir antes.
+
+---
+
+## Quando o veredito é SEGURAR
+
+O tom não muda. O que muda é que o bloqueador precisa ser **acionável**: arquivo, linha, o defeito, e
+**como reproduzir**. Se ele não consegue reproduzir com o que você escreveu, o bloqueador não está
+pronto para ser publicado.
+
+E diga o que **não** é bloqueador, para ele não gastar tempo com o que já está bom.
+
+```markdown
+<!-- triagem-de-pr:v1:pass=10 -->
+Medi, e tem um bloqueador — o resto está bom e eu digo o que está bom, para você não mexer à toa.
+
+**Bloqueia:** `hostgator-setup-kit/install.sh:412` — o script termina com "Instalação concluída"
+mesmo quando o site não responde de fora, porque a sonda roda dentro do contêiner. Reproduzi assim:
+<comando> → <saída>. Num produto que a pessoa instala sozinha, isso é o pior desfecho: ela não
+descobre que quebrou.
+
+**Não bloqueia, e é bom:** <o que está certo>.
+
+**Sugestão, se fizer sentido pra você:** <opção>. Mas o desenho é seu — se preferir outro caminho,
+me diz que eu meço o seu.
+```
+
+---
+
+## Proibido
+
+| não escreva | por quê |
+|---|---|
+| "Ótima contribuição!", "Boa pergunta!" como abertura | filler; a pessoa quer o resultado |
+| "Só faltou você rodar os testes" | provavelmente ele rodou os que estavam documentados |
+| pedido sem medição | pode ser fantasma |
+| tom de correção ou de aula | ele não trabalha aqui |
+| link para o Discord interno | é um beco sem saída para quem é de fora — mande para **Discussions** |
+| prometer prazo que você não cumpre | a promessa não cumprida custa mais que o silêncio |
+
+---
+
+## O número que a triagem reporta
+
+**Tempo entre abrir o PR e a primeira resposta humana.** É a única métrica de acolhimento que
+mede o que a triagem controla.
+
+Que creditar medição faça o contribuidor voltar é **hipótese** — ninguém perguntou a ele. Não escreva
+como se fosse fato. O teste mais barato para converter a hipótese em dado é literalmente perguntar,
+e vale a pena fazê-lo com quem já voltou.


### PR DESCRIPTION
Instala o procedimento de triagem de PR de contribuidor, e conserta no mesmo movimento as dívidas de acolhimento que ele tropeçaria.

## O número que define a calibragem

Em 60 dias — janela que cobre **100% do histórico** do repositório — seis humanos externos abriram 16 PRs. **Quinze mergeados, zero fechados.** A taxa de rejeição é zero.

O gargalo nunca foi qualidade. Foi latência: os 7 PRs de um mesmo contribuidor esperaram **5h08min** entre serem abertos e o CI começar, e depois foram do verde ao merge em 25 minutos. Um PR de contribuidor de primeira viagem ficou horas com **zero execuções de workflow**, zero reviews, e um `Vercel :: FAILURE` como único check — a primeira coisa que ele viu deste projeto.

Por isso a triagem entra calibrada como **desbloqueadora, não como porteiro**: acolhe e libera o CI em minutos, **sem uma linha de avaliação**, e só depois verifica com rigor. A acolhida não pode estar errada sobre o mérito porque não fala do mérito — é isso que a torna segura de ser automática.

E o rigor precisa ser real, porque a branch protection **não exige review humano** (`required_pull_request_reviews` ausente; os 7 PRs citados foram mergeados com `reviews=0`). Não há rede embaixo.

## Arquitetura: comando fino → procedimento gordo versionado → agentes

`.claude/skills/` está no `.gitignore`, então uma skill nasceria fora do versionamento — ninguém mais aplicaria e não passaria por PR. O gov-loop já resolveu isso e o padrão é o copiado aqui:

```
.claude/commands/triagem-de-pr.md   porta de entrada, 17 linhas
triagem/TRIAGEM.md                  os 11 passes
triagem/references/                 complemento-do-ci · resposta-ao-contribuidor · eixo-selfhost
.claude/agents/triagem-{medidor,reprodutor,cetico}.md
```

## O passe 4 é o coração

A tabela do que a doutrina exige e **nenhum job reprova**:

| exigência | quem reprova hoje |
|---|---|
| tripla de migration (`migrations/` + baseline + MANIFEST) | hook local via `core.hooksPath` — **fork nunca roda** |
| RLS em tabela tenant-aware nova | lista **fixa de 10 tabelas** |
| `security definer` não exposto a `anon` | lista fixa de **6 funções** |
| sem `console.log` | `no-console` é **warn** sem `--max-warnings` → passa verde |
| kit self-host funciona | **nenhum job testa o kit** |

Essa tabela é, de propósito, a **lista de tarefas do CI**: cada linha que virar gate de verdade é uma linha que a triagem para de fazer à mão. O procedimento deve ficar mais leve com o tempo — se ficar mais pesado, o passe 11 não está sendo cumprido.

## Dívidas consertadas junto

- **`.claude/skills/DeskcommCRM/SKILL.md`** estava sem frontmatter, com o corpo inteiro dentro de uma cerca ` ```markdown `, e ensinava `snake_case` com imports relativos (o repo usa kebab-case com alias `@/`) mais dois comandos que não existem. Estava ativa em toda sessão.
- **CONTRIBUTING mandava o contribuidor externo para um Discord interno** cujo convite mora num Notion privado — beco sem saída justamente para quem vem de fora. Agora aponta Discussions.
- **A Definition of Done misturava** o que a máquina reprova com o que só uma pessoa percebe. Separada em duas, com a cadeia completa de 6 gates copiável e o aviso explícito de que `pnpm lint` **não** reprova `console.log`.
- **O README publicava um "fluxo curto" com 3 dos 6 gates** obrigatórios — a diferença caía como surpresa vermelha depois das horas de espera.

O princípio por trás dos quatro é o mesmo, e está escrito no passe 10: **não se cobra alguém por regra que não foi contada**.

## Gates

`typecheck` 0 · `lint` 0 erros · `lint:channels` 0 · `test:unit` 223 arquivos / 1890 testes · `test:shell` 0 · `build` 0 — todos com exit medido direto, sem pipe.

E a **cadeia exata que passei a publicar no README** foi rodada de ponta a ponta: exit 0. Publicar comando sem rodá-lo seria o próprio defeito que este PR conserta.

**Não medido:** `pnpm test:db` — nada aqui toca schema. E o procedimento em si ainda não foi exercido num PR real; o ensaio é o passo seguinte, no PR #121, que está aberto agora.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4NxbuaBH2rNizak9HkDpd