### PR TITLE
fix: corrige sent_via inválido no ai-response-worker

### DIFF
--- a/workers/ai-response-worker.ts
+++ b/workers/ai-response-worker.ts
@@ -603,7 +603,7 @@ async function persistAndDispatch(
     direction: "outbound" as const,
     status: "sending",
     body: finalText,
-    sent_via: "bot" as const,
+    sent_via: "ai" as const,
     sent_at: new Date().toISOString(),
     metadata: {
       ai_generated: true,


### PR DESCRIPTION
## Resumo

- `persistAndDispatch` (em `workers/ai-response-worker.ts`) gravava `sent_via: "bot"`, valor que **não existe** na constraint `messages_sent_via_check` do banco (`crm`, `external_device`, `automation`, `ai`, `user`, `system`).
- O insert falhava **sempre** que passava por esse caminho (`outbound_insert_failed: ... violates check constraint "messages_sent_via_check"`), não é intermitente.
- A mensagem só chega ao cliente porque existe um segundo caminho correto em `app/api/v1/messages/_handler.ts:289`, que já usa `sent_via: "ai"`.
- Troca o literal para `"ai"`, alinhando com a constraint e com o outro caminho.

## Como reproduzi

Deploy self-host em produção (hostgator-setup-kit), testando o agente de IA respondendo uma pergunta via WhatsApp depois de configurar uma fonte de conhecimento. Logs:

```
[ai-response-worker] invocation failed
error: "outbound_insert_failed: new row for relation \"messages\" violates check constraint \"messages_sent_via_check\""
```

## Testes

- `npx vitest run tests/unit/ai-response-worker-model-routing.test.ts` — 3 passed
- `npx tsc --noEmit` — sem erros novos
- `npx eslint workers/ai-response-worker.ts` — limpo

Não achei um teste existente que cubra `persistAndDispatch`/`sent_via` especificamente (é por isso que o bug passou despercebido) — fica como sugestão para um follow-up, não incluí aqui pra manter o PR focado no fix.

Fixes #125