### PR TITLE
feat(kit): instalador com marca, porta antes da VPS, e 8 defeitos achados rodando

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@
 > **[👉 Assinar a VPS HostGator com desconto da parceria](https://www.hostgator.com.br/52708-141-3-52.html)** —
 > datacenter em São Paulo, ideal pro WhatsApp rodando 24/7. *(link de parceiro — assinar por ele apoia o projeto e sai mais barato)*
 >
+> **Ainda não tem servidor?** Rode isto **no seu computador** (macOS, Linux ou WSL). Ele diz
+> qual plano contratar — com os números do runbook, não um "depende" — e te devolve o
+> comando certo pro seu caso:
+>
+> ```bash
+> curl -fsSL https://raw.githubusercontent.com/melgarafael/DeskcommCRM/main/hostgator-setup-kit/comecar.sh | bash
+> ```
+>
+> *(prefere ler antes de executar? clone o repo e rode `bash hostgator-setup-kit/comecar.sh` —
+> ele não instala nada sem você confirmar.)*
+>
 > Já tem a VPS? Entre nela por SSH e rode:
 >
 > ```bash

--- a/hostgator-setup-kit/README.md
+++ b/hostgator-setup-kit/README.md
@@ -2,6 +2,16 @@
 
 Este kit sobe o **DeskcommCRM** no seu servidor VPS da HostGator. Você tem dois caminhos:
 
+> **Ainda nem tem servidor?** Comece por `comecar.sh` — ele roda **no seu computador**, antes
+> de existir VPS, e responde a pergunta que trava todo mundo no início: *o que eu preciso
+> contratar?* Ele nomeia o plano (VPS Turing, 2 vCPU / 4 GB — o Cartesius não dá conta do
+> WhatsApp), abre a página se você quiser, e devolve o comando exato do seu caso. Depois que
+> a VPS existir, o caminho é o `install.sh` daqui de baixo.
+>
+> ```bash
+> bash comecar.sh
+> ```
+
 > **Outra hospedagem?** O kit é feito para a HostGator (é a parceria do projeto e o caminho
 > testado de ponta a ponta), mas roda em qualquer VPS com Docker. Se a sua já vem com um
 > **proxy reverso próprio** ocupando as portas 80/443 — caso de Hostinger, Coolify, Dokploy

--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -52,6 +52,14 @@ c_ylw() { paint 33 "$*"; }
 die()   { c_red "✖ $*"; exit 1; }
 step()  { printf '\n'; paint 1 "▶ $*"; }
 
+# Gêmea da de install.sh (se mexer numa, mexa na outra) — ver o comentário lá
+# para o defeito que ela fecha. Coberta por test-validators.sh.
+resposta_sim() {
+  local r
+  r="$(printf '%s' "${1:-}" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+  case "$r" in s|sim|y|yes) return 0;; *) return 1;; esac
+}
+
 # Código de saída de quem RECUSOU antes de tocar em qualquer coisa — distinto
 # de "falhei no meio" (1). O agent.sh usa isso para não desfazer uma
 # atualização que nunca começou: reiniciar o container e reescrever o .env

--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -34,11 +34,23 @@ dc_files() {
   fi
 }
 
-c_red() { printf '\033[31m%s\033[0m\n' "$*"; }
-c_grn() { printf '\033[32m%s\033[0m\n' "$*"; }
-c_ylw() { printf '\033[33m%s\033[0m\n' "$*"; }
+# Cor só quando há terminal de verdade — mesma regra do install.sh (se mexer
+# numa, mexa na outra). Aqui isso vale dobrado: o update.sh, que herda estas
+# funções, é rodado pelo agent.sh com a saída redirecionada para arquivo
+# (`> "$LOG"`) a cada 5 minutos, para sempre, em toda instalação. Era daí que
+# vinha o escape ANSI que o esc() do agent.sh precisa varrer byte a byte antes
+# de mandar o log no heartbeat; não emitir na origem é a correção de causa.
+if   [ -n "${NO_COLOR:-}" ];    then COLOR=0
+elif [ -n "${FORCE_COLOR:-}" ]; then COLOR=1
+elif [ -t 1 ];                  then COLOR=1
+else                                 COLOR=0
+fi
+paint() { local code="$1"; shift; if [ "$COLOR" = 1 ]; then printf '\033[%sm%s\033[0m\n' "$code" "$*"; else printf '%s\n' "$*"; fi; }
+c_red() { paint 31 "$*"; }
+c_grn() { paint 32 "$*"; }
+c_ylw() { paint 33 "$*"; }
 die()   { c_red "✖ $*"; exit 1; }
-step()  { printf '\n\033[1m▶ %s\033[0m\n' "$*"; }
+step()  { printf '\n'; paint 1 "▶ $*"; }
 
 # Código de saída de quem RECUSOU antes de tocar em qualquer coisa — distinto
 # de "falhei no meio" (1). O agent.sh usa isso para não desfazer uma

--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -232,7 +232,12 @@ owner_id_by_email() {
 #
 # Agora cada linha carrega um marcador com o diretório da instalação, e o
 # filtro remove só as que são dela.
-cron_tag() { printf '# deskcomm:%s' "${PROJECT_DIR:-$PWD}"; }
+# O marcador identifica a instalação E O PAPEL da linha. O papel não é enfeite:
+# com um marcador só por instalação, a segunda função a rodar apagava a linha da
+# primeira (o filtro remove tudo que casa com o marcador, e as duas linhas
+# casavam). Medido na VPS: depois de instalar, sobrava só o agente e o CRM ficava
+# SEM o drain de eventos — a automação inteira parada, em silêncio.
+cron_tag() { printf '# deskcomm:%s:%s' "${PROJECT_DIR:-$PWD}" "${1:?papel da linha (drain|agent)}"; }
 
 # Puro (testável sem tocar no crontab real): lê o crontab atual em stdin e
 # imprime o novo. Tira as linhas DESTA instalação — pelo marcador, e também
@@ -253,7 +258,7 @@ setup_event_log_drain_cron() {
   [ -n "${NEXT_PUBLIC_APP_URL:-}" ] || { c_ylw "⚠ falta NEXT_PUBLIC_APP_URL — não ativei o cron das automações."; return 0; }
 
   local url_drain="${NEXT_PUBLIC_APP_URL}/api/v1/cron/event-log-drain"
-  local marcador; marcador="$(cron_tag)"
+  local marcador; marcador="$(cron_tag drain)"
 
   # "primeira vez" é sobre ESTA instalação, não sobre o host: com o teste antigo
   # ('existe alguma linha de event-log-drain?'), uma instalação nova numa VPS
@@ -299,7 +304,7 @@ setup_update_agent_cron() {
   # A assinatura legada inclui o PROJECT_DIR: é o que distingue a linha desta
   # instalação da linha de uma vizinha, que roda o mesmo agent.sh em outra pasta.
   local legado="cd ${PROJECT_DIR} && bash hostgator-setup-kit/agent.sh"
-  local marcador; marcador="$(cron_tag)"
+  local marcador; marcador="$(cron_tag agent)"
   local cron_line="*/5 * * * * ${legado} >/dev/null 2>&1 ${marcador}"
   ( crontab -l 2>/dev/null | cron_merge "$marcador" "$legado" "$cron_line" ) | crontab -
   c_grn "✓ atualização pela tela ativa (agente a cada 5 minutos)"

--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -222,6 +222,28 @@ owner_id_by_email() {
 # lidos por cron, não por trigger→HTTP nem fila gerenciada (doutrina do
 # projeto: trigger Postgres nunca faz HTTP). Chamada por install.sh e
 # update.sh — re-rodar não duplica a linha do crontab.
+# ── Cron: uma instalação nunca mexe na linha de outra ────────────────────────
+# O filtro era `crontab -l | grep -v 'event-log-drain' | crontab -`: casava com
+# a linha de QUALQUER instalação do host. Instalar uma segunda instância na
+# mesma VPS apagava as duas linhas da primeira — o drain de eventos e o agente
+# de atualização — em silêncio, e o dono só descobriria pelo que parou de
+# acontecer. Confirmado numa VPS com produção rodando: as linhas dela seriam
+# levadas por uma instalação nova em outra pasta.
+#
+# Agora cada linha carrega um marcador com o diretório da instalação, e o
+# filtro remove só as que são dela.
+cron_tag() { printf '# deskcomm:%s' "${PROJECT_DIR:-$PWD}"; }
+
+# Puro (testável sem tocar no crontab real): lê o crontab atual em stdin e
+# imprime o novo. Tira as linhas DESTA instalação — pelo marcador, e também
+# pela `assinatura` para as linhas legadas, escritas antes de o marcador
+# existir, que sem isso ficariam duplicadas a cada re-execução.
+cron_merge() {  # cron_merge <marcador> <assinatura_legada> <linha_nova>
+  local marcador="$1" legado="$2" nova="$3"
+  { grep -vF -e "$marcador" | grep -vF -e "$legado"; } || true
+  printf '%s\n' "$nova"
+}
+
 setup_event_log_drain_cron() {
   command -v crontab >/dev/null 2>&1 || { c_ylw "⚠ 'crontab' não encontrado — instale o pacote 'cron' e rode de novo pra ativar as automações."; return 0; }
 
@@ -230,14 +252,17 @@ setup_event_log_drain_cron() {
   [ -n "$secret" ] || { c_ylw "⚠ falta INTERNAL_SECRET/INTERNAL_CRON_SECRET — não ativei o cron das automações."; return 0; }
   [ -n "${NEXT_PUBLIC_APP_URL:-}" ] || { c_ylw "⚠ falta NEXT_PUBLIC_APP_URL — não ativei o cron das automações."; return 0; }
 
-  local first_time=1
-  if crontab -l 2>/dev/null | grep -q 'event-log-drain'; then first_time=0; fi
+  local url_drain="${NEXT_PUBLIC_APP_URL}/api/v1/cron/event-log-drain"
+  local marcador; marcador="$(cron_tag)"
 
-  local cron_line="* * * * * curl -fsS -H \"Authorization: Bearer ${secret}\" \"${NEXT_PUBLIC_APP_URL}/api/v1/cron/event-log-drain\" >/dev/null 2>&1"
-  # "|| true": com pipefail ativo, grep -v sem match nenhum (crontab vazio ou
-  # sem a linha ainda) sai com status 1 e derrubaria o subshell por set -e
-  # ANTES do echo do novo cron_line — neutralizamos aqui, de propósito.
-  ( crontab -l 2>/dev/null | grep -v 'event-log-drain' || true; echo "$cron_line" ) | crontab -
+  # "primeira vez" é sobre ESTA instalação, não sobre o host: com o teste antigo
+  # ('existe alguma linha de event-log-drain?'), uma instalação nova numa VPS
+  # que já roda outra se achava veterana e pulava a higienização de eventos.
+  local first_time=1
+  if crontab -l 2>/dev/null | grep -qF -e "$url_drain"; then first_time=0; fi
+
+  local cron_line="* * * * * curl -fsS -H \"Authorization: Bearer ${secret}\" \"${url_drain}\" >/dev/null 2>&1 ${marcador}"
+  ( crontab -l 2>/dev/null | cron_merge "$marcador" "$url_drain" "$cron_line" ) | crontab -
   c_grn "✓ automações ativas (cron do event-log-drain, a cada minuto)"
 
   if [ "$first_time" = 1 ]; then
@@ -271,9 +296,12 @@ setup_update_agent_cron() {
   # DIRETÓRIO CORRENTE. No cron o CWD é o home do dono do crontab — sem o cd,
   # a linha só funciona por acidente (instalação padrão em /root/deskcommcrm) e
   # morre calada a cada 5 minutos em qualquer REPO_DIR customizado ou /opt.
-  local cron_line="*/5 * * * * cd ${PROJECT_DIR} && bash hostgator-setup-kit/agent.sh >/dev/null 2>&1"
-  # "|| true": com pipefail, grep -v sem match sai 1 e derrubaria o subshell.
-  ( crontab -l 2>/dev/null | grep -v 'hostgator-setup-kit/agent.sh' || true; echo "$cron_line" ) | crontab -
+  # A assinatura legada inclui o PROJECT_DIR: é o que distingue a linha desta
+  # instalação da linha de uma vizinha, que roda o mesmo agent.sh em outra pasta.
+  local legado="cd ${PROJECT_DIR} && bash hostgator-setup-kit/agent.sh"
+  local marcador; marcador="$(cron_tag)"
+  local cron_line="*/5 * * * * ${legado} >/dev/null 2>&1 ${marcador}"
+  ( crontab -l 2>/dev/null | cron_merge "$marcador" "$legado" "$cron_line" ) | crontab -
   c_grn "✓ atualização pela tela ativa (agente a cada 5 minutos)"
 }
 

--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -140,7 +140,16 @@ load_env() {
     case "$key" in ''|*[!A-Za-z0-9_]*) continue;; esac
     case "$val" in
       \"*\") val="${val:1:${#val}-2}";;
-      \'*\') val="${val:1:${#val}-2}";;
+      \'*\')
+        val="${val:1:${#val}-2}"
+        # envq escreve a aspa simples do CONTEÚDO como '\'' (fecha o literal,
+        # escapa a aspa, reabre) — é o que faz a linha ser shell válido. Só que
+        # tirar as aspas de fora não desfaz isso: sem esta troca, uma senha com
+        # aspa volta da releitura com quatro caracteres a mais, e o erro só
+        # aparece longe daqui (o psql recusa a conexão, o login não bate) sem
+        # nada apontando para o .env. Achado pelo teste de round-trip.
+        val="${val//"'\\''"/"'"}"
+        ;;
     esac
     printf -v "$key" '%s' "$val"
     export "${key?}"

--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -60,6 +60,32 @@ resposta_sim() {
   case "$r" in s|sim|y|yes) return 0;; *) return 1;; esac
 }
 
+# Saúde do app pela rota que ele responde de verdade, não pela porta. A porta
+# 3000 aceita conexão assim que o Node sobe — ANTES de o app saber se alcança
+# banco, Redis e WhatsApp. Era exatamente a diferença entre o install.sh, que
+# testava a porta e imprimia "Instalação concluída!" mesmo sem resposta, e o
+# update.sh, que só declara sucesso com "status":"ok". Um critério, um lugar.
+app_health_body() {
+  dc exec -T app node -e \
+    "fetch('http://127.0.0.1:3000/api/v1/health').then(r=>r.text()).then(t=>{console.log(t);process.exit(0)}).catch(()=>process.exit(1))" \
+    2>/dev/null || echo ''
+}
+
+# wait_app_healthy [tentativas] [intervalo_s] — devolve 0 quando o app responde
+# "status":"ok"; ecoa o último corpo lido (vazio se nunca respondeu), para quem
+# chama poder mostrar o motivo em vez de só dizer que não deu.
+wait_app_healthy() {
+  local tentativas="${1:-20}" intervalo="${2:-3}" out='' i=0
+  while [ "$i" -lt "$tentativas" ]; do
+    out="$(app_health_body)"
+    if printf '%s' "$out" | grep -q '"status":"ok"'; then printf '%s' "$out"; return 0; fi
+    i=$((i+1))
+    [ "$i" -lt "$tentativas" ] && sleep "$intervalo"
+  done
+  printf '%s' "$out"
+  return 1
+}
+
 # Código de saída de quem RECUSOU antes de tocar em qualquer coisa — distinto
 # de "falhei no meio" (1). O agent.sh usa isso para não desfazer uma
 # atualização que nunca começou: reiniciar o container e reescrever o .env

--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -65,24 +65,42 @@ resposta_sim() {
 # banco, Redis e WhatsApp. Era exatamente a diferença entre o install.sh, que
 # testava a porta e imprimia "Instalação concluída!" mesmo sem resposta, e o
 # update.sh, que só declara sucesso com "status":"ok". Um critério, um lugar.
-app_health_body() {
+# Devolve DUAS linhas: o status GERAL na primeira, o corpo inteiro na segunda.
+#
+# A separação existe porque procurar '"status":"ok"' no JSON cru é errado, e
+# erra em silêncio: `ok` é o vocabulário dos CHECKS individuais
+# (ok|degraded|down), enquanto o status geral usa outro (healthy|degraded|
+# unhealthy). Medido contra o app real: um `grep '"status":"ok"'` casa com o
+# `checks.redis`, então um app com o BANCO FORA — status geral "unhealthy" —
+# passava como saudável, desde que qualquer outro check estivesse de pé. Quem
+# decide é o app, no Node que já está sendo invocado; o shell não repete a
+# regra dele.
+app_health_probe() {
   dc exec -T app node -e \
-    "fetch('http://127.0.0.1:3000/api/v1/health').then(r=>r.text()).then(t=>{console.log(t);process.exit(0)}).catch(()=>process.exit(1))" \
+    "fetch('http://127.0.0.1:3000/api/v1/health').then(r=>r.json()).then(j=>{console.log((j&&j.data&&j.data.status)||'sem_status');console.log(JSON.stringify(j))}).catch(()=>process.exit(1))" \
     2>/dev/null || echo ''
 }
 
-# wait_app_healthy [tentativas] [intervalo_s] — devolve 0 quando o app responde
-# "status":"ok"; ecoa o último corpo lido (vazio se nunca respondeu), para quem
-# chama poder mostrar o motivo em vez de só dizer que não deu.
+# wait_app_healthy [tentativas] [intervalo_s] — 0 quando o app se declara
+# `healthy` ou `degraded`, 1 caso contrário. `degraded` entra de propósito:
+# significa que algum serviço OPCIONAL ainda não foi configurado (o check
+# devolve degraded/not_configured), e recusar a instalação por isso reprovaria
+# um CRM que está de pé e atendendo. `unhealthy` é outra história — quer dizer
+# check DOWN, e aí o app não serve. Ecoa o corpo lido, para quem chama poder
+# mostrar o motivo em vez de só dizer que não deu.
 wait_app_healthy() {
-  local tentativas="${1:-20}" intervalo="${2:-3}" out='' i=0
+  local tentativas="${1:-20}" intervalo="${2:-3}" saida='' status='' corpo='' i=0
   while [ "$i" -lt "$tentativas" ]; do
-    out="$(app_health_body)"
-    if printf '%s' "$out" | grep -q '"status":"ok"'; then printf '%s' "$out"; return 0; fi
+    saida="$(app_health_probe)"
+    status="$(printf '%s\n' "$saida" | head -1 | tr -d '\r')"
+    corpo="$(printf '%s\n' "$saida" | tail -n +2)"
+    case "$status" in
+      healthy|degraded) printf '%s' "$corpo"; return 0;;
+    esac
     i=$((i+1))
     [ "$i" -lt "$tentativas" ] && sleep "$intervalo"
   done
-  printf '%s' "$out"
+  printf '%s' "$corpo"
   return 1
 }
 

--- a/hostgator-setup-kit/comecar.sh
+++ b/hostgator-setup-kit/comecar.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+#
+# DeskcommCRM — a porta de entrada.
+#
+# Diferente do install.sh, este script roda no SEU computador (macOS, Linux ou
+# WSL), antes de existir servidor. Ele responde a única pergunta que trava quem
+# está começando — "o que eu preciso ter antes de instalar isso?" — e entrega o
+# comando certo para o caso de cada um.
+#
+# Uso:
+#   bash comecar.sh
+#   curl -fsSL https://raw.githubusercontent.com/melgarafael/DeskcommCRM/main/hostgator-setup-kit/comecar.sh | bash
+#
+set -euo pipefail
+
+REPO_URL="${REPO_URL:-https://github.com/melgarafael/DeskcommCRM.git}"
+# Link de parceria com a HostGator. Mesma URL e mesmo rótulo do README: uma
+# promessa só, num lugar só — duas redações da mesma oferta viram duas ofertas.
+VPS_URL="https://www.hostgator.com.br/52708-141-3-52.html"
+COMUNIDADE_URL="https://lp-comunidade.automatiklabs.com.br"
+
+# ── Aparência ───────────────────────────────────────────────────────────────
+# Gêmeas das do install.sh (que por sua vez é standalone porque roda antes do
+# clone). Este aqui roda antes AINDA — pode chegar pela rede sozinho, sem repo
+# e sem o irmão ao lado. Se mexer numa, mexa na outra.
+if   [ -n "${NO_COLOR:-}" ];    then COLOR=0
+elif [ -n "${FORCE_COLOR:-}" ]; then COLOR=1
+elif [ -t 1 ];                  then COLOR=1
+else                                 COLOR=0
+fi
+paint() { local code="$1"; shift; if [ "$COLOR" = 1 ]; then printf '\033[%sm%s\033[0m\n' "$code" "$*"; else printf '%s\n' "$*"; fi; }
+c_grn() { paint 32 "$*"; }
+c_ylw() { paint 33 "$*"; }
+c_dim() { paint 2  "$*"; }
+die()   { paint 31 "✖ $*"; exit 1; }
+
+LOGO_COLS=71
+banner() {
+  local cols linha ch
+  cols="$(tput cols 2>/dev/null || echo 80)"
+  case "$cols" in ''|*[!0-9]*) cols=80;; esac
+  printf '\n'
+  if [ "$COLOR" != 1 ] || [ "$cols" -lt $((LOGO_COLS + 2)) ]; then
+    paint 1 "  DESKCOMM"
+  else
+    [ -t 1 ] && printf '\033[2J\033[H'
+    while IFS= read -r linha; do
+      linha="${linha//█/$'\033[32m'█$'\033[0m'}"
+      for ch in ═ ╗ ║ ╝ ╚ ╔; do linha="${linha//$ch/$'\033[2m'$ch$'\033[0m'}"; done
+      printf '  %s\n' "$linha"
+    done <<'LOGO'
+██████╗ ███████╗███████╗██╗  ██╗ ██████╗ ██████╗ ███╗   ███╗███╗   ███╗
+██╔══██╗██╔════╝██╔════╝██║ ██╔╝██╔════╝██╔═══██╗████╗ ████║████╗ ████║
+██║  ██║█████╗  ███████╗█████╔╝ ██║     ██║   ██║██╔████╔██║██╔████╔██║
+██║  ██║██╔══╝  ╚════██║██╔═██╗ ██║     ██║   ██║██║╚██╔╝██║██║╚██╔╝██║
+██████╔╝███████╗███████║██║  ██╗╚██████╗╚██████╔╝██║ ╚═╝ ██║██║ ╚═╝ ██║
+╚═════╝ ╚══════╝╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚═════╝ ╚═╝     ╚═╝╚═╝     ╚═╝
+LOGO
+  fi
+  printf '\n'
+  c_dim "  Agentes de IA que atendem no WhatsApp, dentro do seu CRM."
+  c_dim "  Open-source · roda no seu servidor · os dados são seus."
+}
+
+# ── Entrada do teclado ──────────────────────────────────────────────────────
+# Este script existe para ser chamado por `curl -fsSL … | bash`, e nesse modo o
+# stdin do processo É O PIPE (o texto do próprio script), não o teclado: um
+# `read` comum consumiria o código-fonte como se fosse resposta, ou veria EOF na
+# primeira pergunta. Reatar em /dev/tty é o que faz o menu existir nesse
+# caminho; sem terminal nenhum (CI, cron), não há o que perguntar.
+TTY_IN=""
+if [ -t 0 ]; then TTY_IN="/dev/stdin"
+elif [ -r /dev/tty ] && { : < /dev/tty; } 2>/dev/null; then TTY_IN="/dev/tty"
+fi
+
+perguntar() {  # perguntar <variável> <texto> [default]
+  local var="$1" texto="$2" padrao="${3:-}" resposta=""
+  if [ -z "$TTY_IN" ]; then printf -v "$var" '%s' "$padrao"; return 0; fi
+  printf '%s' "$texto"
+  read -r resposta < "$TTY_IN" || resposta=""
+  printf -v "$var" '%s' "${resposta:-$padrao}"
+}
+
+# Abre uma URL no navegador — só onde existe navegador. Numa sessão SSH (o caso
+# de quem já está dentro do servidor) não há: aí o link fica na tela e pronto,
+# que é melhor do que um erro de comando não encontrado no meio da conversa.
+tem_navegador() {
+  if command -v open >/dev/null 2>&1 && [ "$(uname -s)" = "Darwin" ]; then return 0; fi
+  if command -v xdg-open >/dev/null 2>&1 && [ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ]; then return 0; fi
+  return 1
+}
+abrir() {
+  tem_navegador || return 0
+  local sim=""
+  perguntar sim "  Abro isso no seu navegador agora? (S/n) " "S"
+  case "$sim" in [Nn]*) return 0;; esac
+  if [ "$(uname -s)" = "Darwin" ]; then open "$1" >/dev/null 2>&1 || true
+  else xdg-open "$1" >/dev/null 2>&1 || true; fi
+  c_grn "  ✓ abri no navegador. Volte aqui quando terminar."
+}
+
+# ── O que contratar ─────────────────────────────────────────────────────────
+# Os números não são chute: saem de docs/runbooks/waha-hostgator.md, que é o
+# ambiente onde o CRM é operado de verdade. Nomear o PLANO é o que mais importa
+# aqui — "2 vCPU / 4 GB" ainda deixa a pessoa escolhendo entre seis caixinhas no
+# site, e escolher errado é descobrir o problema semanas depois, com o WhatsApp
+# caindo por falta de memória.
+mostrar_requisitos() {
+  cat <<REQ
+
+  O CRM roda 24 horas por dia, com o WhatsApp junto. Para isso ele precisa de:
+
+    • Plano VPS Turing (ou superior) — 2 vCPU e 4 GB de RAM
+      O plano Cartesius (1 vCPU / 2 GB) NÃO dá conta: o WhatsApp usa cerca de
+      150 MB por número conectado, e a stack inteira não cabe.
+    • 80 GB de disco
+    • Ubuntu 22.04 LTS ou 24.04 LTS
+    • Datacenter em São Paulo — é o que segura a latência do WhatsApp no Brasil
+
+  Onde contratar:
+
+       ${VPS_URL}
+
+REQ
+  c_dim "  Esse é um link de parceria: assinar por ele sai com desconto e ajuda a"
+  c_dim "  manter o projeto. O CRM é MIT e roda em qualquer servidor — se você já"
+  c_dim "  tem um, ou prefere outro provedor, funciona igual."
+  printf '\n'
+}
+
+comando_de_instalacao() {
+  cat <<CMD
+
+  Já dentro do servidor, cole isto:
+
+       git clone ${REPO_URL} deskcommcrm
+       cd deskcommcrm
+       bash hostgator-setup-kit/install.sh
+
+  O instalador cuida do resto: instala o Docker se faltar, cria o banco,
+  configura o domínio com HTTPS e sobe o CRM. Ele pergunta o que só você sabe
+  (o domínio, as chaves, a senha do primeiro acesso) e valida cada resposta na
+  hora — nada de descobrir um dado errado dez minutos depois.
+
+CMD
+}
+
+# ── Fluxo ───────────────────────────────────────────────────────────────────
+banner
+
+if [ -z "$TTY_IN" ]; then
+  # Sem teclado (pipe puro, CI): não dá para conduzir ninguém. Entrega os dois
+  # caminhos de uma vez, em vez de escolher um por conta própria.
+  c_ylw "  (sem terminal interativo — segue o resumo dos dois caminhos)"
+  mostrar_requisitos
+  comando_de_instalacao
+  exit 0
+fi
+
+while :; do
+  cat <<MENU
+
+  Onde o seu CRM vai rodar?
+
+    1) Ainda não tenho servidor
+    2) Já tenho um servidor (VPS), mas estou no meu computador
+    3) Já estou dentro do servidor agora
+
+MENU
+  # Enter cai no 1 de propósito: quem já tem servidor costuma chegar ao produto
+  # pelo README com o SSH aberto e ir direto ao install.sh. Quem chega por AQUI
+  # — um vídeo, a comunidade, um link solto — é, na maioria, quem ainda não tem.
+  perguntar escolha "  Digite 1, 2 ou 3 (Enter = 1): " "1"
+
+  case "$escolha" in
+    1)
+      mostrar_requisitos
+      abrir "$VPS_URL"
+      c_dim "  Quando o servidor estiver de pé, rode este mesmo comando de novo e"
+      c_dim "  escolha a opção 2 — eu te dou o passo seguinte."
+      ;;
+    2)
+      cat <<SSH
+
+  Entre no servidor pelo terminal. O provedor te mandou o IP e a senha de root
+  por e-mail quando a VPS ficou pronta:
+
+       ssh root@SEU_IP_AQUI
+
+SSH
+      comando_de_instalacao
+      break
+      ;;
+    3)
+      if [ -f "$(dirname "$0")/install.sh" ]; then
+        # Confirmação explícita porque este é o único ramo que MUDA a máquina, e
+        # o engano é fácil: quem clonou o repo no próprio notebook para ler o
+        # código está a uma tecla de instalar a stack inteira nele. Mostrar o
+        # hostname é o que faz a pessoa perceber onde ela está de verdade.
+        printf '\n'
+        c_ylw "  Atenção: isso instala o CRM NESTA máquina — $(hostname 2>/dev/null || echo 'esta')."
+        c_ylw "  Se você está no seu computador pessoal, e não no servidor, responda n."
+        perguntar ok "  Continuar? (s/N) " "N"
+        case "$ok" in
+          [Ss]*)
+            c_grn "  ✓ achei o instalador aqui do lado. Começando."
+            printf '\n'
+            exec bash "$(dirname "$0")/install.sh"
+            ;;
+        esac
+        c_dim "  Ok, não instalei nada. Escolha 1 ou 2 se precisar do outro caminho."
+        continue
+      fi
+      c_ylw "  Você está no servidor, mas o projeto ainda não foi baixado aqui."
+      comando_de_instalacao
+      break
+      ;;
+    *)
+      c_ylw "  Não entendi '${escolha}'. Digite 1, 2 ou 3."
+      ;;
+  esac
+done
+
+cat <<FIM
+  ─── Quando travar ────────────────────────────────────────
+
+  Tem gente rodando exatamente este CRM na comunidade, e é lá que saem os
+  avisos de versão nova:
+
+       ${COMUNIDADE_URL}
+
+FIM

--- a/hostgator-setup-kit/comecar.sh
+++ b/hostgator-setup-kit/comecar.sh
@@ -73,11 +73,22 @@ if [ -t 0 ]; then TTY_IN="/dev/stdin"
 elif [ -r /dev/tty ] && { : < /dev/tty; } 2>/dev/null; then TTY_IN="/dev/tty"
 fi
 
+# Devolve != 0 quando a ENTRADA ACABOU, que é diferente de "respondeu vazio"
+# (Enter, que vale o default). Confundir os dois prendia o script: alimentado
+# por um pipe que termina antes das perguntas — `curl … | bash` de quem só
+# responde a primeira —, o processo NÃO terminava (medido: teto de 20s estourado,
+# com o menu parado na tela e nada indicando que só um Ctrl-C sai dali). Com a
+# distinção, o mesmo caso encerra em 0 imprimindo os dois caminhos.
+#
+# O mecanismo exato ficou em aberto: o consumo de CPU na espera é ~0 (perfil de
+# bloqueio), mas a leitura do código sugeriria reentrada no mesmo ramo. Os dois
+# sinais discordam e não vale fechar a questão aqui — o comportamento que
+# importa (não termina × termina) está medido nas duas versões.
 perguntar() {  # perguntar <variável> <texto> [default]
   local var="$1" texto="$2" padrao="${3:-}" resposta=""
   if [ -z "$TTY_IN" ]; then printf -v "$var" '%s' "$padrao"; return 0; fi
   printf '%s' "$texto"
-  read -r resposta < "$TTY_IN" || resposta=""
+  if ! read -r resposta < "$TTY_IN"; then printf '\n'; return 1; fi
   printf -v "$var" '%s' "${resposta:-$padrao}"
 }
 
@@ -92,7 +103,8 @@ tem_navegador() {
 abrir() {
   tem_navegador || return 0
   local sim=""
-  perguntar sim "  Abro isso no seu navegador agora? (S/n) " "S"
+  # EOF aqui não é motivo para abrir nada: na dúvida, não age.
+  perguntar sim "  Abro isso no seu navegador agora? (S/n) " "S" || return 0
   case "$sim" in [Nn]*) return 0;; esac
   if [ "$(uname -s)" = "Darwin" ]; then open "$1" >/dev/null 2>&1 || true
   else xdg-open "$1" >/dev/null 2>&1 || true; fi
@@ -170,7 +182,12 @@ MENU
   # Enter cai no 1 de propósito: quem já tem servidor costuma chegar ao produto
   # pelo README com o SSH aberto e ir direto ao install.sh. Quem chega por AQUI
   # — um vídeo, a comunidade, um link solto — é, na maioria, quem ainda não tem.
-  perguntar escolha "  Digite 1, 2 ou 3 (Enter = 1): " "1"
+  if ! perguntar escolha "  Digite 1, 2 ou 3 (Enter = 1): " "1"; then
+    c_ylw "  (a entrada terminou — deixo os dois caminhos aqui)"
+    mostrar_requisitos
+    comando_de_instalacao
+    exit 0
+  fi
 
   case "$escolha" in
     1)
@@ -200,7 +217,9 @@ SSH
         printf '\n'
         c_ylw "  Atenção: isso instala o CRM NESTA máquina — $(hostname 2>/dev/null || echo 'esta')."
         c_ylw "  Se você está no seu computador pessoal, e não no servidor, responda n."
-        perguntar ok "  Continuar? (s/N) " "N"
+        # EOF aqui cai no ramo de NÃO instalar: este é o único ponto do script
+        # que muda a máquina, e "não consegui perguntar" nunca vira um sim.
+        perguntar ok "  Continuar? (s/N) " "N" || ok="N"
         case "$ok" in
           [Ss]*)
             c_grn "  ✓ achei o instalador aqui do lado. Começando."

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -415,21 +415,54 @@ save_partial() {
   mv "$tmp" "$PARTIAL_FILE"
 }
 
-# Dado QUEM ocupa as portas 80/443, o que fazer? Puro, para ser exercitado sem
-# Docker. Ecoa `traefik` (publicar através dele), `caddy` (portas livres, subimos
-# o nosso) ou `ocupado` (alguém está lá e não sabemos falar com ele).
+# Quem publica 80 ou 443 NO HOST? Lê linhas "nome|projeto|imagem|portas" (o
+# formato do docker ps) e ecoa "nome|imagem" do primeiro que casar.
 #
-# A ordem importa: pergunta-se PRIMEIRO se é Traefik, e só depois se está
-# ocupado. Antes o código só sabia procurar Traefik — qualquer outro proxy,
-# inclusive o Caddy de outro DeskcommCRM na mesma VPS, caía no ramo "portas
-# livres" e a instalação seguia direto para o choque de portas.
-classifica_proxy() {  # classifica_proxy <imagem_do_dono> <nome_do_dono> <ocupante_no_host>
-  local img="${1:-}" nome="${2:-}" host="${3:-}"
-  case "$img $nome" in
-    *[Tt]raefik*) printf 'traefik'; return 0;;
+# O lado que importa da coluna Ports é o ANTES da seta — "0.0.0.0:80->80/tcp" é
+# host 80; "0.0.0.0:8080->80/tcp" é host 8080 e NÃO disputa nada. A primeira
+# versão disto olhava `docker port` ancorado na porta INTERNA, e errava dos dois
+# lados: abortava a instalação por causa de um phpMyAdmin em `-p 8080:80` (com
+# 80/443 livres, mandando o dono derrubar o site dele), e deixava passar um proxy
+# real em `-p 80:8080`, que é como se sobe Traefik sem privilégio.
+#
+# Separador é "|", não TAB: tab é IFS-whitespace, então dois tabs seguidos viram
+# um só e o campo vazio do meio SOME — um proxy subido com `docker run` (sem
+# label de compose) perdia a imagem, e o Traefik da hospedagem chamado
+# "coolify-proxy" era classificado como intruso.
+dono_das_portas() {  # dono_das_portas <projeto_a_ignorar>  < linhas
+  local ignorar="${1:-}" nome proj img ports
+  while IFS='|' read -r nome proj img ports; do
+    [ -n "$nome" ] || continue
+    # Contêiner DESTA instalação: numa re-execução o nosso próprio Caddy está de
+    # pé publicando as portas, e tratá-lo como intruso mataria a idempotência.
+    [ -n "$ignorar" ] && [ "$proj" = "$ignorar" ] && continue
+    case "${ports// /}" in
+      *:80-\>*|*:443-\>*) printf '%s|%s' "$nome" "$img"; return 0;;
+    esac
+  done
+  return 1
+}
+
+# A pergunta que decide é "o Docker consegue publicar a porta?", e a resposta
+# vem de TENTAR — não de inferir. Toda heurística sobre `docker port` ou `ss`
+# erra em algum caso real (proxy sem privilégio publicando 80:8080, app em
+# 8080:80, bind só no loopback, `ss` fora do PATH, userland-proxy desligado), e
+# erra dos dois lados: ou aborta uma instalação boa, ou entrega o choque de
+# portas lá na frente. Publicar de mentirinha usa exatamente a mecânica que o
+# Caddy vai usar, então não há espaço entre o teste e a realidade.
+# O contêiner sai na hora; a imagem é a mesma que o compose do kit já usa.
+porta_publicavel() {  # porta_publicavel <porta>
+  docker run --rm -p "$1:$1" --entrypoint /bin/true alpine:3.20 >/dev/null 2>&1
+}
+
+# É um Traefik? Compara em minúsculas o par imagem+nome. A versão anterior usava
+# `*[Tt]raefik*`, que só tem classe de equivalência no primeiro caractere:
+# um contêiner "TRAEFIK-PROXY" escapava e era tratado como intruso.
+eh_traefik() {  # eh_traefik <imagem> <nome>
+  case "$(printf '%s %s' "${1:-}" "${2:-}" | tr '[:upper:]' '[:lower:]')" in
+    *traefik*) return 0;;
   esac
-  if [ -n "$nome" ] || [ -n "$host" ]; then printf 'ocupado'; return 0; fi
-  printf 'caddy'
+  return 1
 }
 
 # Esconde o miolo de um segredo para a tela de conferência.
@@ -572,22 +605,23 @@ fi
 # idempotência — que é justamente o que permite rodar de novo para corrigir uma
 # resposta errada.
 proj_atual="${COMPOSE_PROJECT_NAME:-$(basename "$PROJECT_DIR" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')}"
-dono_portas=""; dono_imagem=""
-while IFS="$(printf '\t')" read -r _nome _proj _img; do
-  [ -n "$_nome" ] || continue
-  [ "$_proj" = "$proj_atual" ] && continue
-  if docker port "$_nome" 2>/dev/null | grep -qE '^(80|443)/tcp'; then
-    dono_portas="$_nome"; dono_imagem="$_img"; break
-  fi
-done <<DOCKERPS
-$(docker ps --format '{{.Names}}\t{{.Label "com.docker.compose.project"}}\t{{.Image}}' 2>/dev/null)
-DOCKERPS
 
-# Nem todo proxy é contêiner: nginx ou apache instalados direto no host seguram
-# as mesmas portas e o Docker recusa o bind igual.
-dono_host=""
-if [ -z "$dono_portas" ] && command -v ss >/dev/null 2>&1; then
-  dono_host="$(ss -tlnp 2>/dev/null | awk '$4 ~ /:(80|443)$/ {print; exit}')"
+portas_ocupadas=""; n_ocupadas=0
+porta_publicavel 80  || { portas_ocupadas="80"; n_ocupadas=1; }
+porta_publicavel 443 || { portas_ocupadas="${portas_ocupadas:+$portas_ocupadas e }443"; n_ocupadas=$((n_ocupadas + 1)); }
+
+# Identificação do ocupante — só para a MENSAGEM. Quem decide é o teste acima,
+# então não saber quem é NUNCA vira "pode instalar": a falha é fechada.
+# O "|| true" não é decorativo: numa atribuição o status do pipeline vira o
+# status do script, e sob `set -e` + `pipefail` um docker ps que falhe (ou um
+# SIGPIPE do consumidor) mataria o instalador mudo, no meio da fase 2.
+dono_portas=""; dono_imagem=""
+if [ -n "$portas_ocupadas" ]; then
+  _dono="$(docker ps --format '{{.Names}}|{{.Label "com.docker.compose.project"}}|{{.Image}}|{{.Ports}}' 2>/dev/null | dono_das_portas "$proj_atual" || true)"
+  dono_portas="${_dono%%|*}"
+  dono_imagem="${_dono#*|}"
+  [ "$dono_imagem" = "$dono_portas" ] && dono_imagem=""
+  unset _dono
 fi
 
 # Inicializado sempre: o bloco da rede do Traefik, mais abaixo, lê esta variável
@@ -596,36 +630,42 @@ fi
 traefik_container=""
 
 if [ -z "${REVERSE_PROXY:-}" ]; then
-  case "$(classifica_proxy "$dono_imagem" "$dono_portas" "$dono_host")" in
-    traefik)
-      REVERSE_PROXY=traefik
-      traefik_container="$dono_portas"
-      c_ylw "⚠ Detectei um Traefik já rodando neste VPS (contêiner '${dono_portas}', ocupando 80/443)."
-      c_ylw "  Vou publicar o CRM através dele em vez de subir um proxy próprio —"
-      c_ylw "  desligar o Traefik quebraria o que a sua hospedagem instalou."
-      ;;
-    ocupado)
-      # A preposição vem junto do trecho: "por o contêiner" sai errado se a
-      # frase fixar "por" e o pedaço variável começar com artigo.
-      ocupante="${dono_portas:+pelo contêiner '${dono_portas}' (imagem ${dono_imagem})}"
-      ocupante="${ocupante:-por um programa do próprio servidor}"
-      c_red "✖ As portas 80 e 443 já estão ocupadas ${ocupante}."
-      printf '\n%s\n'   "  O CRM precisa dessas duas portas para publicar o site com HTTPS. Subir um"
-      printf '%s\n\n'   "  segundo proxy nelas não funciona: o Docker recusa e a instalação para."
-      printf '%s\n'     "  Como resolver, na ordem do mais provável:"
-      printf '\n%s\n'   "  1. Já é outro DeskcommCRM neste servidor? Então use aquele — entre na"
-      printf '%s\n'     "     pasta dele e rode: bash hostgator-setup-kit/update.sh"
-      printf '\n%s\n'   "  2. Não usa mais o que está ocupando? Desligue e rode este instalador de novo:"
-      [ -n "$dono_portas" ] && printf '%s\n' "       docker stop ${dono_portas}"
-      printf '\n%s\n'   "  3. Quer manter os dois no ar? Aí o CRM tem de sair por um proxy só, e isso"
-      printf '%s\n'     "     é configuração manual — o kit automatiza esse caminho apenas para"
-      printf '%s\n\n'   "     Traefik (ponha REVERSE_PROXY=traefik no .env)."
-      die "Libere as portas 80 e 443 (ou use a instalação que já existe) e rode de novo."
-      ;;
-    *)
-      REVERSE_PROXY=caddy
-      ;;
-  esac
+  if [ -z "$portas_ocupadas" ]; then
+    REVERSE_PROXY=caddy
+  elif eh_traefik "$dono_imagem" "$dono_portas"; then
+    REVERSE_PROXY=traefik
+    traefik_container="$dono_portas"
+    c_ylw "⚠ Detectei um Traefik já rodando neste VPS (contêiner '${dono_portas}', ocupando 80/443)."
+    c_ylw "  Vou publicar o CRM através dele em vez de subir um proxy próprio —"
+    c_ylw "  desligar o Traefik quebraria o que a sua hospedagem instalou."
+  else
+    # A preposição vem junto do trecho: "por o contêiner" sai errado se a frase
+    # fixar "por" e o pedaço variável começar com artigo. E a imagem só entra se
+    # for conhecida — "(imagem )" vazio era o sintoma de um campo perdido.
+    ocupante="${dono_portas:+pelo contêiner '${dono_portas}'${dono_imagem:+ (imagem ${dono_imagem})}}"
+    ocupante="${ocupante:-por um programa do próprio servidor}"
+    # Concordância com o número de portas: "A porta 80 e 443 já está ocupada"
+    # saiu na prova real e denuncia texto montado sem olhar o próprio dado.
+    if [ "$n_ocupadas" -gt 1 ]; then
+      c_red "✖ As portas ${portas_ocupadas} já estão ocupadas ${ocupante}."
+    else
+      c_red "✖ A porta ${portas_ocupadas} já está ocupada ${ocupante}."
+    fi
+    printf '\n%s\n'   "  O CRM precisa dessas duas portas para publicar o site com HTTPS. Subir um"
+    printf '%s\n\n'   "  segundo proxy nelas não funciona: o Docker recusa e a instalação para."
+    printf '%s\n'     "  Como resolver, na ordem do mais provável:"
+    printf '\n%s\n'   "  1. Já é outro DeskcommCRM neste servidor? Então use aquele — entre na"
+    printf '%s\n'     "     pasta dele e rode: bash hostgator-setup-kit/update.sh"
+    printf '\n%s\n'   "  2. Não usa mais o que está ocupando? Desligue e rode este instalador de novo:"
+    [ -n "$dono_portas" ] && printf '%s\n' "       docker stop ${dono_portas}"
+    printf '\n%s\n'   "  3. Quer manter os dois no ar? Aí o CRM tem de sair por um proxy só, e isso"
+    printf '%s\n'     "     é configuração manual — o kit automatiza esse caminho apenas para"
+    printf '%s\n\n'   "     Traefik (ponha REVERSE_PROXY=traefik no .env)."
+    if [ "$n_ocupadas" -gt 1 ]; then
+      die "Libere as portas ${portas_ocupadas} (ou use a instalação que já existe) e rode de novo."
+    fi
+    die "Libere a porta ${portas_ocupadas} (ou use a instalação que já existe) e rode de novo."
+  fi
 fi
 
 # ── Supabase automático (opcional) ──────────────────────────────────────────
@@ -767,7 +807,12 @@ c_grn "✓ segredos prontos"
 # nas duas redes. Medido com Traefik v3.3 real: só com o label apontando pra rede do
 # PROXY a requisição sai de HTTP 000 (timeout) para HTTP 200.
 if [ "$REVERSE_PROXY" = "traefik" ] && [ -z "${TRAEFIK_NETWORK:-}" ] && [ -n "$traefik_container" ]; then
-  TRAEFIK_NETWORK="$(docker inspect -f '{{range $k,$v := .NetworkSettings.Networks}}{{$k}} {{end}}' "$traefik_container" 2>/dev/null | awk '{print $1}')"
+  # "|| true": sem ele o `die` explicativo logo abaixo — que é o tratamento
+  # CERTO deste caso — é inalcançável. Numa atribuição o status do pipeline vira
+  # o status do script; se o painel da hospedagem recriou o proxy entre a
+  # detecção e aqui, o docker inspect sai 1, o 2>/dev/null engole a mensagem e o
+  # instalador cai no painel genérico de erro sem dizer o que houve.
+  TRAEFIK_NETWORK="$(docker inspect -f '{{range $k,$v := .NetworkSettings.Networks}}{{$k}} {{end}}' "$traefik_container" 2>/dev/null | awk '{print $1}' || true)"
 fi
 if [ "$REVERSE_PROXY" = "traefik" ] && [ -z "${TRAEFIK_NETWORK:-}" ]; then
   die "Não consegui descobrir a rede Docker do seu Traefik. Rode 'docker network ls',

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -429,18 +429,28 @@ save_partial() {
 # um só e o campo vazio do meio SOME — um proxy subido com `docker run` (sem
 # label de compose) perdia a imagem, e o Traefik da hospedagem chamado
 # "coolify-proxy" era classificado como intruso.
-dono_das_portas() {  # dono_das_portas <projeto_a_ignorar>  < linhas
-  local ignorar="${1:-}" nome proj img ports
+dono_das_portas() {  # dono_das_portas  < linhas   → ecoa "nome|projeto|imagem"
+  local nome proj img ports
   while IFS='|' read -r nome proj img ports; do
     [ -n "$nome" ] || continue
-    # Contêiner DESTA instalação: numa re-execução o nosso próprio Caddy está de
-    # pé publicando as portas, e tratá-lo como intruso mataria a idempotência.
-    [ -n "$ignorar" ] && [ "$proj" = "$ignorar" ] && continue
     case "${ports// /}" in
-      *:80-\>*|*:443-\>*) printf '%s|%s' "$nome" "$img"; return 0;;
+      *:80-\>*|*:443-\>*) printf '%s|%s|%s' "$nome" "$proj" "$img"; return 0;;
     esac
   done
   return 1
+}
+
+# O nome que o docker compose dá ao projeto quando ninguém passa -p: basename do
+# diretório, minúsculo, só [a-z0-9_-] — E com os `_`/`-` do INÍCIO aparados
+# (NormalizeProjectName faz TrimLeft). Sem essa aparada, uma pasta como
+# `/root/_deskcomm` faz o kit calcular `_deskcomm` enquanto os contêineres
+# carregam `deskcomm`: a instalação deixa de se reconhecer e passa a se tratar
+# como intrusa. Medido contra o docker compose v2.38.2 em `_deskcomm`,
+# `-deskcomm`, `_-_crm` e `_123` — todos divergiam.
+nome_do_projeto_compose() {  # nome_do_projeto_compose <diretório>
+  local n
+  n="$(basename "$1" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')"
+  printf '%s' "${n#"${n%%[!_-]*}"}"
 }
 
 # A pergunta que decide é "o Docker consegue publicar a porta?", e a resposta
@@ -453,6 +463,21 @@ dono_das_portas() {  # dono_das_portas <projeto_a_ignorar>  < linhas
 # O contêiner sai na hora; a imagem é a mesma que o compose do kit já usa.
 porta_publicavel() {  # porta_publicavel <porta>
   docker run --rm -p "$1:$1" --entrypoint /bin/true alpine:3.20 >/dev/null 2>&1
+}
+
+# A decisão final, isolada para poder ser exercitada sem Docker: este é o ponto
+# que já errou duas vezes (uma tratando o próprio Caddy como intruso, outra
+# deixando passar proxy que não fosse Traefik), e nas duas o erro só apareceu
+# rodando de verdade numa VPS.
+# Ecoa: caddy | traefik | bloqueia
+decide_proxy() {  # decide_proxy <portas_ocupadas> <projeto_do_dono> <projeto_atual> <imagem> <nome>
+  local ocupadas="${1:-}" dono_proj="${2:-}" meu_proj="${3:-}" img="${4:-}" nome="${5:-}"
+  [ -z "$ocupadas" ] && { printf 'caddy'; return 0; }
+  # As portas estão com ESTA MESMA instalação, já no ar: é a re-execução, que o
+  # próprio kit ensina como caminho para corrigir uma resposta.
+  [ -n "$dono_proj" ] && [ "$dono_proj" = "$meu_proj" ] && { printf 'caddy'; return 0; }
+  eh_traefik "$img" "$nome" && { printf 'traefik'; return 0; }
+  printf 'bloqueia'
 }
 
 # É um Traefik? Compara em minúsculas o par imagem+nome. A versão anterior usava
@@ -604,7 +629,7 @@ fi
 # Caddy está de pé publicando 80/443, e tratá-lo como "outro proxy" mataria a
 # idempotência — que é justamente o que permite rodar de novo para corrigir uma
 # resposta errada.
-proj_atual="${COMPOSE_PROJECT_NAME:-$(basename "$PROJECT_DIR" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')}"
+proj_atual="${COMPOSE_PROJECT_NAME:-$(nome_do_projeto_compose "$PROJECT_DIR")}"
 
 portas_ocupadas=""; n_ocupadas=0
 porta_publicavel 80  || { portas_ocupadas="80"; n_ocupadas=1; }
@@ -615,12 +640,14 @@ porta_publicavel 443 || { portas_ocupadas="${portas_ocupadas:+$portas_ocupadas e
 # O "|| true" não é decorativo: numa atribuição o status do pipeline vira o
 # status do script, e sob `set -e` + `pipefail` um docker ps que falhe (ou um
 # SIGPIPE do consumidor) mataria o instalador mudo, no meio da fase 2.
-dono_portas=""; dono_imagem=""
+dono_portas=""; dono_projeto=""; dono_imagem=""
 if [ -n "$portas_ocupadas" ]; then
-  _dono="$(docker ps --format '{{.Names}}|{{.Label "com.docker.compose.project"}}|{{.Image}}|{{.Ports}}' 2>/dev/null | dono_das_portas "$proj_atual" || true)"
-  dono_portas="${_dono%%|*}"
-  dono_imagem="${_dono#*|}"
-  [ "$dono_imagem" = "$dono_portas" ] && dono_imagem=""
+  _dono="$(docker ps --format '{{.Names}}|{{.Label "com.docker.compose.project"}}|{{.Image}}|{{.Ports}}' 2>/dev/null | dono_das_portas || true)"
+  if [ -n "$_dono" ]; then
+    dono_portas="${_dono%%|*}"; _resto="${_dono#*|}"
+    dono_projeto="${_resto%%|*}"; dono_imagem="${_resto#*|}"
+    unset _resto
+  fi
   unset _dono
 fi
 
@@ -630,15 +657,22 @@ fi
 traefik_container=""
 
 if [ -z "${REVERSE_PROXY:-}" ]; then
-  if [ -z "$portas_ocupadas" ]; then
+  # A exclusão da própria instalação acontece AQUI, não na varredura: o teste de
+  # bind não tem como se auto-excluir, então filtrar o nosso contêiner antes só
+  # produzia um "ocupado por ninguém" — bloqueio sem um comando sequer.
+  case "$(decide_proxy "$portas_ocupadas" "$dono_projeto" "$proj_atual" "$dono_imagem" "$dono_portas")" in
+  caddy)
     REVERSE_PROXY=caddy
-  elif eh_traefik "$dono_imagem" "$dono_portas"; then
+    [ -n "$portas_ocupadas" ] && c_dim "  (as portas 80/443 já estão com esta instalação — seguindo)"
+    ;;
+  traefik)
     REVERSE_PROXY=traefik
     traefik_container="$dono_portas"
     c_ylw "⚠ Detectei um Traefik já rodando neste VPS (contêiner '${dono_portas}', ocupando 80/443)."
     c_ylw "  Vou publicar o CRM através dele em vez de subir um proxy próprio —"
     c_ylw "  desligar o Traefik quebraria o que a sua hospedagem instalou."
-  else
+    ;;
+  *)
     # A preposição vem junto do trecho: "por o contêiner" sai errado se a frase
     # fixar "por" e o pedaço variável começar com artigo. E a imagem só entra se
     # for conhecida — "(imagem )" vazio era o sintoma de um campo perdido.
@@ -665,7 +699,8 @@ if [ -z "${REVERSE_PROXY:-}" ]; then
       die "Libere as portas ${portas_ocupadas} (ou use a instalação que já existe) e rode de novo."
     fi
     die "Libere a porta ${portas_ocupadas} (ou use a instalação que já existe) e rode de novo."
-  fi
+    ;;
+  esac
 fi
 
 # ── Supabase automático (opcional) ──────────────────────────────────────────

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -16,6 +16,9 @@ set -euo pipefail
 KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 
 REPO_URL="${REPO_URL:-https://github.com/melgarafael/DeskcommCRM.git}"
+# Uma constante, dois usos (o fim feliz e o fim travado) — e o comecar.sh tem a
+# gêmea. Link repetido à mão vira link divergente na primeira troca.
+COMUNIDADE_URL="https://lp-comunidade.automatiklabs.com.br"
 REPO_DIR="${REPO_DIR:-deskcommcrm}"
 COMPOSE="docker-compose.prod.yml"
 COMPOSE_TRAEFIK="docker-compose.traefik.yml"
@@ -945,14 +948,19 @@ c_grn "✓ containers no ar"
 
 # ── 10. Healthcheck ─────────────────────────────────────────────────────────
 step "Aguardando o app ficar saudável"
-ok=0
-for i in $(seq 1 30); do
-  if dc exec -T app node -e "require('net').connect(3000,'127.0.0.1').on('connect',()=>process.exit(0)).on('error',()=>process.exit(1))" 2>/dev/null; then
-    ok=1; break
-  fi
-  sleep 3
-done
-[ "$ok" = 1 ] && c_grn "✓ app respondendo" || c_ylw "⚠ app ainda não respondeu. Veja: docker compose $(dc_files) logs app"
+# Antes isto abria um socket na porta 3000 e dava por bom. A porta abre assim
+# que o Node sobe, então o "✓" saía com o app ainda sem banco — e o bloco
+# "Instalação concluída!" saía logo atrás, incondicionalmente. Um falso verde
+# no exato momento em que a pessoa decide se confia no produto. Agora o critério
+# é o mesmo do update.sh: a rota /api/v1/health responder "status":"ok".
+if health_body="$(wait_app_healthy 30 3)"; then
+  APP_SAUDAVEL=1
+  c_grn "✓ app no ar e saudável"
+else
+  APP_SAUDAVEL=0
+  c_ylw "⚠ os contêineres subiram, mas o app não respondeu que está saudável."
+  [ -n "$health_body" ] && c_dim "  última resposta: $(printf '%s' "$health_body" | head -c 200)"
+fi
 
 # ── 11. Automações (cron do drain de eventos) ───────────────────────────────
 step "Ativando as automações"
@@ -961,6 +969,46 @@ setup_event_log_drain_cron
 setup_update_agent_cron
 
 # ── Final ───────────────────────────────────────────────────────────────────
+# O app não confirmou que está de pé: dizer "Instalação concluída!" aqui seria
+# mentir na única tela que a pessoa vai ler inteira. Ela recebe o estado real e
+# o caminho de diagnóstico — e não a receita de apagar tudo do show_recovery,
+# que existe para quem parou no MEIO. Aqui nada ficou pela metade: a config
+# está salva e a stack está de pé; falta o app responder.
+if [ "${APP_SAUDAVEL:-0}" != 1 ]; then
+  cat <<INCOMPLETO
+
+$(c_ylw "═══════════════════════════════════════════════════════")
+$(c_ylw " Quase lá — falta o app responder")
+$(c_ylw "═══════════════════════════════════════════════════════")
+
+  A configuração está salva e os contêineres estão no ar. Você NÃO precisa
+  refazer nada — falta o app dizer que está saudável.
+
+  O motivo mais comum é uma chave faltando ou errada no .env. O log diz qual:
+
+       docker compose $(dc_files) logs --tail=50 app
+
+     procure por: [env] Falha de validação
+
+  Diagnóstico completo dos serviços:
+
+       bash ${KIT_DIR}/healthcheck.sh
+
+  Depois de corrigir o .env, é só subir de novo (nada é perdido):
+
+       docker compose $(dc_files) up -d
+
+  Travou? Leve o log para a comunidade — tem gente que já passou por isso:
+
+       ${COMUNIDADE_URL}
+
+INCOMPLETO
+  # Sai != 0 para que automação (e o --yes) saiba que não terminou saudável,
+  # mas sem o trap: a receita de "apague tudo e recomece" não cabe aqui.
+  trap - EXIT
+  exit 1
+fi
+
 cat <<DONE
 
 $(c_grn "═══════════════════════════════════════════════════════")
@@ -988,7 +1036,7 @@ $(c_grn "  ─── A comunidade ───────────────�
   É onde saem os avisos de versão nova, os agentes que outras pessoas já
   configuraram e a resposta de quem roda exatamente este CRM:
 
-       https://lp-comunidade.automatiklabs.com.br
+       ${COMUNIDADE_URL}
 
   Telemetria: por padrão os erros desta instalação são enviados ao Sentry do
   projeto, o que ajuda a corrigir falhas que afetam todo mundo. Para desligar,

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -40,12 +40,79 @@ dc_files() {
   fi
 }
 
-c_red() { printf '\033[31m%s\033[0m\n' "$*"; }
-c_grn() { printf '\033[32m%s\033[0m\n' "$*"; }
-c_ylw() { printf '\033[33m%s\033[0m\n' "$*"; }
-c_dim() { printf '\033[2m%s\033[0m\n' "$*"; }
+# ── Aparência ───────────────────────────────────────────────────────────────
+# Cor só quando há terminal de verdade. Antes o ANSI saía sempre, inclusive
+# quando a saída vai para arquivo — o agent.sh redireciona o update.sh (`>
+# "$LOG"`) e o esc() de lá precisa varrer byte a byte para tirar esses escapes
+# do heartbeat. Desligar na origem é a correção de causa. NO_COLOR é a
+# convenção que quem roda em CI espera; FORCE_COLOR é a válvula de quem quer
+# cor mesmo em pipe.
+if   [ -n "${NO_COLOR:-}" ];    then COLOR=0
+elif [ -n "${FORCE_COLOR:-}" ]; then COLOR=1
+elif [ -t 1 ];                  then COLOR=1
+else                                 COLOR=0
+fi
+
+# paint <código ANSI> <texto…>. Sem cor, imprime o texto cru — nunca some.
+paint() { local code="$1"; shift; if [ "$COLOR" = 1 ]; then printf '\033[%sm%s\033[0m\n' "$code" "$*"; else printf '%s\n' "$*"; fi; }
+c_red() { paint 31 "$*"; }
+c_grn() { paint 32 "$*"; }
+c_ylw() { paint 33 "$*"; }
+c_dim() { paint 2  "$*"; }
 die()   { c_red "✖ $*"; exit 1; }
-step()  { printf '\n\033[1m▶ %s\033[0m\n' "$*"; }
+step()  { printf '\n'; paint 1 "▶ $*"; }
+
+# ── Fases da jornada ────────────────────────────────────────────────────────
+# Os passos técnicos (step) são muitos e alguns são condicionais — numerá-los
+# daria um "7 de 11" que muda conforme o caminho de cada instalação. As FASES
+# são estáveis: são o mapa que a pessoa acompanha para saber onde está e
+# quanto falta, num processo que leva minutos e é o primeiro contato dela com
+# o produto.
+FASE_TOTAL=4
+fase() { printf '\n'; paint 1 "━━━ Fase $1/$FASE_TOTAL · $2"; }
+
+# ── Marca ───────────────────────────────────────────────────────────────────
+# Logo em blocos (fonte ANSI Shadow). Os blocos saem no MESMO verde do "✓" já
+# usado aqui, e o relevo (═╗║╝╚╔) em dim: essa dupla lê tanto em terminal de
+# fundo escuro quanto claro, sem precisar detectar o tema — uma cor de acento
+# clara sumiria no branco de quem usa terminal claro.
+#
+# A pintura é por substituição literal de string (${x//…}), não por classe de
+# caractere em sed/awk: sob LC_ALL=C essas ferramentas tratam a entrada como
+# BYTES, e todos esses glifos começam com 0xE2 — uma classe [╗║…] casaria
+# pedaço de █ e embaralharia o desenho na VPS de quem roda em locale C.
+LOGO_COLS=71
+banner() {
+  local cols linha ch
+  cols="$(tput cols 2>/dev/null || echo 80)"
+  case "$cols" in ''|*[!0-9]*) cols=80;; esac
+  printf '\n'
+  # Terminal estreito recebe a versão de uma linha: logo quebrado no meio é
+  # pior do que logo nenhum.
+  if [ "$COLOR" != 1 ] || [ "$cols" -lt $((LOGO_COLS + 2)) ]; then
+    paint 1 "  DESKCOMM"
+  else
+    # Tela limpa: tira o ruído do clone/apt de cima do logo. Exige TTY de
+    # verdade (não basta COLOR=1): com FORCE_COLOR numa saída redirecionada, um
+    # "limpe a tela" no meio do arquivo é lixo que ninguém pediu.
+    [ -t 1 ] && printf '\033[2J\033[H'
+    while IFS= read -r linha; do
+      linha="${linha//█/$'\033[32m'█$'\033[0m'}"
+      for ch in ═ ╗ ║ ╝ ╚ ╔; do linha="${linha//$ch/$'\033[2m'$ch$'\033[0m'}"; done
+      printf '  %s\n' "$linha"
+    done <<'LOGO'
+██████╗ ███████╗███████╗██╗  ██╗ ██████╗ ██████╗ ███╗   ███╗███╗   ███╗
+██╔══██╗██╔════╝██╔════╝██║ ██╔╝██╔════╝██╔═══██╗████╗ ████║████╗ ████║
+██║  ██║█████╗  ███████╗█████╔╝ ██║     ██║   ██║██╔████╔██║██╔████╔██║
+██║  ██║██╔══╝  ╚════██║██╔═██╗ ██║     ██║   ██║██║╚██╔╝██║██║╚██╔╝██║
+██████╔╝███████╗███████║██║  ██╗╚██████╗╚██████╔╝██║ ╚═╝ ██║██║ ╚═╝ ██║
+╚═════╝ ╚══════╝╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚═════╝ ╚═╝     ╚═╝╚═╝     ╚═╝
+LOGO
+  fi
+  printf '\n'
+  c_dim "  Agentes de IA que atendem no WhatsApp, dentro do seu CRM."
+  c_dim "  Open-source · roda no seu servidor · os dados são seus."
+}
 
 # ── Rede de segurança: nenhuma saída silenciosa ─────────────────────────────
 # Antes, qualquer comando que falhasse sob `set -e` derrubava o script sem
@@ -331,7 +398,10 @@ sb_carrega_credenciais() {
 # `test-validators.sh` exercita os validadores:  INSTALL_SH_LIB=1 . install.sh
 if [ "${INSTALL_SH_LIB:-}" = "1" ]; then trap - EXIT; return 0; fi
 
+banner
+
 # ── 1. Preflight ────────────────────────────────────────────────────────────
+fase 1 "Preparando o servidor"
 step "Verificando dependências"
 
 # VPS "cru" (Hetzner, DigitalOcean, Contabo…) não vem com Docker. Antes isto era
@@ -404,6 +474,7 @@ PROJECT_DIR="$(pwd)"
 source "$KIT_DIR/_common.sh"
 
 # ── 3. Coleta de config ─────────────────────────────────────────────────────
+fase 2 "Suas informações"
 step "Configuração"
 # Se já existe .env, carrega pra não repetir perguntas (idempotência).
 if [ -f .env ]; then load_env .env; c_grn "✓ .env existente carregado"; fi
@@ -699,6 +770,7 @@ chmod 600 .env
 c_grn "✓ .env escrito (permissão 600)"
 
 # ── 6. Checagem de DNS ──────────────────────────────────────────────────────
+fase 3 "Banco de dados e domínio"
 step "Conferindo DNS de ${DOMAIN}"
 public_ip="$(curl -fsS --max-time 8 https://api.ipify.org 2>/dev/null || echo '')"
 # Um domínio pode ter A (IPv4) e AAAA (IPv6) ao mesmo tempo, e o resolver não
@@ -818,6 +890,7 @@ end \$\$;
 SQL
 
 # ── 9. Sobe a stack ─────────────────────────────────────────────────────────
+fase 4 "Colocando o CRM no ar"
 step "Puxando a imagem e subindo os serviços"
 dc pull
 dc up -d
@@ -862,6 +935,13 @@ $(c_grn "═══════════════════════�
   4. Ao terminar o onboarding, o CRM pede a verificação em duas etapas:
        tenha o Google Authenticator/Authy à mão e GUARDE os códigos de
        recuperação que aparecem. Perdeu o celular? bash hostgator-setup-kit/reset-mfa.sh ${OWNER_EMAIL}
+
+$(c_grn "  ─── A comunidade ──────────────────────────────────────")
+
+  É onde saem os avisos de versão nova, os agentes que outras pessoas já
+  configuraram e a resposta de quem roda exatamente este CRM:
+
+       https://lp-comunidade.automatiklabs.com.br
 
   Telemetria: por padrão os erros desta instalação são enviados ao Sentry do
   projeto, o que ajuda a corrigir falhas que afetam todo mundo. Para desligar,

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -992,7 +992,9 @@ if health_body="$(wait_app_healthy 30 3)"; then
 else
   APP_SAUDAVEL=0
   c_ylw "⚠ os contêineres subiram, mas o app não respondeu que está saudável."
-  [ -n "$health_body" ] && c_dim "  última resposta: $(printf '%s' "$health_body" | head -c 200)"
+  # "|| true": mesma família do pipe que matava o supabase-provision.sh — o
+  # corpo passa de 200 bytes, o head fecha o pipe e o printf leva SIGPIPE.
+  [ -n "$health_body" ] && c_dim "  última resposta: $(printf '%s' "$health_body" | head -c 200 || true)"
 fi
 
 # ── 11. Automações (cron do drain de eventos) ───────────────────────────────

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -415,6 +415,23 @@ save_partial() {
   mv "$tmp" "$PARTIAL_FILE"
 }
 
+# Dado QUEM ocupa as portas 80/443, o que fazer? Puro, para ser exercitado sem
+# Docker. Ecoa `traefik` (publicar através dele), `caddy` (portas livres, subimos
+# o nosso) ou `ocupado` (alguém está lá e não sabemos falar com ele).
+#
+# A ordem importa: pergunta-se PRIMEIRO se é Traefik, e só depois se está
+# ocupado. Antes o código só sabia procurar Traefik — qualquer outro proxy,
+# inclusive o Caddy de outro DeskcommCRM na mesma VPS, caía no ramo "portas
+# livres" e a instalação seguia direto para o choque de portas.
+classifica_proxy() {  # classifica_proxy <imagem_do_dono> <nome_do_dono> <ocupante_no_host>
+  local img="${1:-}" nome="${2:-}" host="${3:-}"
+  case "$img $nome" in
+    *[Tt]raefik*) printf 'traefik'; return 0;;
+  esac
+  if [ -n "$nome" ] || [ -n "$host" ]; then printf 'ocupado'; return 0; fi
+  printf 'caddy'
+}
+
 # Esconde o miolo de um segredo para a tela de conferência.
 mask() {
   local v="$1"
@@ -535,6 +552,80 @@ if [ -f "$PARTIAL_FILE" ]; then
   load_env "$PARTIAL_FILE"
   c_grn "✓ retomando: $(grep -c '=' "$PARTIAL_FILE" 2>/dev/null || echo 0) resposta(s) guardadas da tentativa anterior"
   c_dim "  (para responder tudo de novo do zero: rm $PARTIAL_FILE)"
+fi
+
+# ── Proxy reverso: quem está com as portas 80 e 443? ────────────────────────
+# Fica AQUI, logo depois de ler o .env e ANTES de qualquer coisa cara: era a
+# última etapa da fase 2, então quem esbarrava neste problema já tinha criado um
+# projeto Supabase, respondido tudo e esperado o clone — para só então o
+# `docker compose up` morrer com "Bind for 0.0.0.0:80 failed: port is already
+# allocated". Descobrir isso antes de cobrar qualquer trabalho é o mínimo.
+#
+# A varredura NÃO procura por "traefik": procura por QUEM PUBLICA as portas, e
+# só depois pergunta o que é. A versão anterior só reconhecia Traefik, então um
+# Caddy — inclusive o de outro DeskcommCRM instalado na mesma VPS — passava
+# despercebido e a instalação escolhia `caddy`, garantindo o choque de portas.
+# Medido numa VPS com produção rodando: exatamente esse erro, na fase 4.
+#
+# Contêineres DESTA instalação são ignorados: numa re-execução o nosso próprio
+# Caddy está de pé publicando 80/443, e tratá-lo como "outro proxy" mataria a
+# idempotência — que é justamente o que permite rodar de novo para corrigir uma
+# resposta errada.
+proj_atual="${COMPOSE_PROJECT_NAME:-$(basename "$PROJECT_DIR" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')}"
+dono_portas=""; dono_imagem=""
+while IFS="$(printf '\t')" read -r _nome _proj _img; do
+  [ -n "$_nome" ] || continue
+  [ "$_proj" = "$proj_atual" ] && continue
+  if docker port "$_nome" 2>/dev/null | grep -qE '^(80|443)/tcp'; then
+    dono_portas="$_nome"; dono_imagem="$_img"; break
+  fi
+done <<DOCKERPS
+$(docker ps --format '{{.Names}}\t{{.Label "com.docker.compose.project"}}\t{{.Image}}' 2>/dev/null)
+DOCKERPS
+
+# Nem todo proxy é contêiner: nginx ou apache instalados direto no host seguram
+# as mesmas portas e o Docker recusa o bind igual.
+dono_host=""
+if [ -z "$dono_portas" ] && command -v ss >/dev/null 2>&1; then
+  dono_host="$(ss -tlnp 2>/dev/null | awk '$4 ~ /:(80|443)$/ {print; exit}')"
+fi
+
+# Inicializado sempre: o bloco da rede do Traefik, mais abaixo, lê esta variável
+# sem default, e sob `set -u` uma instalação que já traz REVERSE_PROXY=traefik no
+# .env (portanto sem passar pela detecção) morreria com "unbound variable".
+traefik_container=""
+
+if [ -z "${REVERSE_PROXY:-}" ]; then
+  case "$(classifica_proxy "$dono_imagem" "$dono_portas" "$dono_host")" in
+    traefik)
+      REVERSE_PROXY=traefik
+      traefik_container="$dono_portas"
+      c_ylw "⚠ Detectei um Traefik já rodando neste VPS (contêiner '${dono_portas}', ocupando 80/443)."
+      c_ylw "  Vou publicar o CRM através dele em vez de subir um proxy próprio —"
+      c_ylw "  desligar o Traefik quebraria o que a sua hospedagem instalou."
+      ;;
+    ocupado)
+      # A preposição vem junto do trecho: "por o contêiner" sai errado se a
+      # frase fixar "por" e o pedaço variável começar com artigo.
+      ocupante="${dono_portas:+pelo contêiner '${dono_portas}' (imagem ${dono_imagem})}"
+      ocupante="${ocupante:-por um programa do próprio servidor}"
+      c_red "✖ As portas 80 e 443 já estão ocupadas ${ocupante}."
+      printf '\n%s\n'   "  O CRM precisa dessas duas portas para publicar o site com HTTPS. Subir um"
+      printf '%s\n\n'   "  segundo proxy nelas não funciona: o Docker recusa e a instalação para."
+      printf '%s\n'     "  Como resolver, na ordem do mais provável:"
+      printf '\n%s\n'   "  1. Já é outro DeskcommCRM neste servidor? Então use aquele — entre na"
+      printf '%s\n'     "     pasta dele e rode: bash hostgator-setup-kit/update.sh"
+      printf '\n%s\n'   "  2. Não usa mais o que está ocupando? Desligue e rode este instalador de novo:"
+      [ -n "$dono_portas" ] && printf '%s\n' "       docker stop ${dono_portas}"
+      printf '\n%s\n'   "  3. Quer manter os dois no ar? Aí o CRM tem de sair por um proxy só, e isso"
+      printf '%s\n'     "     é configuração manual — o kit automatiza esse caminho apenas para"
+      printf '%s\n\n'   "     Traefik (ponha REVERSE_PROXY=traefik no .env)."
+      die "Libere as portas 80 e 443 (ou use a instalação que já existe) e rode de novo."
+      ;;
+    *)
+      REVERSE_PROXY=caddy
+      ;;
+  esac
 fi
 
 # ── Supabase automático (opcional) ──────────────────────────────────────────
@@ -669,37 +760,6 @@ UPSTASH_REDIS_REST_TOKEN="$SRH_TOKEN"
 c_grn "✓ segredos prontos"
 
 # ── 5. Escreve .env (600) ───────────────────────────────────────────────────
-# ── Proxy reverso: o VPS já tem um? ─────────────────────────────────────────
-# Várias hospedagens entregam a VPS com um Traefik próprio já ocupando 80/443
-# (Hostinger, Coolify, Dokploy...). Nesse caso o Caddy do kit não consegue subir
-# — falha no bind da porta e a instalação morre no meio, com um erro que não diz
-# nada a quem não é técnico. Detectar isso sozinho é o que separa "instalou" de
-# "desistiu". Quem já tem REVERSE_PROXY no .env manda: a detecção não sobrescreve.
-# O candidato precisa PUBLICAR 80/443. Só casar "traefik" no nome/imagem aceita
-# qualquer contêiner chamado `traefik-backup` e desligaria o TLS que o kit
-# controla por causa de um homônimo parado.
-traefik_container=""
-for _c in $(docker ps --format '{{.Names}}' 2>/dev/null); do
-  case "$(docker inspect -f '{{.Config.Image}} {{.Name}}' "$_c" 2>/dev/null)" in
-    *[Tt]raefik*)
-      if docker port "$_c" 2>/dev/null | grep -qE '^(80|443)/tcp'; then
-        traefik_container="$_c"; break
-      fi
-      ;;
-  esac
-done
-
-if [ -z "${REVERSE_PROXY:-}" ]; then
-  if [ -n "$traefik_container" ]; then
-    REVERSE_PROXY=traefik
-    c_ylw "⚠ Detectei um Traefik já rodando neste VPS (contêiner '${traefik_container}', ocupando 80/443)."
-    c_ylw "  Vou publicar o CRM através dele em vez de subir um proxy próprio —"
-    c_ylw "  desligar o Traefik quebraria o que a sua hospedagem instalou."
-  else
-    REVERSE_PROXY=caddy
-  fi
-fi
-
 # A rede em que o Traefik REALMENTE está. Antes isto era calculado como
 # "<pasta>_internal", ou seja, a rede do PRÓPRIO projeto — e aí nada funcionava:
 # o Traefik não alcança uma bridge que não é dele, e o label `traefik.docker.network`

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -376,6 +376,7 @@ ask_one() {
     fi
     if [ "$secret" = "secret" ]; then c_grn "  ✓ recebido (${#input} caracteres)"; else c_grn "  ✓"; fi
     printf -v "$var" '%s' "$input"
+    save_partial "$var"
     return 0
   done
 }
@@ -391,6 +392,28 @@ ask_one() {
 # qualquer convenção e ainda pega de sobra as de 2 e 3 GB, que sofrem de verdade.
 RAM_MINIMA_KB=3500000
 ram_abaixo_do_recomendado() { [ "${1:-0}" -lt "$RAM_MINIMA_KB" ]; }
+
+# Uma linha de .env com o valor entre aspas simples e as aspas do conteúdo
+# escapadas — o que faz senha com espaço, `#` ou `$` sobreviver à releitura.
+# Fica aqui em cima (e não junto do bloco que escreve o .env) porque o
+# save_partial abaixo grava durante a ENTREVISTA, muito antes daquele bloco.
+envq() { printf "%s='%s'\n" "$1" "$(printf '%s' "${2-}" | sed "s/'/'\\\\''/g")"; }
+
+# Guarda cada resposta no instante em que ela é aceita. Antes, as 12 respostas
+# só viravam arquivo no FIM: quem travasse na connection string — a pergunta
+# mais difícil, e a última das credenciais — perdia tudo o que já tinha digitado
+# e recomeçava do zero na tentativa seguinte. Justamente quem mais precisa de
+# uma segunda tentativa é quem tem menos paciência para redigitar 11 campos.
+# Mesma permissão do .env (600): o conteúdo é o mesmo, inclusive os segredos.
+PARTIAL_FILE="${PARTIAL_FILE:-.env.partial}"
+save_partial() {
+  local var="$1" val="${!1-}" tmp="${PARTIAL_FILE}.tmp.$$"
+  umask 077
+  { [ -f "$PARTIAL_FILE" ] && grep -vE "^${var}=" "$PARTIAL_FILE" || true; } > "$tmp"
+  envq "$var" "$val" >> "$tmp"
+  chmod 600 "$tmp"
+  mv "$tmp" "$PARTIAL_FILE"
+}
 
 # Esconde o miolo de um segredo para a tela de conferência.
 mask() {
@@ -506,6 +529,13 @@ fase 2 "Suas informações"
 step "Configuração"
 # Se já existe .env, carrega pra não repetir perguntas (idempotência).
 if [ -f .env ]; then load_env .env; c_grn "✓ .env existente carregado"; fi
+# Respostas guardadas de uma tentativa que não chegou ao fim. Carregam DEPOIS do
+# .env de propósito: se as duas fontes têm a chave, a mais recente é esta.
+if [ -f "$PARTIAL_FILE" ]; then
+  load_env "$PARTIAL_FILE"
+  c_grn "✓ retomando: $(grep -c '=' "$PARTIAL_FILE" 2>/dev/null || echo 0) resposta(s) guardadas da tentativa anterior"
+  c_dim "  (para responder tudo de novo do zero: rm $PARTIAL_FILE)"
+fi
 
 # ── Supabase automático (opcional) ──────────────────────────────────────────
 # Criar o projeto no navegador e copiar 4 campos era o passo mais LENTO da
@@ -722,7 +752,6 @@ umask 077
 # arquivo com `source` — os scripts do kit e a receita do próprio README
 # (`source .env && curl ...`). O Docker Compose remove as aspas ao carregar,
 # então o contêiner recebe exatamente o valor digitado.
-envq() { printf "%s='%s'\n" "$1" "$(printf '%s' "${2-}" | sed "s/'/'\\\\''/g")"; }
 
 {
   printf '# Gerado por install.sh — NÃO comitar. Contém segredos.\n'
@@ -795,6 +824,10 @@ envq() { printf "%s='%s'\n" "$1" "$(printf '%s' "${2-}" | sed "s/'/'\\\\''/g")";
   envq OWNER_PASSWORD "$OWNER_PASSWORD"
 } > .env
 chmod 600 .env
+# O .env definitivo existe: o rascunho cumpriu o papel e some — deixá-lo no
+# disco seria uma segunda cópia dos segredos, e desatualizada na primeira
+# correção que alguém fizer no .env.
+rm -f "$PARTIAL_FILE"
 c_grn "✓ .env escrito (permissão 600)"
 
 # ── 6. Checagem de DNS ──────────────────────────────────────────────────────

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -62,6 +62,18 @@ c_dim() { paint 2  "$*"; }
 die()   { c_red "✖ $*"; exit 1; }
 step()  { printf '\n'; paint 1 "▶ $*"; }
 
+# A resposta é sim? Aceita o que gente digita de verdade: s, S, sim, SIM, y,
+# yes, com espaço em volta. Cada prompt comparava a resposta com uma string
+# exata, então "S" e "sim" — a resposta certa, com a tecla errada — caíam no
+# ramo do NÃO. No gate do DNS isso encerrava a instalação com uma frase que nem
+# correspondia à escolha da pessoa. Gêmea da de _common.sh: se mexer numa,
+# mexa na outra. Coberta por test-validators.sh.
+resposta_sim() {
+  local r
+  r="$(printf '%s' "${1:-}" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+  case "$r" in s|sim|y|yes) return 0;; *) return 1;; esac
+}
+
 # ── Fases da jornada ────────────────────────────────────────────────────────
 # Os passos técnicos (step) são muitos e alguns são condicionais — numerá-los
 # daria um "7 de 11" que muda conforme o caminho de cada instalação. As FASES
@@ -365,6 +377,18 @@ ask_one() {
   done
 }
 
+# O limiar NÃO é 4 GB, e a diferença importa: `MemTotal` é o que sobra depois
+# do que o kernel reserva para si, sempre menos do que foi vendido. Medido num
+# kernel com 8 GiB configurados: 8025284 KB, ou 95,7% — na mesma proporção uma
+# VPS de 4 GiB reporta ~4.012.000 KB, 0,3% acima de 4.000.000. E quem vende "4
+# GB" em GB decimais entrega 3.906.250 KB, que reporta ~3.735.000. Ou seja: com
+# o corte em 4.000.000 o aviso caía em cima de quem tinha ACABADO de comprar
+# exatamente a VPS recomendada — a pior hora possível para dizer a alguém que o
+# servidor dele é pequeno demais. 3.500.000 KB (3,34 GiB) deixa 4 GB de fora em
+# qualquer convenção e ainda pega de sobra as de 2 e 3 GB, que sofrem de verdade.
+RAM_MINIMA_KB=3500000
+ram_abaixo_do_recomendado() { [ "${1:-0}" -lt "$RAM_MINIMA_KB" ]; }
+
 # Esconde o miolo de um segredo para a tela de conferência.
 mask() {
   local v="$1"
@@ -453,9 +477,10 @@ c_grn "✓ docker, git, openssl, curl ok"
 # instalar em 2GB achando que estava dentro do recomendado.
 if [ -r /proc/meminfo ]; then
   mem_kb=$(awk '/MemTotal/{print $2}' /proc/meminfo)
-  if [ "$mem_kb" -lt 4000000 ]; then
-    c_ylw "⚠ RAM total ~$((mem_kb/1024))MB. Recomendado 4GB para operar (2GB sobe, mas no limite)."
-    c_ylw "  Com menos de 4GB, adicione swap — ver docs/runbooks/waha-hostgator.md."
+  if ram_abaixo_do_recomendado "$mem_kb"; then
+    c_ylw "⚠ Este servidor tem ~$((mem_kb/1024))MB de RAM. O CRM sobe, mas fica no limite:"
+    c_ylw "  são 7 contêineres e o WhatsApp usa ~150MB por número conectado."
+    c_ylw "  Adicione swap antes de operar — ver docs/runbooks/waha-hostgator.md."
   fi
 fi
 
@@ -676,7 +701,7 @@ if [ -z "${SENTRY_DSN+x}" ]; then
     printf '%s\n' "Seus dados de clientes, conversas e banco NUNCA saem daqui."
     printf '\n%s\n' "Você pode mudar depois no .env, a qualquer momento."
     read -r -p "  Enviar relatórios de erro anonimizados? (s/N) " _tel
-    if [ "${_tel:-N}" = "s" ] || [ "${_tel:-N}" = "S" ]; then
+    if resposta_sim "${_tel:-}"; then
       SENTRY_DSN=""
       c_grn "✓ Telemetria de erros ligada — obrigado, isso ajuda o projeto."
     else
@@ -784,9 +809,31 @@ resolved="$(getent ahosts "$DOMAIN" 2>/dev/null | awk '{print $1}' | sort -u | t
 if [ -n "$public_ip" ] && case " $resolved " in *" $public_ip "*) true;; *) false;; esac; then
   c_grn "✓ ${DOMAIN} → ${public_ip} (aponta pra este VPS)"
 else
-  c_ylw "⚠ ${DOMAIN} resolve para '${resolved:-nada}' e o IP deste VPS é '${public_ip:-desconhecido}'."
-  c_ylw "  O SSL (Let's Encrypt) só será emitido quando o A-record apontar pra cá."
-  [ "$NONINTERACTIVE" = 0 ] && { read -r -p "  Continuar mesmo assim? (s/N) " a; [ "${a:-N}" = "s" ] || die "Ajuste o DNS e rode de novo."; }
+  # DNS recém-apontado leva minutos para propagar: chegar aqui é estado NORMAL,
+  # não erro. Antes havia uma única saída — responder exatamente "s" — e
+  # qualquer outra coisa matava a instalação. Agora o padrão é esperar junto com
+  # a pessoa: Enter reconsulta, e sair é uma escolha explícita dela.
+  while [ "$NONINTERACTIVE" = 0 ]; do
+    c_ylw "⚠ ${DOMAIN} resolve para '${resolved:-nada}' e o IP deste VPS é '${public_ip:-desconhecido}'."
+    c_ylw "  O SSL (Let's Encrypt) só será emitido quando o A-record apontar pra cá."
+    printf '\n%s\n'   "  No painel do seu domínio, crie um registro A apontando ${DOMAIN}"
+    printf '%s\n\n'   "  para ${public_ip:-o IP deste servidor}. Costuma valer em poucos minutos."
+    printf '%s\n'     "  Enter = conferir de novo"
+    printf '%s\n'     "  c     = continuar assim mesmo (o site sobe sem cadeado até o DNS valer)"
+    printf '%s\n'     "  s     = sair e voltar depois (o que você já respondeu fica guardado)"
+    if ! read -r -p "  > " a; then a="s"; fi
+    case "$(printf '%s' "$a" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')" in
+      c|continuar) c_ylw "  Seguindo sem o DNS pronto — lembre de apontar o A-record."; break;;
+      s|sair|n|nao) die "Ajuste o A-record de ${DOMAIN} para ${public_ip:-o IP deste servidor} e rode o instalador de novo.";;
+      *)
+        resolved="$(getent ahosts "$DOMAIN" 2>/dev/null | awk '{print $1}' | sort -u | tr '\n' ' ' || echo '')"
+        if [ -n "$public_ip" ] && case " $resolved " in *" $public_ip "*) true;; *) false;; esac; then
+          c_grn "✓ ${DOMAIN} → ${public_ip} (agora aponta pra este VPS)"; break
+        fi
+        c_ylw "  Ainda não propagou. Dá pra esperar e tentar de novo."
+        ;;
+    esac
+  done
 fi
 
 # ── 7. Aplica o schema (baseline) no Supabase — via container postgres ───────

--- a/hostgator-setup-kit/reset-mfa.sh
+++ b/hostgator-setup-kit/reset-mfa.sh
@@ -10,7 +10,7 @@ EMAIL="${1:-}"
 [ -n "$EMAIL" ] || die "Uso: reset-mfa.sh <email>"
 
 c_ylw "Isto remove TODOS os fatores MFA de $EMAIL."
-read -r -p "Confirmar? (s/N) " a; [ "${a:-N}" = "s" ] || die "Cancelado."
+read -r -p "Confirmar? (s/N) " a; resposta_sim "$a" || die "Cancelado."
 
 step "Removendo fatores MFA"
 psql_run <<SQL

--- a/hostgator-setup-kit/supabase-provision.sh
+++ b/hostgator-setup-kit/supabase-provision.sh
@@ -42,6 +42,35 @@ c_ylw() { printf '\033[33m%s\033[0m\n' "$*" >&2; }
 c_dim() { printf '\033[2m%s\033[0m\n' "$*" >&2; }
 die()   { c_red "✖ $*"; exit 1; }
 
+# Senha do banco: 32 alfanuméricos, sem os caracteres que quebram uma URL
+# (@ : / ? # &) — ela entra na connection string, e um '@' aqui parte o host.
+#
+# Antes isto era uma ATRIBUIÇÃO NO ESCOPO DO SCRIPT:
+#   DB_PASS="$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32)"
+# e o script morria ali, todas as vezes. O head fecha o pipe ao juntar os 32
+# caracteres, o `tr` — que continuaria lendo /dev/urandom para sempre — leva
+# SIGPIPE e sai 141, e com pipefail esse 141 vira o status da atribuição, que
+# sob `set -e` mata o script inteiro DEPOIS de a senha existir. Medido na VPS e
+# reproduzido fora dela: a criação automática do banco falhava sempre, e o
+# instalador só dizia "Não consegui criar o projeto Supabase", sem motivo.
+#
+# O que fecha o buraco é ESTA função existir: o status de `$(gen_db_pass)` passa
+# a ser o do `printf` final, não o do pipe lá dentro (medido: com o pipe antigo
+# dentro de uma função, o script sobrevive; no escopo, sai 141). Ler um bloco
+# FINITO é defesa em profundidade — não depende desse detalhe de propagação, e
+# vale se alguém um dia inlinar a chamada de volta. 4096 bytes rendem ~980
+# alfanuméricos (24% dos bytes), folga larga para 32.
+# Coberta por test-validators.sh, no call site — que é onde o bug morava.
+gen_db_pass() {
+  local p
+  p="$(LC_ALL=C tr -dc 'A-Za-z0-9' < <(head -c 4096 /dev/urandom))"
+  printf '%s' "${p:0:32}"
+}
+
+# Carrega só as funções acima, sem provisionar nada — é assim que o
+# test-validators.sh exercita o gerador de senha.
+if [ "${SUPABASE_PROVISION_LIB:-}" = "1" ]; then return 0; fi
+
 # Passo numerado: quem instala precisa saber ONDE está e QUANTO falta. "▶ Criando
 # projeto" sozinho não diz se é o começo ou o fim.
 TOTAL_PASSOS=6
@@ -117,7 +146,8 @@ fi
 # ── 2. Senha do banco ───────────────────────────────────────────────────────
 # Sem caracteres que quebram uma URL (@ : / ? # &) — a senha entra na
 # connection string, e um '@' aqui parte o host no meio.
-DB_PASS="$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32)"
+DB_PASS="$(gen_db_pass)"
+[ "${#DB_PASS}" -eq 32 ] || die "não consegui gerar a senha do banco (só ${#DB_PASS} caracteres). Rode de novo."
 
 # ── 3. Cria o projeto ───────────────────────────────────────────────────────
 step "Criando o projeto '$PROJECT_NAME' em $REGION"

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -311,6 +311,44 @@ saude_ok "porta aberta, corpo vazio"             nao      ''
 saude_ok "responde, mas degraded"                nao      '{"status":"degraded","db":"down"}'
 saude_ok "proxy devolveu HTML de erro"           nao      '<html>502 Bad Gateway</html>'
 
+echo "rascunho das respostas (save_partial → load_env)"
+# Quem trava na connection string — a pergunta mais difícil, e a última das
+# credenciais — perdia as 11 respostas anteriores. O que importa aqui é o
+# ROUND-TRIP: o valor que volta tem de ser byte a byte o que foi digitado,
+# senão a retomada entrega uma senha adulterada e o erro só aparece lá no
+# psql. Os valores abaixo são os que quebram parser ingênuo.
+partial_ok() {  # partial_ok <descrição> <valor>
+  # kit capturado ANTES do cd: dentro de $( cd "$dir" && … ) o $PWD já é o
+  # temporário, e passar ele como origem dos scripts fazia o subshell não achar
+  # nem install.sh nem _common.sh — e o round-trip voltava vazio, indistinguível
+  # de "o valor se perdeu no arquivo".
+  local desc="$1" val="$2" dir out kit="$PWD"
+  dir="$(mktemp -d)"
+  # As duas fontes: envq/save_partial vivem no install.sh, load_env no
+  # _common.sh — e o guard de biblioteca do install.sh retorna antes de
+  # sourceá-lo. Carregar só um dos dois deixa a metade que falta indefinida, e
+  # o round-trip volta vazio como se o valor tivesse se perdido.
+  out="$(cd "$dir" && PARTIAL_FILE=".p" bash -c '
+      . "$1/_common.sh"
+      INSTALL_SH_LIB=1 . "$1/install.sh"
+      SENHA="$2"
+      save_partial SENHA
+      unset SENHA
+      load_env .p
+      printf "%s" "$SENHA"
+    ' _ "$kit" "$val")"
+  rm -rf "$dir"
+  if [ "$out" = "$val" ]; then printf '  ✓ %s\n' "$desc"
+  else printf '  ✗ %s\n     escreveu: [%s]\n     voltou:   [%s]\n' "$desc" "$val" "$out"; fail=1; fi
+}
+partial_ok "senha simples"              'abc123'
+partial_ok "com espaço"                 'minha senha boa'
+partial_ok "com # (não é comentário)"   'se#nha'
+partial_ok "com \$ (não expande)"       'se$nha$HOME'
+partial_ok "com aspa simples"           "se'nha"
+partial_ok "com aspas duplas"           'se"nha"'
+partial_ok "connection string real"     'postgresql://postgres.abc:p%40ss@aws-1-sa-east-1.pooler.supabase.com:5432/postgres'
+
 echo
 if [ "$fail" = 0 ]; then echo "todos os validadores passaram"; else echo "FALHOU"; fi
 exit "$fail"

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -454,24 +454,46 @@ echo "proxy reverso: quem está com as portas 80/443"
 # Caddy de OUTRO DeskcommCRM na mesma VPS — caía no ramo "portas livres", e a
 # instalação seguia até a fase 4 para morrer com "Bind for 0.0.0.0:80 failed:
 # port is already allocated". Medido numa VPS com produção rodando.
-proxy_ok() {  # proxy_ok <descrição> <esperado> <imagem> <nome> <host>
+# dono_das_portas lê o que o `docker ps` imprime de verdade. Os casos com "->"
+# vêm da coluna Ports real; o que decide é o lado ANTES da seta (a porta do
+# HOST). A primeira versão disto olhava a porta INTERNA e errava dos dois lados.
+dono_ok() {  # dono_ok <descrição> <esperado: nome|imagem ou vazio> <linhas do docker ps>
+  local desc="$1" esperado="$2" linhas="$3" real
+  real="$(printf '%s\n' "$linhas" | dono_das_portas meu-projeto || true)"
+  if [ "$real" = "$esperado" ]; then printf '  ✓ %s\n' "$desc"
+  else printf '  ✗ %s\n     deu:      [%s]\n     esperava: [%s]\n' "$desc" "$real" "$esperado"; fail=1; fi
+}
+dono_ok "proxy publicando 80 no host é encontrado" \
+  'traefik|traefik:v3.3' 'traefik|infra|traefik:v3.3|0.0.0.0:80->80/tcp, [::]:80->80/tcp'
+dono_ok "app em 8080->80 NÃO é ocupante (80 do host livre)" \
+  '' 'phpmyadmin|web|phpmyadmin:latest|0.0.0.0:8080->80/tcp'
+dono_ok "proxy sem privilégio (80->8080) É ocupante" \
+  'traefik|traefik:v3' 'traefik|infra|traefik:v3|0.0.0.0:80->8080/tcp'
+dono_ok "Caddy de outro Deskcomm é encontrado" \
+  'outro-caddy-1|caddy:2-alpine' 'outro-caddy-1|outro|caddy:2-alpine|0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp'
+dono_ok "contêiner sem porta publicada é ignorado" \
+  '' 'worker|app|meu/worker|'
+dono_ok "só 443 no host também conta" \
+  'proxy|nginx' 'proxy|infra|nginx|0.0.0.0:443->443/tcp'
+dono_ok "contêiner DESTA instalação é ignorado (idempotência)" \
+  '' 'crm-caddy-1|meu-projeto|caddy:2-alpine|0.0.0.0:80->80/tcp'
+# Sem label de compose, o campo do meio vem VAZIO — com IFS de tab ele colapsava
+# e a imagem sumia, fazendo um Traefik de `docker run` virar intruso.
+dono_ok "contêiner sem label de compose mantém a imagem" \
+  'meu-traefik|traefik:v3.1' 'meu-traefik||traefik:v3.1|0.0.0.0:80->80/tcp'
+
+echo "proxy reverso: é um Traefik?"
+tk_ok() {  # tk_ok <descrição> <sim|nao> <imagem> <nome>
   local desc="$1" esperado="$2" real
-  real="$(classifica_proxy "${3:-}" "${4:-}" "${5:-}")"
+  if eh_traefik "${3:-}" "${4:-}"; then real=sim; else real=nao; fi
   if [ "$real" = "$esperado" ]; then printf '  ✓ %s\n' "$desc"
   else printf '  ✗ %s  (deu %s, esperava %s)\n' "$desc" "$real" "$esperado"; fail=1; fi
 }
-proxy_ok "portas livres → sobe o nosso Caddy"        caddy    ""                    ""                ""
-proxy_ok "Traefik da hospedagem → publica por ele"   traefik  "traefik:v3.3"        "traefik"         ""
-proxy_ok "Traefik com nome maiúsculo"                traefik  "library/Traefik"     "meu-Traefik"     ""
-proxy_ok "Caddy de outro Deskcomm → bloqueia"        ocupado  "caddy:2-alpine"      "outro-caddy-1"   ""
-proxy_ok "nginx-proxy de outro app → bloqueia"       ocupado  "nginxproxy/nginx"    "webproxy"        ""
-proxy_ok "nginx do próprio host → bloqueia"          ocupado  ""                    ""                "LISTEN 0 511 *:80 users:((\"nginx\"))"
-# Sem este caso, um contêiner qualquer chamado "traefik-backup" PARADO (que não
-# publica porta, logo não chega aqui) não é o risco — o risco é o inverso: um
-# ocupante real ser lido como Traefik por causa do nome. O kit já exigia que o
-# candidato publicasse as portas; o teste guarda que a classificação continua
-# olhando imagem E nome.
-proxy_ok "imagem traefik vence nome genérico"        traefik  "traefik:v2"          "proxy-01"        ""
+tk_ok "imagem traefik"                   sim "traefik:v3.3"      "proxy-01"
+tk_ok "nome com maiúsculas (TRAEFIK)"    sim "meureg/proxy:3"    "TRAEFIK-PROXY"
+tk_ok "coolify-proxy é traefik na imagem" sim "traefik:v2.11"    "coolify-proxy"
+tk_ok "caddy não é traefik"              nao "caddy:2-alpine"    "outro-caddy-1"
+tk_ok "nginx não é traefik"              nao "nginxproxy/nginx"  "webproxy"
 
 echo
 if [ "$fail" = 0 ]; then echo "todos os validadores passaram"; else echo "FALHOU"; fi

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -392,6 +392,30 @@ n_agent="$(printf '%s\n' "$reexec" | grep -cF 'hostgator-setup-kit/agent.sh')"
 if [ "$n_agent" = 1 ]; then printf '  ✓ re-executar a mesma instalação não duplica a linha\n'
 else printf '  ✗ re-executar duplicou: %s linhas de agent.sh\n' "$n_agent"; fail=1; fi
 
+# As DUAS linhas da mesma instalação têm de coexistir. Com um marcador só por
+# instalação (sem o papel), a segunda função a rodar apagava a linha da
+# primeira — as duas casavam com o mesmo marcador. Medido na VPS: depois de
+# instalar sobrava só o agente, e o CRM ficava SEM o drain de eventos, com a
+# automação inteira parada em silêncio. Este teste roda as duas em sequência,
+# como a instalação faz.
+DIR=/root/instalacao-nova
+TAG_DRAIN="# deskcomm:${DIR}:drain"; TAG_AGENT="# deskcomm:${DIR}:agent"
+L_DRAIN="* * * * * curl \"https://novo.exemplo.com.br/api/v1/cron/event-log-drain\" $TAG_DRAIN"
+L_AGENT="*/5 * * * * cd ${DIR} && bash hostgator-setup-kit/agent.sh $TAG_AGENT"
+depois_drain="$(printf '%s\n' "$CRONTAB_VIZINHO" | cron_merge "$TAG_DRAIN" 'https://novo.exemplo.com.br/api/v1/cron/event-log-drain' "$L_DRAIN")"
+depois_agent="$(printf '%s\n' "$depois_drain" | cron_merge "$TAG_AGENT" "cd ${DIR} && bash hostgator-setup-kit/agent.sh" "$L_AGENT")"
+# Conta as DUAS linhas pelo que elas fazem (a URL do drain, o cd do agente), não
+# pelo formato do marcador: uma asserção sobre o marcador reprovaria uma mudança
+# de formato inofensiva e passaria por perto do que importa, que é as duas
+# tarefas continuarem agendadas.
+tem_drain="$(printf '%s\n' "$depois_agent" | grep -cF 'novo.exemplo.com.br/api/v1/cron/event-log-drain')"
+tem_agent="$(printf '%s\n' "$depois_agent" | grep -cF "cd ${DIR} && bash hostgator-setup-kit/agent.sh")"
+if [ "$tem_drain" -ge 1 ] && [ "$tem_agent" -ge 1 ]; then
+  printf '  ✓ drain e agente da mesma instalação coexistem\n'
+else
+  printf '  ✗ uma apagou a outra (drain=%s, agente=%s — esperava 1 de cada)\n' "$tem_drain" "$tem_agent"; fail=1
+fi
+
 echo "provisionamento do Supabase: senha do banco"
 # Dois testes distintos, porque o defeito e o contrato moram em lugares
 # diferentes — e o primeiro teste que escrevi aqui era VÁCUO por não separá-los.

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -449,6 +449,30 @@ case "$senha" in
   *)              printf '  ✓ só alfanuméricos (não parte a connection string)\n';;
 esac
 
+echo "proxy reverso: quem está com as portas 80/443"
+# A versão anterior só sabia procurar Traefik. Qualquer outro proxy — inclusive o
+# Caddy de OUTRO DeskcommCRM na mesma VPS — caía no ramo "portas livres", e a
+# instalação seguia até a fase 4 para morrer com "Bind for 0.0.0.0:80 failed:
+# port is already allocated". Medido numa VPS com produção rodando.
+proxy_ok() {  # proxy_ok <descrição> <esperado> <imagem> <nome> <host>
+  local desc="$1" esperado="$2" real
+  real="$(classifica_proxy "${3:-}" "${4:-}" "${5:-}")"
+  if [ "$real" = "$esperado" ]; then printf '  ✓ %s\n' "$desc"
+  else printf '  ✗ %s  (deu %s, esperava %s)\n' "$desc" "$real" "$esperado"; fail=1; fi
+}
+proxy_ok "portas livres → sobe o nosso Caddy"        caddy    ""                    ""                ""
+proxy_ok "Traefik da hospedagem → publica por ele"   traefik  "traefik:v3.3"        "traefik"         ""
+proxy_ok "Traefik com nome maiúsculo"                traefik  "library/Traefik"     "meu-Traefik"     ""
+proxy_ok "Caddy de outro Deskcomm → bloqueia"        ocupado  "caddy:2-alpine"      "outro-caddy-1"   ""
+proxy_ok "nginx-proxy de outro app → bloqueia"       ocupado  "nginxproxy/nginx"    "webproxy"        ""
+proxy_ok "nginx do próprio host → bloqueia"          ocupado  ""                    ""                "LISTEN 0 511 *:80 users:((\"nginx\"))"
+# Sem este caso, um contêiner qualquer chamado "traefik-backup" PARADO (que não
+# publica porta, logo não chega aqui) não é o risco — o risco é o inverso: um
+# ocupante real ser lido como Traefik por causa do nome. O kit já exigia que o
+# candidato publicasse as portas; o teste guarda que a classificação continua
+# olhando imagem E nome.
+proxy_ok "imagem traefik vence nome genérico"        traefik  "traefik:v2"          "proxy-01"        ""
+
 echo
 if [ "$fail" = 0 ]; then echo "todos os validadores passaram"; else echo "FALHOU"; fi
 exit "$fail"

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -392,6 +392,39 @@ n_agent="$(printf '%s\n' "$reexec" | grep -cF 'hostgator-setup-kit/agent.sh')"
 if [ "$n_agent" = 1 ]; then printf '  ✓ re-executar a mesma instalação não duplica a linha\n'
 else printf '  ✗ re-executar duplicou: %s linhas de agent.sh\n' "$n_agent"; fail=1; fi
 
+echo "provisionamento do Supabase: senha do banco"
+# Dois testes distintos, porque o defeito e o contrato moram em lugares
+# diferentes — e o primeiro teste que escrevi aqui era VÁCUO por não separá-los.
+#
+# (1) CALL SITE. O bug era a atribuição no escopo do script: com pipefail, o
+#     SIGPIPE do `tr` virava o status da atribuição e o `set -e` matava tudo,
+#     logo depois de a senha existir. Medido: o mesmo pipe DENTRO de uma função
+#     sobrevive (o status passa a ser o do printf final), no escopo sai 141.
+#     Então testar a função não pega a regressão que importa — quem pega é
+#     rodar o script e exigir que ele CHEGUE ao passo seguinte.
+#     O passo 3 imprime o título antes de tocar a rede, então a asserção não
+#     depende de a API responder (e o token aqui é propositalmente inválido).
+saida="$(SUPABASE_ACCESS_TOKEN=token-invalido-de-teste SUPABASE_ORG_ID=org-de-teste \
+         bash ./supabase-provision.sh "Projeto de Teste" sa-east-1 2>&1 || true)"
+if printf '%s' "$saida" | grep -q 'Criando o projeto'; then
+  printf '  ✓ o script passa da geração da senha e chega ao passo de criar\n'
+else
+  printf '  ✗ o script MORREU antes de criar o projeto (o defeito voltou)\n'
+  printf '     última linha vista: %s\n' "$(printf '%s' "$saida" | sed -E 's/\x1b\[[0-9;]*m//g' | grep -v '^$' | tail -1)"
+  fail=1
+fi
+
+# (2) CONTRATO da senha. Ela entra na connection string: um '@' ou '/' aqui
+#     parte o host no meio, e o erro só apareceria no psql.
+senha="$(bash -c 'set -euo pipefail; SUPABASE_PROVISION_LIB=1 . ./supabase-provision.sh; gen_db_pass' 2>/dev/null)"
+if [ "${#senha}" = 32 ]; then printf '  ✓ 32 caracteres\n'
+else printf '  ✗ senha com %s caracteres, esperava 32\n' "${#senha}"; fail=1; fi
+case "$senha" in
+  *[!A-Za-z0-9]*) printf '  ✗ tem caractere que quebra a connection string\n'; fail=1;;
+  '')             printf '  ✗ senha vazia\n'; fail=1;;
+  *)              printf '  ✓ só alfanuméricos (não parte a connection string)\n';;
+esac
+
 echo
 if [ "$fail" = 0 ]; then echo "todos os validadores passaram"; else echo "FALHOU"; fi
 exit "$fail"

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -294,22 +294,31 @@ echo "saúde do app (wait_app_healthy)"
 # acontece assim que o Node sobe, antes de ele saber se alcança o banco. O caso
 # "corpo vazio" abaixo é exatamente esse: com o probe antigo era verde, e o
 # "Instalação concluída!" saía por cima de um app quebrado.
-saude_ok() {  # saude_ok <descrição> <saudavel|nao> <corpo que o app devolve>
-  local desc="$1" esperado="$2" corpo="$3" real
-  if CORPO="$corpo" bash -c '
+# Os payloads abaixo são o CONTRATO REAL da rota, capturado do app em produção
+# — não um formato inventado aqui. A versão anterior destes testes mockava
+# {"status":"ok"}, que o produto NUNCA emite: `ok` é o vocabulário dos checks
+# individuais, e o status geral usa healthy|degraded|unhealthy. O teste passava
+# validando um contrato que não existia.
+HEALTHY='{"data":{"status":"healthy","version":"0.1.0","checks":{"supabase":{"status":"ok","latency_ms":268},"redis":{"status":"ok","latency_ms":4},"waha":{"status":"ok","latency_ms":6}}}}'
+DEGRADED='{"data":{"status":"degraded","checks":{"supabase":{"status":"ok"},"waha":{"status":"degraded","error":"not_configured"}}}}'
+UNHEALTHY='{"data":{"status":"unhealthy","checks":{"supabase":{"status":"down","error":"http_500"},"redis":{"status":"ok"}}}}'
+
+saude_ok() {  # saude_ok <descrição> <saudavel|nao> <status> <corpo real>
+  local desc="$1" esperado="$2" st="$3" corpo="$4" real
+  if ST="$st" CORPO="$corpo" bash -c '
         . ./_common.sh
-        app_health_body() { printf "%s" "${CORPO}"; }
+        app_health_probe() { printf "%s\n%s\n" "${ST}" "${CORPO}"; }
         wait_app_healthy 2 0
       ' >/dev/null 2>&1
   then real=saudavel; else real=nao; fi
   if [ "$real" = "$esperado" ]; then printf '  ✓ %s\n' "$desc"
   else printf '  ✗ %s  (deu %s, esperava %s)\n' "$desc" "$real" "$esperado"; fail=1; fi
 }
-saude_ok "responde status ok"                    saudavel '{"status":"ok","db":"up"}'
-saude_ok "status ok no meio do JSON"             saudavel '{"uptime":12,"status":"ok"}'
-saude_ok "porta aberta, corpo vazio"             nao      ''
-saude_ok "responde, mas degraded"                nao      '{"status":"degraded","db":"down"}'
-saude_ok "proxy devolveu HTML de erro"           nao      '<html>502 Bad Gateway</html>'
+saude_ok "healthy (payload real de produção)"   saudavel healthy   "$HEALTHY"
+saude_ok "degraded: serviço opcional sem config" saudavel degraded "$DEGRADED"
+saude_ok "unhealthy AINDA QUE o redis esteja ok" nao      unhealthy "$UNHEALTHY"
+saude_ok "porta aberta, app mudo"                nao      ''        ''
+saude_ok "proxy devolveu HTML de erro"           nao      ''        '<html>502 Bad Gateway</html>'
 
 echo "rascunho das respostas (save_partial → load_env)"
 # Quem trava na connection string — a pergunta mais difícil, e a última das

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -225,6 +225,70 @@ else
   fi
 fi
 
+echo "resposta afirmativa (resposta_sim)"
+# O gate do DNS comparava a resposta com a string "s" EXATA: quem digitava "S"
+# ou "sim" — a resposta certa, com a tecla errada — era morto por um `die` que
+# ainda dizia "Ajuste o DNS", frase que não corresponde ao que a pessoa
+# escolheu. Mesmo defeito no reset-mfa.sh. Estes casos são o contrato de que
+# nenhum prompt do kit volte a ler a intenção pela grafia.
+sim_ok() {  # sim_ok <descrição> <sim|nao> <entrada>
+  local desc="$1" esperado="$2" val="${3-}" real
+  if resposta_sim "$val"; then real=sim; else real=nao; fi
+  if [ "$real" = "$esperado" ]; then printf '  ✓ %s\n' "$desc"
+  else printf '  ✗ %s  (esperava %s, deu %s para "%s")\n' "$desc" "$esperado" "$real" "$val"; fail=1; fi
+}
+sim_ok "s minúsculo"             sim "s"
+sim_ok "S maiúsculo"             sim "S"
+sim_ok "sim por extenso"         sim "sim"
+sim_ok "SIM em caixa alta"       sim "SIM"
+sim_ok "y (teclado em inglês)"   sim "y"
+sim_ok "yes"                     sim "yes"
+sim_ok "espaço em volta"         sim "  s  "
+sim_ok "Enter (vazio) é não"     nao ""
+sim_ok "n"                       nao "n"
+sim_ok "nao"                     nao "nao"
+sim_ok "não com acento"          nao "não"
+sim_ok "palavra qualquer"        nao "talvez"
+sim_ok "'sims' não vira sim"     nao "sims"
+
+echo "gêmeas: resposta_sim vale nos DOIS arquivos"
+# Esta suíte sourceia install.sh, mas outros blocos sourceiam _common.sh — e a
+# definição que sobrevive é a do último. Descoberto sabotando: com a gêmea do
+# install.sh devolvendo "sim" para tudo, os casos acima continuavam VERDES,
+# porque quem respondia era a cópia boa do _common.sh. Metade da correção
+# estava sem rede. Cada gêmea passa a ser exercitada dentro do seu arquivo,
+# num shell separado.
+gemea_ok() {  # gemea_ok <arquivo> <entrada> <sim|nao>
+  local arq="$1" val="$2" esperado="$3" real
+  if bash -c 'INSTALL_SH_LIB=1 . "./$0" >/dev/null 2>&1; resposta_sim "$1"' "$arq" "$val"
+  then real=sim; else real=nao; fi
+  if [ "$real" = "$esperado" ]; then printf '  ✓ %s: "%s" → %s\n' "$arq" "$val" "$real"
+  else printf '  ✗ %s: "%s" deu %s, esperava %s\n' "$arq" "$val" "$real" "$esperado"; fail=1; fi
+}
+for arquivo in install.sh _common.sh; do
+  gemea_ok "$arquivo" "S"      sim
+  gemea_ok "$arquivo" "sim"    sim
+  gemea_ok "$arquivo" "nao"    nao
+  gemea_ok "$arquivo" ""       nao
+done
+
+echo "RAM: o aviso não pode cair em quem comprou a VPS recomendada"
+# MemTotal é sempre MENOR que o vendido (o kernel reserva). Medido: 8 GiB
+# configurados reportam 8025284 KB (95,7%). Os valores abaixo são o que cada
+# tamanho de VPS realmente reporta — o de 4 GB é o caso que este teste existe
+# para proteger, nas duas convenções em que provedores vendem "4 GB".
+ram_ok() {  # ram_ok <descrição> <avisa|silencia> <mem_kb>
+  local desc="$1" esperado="$2" kb="$3" real
+  if ram_abaixo_do_recomendado "$kb"; then real=avisa; else real=silencia; fi
+  if [ "$real" = "$esperado" ]; then printf '  ✓ %s\n' "$desc"
+  else printf '  ✗ %s  (%s KB → %s, esperava %s)\n' "$desc" "$kb" "$real" "$esperado"; fail=1; fi
+}
+ram_ok "VPS de 4 GiB (95,7% reportado)"        silencia 4012000
+ram_ok "VPS de 4 GB decimais (pior caso)"      silencia 3735000
+ram_ok "VPS de 8 GB (medido de verdade)"       silencia 8025284
+ram_ok "VPS de 3 GB — abaixo do recomendado"   avisa    2900000
+ram_ok "VPS de 2 GB — o plano que não dá conta" avisa   1950000
+
 echo
 if [ "$fail" = 0 ]; then echo "todos os validadores passaram"; else echo "FALHOU"; fi
 exit "$fail"

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -459,28 +459,31 @@ echo "proxy reverso: quem está com as portas 80/443"
 # HOST). A primeira versão disto olhava a porta INTERNA e errava dos dois lados.
 dono_ok() {  # dono_ok <descrição> <esperado: nome|imagem ou vazio> <linhas do docker ps>
   local desc="$1" esperado="$2" linhas="$3" real
-  real="$(printf '%s\n' "$linhas" | dono_das_portas meu-projeto || true)"
+  real="$(printf '%s\n' "$linhas" | dono_das_portas || true)"
   if [ "$real" = "$esperado" ]; then printf '  ✓ %s\n' "$desc"
   else printf '  ✗ %s\n     deu:      [%s]\n     esperava: [%s]\n' "$desc" "$real" "$esperado"; fail=1; fi
 }
 dono_ok "proxy publicando 80 no host é encontrado" \
-  'traefik|traefik:v3.3' 'traefik|infra|traefik:v3.3|0.0.0.0:80->80/tcp, [::]:80->80/tcp'
+  'traefik|infra|traefik:v3.3' 'traefik|infra|traefik:v3.3|0.0.0.0:80->80/tcp, [::]:80->80/tcp'
 dono_ok "app em 8080->80 NÃO é ocupante (80 do host livre)" \
   '' 'phpmyadmin|web|phpmyadmin:latest|0.0.0.0:8080->80/tcp'
 dono_ok "proxy sem privilégio (80->8080) É ocupante" \
-  'traefik|traefik:v3' 'traefik|infra|traefik:v3|0.0.0.0:80->8080/tcp'
+  'traefik|infra|traefik:v3' 'traefik|infra|traefik:v3|0.0.0.0:80->8080/tcp'
 dono_ok "Caddy de outro Deskcomm é encontrado" \
-  'outro-caddy-1|caddy:2-alpine' 'outro-caddy-1|outro|caddy:2-alpine|0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp'
+  'outro-caddy-1|outro|caddy:2-alpine' 'outro-caddy-1|outro|caddy:2-alpine|0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp'
 dono_ok "contêiner sem porta publicada é ignorado" \
   '' 'worker|app|meu/worker|'
 dono_ok "só 443 no host também conta" \
-  'proxy|nginx' 'proxy|infra|nginx|0.0.0.0:443->443/tcp'
-dono_ok "contêiner DESTA instalação é ignorado (idempotência)" \
-  '' 'crm-caddy-1|meu-projeto|caddy:2-alpine|0.0.0.0:80->80/tcp'
+  'proxy|infra|nginx' 'proxy|infra|nginx|0.0.0.0:443->443/tcp'
+# A varredura NÃO exclui mais ninguém: quem decide é o chamador, comparando o
+# projeto. Excluir aqui produzia um "ocupado por ninguém" — bloqueio sem
+# comando acionável — porque o teste de bind não tem como se auto-excluir.
+dono_ok "contêiner desta instalação é IDENTIFICADO (com o projeto)" \
+  'crm-caddy-1|meu-projeto|caddy:2-alpine' 'crm-caddy-1|meu-projeto|caddy:2-alpine|0.0.0.0:80->80/tcp'
 # Sem label de compose, o campo do meio vem VAZIO — com IFS de tab ele colapsava
 # e a imagem sumia, fazendo um Traefik de `docker run` virar intruso.
 dono_ok "contêiner sem label de compose mantém a imagem" \
-  'meu-traefik|traefik:v3.1' 'meu-traefik||traefik:v3.1|0.0.0.0:80->80/tcp'
+  'meu-traefik||traefik:v3.1' 'meu-traefik||traefik:v3.1|0.0.0.0:80->80/tcp'
 
 echo "proxy reverso: é um Traefik?"
 tk_ok() {  # tk_ok <descrição> <sim|nao> <imagem> <nome>
@@ -494,6 +497,43 @@ tk_ok "nome com maiúsculas (TRAEFIK)"    sim "meureg/proxy:3"    "TRAEFIK-PROXY
 tk_ok "coolify-proxy é traefik na imagem" sim "traefik:v2.11"    "coolify-proxy"
 tk_ok "caddy não é traefik"              nao "caddy:2-alpine"    "outro-caddy-1"
 tk_ok "nginx não é traefik"              nao "nginxproxy/nginx"  "webproxy"
+
+echo "proxy reverso: a decisão"
+dec_ok() {  # dec_ok <descrição> <esperado> <ocupadas> <proj_dono> <proj_atual> <img> <nome>
+  local desc="$1" esperado="$2" real
+  real="$(decide_proxy "${3:-}" "${4:-}" "${5:-}" "${6:-}" "${7:-}")"
+  if [ "$real" = "$esperado" ]; then printf '  ✓ %s\n' "$desc"
+  else printf '  ✗ %s  (deu %s, esperava %s)\n' "$desc" "$real" "$esperado"; fail=1; fi
+}
+dec_ok "portas livres → nosso Caddy"        caddy    ""        ""          "crm" ""              ""
+# ESTE é o caso que a revisão pegou: o teste de bind não tem como se
+# auto-excluir, então numa re-execução as portas aparecem ocupadas — pelo nosso
+# PRÓPRIO Caddy. Tratar isso como intruso bloqueia a instalação que o kit manda
+# rodar de novo para corrigir uma resposta, e sem nem um comando acionável.
+dec_ok "re-execução: portas com esta mesma instalação" caddy "80 e 443" "crm" "crm" "caddy:2-alpine" "crm-caddy-1"
+dec_ok "Caddy de OUTRO Deskcomm → bloqueia" bloqueia "80 e 443" "outro"     "crm" "caddy:2-alpine" "outro-caddy-1"
+dec_ok "Traefik da hospedagem → por ele"    traefik  "80 e 443" "coolify"   "crm" "traefik:v3.3"   "coolify-proxy"
+dec_ok "ocupante não identificado → bloqueia" bloqueia "80"     ""          "crm" ""              ""
+dec_ok "projeto vazio não casa projeto vazio" bloqueia "80"     ""          ""    "nginx"         "web"
+
+echo "nome do projeto que o docker compose usa"
+# O compose faz TrimLeft("_-") no basename. Sem isso, uma pasta /root/_deskcomm
+# faz o kit calcular "_deskcomm" enquanto os contêineres carregam "deskcomm" — a
+# instalação deixa de se reconhecer e se trata como intrusa. Medido contra o
+# docker compose v2.38.2.
+np_ok() {  # np_ok <caminho> <esperado>
+  local real; real="$(nome_do_projeto_compose "$1")"
+  if [ "$real" = "$2" ]; then printf '  ✓ %s → %s\n' "$1" "$real"
+  else printf '  ✗ %s → deu [%s], esperava [%s]\n' "$1" "$real" "$2"; fail=1; fi
+}
+np_ok /root/deskcommcrm  deskcommcrm
+np_ok /root/DeskcommCRM  deskcommcrm
+np_ok /root/_deskcomm    deskcomm
+np_ok /root/-deskcomm    deskcomm
+np_ok /root/_-_crm       crm
+np_ok /root/_123         123
+np_ok /root/deskcomm.crm deskcommcrm
+np_ok /root/crm_cliente  crm_cliente
 
 echo
 if [ "$fail" = 0 ]; then echo "todos os validadores passaram"; else echo "FALHOU"; fi

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -358,6 +358,40 @@ partial_ok "com aspa simples"           "se'nha"
 partial_ok "com aspas duplas"           'se"nha"'
 partial_ok "connection string real"     'postgresql://postgres.abc:p%40ss@aws-1-sa-east-1.pooler.supabase.com:5432/postgres'
 
+echo "cron: instalar uma instância não pode silenciar a outra"
+# Fixture = o crontab REAL de uma VPS com produção rodando (o Bearer trocado por
+# placeholder). O filtro antigo era `grep -v 'event-log-drain'`, que casava com
+# a linha de QUALQUER instalação: subir uma segunda instância na mesma máquina
+# apagava as duas linhas da primeira, em silêncio.
+CRONTAB_VIZINHO='0 8 * * * /root/trend-radar/run_full_vps.sh
+* * * * * curl -fsS -H "Authorization: Bearer SEGREDO" "https://crm.deskcomm.com.br/api/v1/cron/event-log-drain" >/dev/null 2>&1
+*/5 * * * * cd /root/Aula-Youtube/DeskcommCRM && bash hostgator-setup-kit/agent.sh >/dev/null 2>&1'
+
+cron_ok() {  # cron_ok <descrição> <esperado_no_resultado> <marcador> <legado> <linha_nova>
+  local desc="$1" espera="$2" marcador="$3" legado="$4" nova="$5" out
+  out="$(printf '%s\n' "$CRONTAB_VIZINHO" | cron_merge "$marcador" "$legado" "$nova")"
+  if printf '%s' "$out" | grep -qF -e "$espera"; then printf '  ✓ %s\n' "$desc"
+  else printf '  ✗ %s\n     sumiu do crontab: %s\n' "$desc" "$espera"; fail=1; fi
+}
+NOVO_TAG='# deskcomm:/root/instalacao-nova'
+NOVA_URL='https://crm-novo.exemplo.com.br/api/v1/cron/event-log-drain'
+cron_ok "o drain do vizinho sobrevive"  'crm.deskcomm.com.br/api/v1/cron/event-log-drain' \
+        "$NOVO_TAG" "$NOVA_URL" "* * * * * curl \"$NOVA_URL\" $NOVO_TAG"
+cron_ok "o agente do vizinho sobrevive" 'cd /root/Aula-Youtube/DeskcommCRM && bash hostgator-setup-kit/agent.sh' \
+        "$NOVO_TAG" "cd /root/instalacao-nova && bash hostgator-setup-kit/agent.sh" \
+        "*/5 * * * * cd /root/instalacao-nova && bash hostgator-setup-kit/agent.sh $NOVO_TAG"
+cron_ok "a linha alheia (trend-radar) sobrevive" '/root/trend-radar/run_full_vps.sh' \
+        "$NOVO_TAG" "$NOVA_URL" "* * * * * curl \"$NOVA_URL\" $NOVO_TAG"
+
+# Re-executar a MESMA instalação substitui a própria linha em vez de empilhar —
+# inclusive a legada, escrita antes de o marcador existir.
+reexec="$(printf '%s\n' "$CRONTAB_VIZINHO" | cron_merge '# deskcomm:/root/Aula-Youtube/DeskcommCRM' \
+          'cd /root/Aula-Youtube/DeskcommCRM && bash hostgator-setup-kit/agent.sh' \
+          '*/5 * * * * cd /root/Aula-Youtube/DeskcommCRM && bash hostgator-setup-kit/agent.sh # deskcomm:/root/Aula-Youtube/DeskcommCRM')"
+n_agent="$(printf '%s\n' "$reexec" | grep -cF 'hostgator-setup-kit/agent.sh')"
+if [ "$n_agent" = 1 ]; then printf '  ✓ re-executar a mesma instalação não duplica a linha\n'
+else printf '  ✗ re-executar duplicou: %s linhas de agent.sh\n' "$n_agent"; fail=1; fi
+
 echo
 if [ "$fail" = 0 ]; then echo "todos os validadores passaram"; else echo "FALHOU"; fi
 exit "$fail"

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -289,6 +289,28 @@ ram_ok "VPS de 8 GB (medido de verdade)"       silencia 8025284
 ram_ok "VPS de 3 GB — abaixo do recomendado"   avisa    2900000
 ram_ok "VPS de 2 GB — o plano que não dá conta" avisa   1950000
 
+echo "saúde do app (wait_app_healthy)"
+# O install.sh dava o app por bom quando a PORTA 3000 aceitava conexão — o que
+# acontece assim que o Node sobe, antes de ele saber se alcança o banco. O caso
+# "corpo vazio" abaixo é exatamente esse: com o probe antigo era verde, e o
+# "Instalação concluída!" saía por cima de um app quebrado.
+saude_ok() {  # saude_ok <descrição> <saudavel|nao> <corpo que o app devolve>
+  local desc="$1" esperado="$2" corpo="$3" real
+  if CORPO="$corpo" bash -c '
+        . ./_common.sh
+        app_health_body() { printf "%s" "${CORPO}"; }
+        wait_app_healthy 2 0
+      ' >/dev/null 2>&1
+  then real=saudavel; else real=nao; fi
+  if [ "$real" = "$esperado" ]; then printf '  ✓ %s\n' "$desc"
+  else printf '  ✗ %s  (deu %s, esperava %s)\n' "$desc" "$real" "$esperado"; fail=1; fi
+}
+saude_ok "responde status ok"                    saudavel '{"status":"ok","db":"up"}'
+saude_ok "status ok no meio do JSON"             saudavel '{"uptime":12,"status":"ok"}'
+saude_ok "porta aberta, corpo vazio"             nao      ''
+saude_ok "responde, mas degraded"                nao      '{"status":"degraded","db":"down"}'
+saude_ok "proxy devolveu HTML de erro"           nao      '<html>502 Bad Gateway</html>'
+
 echo
 if [ "$fail" = 0 ]; then echo "todos os validadores passaram"; else echo "FALHOU"; fi
 exit "$fail"

--- a/hostgator-setup-kit/update.sh
+++ b/hostgator-setup-kit/update.sh
@@ -193,13 +193,7 @@ fi
 # ── 6. O app voltou no ar? ───────────────────────────────────────────────────
 step "Conferindo se o app voltou no ar"
 ok=""
-for _ in $(seq 1 20); do
-  out="$(dc exec -T app node -e \
-    "fetch('http://127.0.0.1:3000/api/v1/health').then(r=>r.text()).then(t=>{console.log(t);process.exit(0)}).catch(()=>process.exit(1))" \
-    2>/dev/null || echo '')"
-  printf '%s' "$out" | grep -q '"status":"ok"' && { ok=1; break; }
-  sleep 3
-done
+wait_app_healthy 20 3 >/dev/null && ok=1
 if [ -n "$ok" ]; then
   c_grn "✓ Atualização concluída — app no ar e saudável."
 else

--- a/tests/shell/update-guard.test.sh
+++ b/tests/shell/update-guard.test.sh
@@ -43,8 +43,16 @@ cat > "$WORK/bin/docker" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$DOCKER_LOG"
 case " $* " in
-  # Healthcheck do update.sh: "docker compose ... exec -T app node -e ..."
-  *" exec "*)   printf '{"status":"ok"}\n' ;;
+  # Healthcheck do update.sh: "docker compose ... exec -T app node -e ...".
+  # O dublê responde o que o app RESPONDE DE VERDADE — capturado da instalação
+  # em produção. Antes aqui vinha {"status":"ok"}, um formato que /api/v1/health
+  # nunca emitiu: `ok` é o vocabulário dos CHECKS individuais, e o status geral
+  # usa healthy|degraded|unhealthy. Um dublê que fala um dialeto inventado
+  # aprova código que o app real reprovaria — foi exatamente por casar
+  # '"status":"ok"' no JSON cru que o kit dava por saudável um app com o BANCO
+  # FORA, desde que qualquer outro check estivesse de pé.
+  # São duas linhas porque o probe imprime o status geral e depois o corpo.
+  *" exec "*)   printf 'healthy\n{"data":{"status":"healthy","version":"0.1.0","checks":{"supabase":{"status":"ok","latency_ms":268},"redis":{"status":"ok","latency_ms":4},"waha":{"status":"ok","latency_ms":6}}}}\n' ;;
   # Imagem em execução, que o agent.sh guarda para poder voltar. Precisa
   # devolver algo: com PREV_IMAGE vazio o rollback nem seria tentado, e o teste
   # do agente passaria mesmo com o defeito de volta.


### PR DESCRIPTION
Duas frentes pedidas — dar marca à instalação e criar uma porta que fale com quem **ainda não tem servidor** — mais os defeitos que apareceram ao provar cada passo numa VPS de verdade.

Nenhum arquivo de aplicação foi tocado: 8 arquivos do `hostgator-setup-kit/` + `README.md`.

## Frente 1 — a porta que existe antes da VPS

`comecar.sh`, novo. Roda no computador da pessoa, antes de existir servidor, e responde a pergunta que trava o começo: *o que eu preciso contratar?*

- Nomeia o **plano** (VPS Turing, 2 vCPU / 4 GB — e por que o Cartesius não dá conta), com os números vindos de `docs/runbooks/waha-hostgator.md`, não de estimativa
- Enter cai em "ainda não tenho servidor": quem já tem chega pelo README com o SSH aberto
- Lê o teclado por `/dev/tty` — o script é feito para `curl … | bash`, e nesse modo o stdin é o próprio código-fonte
- A opção "já estou no servidor" exige confirmação e mostra o hostname: é o único ramo que muda a máquina

## Frente 2 — a instalação passou a ter marca e fim

- Banner DESKCOMM em blocos, com os blocos no verde do `✓` e o relevo em dim — lê em terminal claro e escuro sem detectar tema. Pintura por substituição literal de string: sob `LC_ALL=C`, uma classe `[╗║…]` em sed/awk casa BYTE e embaralha o desenho
- Fases 1..4 no vocabulário de quem instala
- O fim convida para a comunidade
- Cor só com terminal de verdade (`NO_COLOR` > `FORCE_COLOR` > isatty), aqui e no `_common.sh` — este último é o que o `update.sh` herda, e o `agent.sh` o roda redirecionado para arquivo a cada 5 minutos, para sempre

## Defeitos achados rodando (não previstos no escopo)

| # | Defeito | Como aparecia |
|---|---|---|
| 1 | **Instalar uma 2ª instância silenciava a 1ª** | `crontab -l \| grep -v <padrão> \| crontab -` apagava as linhas de QUALQUER instalação: produção perdia o drain de eventos e o agente de atualização, sem aviso |
| 2 | **"Instalação concluída!" com o app fora** | O último passo abria um socket na porta 3000 — que abre assim que o Node sobe, antes de o app saber se alcança o banco |
| 3 | **A saúde lia o vocabulário errado** | `grep '"status":"ok"'` casa os CHECKS (`ok\|degraded\|down`), nunca o status geral (`healthy\|degraded\|unhealthy`): app com o **banco fora** passava, desde que o Redis estivesse de pé |
| 4 | **Criar o banco sozinho morria calado** | `tr … </dev/urandom \| head -c 32` no escopo do script: SIGPIPE → 141 → `pipefail` → `set -e`, logo depois de a senha existir. A criação automática do Supabase **não funcionava** |
| 5 | **A resposta certa com a tecla errada matava** | O gate do DNS comparava com `"s"` exato: quem digitasse "S" ou "sim" levava `die` |
| 6 | **O aviso de RAM acusava quem seguiu a recomendação** | `MemTotal` é sempre menor que o vendido (medido: 8 GiB → 8131196 KB). "4 GB" em GB decimais reporta ~3.735.000 e disparava o corte de 4.000.000 |
| 7 | **Detecção de proxy só via Traefik** | O Caddy de outra instalação passava batido, e o `up -d` morria com `Bind for 0.0.0.0:80 failed` na fase 4 |
| 8 | **`envq`/`load_env` corrompiam aspa simples** | Pré-existente: senha com `'` voltava da releitura com 4 caracteres a mais, e o sintoma aparecia longe (psql recusando conexão) |

## Provado na VPS, não em mock

Instalação do zero numa VPS com produção rodando: Supabase criado sozinho, **97 tabelas**, admin promovido, 6 containers up, `app Healthy`, fechamento com o bloco da comunidade. O gate do DNS aceitou `c` e seguiu — antes isso matava a instalação.

Crontab da VPS ao fim do teste, com produção presente: as 3 linhas originais preservadas + as 2 da instalação de teste. Antes do conserto, as de produção sumiriam.

Produção intacta em todos os testes: crontab idêntico ao backup, 7 containers de pé, zero resíduos.

## Sobre a detecção de proxy

A primeira correção que escrevi estava **errada** e uma revisão adversarial (3 lentes, 18 achados confirmados) pegou: `docker port` imprime `80/tcp -> 0.0.0.0:8080` e o grep ancorava na porta **interna** — um phpMyAdmin em `-p 8080:80`, com 80/443 livres, abortaria a instalação mandando o dono derrubar o site dele.

A decisão passou a vir de **tentar publicar** (`docker run --rm -p 80:80`), que é a mesma mecânica que o Caddy vai usar. Medido com controle positivo na VPS: 80/443 ocupadas, 9877 livre, e 9877 ocupada de novo depois de prender a porta.

Dois defeitos sobreviveram à reescrita e também foram corrigidos: o teste de bind **não tem como se auto-excluir** (numa re-execução, quem ocupa as portas é o nosso próprio Caddy — a instalação se bloqueava), e o `docker compose` aplica `TrimLeft("_-")` ao nome do projeto e o kit não (calibrado contra o compose real da VPS).

## Testes

`test-validators.sh`: **106 casos**, de 14 para 106. Cada guarda nova foi sabotada e reprova pelo motivo certo — inclusive um teste meu que era **vácuo** (exercitava a função onde os dois padrões passam; o defeito morava no call site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186uhSjxkjwHgMzbkbytbSq