### PR TITLE
fix: pushName de msg fromMe não vira nome do contato do cliente

### DIFF
--- a/lib/waha/ingest-celular.test.ts
+++ b/lib/waha/ingest-celular.test.ts
@@ -179,6 +179,26 @@ describe("mensagem digitada no celular do dono (fromMe)", () => {
     // `whatsapp.chat_id_not_recognized`. Ver ingest-chat-desconhecido.test.ts.
     expect(parseChatId("")).toEqual({ kind: "unknown", phone: null, lid: null });
   });
+
+  it("pushName de mensagem fromMe é do OPERADOR — nunca vira nome do contato", async () => {
+    // Sintoma real: dono manda msg do celular p/ cliente novo e o contato nasce
+    // na lista como "connectsmartphones" (o nome de WhatsApp da LOJA). Em
+    // payload fromMe, _data.pushName identifica o remetente — o operador — e
+    // não o destinatário; e o coalesce do fn_upsert_wa_contact congela o nome
+    // errado para sempre.
+    const { admin, rpcs } = bancoDeMentira();
+
+    await dispatchWahaEvent(
+      admin as never,
+      SESSION as never,
+      envelope({ ...CELULAR_NOWEB, _data: { pushName: "connectsmartphones" } }),
+      "req-1",
+    );
+
+    const contato = rpcs.find((c) => c.fn === "fn_upsert_wa_contact");
+    expect(contato, "o contato do cliente nem foi criado").toBeDefined();
+    expect(contato!.args.p_notify, "outbound batizou o cliente com o nome do operador").toBeNull();
+  });
 });
 
 describe("controles — o que tem que continuar sendo descartado", () => {

--- a/lib/waha/ingest.ts
+++ b/lib/waha/ingest.ts
@@ -567,7 +567,10 @@ async function handleOutboundFromUserPhone(
     .maybeSingle();
   if (jaRegistrada) return; // nasceu no envio; quem atualiza o status é o ack
 
-  const contactId = await upsertContact(admin, session.organization_id, parsed, chatId, notifyNameOf(p));
+  // fromMe: o pushName do payload é o do OPERADOR, não do destinatário —
+  // repassá-lo batizaria o contato do cliente com o nome da loja (e o
+  // coalesce do fn_upsert_wa_contact congelaria o nome errado).
+  const contactId = await upsertContact(admin, session.organization_id, parsed, chatId, null);
   if (!contactId) return;
   const conversationId = await upsertConversation(admin, session.organization_id, contactId, session.id);
   if (!conversationId) return;


### PR DESCRIPTION
Em payload fromMe, _data.pushName é o nome do OPERADOR (remetente), não do destinatário. handleOutboundFromUserPhone repassava esse valor a fn_upsert_wa_contact, que o grava em display_name na criação — e o coalesce do on conflict congela o nome errado. Resultado observado em instalação real: cliente novo aparece na lista de contatos com o nome de WhatsApp da própria loja. Patch: outbound passa null; inbound continua usando o pushName (lá ele é do cliente). Teste de regressão incluso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)