### PR TITLE
fix(test): testes não subiam no Windows — `npx` não é um executável

### DIFF
--- a/tests/capture-wave-6-cenarios.ts
+++ b/tests/capture-wave-6-cenarios.ts
@@ -1210,9 +1210,17 @@ async function main(): Promise<void> {
       // e o que eu ia perder tratando o meu próprio zero como veredito.
       const quadrosNavegadorAntes = quadrosDeAtividade;
       let controleExterno = await new Promise<string>((resolve) => {
+        // `process.execPath` + `--import tsx` em vez de `npx tsx`: no Windows o
+        // `npx` não é executável, é o shim `npx.cmd`, e o `execFile` sem shell
+        // devolve ENOENT para um e EINVAL para o outro (CVE-2024-27980). O
+        // `execFile` engole o erro no callback — o controle irmão viraria
+        // "(não mediu)" caladamente, e o critério cairia no ramo que trata
+        // "ninguém recebeu" como ambiente morto. Ou seja: não é vermelho que
+        // aparece, é veredito trocado, que é pior. Mesma porta que os seeds E2E
+        // usam (tests/e2e/helpers/seed.ts), aqui em forma assíncrona.
         execFile(
-          "npx",
-          ["tsx", "tests/prova-taxa-de-entrega.ts"],
+          process.execPath,
+          ["--import", "tsx", "tests/prova-taxa-de-entrega.ts"],
           // N=1 basta desde que a raiz foi nomeada: aqui o controle não investiga
           // mais nada, só responde "havia como chegar?". Três rodadas eram o
           // preço de uma pergunta que já foi respondida noutro lugar.

--- a/tests/e2e/degradacao-silenciosa.spec.ts
+++ b/tests/e2e/degradacao-silenciosa.spec.ts
@@ -31,12 +31,13 @@
  * A peça que falta é do produto, não do teste: um REFETCH DE SEGURANÇA. Ele é ao
  * mesmo tempo a base da tela, a cura da perda e o detector da falha.
  */
-import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { test, expect } from "@playwright/test";
 import { createClient } from "@supabase/supabase-js";
+
+import { rodaSeed } from "./helpers/seed";
 
 const CREDS_PATH = path.join(process.cwd(), ".e2e-creds.json");
 
@@ -48,7 +49,7 @@ interface Creds {
 
 function loadCreds(): Creds {
   if (!fs.existsSync(CREDS_PATH)) {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-credentials.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-credentials.ts");
   }
   return JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
 }

--- a/tests/e2e/followup-builder.spec.ts
+++ b/tests/e2e/followup-builder.spec.ts
@@ -10,13 +10,13 @@
  * único, então não colide entre execuções; os drafts de teste se acumulam no
  * banco e exigem um sweep manual periódico (fora do escopo desta task).
  */
-import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { test, expect, type Page } from "@playwright/test";
 
 import { generateTotp, msUntilNextTotpWindow } from "./utils/totp";
+import { rodaSeed } from "./helpers/seed";
 
 const CREDS_PATH = path.join(process.cwd(), ".e2e-creds.json");
 // test-results/ é limpo pelo outputDir do Playwright a cada run — preserva a
@@ -38,7 +38,7 @@ function loadCreds(): Creds {
     return !c.users?.manager;
   };
   if (needsSeed()) {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-credentials.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-credentials.ts");
   }
   return JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
 }
@@ -597,7 +597,7 @@ test.describe("followup flow builder — editor de condição de aresta / ai_cla
  */
 test.describe("followup flow selector no editor do agente (Task 7.2)", () => {
   test.beforeAll(() => {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-followup-agent.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-followup-agent.ts");
   });
 
   test("admin vincula um fluxo publicado ao agente, salva, e a persistência é provada via API", async ({

--- a/tests/e2e/followup-journey.spec.ts
+++ b/tests/e2e/followup-journey.spec.ts
@@ -33,13 +33,13 @@
  * conversa/mensagens via helper) — nomes com timestamp único, não acumula
  * nem colide entre runs.
  */
-import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { test, expect, type Page } from "@playwright/test";
 
 import { generateTotp, msUntilNextTotpWindow } from "./utils/totp";
+import { rodaSeed, rodaSeedCapturando } from "./helpers/seed";
 
 const CREDS_PATH = path.join(process.cwd(), ".e2e-creds.json");
 const ARTIFACTS_DIR = path.join(process.cwd(), "e2e-artifacts");
@@ -60,7 +60,7 @@ function loadCreds(): Creds {
     return !c.users?.admin || !c.admin_totp;
   };
   if (needsSeed()) {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-credentials.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-credentials.ts");
   }
   return JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
 }
@@ -78,9 +78,7 @@ const secret = loadInternalSecret();
 
 /** Roda 1 subcomando do helper de SQL cru e devolve o JSON impresso na última linha. */
 function runHelper(args: string[]): unknown {
-  const stdout = execFileSync("npx", ["tsx", "scripts/e2e-followup-journey-helpers.ts", ...args], {
-    encoding: "utf8",
-  });
+  const stdout = rodaSeedCapturando("scripts/e2e-followup-journey-helpers.ts", ...args);
   const lastLine = stdout.trim().split("\n").filter(Boolean).pop();
   if (!lastLine) throw new Error(`e2e-followup-journey-helpers ${args[0]} não imprimiu JSON`);
   return JSON.parse(lastLine);
@@ -187,7 +185,7 @@ test.describe("followup — jornada completa (Task 8.3)", () => {
   test.use({ viewport: { width: 1600, height: 1000 } });
 
   test.beforeAll(() => {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-followup-agent.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-followup-agent.ts");
   });
 
   test("silêncio → enroll → trigger→wait→action→classify → resposta → outcome → fila", async ({ page }) => {

--- a/tests/e2e/followup-queue.spec.ts
+++ b/tests/e2e/followup-queue.spec.ts
@@ -25,11 +25,12 @@
  * saída) antes de qualquer interação seguinte — serializa cada troca de
  * filtro em vez de confiar que o clique do item já fechou tudo a tempo.
  */
-import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { test, expect, type Page } from "@playwright/test";
+
+import { rodaSeed } from "./helpers/seed";
 
 const CREDS_PATH = path.join(process.cwd(), ".e2e-creds.json");
 // test-results/ é limpo pelo outputDir do Playwright a cada run — preserva as
@@ -50,7 +51,7 @@ function loadCreds(): Creds {
     return !c.users?.manager;
   };
   if (needsSeed()) {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-credentials.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-credentials.ts");
   }
   return JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
 }
@@ -141,7 +142,7 @@ async function cleanupLiveEnrollment(page: Page, live: LiveEnrollment): Promise<
 
 test.describe("followup queue — fila unificada (Task 7.1)", () => {
   test.beforeAll(() => {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-followup-promise.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-followup-promise.ts");
   });
 
   test("manager vê enrollment na fila, filtra por status/fluxo, cancela, e a promessa seedada aparece", async ({

--- a/tests/e2e/helpers/seed.ts
+++ b/tests/e2e/helpers/seed.ts
@@ -1,0 +1,38 @@
+/**
+ * Sobe um script `.ts` do repo num processo filho — é assim que todo spec E2E
+ * roda o seu seed.
+ *
+ * POR QUE NÃO `execFileSync("npx", ["tsx", ...])`, que era o que estava nos
+ * specs: no Windows o `npx` não é um executável, é o shim `npx.cmd`.
+ * `execFileSync` sem shell não acha `"npx"` (ENOENT) e — desde a mitigação do
+ * CVE-2024-27980 (Node >= 18.20 / 20.12 / 22.0) — recusa spawnar `"npx.cmd"`
+ * direto (EINVAL). Os 20 call sites morriam no `beforeAll`, antes de o
+ * navegador abrir: em Windows a suíte E2E inteira não subia, e o vermelho não
+ * falava de produto nenhum.
+ *
+ * `shell: true` faria funcionar e é exatamente o que NÃO se deve fazer aqui:
+ * reabre o buraco de injeção de comando que a mitigação fechou, num lugar que
+ * interpola caminho de arquivo.
+ *
+ * `process.execPath` é o binário do Node que já está rodando: existe em
+ * qualquer SO, não depende do PATH e não passa por shim nenhum. `--import tsx`
+ * registra o loader de TypeScript no filho — mesmo efeito de `npx tsx`, sem o
+ * `npx`.
+ *
+ * Existe UMA porta porque são ~20 chamadas idênticas: guarda espalhada é
+ * guarda que volta a divergir. `tests/unit/seed-e2e-sem-npx.test.ts` reprova
+ * quem contornar esta porta.
+ */
+import { execFileSync } from "node:child_process";
+
+const argv = (script: string, args: string[]): string[] => ["--import", "tsx", script, ...args];
+
+/** Roda o seed despejando a saída no terminal (o padrão dos specs). */
+export function rodaSeed(script: string, ...args: string[]): void {
+  execFileSync(process.execPath, argv(script, args), { stdio: "inherit" });
+}
+
+/** Igual, mas devolve o stdout — para os helpers que imprimem JSON na saída. */
+export function rodaSeedCapturando(script: string, ...args: string[]): string {
+  return execFileSync(process.execPath, argv(script, args), { encoding: "utf8" });
+}

--- a/tests/e2e/invite-lifecycle.spec.ts
+++ b/tests/e2e/invite-lifecycle.spec.ts
@@ -17,7 +17,6 @@
  * Contra o Supabase do env (local recomendado — precisa das migrations de RLS
  * 0035/0036/0042/0044 pro escopo do agent ser real).
  */
-import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -27,6 +26,7 @@ import { createClient } from "@supabase/supabase-js";
 
 import { signInviteToken } from "../../lib/auth/invite-token";
 import { generateTotp, msUntilNextTotpWindow } from "./utils/totp";
+import { rodaSeed } from "./helpers/seed";
 
 // ---- creds do seed base (.e2e-creds.json) + do convite (.e2e-invite.json) ----
 interface BaseCreds {
@@ -45,7 +45,7 @@ const INVITE_PATH = path.join(process.cwd(), ".e2e-invite.json");
 
 function load(): { base: BaseCreds; inv: InviteCreds } {
   if (!fs.existsSync(INVITE_PATH) || !fs.existsSync(CREDS_PATH)) {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-invite.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-invite.ts");
   }
   return {
     base: JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as BaseCreds,

--- a/tests/e2e/kanban-owner-filter.spec.ts
+++ b/tests/e2e/kanban-owner-filter.spec.ts
@@ -7,11 +7,12 @@
  *
  * Pré-requisito: seed de credenciais + seed de kanban (rodados aqui se faltarem).
  */
-import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { test, expect, type Page } from "@playwright/test";
+
+import { rodaSeed } from "./helpers/seed";
 
 const CREDS_PATH = path.join(process.cwd(), ".e2e-creds.json");
 
@@ -28,11 +29,11 @@ function loadCreds(): Creds {
     return !c.users?.manager;
   };
   if (needsBase()) {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-credentials.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-credentials.ts");
   }
   let c = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
   if (!c.kanban?.pipeline_id) {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-kanban.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-kanban.ts");
     c = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
   }
   return c;

--- a/tests/e2e/pipelines-gestao.spec.ts
+++ b/tests/e2e/pipelines-gestao.spec.ts
@@ -16,11 +16,12 @@
  *
  * Pré-requisito: seed de credenciais + seed de funis (rodados aqui se faltarem).
  */
-import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { test, expect, type Page } from "@playwright/test";
+
+import { rodaSeed } from "./helpers/seed";
 
 const CREDS_PATH = path.join(process.cwd(), ".e2e-creds.json");
 const EVIDENCIA = path.join(process.cwd(), ".superpowers", "evidence");
@@ -33,15 +34,15 @@ interface Creds {
 
 function loadCreds(): Creds {
   if (!fs.existsSync(CREDS_PATH)) {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-credentials.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-credentials.ts");
   }
   let c = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
   if (!c.users?.manager) {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-credentials.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-credentials.ts");
     c = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
   }
   if (!c.funis?.segunda_org_id) {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-funis.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-funis.ts");
     c = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
   }
   return c;

--- a/tests/e2e/queue-assign.spec.ts
+++ b/tests/e2e/queue-assign.spec.ts
@@ -9,12 +9,13 @@
  * Pré-requisito: scripts/seed-e2e-credentials.ts + scripts/seed-e2e-queue.ts
  * (o beforeAll re-roda o queue seed para restaurar o estado de fila).
  */
-import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { createClient } from "@supabase/supabase-js";
 import { test, expect, type Page } from "@playwright/test";
+
+import { rodaSeed } from "./helpers/seed";
 
 const CREDS_PATH = path.join(process.cwd(), ".e2e-creds.json");
 const EVIDENCE = path.join(process.cwd(), "loop/checkpoints/evidence/G5");
@@ -62,7 +63,7 @@ test.describe("G5-03 — fila com posição + atribuição", () => {
 
   test.beforeAll(() => {
     // Restaura o estado de fila (idempotente) antes do fluxo.
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-queue.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-queue.ts");
     creds = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
     if (!creds.queue) throw new Error("queue seed block ausente em .e2e-creds.json");
   });

--- a/tests/e2e/rbac-roles.spec.ts
+++ b/tests/e2e/rbac-roles.spec.ts
@@ -8,7 +8,6 @@
  * Pré-requisito: `npx tsx scripts/seed-e2e-credentials.ts` (o spec roda o seed
  * sozinho se .e2e-creds.json estiver ausente/incompleto).
  */
-import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
@@ -16,6 +15,7 @@ import { test, expect, type Page } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
 
 import { generateTotp, msUntilNextTotpWindow } from "./utils/totp";
+import { rodaSeed } from "./helpers/seed";
 
 interface E2ECreds {
   password: string;
@@ -32,7 +32,7 @@ function loadCreds(): E2ECreds {
     return !c.users?.viewer || !c.admin_totp?.secret;
   };
   if (needsSeed()) {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-credentials.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-credentials.ts");
   }
   return JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as E2ECreds;
 }

--- a/tests/e2e/risk-radar.spec.ts
+++ b/tests/e2e/risk-radar.spec.ts
@@ -8,11 +8,12 @@
  * O seed do radar roda a cada execução (reseta a conversa para "sem dono"), então
  * o teste de assumir é repetível.
  */
-import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { test, expect, type Page } from "@playwright/test";
+
+import { rodaSeed } from "./helpers/seed";
 
 const CREDS_PATH = path.join(process.cwd(), ".e2e-creds.json");
 
@@ -29,10 +30,10 @@ function loadCreds(): Creds {
     return !c.users?.manager;
   };
   if (needsBase()) {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-credentials.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-credentials.ts");
   }
   // Sempre reseta o fixture do radar (conversa volta a ficar sem dono).
-  execFileSync("npx", ["tsx", "scripts/seed-e2e-radar.ts"], { stdio: "inherit" });
+  rodaSeed("scripts/seed-e2e-radar.ts");
   return JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
 }
 

--- a/tests/e2e/system-update.spec.ts
+++ b/tests/e2e/system-update.spec.ts
@@ -18,13 +18,13 @@
  *   nem autenticaria — o arquivo INTEIRO pula em vez de falhar por motivo
  *   errado (ausência de ambiente ≠ defeito).
  */
-import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { test, expect, type Page, type APIRequestContext } from "@playwright/test";
 
 import { generateTotp, msUntilNextTotpWindow } from "./utils/totp";
+import { rodaSeed } from "./helpers/seed";
 
 const CREDS_PATH = path.join(process.cwd(), ".e2e-creds.json");
 const SECRET = process.env.INTERNAL_SECRET ?? "";
@@ -47,11 +47,11 @@ function loadCreds(): E2ECreds {
     return !c.users?.agent || !c.admin_totp?.secret;
   };
   if (needsSeed()) {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-credentials.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-credentials.ts");
   }
   // Dono do servidor (platform_admins) + system_version/system_update_runs
   // limpos — idempotente, roda sempre pra deixar o teste repetível.
-  execFileSync("npx", ["tsx", "scripts/seed-e2e-system-update.ts"], { stdio: "inherit" });
+  rodaSeed("scripts/seed-e2e-system-update.ts");
   return JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as E2ECreds;
 }
 
@@ -157,7 +157,7 @@ async function runProgress(
 
 /** Volta o estado da instalação ao zero (sem run nenhum), como um seed. */
 function resetEstado(): void {
-  execFileSync("npx", ["tsx", "scripts/seed-e2e-system-update.ts"], { stdio: "inherit" });
+  rodaSeed("scripts/seed-e2e-system-update.ts");
 }
 
 test("o dono vê a versão nova na sidebar e atualiza pela tela", async ({ page, request }) => {

--- a/tests/e2e/vps-webhook-outbound-ssrf.spec.ts
+++ b/tests/e2e/vps-webhook-outbound-ssrf.spec.ts
@@ -14,13 +14,14 @@
  * bloqueia hosts privados —, então essa metade fica para a sessão de deploy
  * real (mesma categoria do WhatsApp com número real).
  */
-import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as http from "node:http";
 import type { AddressInfo } from "node:net";
 import * as path from "node:path";
 
 import { test, expect, type Page, type Locator } from "@playwright/test";
+
+import { rodaSeed } from "./helpers/seed";
 
 const APP_URL = `http://localhost:${process.env.E2E_PORT ?? "3001"}`;
 const CREDS_PATH = path.join(process.cwd(), ".e2e-creds.json");
@@ -32,7 +33,7 @@ interface Creds {
 
 function loadCreds(): Creds {
   if (!fs.existsSync(CREDS_PATH)) {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-credentials.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-credentials.ts");
   }
   return JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
 }

--- a/tests/e2e/webhooks.spec.ts
+++ b/tests/e2e/webhooks.spec.ts
@@ -17,11 +17,12 @@
  * :3001 — reuseExistingServer teria reusado o servidor ERRADO). Por isso este
  * spec usa APP_URL absoluto em vez do baseURL do config.
  */
-import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { test, expect, type Page, type Locator } from "@playwright/test";
+
+import { rodaSeed } from "./helpers/seed";
 
 // Segue o dev server do harness (playwright.config webServer) — nunca hardcodar
 // porta: o config usa E2E_PORT (default 3001).
@@ -40,7 +41,7 @@ function loadCreds(): Creds {
     return !c.users?.manager || !c.users?.agent;
   };
   if (needsBase()) {
-    execFileSync("npx", ["tsx", "scripts/seed-e2e-credentials.ts"], { stdio: "inherit" });
+    rodaSeed("scripts/seed-e2e-credentials.ts");
   }
   return JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
 }

--- a/tests/unit/seed-e2e-sem-npx.test.ts
+++ b/tests/unit/seed-e2e-sem-npx.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 /**
- * SPEC E2E NÃO CHAMA `npx` — nem para rodar seed, nem para nada.
+ * TESTE NENHUM CHAMA `npx` — nem para rodar seed, nem para nada.
  *
  * O defeito: 23 call sites faziam `execFileSync("npx", ["tsx", "scripts/
  * seed-e2e-*.ts"], …)`. No Windows o `npx` não é executável, é o shim
@@ -12,6 +12,13 @@ import { describe, expect, it } from "vitest";
  * mitigação do CVE-2024-27980 (Node >= 18.20 / 20.12 / 22.0), EINVAL para
  * `"npx.cmd"`. Os specs morriam no `beforeAll`, antes de o navegador abrir: a
  * suíte E2E inteira não subia em Windows.
+ *
+ * O 24º call site NÃO estava em `tests/e2e`: `tests/capture-wave-6-cenarios.ts`
+ * subia o controle irmão do cenário D21 com `execFile("npx", …)`. Ali o estrago
+ * é pior que vermelho — o `execFile` entrega o erro no callback, o controle
+ * viraria `"(não mediu)"` calado, e o critério leria isso como "o ambiente não
+ * entrega", absolvendo uma tela sem ter medido nada. Por isso a varredura pega
+ * `tests/` inteiro, não só `tests/e2e`.
  *
  * ⚠️ ESTE TESTE NÃO RODA A SUÍTE E2E — ele lê o FONTE. É de propósito: o CI
  * roda os specs em Linux, onde o defeito não aparece, então nenhum vermelho de
@@ -26,14 +33,26 @@ import { describe, expect, it } from "vitest";
  */
 
 const RAIZ = join(__dirname, "..", "..");
-const E2E = join(RAIZ, "tests", "e2e");
+const TESTES = join(RAIZ, "tests");
 const PORTA = "tests/e2e/helpers/seed.ts";
 
-/** Todo `.ts` sob tests/e2e (specs + helpers + utils), caminho relativo à raiz. */
-function fontesE2E(dir = E2E): string[] {
+/**
+ * `tests/unit/` fica FORA da varredura, e não é conveniência: é ali que moram as
+ * guardas, e guarda cita o defeito que vigia — este arquivo mesmo escreve
+ * `execFileSync("npx"…)` no texto acima. Varrer aqui seria a guarda se acusando.
+ * O único caso REAL de `npx` que sobrou sob `tests/unit/` é o
+ * `import-puro-sem-env.test.ts`, que abre processo filho para provar import sem
+ * ambiente; ele é o mesmo defeito, tem conserto próprio em PR separado e teste
+ * próprio — não fica órfão por estar fora daqui.
+ */
+const FORA = join(TESTES, "unit");
+
+/** Todo `.ts` sob tests/ (menos `FORA`), caminho relativo à raiz. */
+function fontesDeTeste(dir = TESTES): string[] {
+  if (dir === FORA) return [];
   return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
     const abs = join(dir, e.name);
-    if (e.isDirectory()) return fontesE2E(abs);
+    if (e.isDirectory()) return fontesDeTeste(abs);
     // Barra normalizada: no Windows o `join` devolve `\`, e o PORTA (e a
     // mensagem de erro que o dev lê) são com `/`.
     return e.name.endsWith(".ts") ? [abs.slice(RAIZ.length + 1).replace(/\\/g, "/")] : [];
@@ -46,11 +65,13 @@ function semProsa(src: string): string {
 }
 
 describe("seed dos specs E2E sobe processo filho de um jeito portável", () => {
-  it("nenhum arquivo de tests/e2e spawna `npx`", () => {
+  it("nenhum arquivo de tests/ spawna `npx`", () => {
     // Pega `execFileSync("npx"`, `execFile("npx"`, `spawnSync('npx'` etc. — a
-    // forma que quebra é sempre "npx" como PRIMEIRO argumento do spawn.
+    // forma que quebra é sempre "npx" como PRIMEIRO argumento do spawn. O `\s`
+    // casa quebra de linha, então a chamada quebrada em várias linhas (que é
+    // como o capture-wave-6 escrevia a dele) não escapa.
     const spawnaNpx = /\b(exec|execFile|execFileSync|spawn|spawnSync)\s*\(\s*["'`]npx["'`]/;
-    const culpados = fontesE2E()
+    const culpados = fontesDeTeste()
       // A própria porta cita `execFileSync("npx"…)` no comentário que explica
       // por que ela existe. Quem a vigia é o teste seguinte, olhando o CÓDIGO.
       .filter((rel) => rel !== PORTA)
@@ -58,8 +79,10 @@ describe("seed dos specs E2E sobe processo filho de um jeito portável", () => {
     expect(
       culpados,
       `spawn de "npx" em: ${culpados.join(", ")}. Use \`rodaSeed()\` / ` +
-        `\`rodaSeedCapturando()\` de ${PORTA} — elas rodam \`process.execPath\` ` +
-        `com \`--import tsx\`, que existe em qualquer SO. NÃO resolva com ` +
+        `\`rodaSeedCapturando()\` de ${PORTA}; se precisar da forma assíncrona ` +
+        `ou de \`env\` próprio, chame \`process.execPath\` com ` +
+        `\`["--import", "tsx", <script>]\` direto. Os dois caminhos rodam o Node ` +
+        `que já está de pé, que existe em qualquer SO. NÃO resolva com ` +
         `\`shell: true\`: reabre o buraco de injeção que o CVE-2024-27980 fechou.`,
     ).toEqual([]);
   });
@@ -67,7 +90,8 @@ describe("seed dos specs E2E sobe processo filho de um jeito portável", () => {
   it("a porta compartilhada roda o Node do processo atual, não um shim do PATH", () => {
     // Sem isto, alguém "conserta" um erro futuro trocando o miolo do helper de
     // volta para `npx` e os 23 call sites voltam a quebrar de uma vez só — com
-    // o teste acima ainda verde, porque o `npx` estaria fora de tests/e2e.
+    // o teste acima ainda verde, porque ele mede quem CHAMA, não o miolo da
+    // porta (que é o único lugar autorizado a citar `npx` em prosa).
     const src = semProsa(readFileSync(join(RAIZ, PORTA), "utf8"));
     expect(src, `${PORTA} deve spawnar process.execPath`).toContain("process.execPath");
     expect(src, `${PORTA} deve registrar o tsx via --import`).toContain('"--import", "tsx"');
@@ -78,7 +102,7 @@ describe("seed dos specs E2E sobe processo filho de um jeito portável", () => {
   it("os specs realmente passam pela porta (a guarda não vigia arquivo vazio)", () => {
     // Um `tests/e2e` sem nenhum uso do helper deixaria os dois testes acima
     // verdes medindo nada — o verde vazio que a doutrina do repo proíbe.
-    const usam = fontesE2E().filter((rel) =>
+    const usam = fontesDeTeste().filter((rel) =>
       readFileSync(join(RAIZ, rel), "utf8").includes("./helpers/seed"),
     );
     expect(

--- a/tests/unit/seed-e2e-sem-npx.test.ts
+++ b/tests/unit/seed-e2e-sem-npx.test.ts
@@ -1,0 +1,89 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * SPEC E2E NÃO CHAMA `npx` — nem para rodar seed, nem para nada.
+ *
+ * O defeito: 23 call sites faziam `execFileSync("npx", ["tsx", "scripts/
+ * seed-e2e-*.ts"], …)`. No Windows o `npx` não é executável, é o shim
+ * `npx.cmd` — `execFileSync` sem shell devolve ENOENT para `"npx"` e, desde a
+ * mitigação do CVE-2024-27980 (Node >= 18.20 / 20.12 / 22.0), EINVAL para
+ * `"npx.cmd"`. Os specs morriam no `beforeAll`, antes de o navegador abrir: a
+ * suíte E2E inteira não subia em Windows.
+ *
+ * ⚠️ ESTE TESTE NÃO RODA A SUÍTE E2E — ele lê o FONTE. É de propósito: o CI
+ * roda os specs em Linux, onde o defeito não aparece, então nenhum vermelho de
+ * E2E vigiaria isto. Um contribuidor em Windows descobriria sozinho, e a leitura
+ * mais provável ("meu ambiente está torto") é a que faz ele desistir em vez de
+ * abrir issue. Por isso a guarda é estática e mora no `test:unit`, que é check
+ * obrigatório da branch protection.
+ *
+ * O que NÃO está medido aqui: que os seeds efetivamente rodam. Isso é trabalho
+ * do `pnpm test:e2e` com banco e dev server de pé — esta guarda só garante que
+ * a porta de entrada existe e é portável.
+ */
+
+const RAIZ = join(__dirname, "..", "..");
+const E2E = join(RAIZ, "tests", "e2e");
+const PORTA = "tests/e2e/helpers/seed.ts";
+
+/** Todo `.ts` sob tests/e2e (specs + helpers + utils), caminho relativo à raiz. */
+function fontesE2E(dir = E2E): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const abs = join(dir, e.name);
+    if (e.isDirectory()) return fontesE2E(abs);
+    // Barra normalizada: no Windows o `join` devolve `\`, e o PORTA (e a
+    // mensagem de erro que o dev lê) são com `/`.
+    return e.name.endsWith(".ts") ? [abs.slice(RAIZ.length + 1).replace(/\\/g, "/")] : [];
+  });
+}
+
+/** Tira os comentários de bloco: o texto que EXPLICA o defeito não é o defeito. */
+function semProsa(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+describe("seed dos specs E2E sobe processo filho de um jeito portável", () => {
+  it("nenhum arquivo de tests/e2e spawna `npx`", () => {
+    // Pega `execFileSync("npx"`, `execFile("npx"`, `spawnSync('npx'` etc. — a
+    // forma que quebra é sempre "npx" como PRIMEIRO argumento do spawn.
+    const spawnaNpx = /\b(exec|execFile|execFileSync|spawn|spawnSync)\s*\(\s*["'`]npx["'`]/;
+    const culpados = fontesE2E()
+      // A própria porta cita `execFileSync("npx"…)` no comentário que explica
+      // por que ela existe. Quem a vigia é o teste seguinte, olhando o CÓDIGO.
+      .filter((rel) => rel !== PORTA)
+      .filter((rel) => spawnaNpx.test(readFileSync(join(RAIZ, rel), "utf8")));
+    expect(
+      culpados,
+      `spawn de "npx" em: ${culpados.join(", ")}. Use \`rodaSeed()\` / ` +
+        `\`rodaSeedCapturando()\` de ${PORTA} — elas rodam \`process.execPath\` ` +
+        `com \`--import tsx\`, que existe em qualquer SO. NÃO resolva com ` +
+        `\`shell: true\`: reabre o buraco de injeção que o CVE-2024-27980 fechou.`,
+    ).toEqual([]);
+  });
+
+  it("a porta compartilhada roda o Node do processo atual, não um shim do PATH", () => {
+    // Sem isto, alguém "conserta" um erro futuro trocando o miolo do helper de
+    // volta para `npx` e os 23 call sites voltam a quebrar de uma vez só — com
+    // o teste acima ainda verde, porque o `npx` estaria fora de tests/e2e.
+    const src = semProsa(readFileSync(join(RAIZ, PORTA), "utf8"));
+    expect(src, `${PORTA} deve spawnar process.execPath`).toContain("process.execPath");
+    expect(src, `${PORTA} deve registrar o tsx via --import`).toContain('"--import", "tsx"');
+    expect(src, `${PORTA} não pode usar shell: true`).not.toContain("shell: true");
+    expect(src, `${PORTA} não pode voltar a spawnar npx`).not.toMatch(/["'`]npx["'`]/);
+  });
+
+  it("os specs realmente passam pela porta (a guarda não vigia arquivo vazio)", () => {
+    // Um `tests/e2e` sem nenhum uso do helper deixaria os dois testes acima
+    // verdes medindo nada — o verde vazio que a doutrina do repo proíbe.
+    const usam = fontesE2E().filter((rel) =>
+      readFileSync(join(RAIZ, rel), "utf8").includes("./helpers/seed"),
+    );
+    expect(
+      usam.length,
+      "nenhum spec importa helpers/seed — a guarda ficou sem objeto",
+    ).toBeGreaterThan(10);
+  });
+});


### PR DESCRIPTION
## O defeito

23 call sites de seed nos specs E2E faziam:

```ts
execFileSync("npx", ["tsx", "scripts/seed-e2e-credentials.ts"], { stdio: "inherit" });
```

No Windows o `npx` não é um executável — é o shim `npx.cmd`. `execFileSync` sem shell devolve **ENOENT** para `"npx"` e, desde a mitigação do **CVE-2024-27980** (Node >= 18.20 / 20.12 / 22.0), **EINVAL** para `"npx.cmd"` (spawnar `.cmd` sem shell foi proibido).

Efeito: os 13 specs morriam no `beforeAll`, **antes de o navegador abrir**. A suíte E2E inteira não subia em Windows, e o vermelho não falava de produto nenhum.

## Medição

Node v24.19.0, win32, mesmo arquivo `.ts` de alvo:

| chamada | resultado |
|---|---|
| `execFileSync("npx", ["tsx", alvo])` | `ENOENT` |
| `execFileSync("npx.cmd", ["tsx", alvo])` | `EINVAL` |
| `execFileSync(process.execPath, ["--import", "tsx", alvo])` | **OK** — imprimiu a saída do TS |

E com o seed real: `node --import tsx scripts/seed-e2e-credentials.ts` **compila e executa** — avança até o próprio `readFileSync('.env.local')` do script (este worktree não tem `.env.local`). Ou seja, o loader do tsx e a resolução de módulo funcionam pelo caminho novo.

## A correção

`process.execPath` é o binário do Node que já está rodando: existe em qualquer SO, não depende do `PATH` e não passa por shim nenhum. `--import tsx` registra o loader de TypeScript no filho — mesmo efeito de `npx tsx`, sem o `npx`.

**Não** foi usado `shell: true`: faria funcionar reabrindo exatamente o buraco de injeção de comando que a mitigação do CVE fechou, num lugar que interpola caminho de arquivo.

- **`tests/e2e/helpers/seed.ts`** — porta única: `rodaSeed(script, ...args)` e `rodaSeedCapturando(script, ...args)`.
- **13 specs / 23 call sites** passam a entrar por ela (o import de `node:child_process` sai dos specs).
- **`tests/unit/seed-e2e-sem-npx.test.ts`** — catraca estática no `test:unit` (check obrigatório da branch protection).

### Por que a guarda é estática e mora no `test:unit`

O CI roda a suíte E2E em **Linux**, onde o defeito não aparece. Nenhum vermelho de E2E vigiaria a regressão — quem a encontraria é um contribuidor em Windows, e a leitura mais provável ("meu ambiente está torto") é a que faz ele desistir em vez de abrir issue.

A guarda tem três asserções, e as três foram **sabotadas para confirmar que reprovam**:

1. reintroduzi `execFileSync("npx", …)` num spec → vermelho;
2. troquei o miolo do helper de volta para `npx` → vermelho;
3. apontei a contagem para um caminho de import inexistente (simulando "guarda sem objeto") → vermelho.

## Verificação

- `pnpm typecheck` — zerado
- `pnpm lint` (eslint em `tests/`) — zerado
- `pnpm test:unit` — **1893/1894**. A única falha é `tests/unit/import-puro-sem-env.test.ts` com `spawnSync npx ENOENT`: **o mesmo defeito, noutro arquivo**, que é justamente o escopo do #133. Não toquei nele de propósito, para não conflitar.

## O que NÃO está medido

- **Que os seeds concluem.** Isso precisa de Supabase local + dev server de pé (`pnpm test:e2e`); este PR prova o mecanismo de spawn e o carregamento do script, não o resultado do seed. Em Linux o comportamento é idêntico ao de antes — mesmo `tsx`, mesma resolução.
- **A suíte E2E rodando ponta a ponta no Windows.** Passa a ser possível (era impossível antes), mas não foi executada aqui.

## Achados fora do escopo (não corrigidos aqui)

1. **`scripts/lint-channels.ts` também não roda no Windows.** `walk()` monta caminhos com `join()` (→ `\`) e compara com `KNOWN_DEBT`/`ALLOWED`, que usam `/`. Nada bate: `pnpm lint:channels` acusa os ~50 arquivos da lista de dívida como "novos" **e** como "stale" ao mesmo tempo. Pré-existente e independente deste PR (`ROOTS` nem inclui `tests/`). Fix seria normalizar a barra em `walk()`.
2. **`tests/capture-wave-6-cenarios.ts:1214`** tem `execFile("npx", ["tsx", …])` — mesmo defeito, num script de captura manual. Fora do `tests/e2e/`, então fora da catraca deste PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Atualização — o 24º call site, fora de `tests/e2e`

`tests/capture-wave-6-cenarios.ts:1213` fazia `execFile("npx", ["tsx", "tests/prova-taxa-de-entrega.ts"], …)` para subir o **controle irmão** do cenário D21.

Ali o Windows não produz vermelho — produz coisa pior. O `execFile` entrega o erro pelo callback, que só lê `saida`; com ENOENT o `saida` vem vazio, o regex não casa, e `controleExterno` vira `"(não mediu)"` **calado**. Esse valor alimenta o ramo que decide se a entrega de `postgres_changes` está morta naquele ambiente — ou seja, o critério absolveria a tela por uma pré-condição que nunca foi medida. Um controle que não roda é pior que controle nenhum: ele responde.

- Conserto igual ao dos seeds: `process.execPath` com `--import tsx`. **Não** passa pela porta `rodaSeed()` porque a chamada é assíncrona e tem `env` próprio — criar uma terceira variante do helper para um único call site seria mais peça para manter do que o problema pede. A mensagem da guarda passou a citar as duas formas aceitas.
- **A guarda foi alargada de `tests/e2e/**` para `tests/` inteiro**, que é o que teria pego este arquivo desde o começo. `tests/unit/` fica de fora com justificativa escrita no próprio arquivo: é onde as guardas moram, e guarda cita o defeito que vigia — varrer ali seria a guarda se acusando.

**Sabotagem:** reposto o `execFile("npx", …)`, a guarda reprova nomeando o arquivo —

```
AssertionError: spawn de "npx" em: tests/capture-wave-6-cenarios.ts. Use `rodaSeed()` /
`rodaSeedCapturando()` de tests/e2e/helpers/seed.ts; se precisar da forma assíncrona ou de
`env` próprio, chame `process.execPath` com `["--import", "tsx", <script>]` direto.
```

Antes do alargamento, esse mesmo cenário passava calado.

**Medido no Windows nesta branch:** 223/224 arquivos, 1893/1894 testes. O único vermelho é `tests/unit/import-puro-sem-env.test.ts` — o mesmo defeito, num arquivo que esta branch não toca; conserto no PR #133, e é por isso que ele está fora do escopo da varredura. `tsc --noEmit` e `eslint` zerados.
