### PR TITLE
feat(ai): credencial de IA só entrava por uma tela que instalação nova não alcança

### DIFF
--- a/scripts/register-ai-credentials.ts
+++ b/scripts/register-ai-credentials.ts
@@ -1,0 +1,145 @@
+/**
+ * Cadastra credenciais BYO de provedor LLM (`ai_provider_credentials`) a partir
+ * das chaves já presentes no ambiente — mesmo caminho de código que a tela
+ * `/app/ai/credentials` usa no `POST /api/v1/ai/credentials`: cifra AES-GCM,
+ * grava só o `last4` em claro, valida contra o provedor e emite audit log.
+ *
+ * Por que existe: a tela exige login com senha + MFA TOTP. Num self-host recém
+ * instalado (ou num ambiente de dev sem acesso ao autenticador) não há como
+ * chegar nela, e sem credential o agente do CRM não roda — ele NÃO usa
+ * `ANTHROPIC_API_KEY` do env, e sim a credential por organização.
+ *
+ * Idempotente: `(organization_id, provider, label)` é único; label já existente
+ * é pulado, nunca sobrescrito — rotação de chave é ato consciente na tela.
+ *
+ * Uso (o `--env-file` não é opcional: `lib/crypto/aes_gcm` importa `lib/env`,
+ * que valida o ambiente do PROCESSO):
+ *   pnpm exec tsx --env-file=.env.local scripts/register-ai-credentials.ts \
+ *     [--org <uuid>] [--label "Padrão"]
+ *
+ * Lê ANTHROPIC_API_KEY e OPENAI_API_KEY do ambiente. Ausente = provider pulado.
+ */
+import { bufToBytea, encryptKey } from "@/lib/crypto/aes_gcm";
+import { validateProviderKey, type Provider } from "@/lib/ai/provider-validators";
+import { audit } from "@/lib/audit";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+const args = process.argv.slice(2);
+function arg(name: string): string | undefined {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+const LABEL = arg("label") ?? "Padrão";
+
+const SOURCES: { provider: Provider; envVar: string }[] = [
+  { provider: "anthropic", envVar: "ANTHROPIC_API_KEY" },
+  { provider: "openai", envVar: "OPENAI_API_KEY" },
+];
+
+async function main(): Promise<void> {
+  const admin = createAdminClient();
+
+  let orgId = arg("org");
+  if (!orgId) {
+    const { data: orgs, error } = await admin.from("organizations").select("id, legal_name");
+    if (error) throw new Error(`Falha ao listar organizations: ${error.message}`);
+    if (!orgs || orgs.length === 0) throw new Error("Nenhuma organization no banco.");
+    if (orgs.length > 1) {
+      throw new Error(
+        `Mais de uma organization — passe --org <uuid>:\n` +
+          orgs.map((o) => `  ${o.id}  ${o.legal_name}`).join("\n"),
+      );
+    }
+    orgId = orgs[0]!.id;
+    console.info(`org: ${orgs[0]!.legal_name} (${orgId})`);
+  }
+
+  // `created_by` espelha quem criaria pela tela: um admin da org.
+  const { data: adminMember } = await admin
+    .from("user_organizations")
+    .select("user_id")
+    .eq("organization_id", orgId)
+    .eq("role", "admin")
+    .limit(1)
+    .maybeSingle();
+  const actorUserId = adminMember?.user_id ?? null;
+
+  for (const { provider, envVar } of SOURCES) {
+    const apiKey = process.env[envVar]?.trim();
+    if (!apiKey) {
+      console.info(`${provider}: ${envVar} vazia — pulado.`);
+      continue;
+    }
+
+    const { data: existing } = await admin
+      .from("ai_provider_credentials")
+      .select("id, api_key_last4")
+      .eq("organization_id", orgId)
+      .eq("provider", provider)
+      .eq("label", LABEL)
+      .maybeSingle();
+    if (existing) {
+      console.info(
+        `${provider}: já existe credential "${LABEL}" (…${existing.api_key_last4}) — pulado.`,
+      );
+      continue;
+    }
+
+    const encrypted = encryptKey(apiKey);
+    const { data: created, error: insErr } = await admin
+      .from("ai_provider_credentials")
+      .insert({
+        organization_id: orgId,
+        provider,
+        label: LABEL,
+        api_key_encrypted: bufToBytea(encrypted.ciphertext),
+        api_key_iv: bufToBytea(encrypted.iv),
+        api_key_tag: bufToBytea(encrypted.tag),
+        api_key_last4: encrypted.last4,
+        is_active: true,
+        created_by: actorUserId,
+      })
+      .select("id")
+      .single();
+    if (insErr || !created) {
+      throw new Error(`${provider}: falha ao inserir — ${insErr?.message}`);
+    }
+
+    await audit({
+      action: "ai.credential_created",
+      actorUserId,
+      organizationId: orgId,
+      resourceType: "ai_provider_credential",
+      resourceId: created.id,
+      metadata: { provider, label: LABEL, last4: encrypted.last4, source: "script" },
+    });
+
+    // Mesma validação da tela — porém síncrona, pra o script poder reportar.
+    const result = await validateProviderKey(provider, apiKey);
+    const patch = result.ok
+      ? {
+          validated_at: new Date().toISOString(),
+          validation_error: null,
+          models_available: result.models,
+        }
+      : { validated_at: null, validation_error: result.error };
+    const { error: upErr } = await admin
+      .from("ai_provider_credentials")
+      .update(patch)
+      .eq("id", created.id)
+      .eq("organization_id", orgId);
+    if (upErr) console.error(`${provider}: falha ao persistir validação — ${upErr.message}`);
+
+    console.info(
+      result.ok
+        ? `${provider}: criada (…${encrypted.last4}) — validada, ${result.models.length} modelos.`
+        : `${provider}: criada (…${encrypted.last4}) — validação FALHOU: ${result.error}`,
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
A chave BYO do provedor de LLM só entra por `/app/ai/credentials`. Essa tela exige login com senha **mais MFA TOTP**. Numa instalação self-host recém-feita, ou em dev sem acesso ao autenticador, não existe caminho até ela — e sem credential o agente não roda.

## A lacuna

O agente **não** lê `ANTHROPIC_API_KEY` do env. Ele resolve a credential por organização:

```
$ git grep -n "loadCredential" -- lib/ | head -3
lib/ai/credentials.ts:54:export async function loadCredential(
lib/agent-engine/edge/llm/credentials.ts
lib/ai/runtime/agent.ts
```

E `fn_publish_ai_agent_version` recusa publicar sem ela — `credential_missing`, `credential_not_validated`, `credential_provider_mismatch` são três dos treze `PublishErrorCode` em `lib/ai/agents/validation.ts:143`. Preencher o `.env` não substitui: são caminhos diferentes, e o do env alcança só classificação de sentimento e bot de resposta (documentado em `.env.example:63-79`).

Controle positivo, porque "não existe caminho" é indistinguível de eu não ter procurado: `scripts/` tem 40+ utilitários, incluindo `bootstrap-owner.ts`, que cria dono, org e `platform_admins` exatamente porque *o app não tem tela de cadastro*. O padrão de "bootstrap por script onde a tela não alcança" já é do repo — o que faltava era o elo da credential.

## O que o script faz

Percorre o mesmo caminho do `POST /api/v1/ai/credentials`: `encryptKey()` AES-GCM → insert com `bufToBytea` nas três colunas → `audit('ai.credential_created')` → `validateProviderKey()` → persiste `validated_at` / `models_available`. Nenhuma lógica de cifra nova; importa a existente.

Idempotente por `(organization_id, provider, label)`. Label já existente é **pulado, nunca sobrescrito** — rotação de chave é ato consciente e tem tela própria (`docs/runbooks/ai-credentials-rotation.md`).

## Comportamento medido, não suposto

Execução real contra Supabase local, chaves reais nos dois provedores:

```
org: Dev Local (c8b6007a-…)
anthropic: criada (…redigido) — validada, 10 modelos.
openai:    criada (…redigido) — validada, 126 modelos.
```

O que importa não é a linha existir, é ela **voltar**. Li de volta pelo caminho do runtime (`loadCredential`) e usei a chave que saiu do **banco** — não a do env — numa chamada real:

```
anthropic: decrypt==env? true | chamada real com a chave do banco: HTTP 200
openai:    decrypt==env? true | chamada real com a chave do banco: HTTP 200
isolamento: CredentialUnavailableError / wrong_org
```

A terceira linha é o controle de tenancy: a mesma credential pedida com `organization_id` de outra org estoura `wrong_org`, que é o filtro programático obrigatório quando o admin client bypassa RLS.

Ponta a ponta, a credential gerada aqui foi aceita por um `mcp_agent` v1 e o publish recusou pelo motivo **certo** — prova de que a credential passou nos três gates dela e travou no gate seguinte, não antes:

```
publish: RECUSADO — channel_session_offline
```

## Gates

`typecheck` exit 0 · `lint` 0 erros (170 warnings, todas pré-existentes) · `test:unit` **3 arquivos / 7 testes falhando** · `lint:channels` exit 1.

Os dois vermelhos são **pré-existentes**, medidos nos dois lados em vez de assumidos:

| | `upstream/main` @ 687716a | esta branch |
|---|---|---|
| `test:unit` | 3 arquivos / 7 testes falhando · 220 / 1884 verdes | **idêntico** |
| `lint:channels` | exit 1 | **idêntico** |

Arquivos vermelhos: `app/actions/auth/signInWithPassword.test.ts` (1/2), `lib/auth/rate-limit.test.ts` (5/7), `tests/unit/import-puro-sem-env.test.ts` (1/4). O novo arquivo aparece **0 vezes** na saída do `lint:channels` — a lista de dívida é a mesma de antes.

Contagem de arquivos e testes **não muda** (223 / 1891 nos dois lados). Isso é esperado e é o limite honesto deste PR: script não entra na suíte.

## NÃO MEDIDO

- **Nenhum teste automatizado guarda este script.** A evidência acima é execução, não catraca: se o caminho quebrar amanhã, nada fica vermelho. Não escrevi teste porque a lógica é ramificação sobre o admin client e um teste com client mockado exercitaria o mock, não o comportamento — mas o custo disso é real e está declarado, não escondido. O lado do runtime tem `tests/invariants/agent-no-credential.test.ts`; o do script, nada.
- **Não rodei `test:db`.** Não toca schema — nenhuma migration, nenhum apêndice de baseline, nenhuma coluna.
- **Nada foi verificado pela tela.** Não consegui autenticar para comparar o resultado do script com o de um cadastro feito pela UI. A afirmação "produz linha idêntica" vem de leitura do handler, não de diff entre duas linhas reais.
- **Só `anthropic` e `openai` foram exercitados.** `google` é provider válido no schema e o script não o cobre.
- **Os 3 testes vermelhos pré-existentes não foram diagnosticados.** Dois cheiram a ambiente local (rate-limit com Redis real em `.env.local`), mas não medi se passam em CI Linux — só que o baseline e a branch falham igual, aqui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
