### PR TITLE
fix: lint:channels reprovava tudo no Windows por causa do separador de path

### DIFF
--- a/scripts/lint-channels.ts
+++ b/scripts/lint-channels.ts
@@ -29,7 +29,7 @@
  * silenciosa — se você precisar acrescentar uma, escreva o porquê junto.
  */
 import { readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { posix } from "node:path";
 
 const FORBIDDEN = /\b(waha|WAHA|meta_cloud|graph\.facebook\.com)\b/;
 const ROOTS = ["app", "lib", "components", "workers"];
@@ -138,9 +138,17 @@ const KNOWN_DEBT: { reason: string; files: string[] }[] = [
 
 const DEBT = new Set(KNOWN_DEBT.flatMap((g) => g.files));
 
+/**
+ * Monta o caminho com `posix.join`, não com `join`: no Windows o `join` do SO
+ * devolve `\`, e aí nem `ALLOWED` (regex com `/`) nem `KNOWN_DEBT` (strings com
+ * `/`) casam — a catraca acusava os ~50 arquivos da dívida como novos E como
+ * stale ao mesmo tempo, derrubando o `gov:verify` inteiro. A barra é normalizada
+ * na origem para o resto do arquivo comparar um formato só. Node aceita `/` em
+ * `readdirSync`/`readFileSync` nos dois SOs.
+ */
 function walk(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
-    const p = join(dir, e.name);
+    const p = posix.join(dir, e.name);
     if (e.isDirectory()) return e.name === "node_modules" ? [] : walk(p);
     return /\.tsx?$/.test(e.name) ? [p] : [];
   });


### PR DESCRIPTION
## O defeito

`pnpm lint:channels` sai com exit 1 em qualquer máquina Windows, mesmo com a árvore limpa — e como ele é a terceira etapa de `gov:verify` (`typecheck && lint && lint:channels && test:unit`), derruba a verificação inteira.

## Causa raiz

Em `scripts/lint-channels.ts`, o `walk()` montava o caminho com `join()` do `node:path`, que no Windows devolve `\`:

```ts
const p = join(dir, e.name);   // "app\api\v1\health\route.ts" no Windows
```

Só que os dois lados da comparação usam `/`:

- `ALLOWED` é regex com barra normal — `/^lib\/channels\//`, `/^lib\/waha\//`;
- `KNOWN_DEBT` é lista de strings com barra normal — `"app/api/v1/health/route.ts"`.

Com `\` no caminho, `ALLOWED.some(re => re.test(f))` nunca filtra e `DEBT.has(f)` nunca casa. O resultado é que os ~50 arquivos da dívida conhecida são acusados **ao mesmo tempo** como novos (invariante 1 violado) e como stale, e `lib/channels/` e `lib/waha/` param de ser exceção.

Saída no Windows antes do fix — 74 "novos" + 53 "stale", exit 1:

```
Nome de provider fora de lib/channels/ (doutrina restricao-de-canal, invariante 1):
  app\api\v1\admin\dashboard\kpis\route.ts
  ...
  lib\channels\adapters\waha.ts        <- deveria estar em ALLOWED
  lib\waha\client.ts                   <- deveria estar em ALLOWED
  ...
Entradas de KNOWN_DEBT que já não vazam (ou o arquivo sumiu) — apague-as de
scripts/lint-channels.ts para a catraca não afrouxar:
  app/api/v1/admin/dashboard/kpis/route.ts
  ...
```

O mesmo arquivo aparece nas duas listas, com barras diferentes — é a assinatura do defeito.

## A correção

Normaliza a barra **na origem**, dentro do `walk()`, trocando `join` por `posix.join`. O resto do arquivo passa a comparar um formato só; a lista de dívida e os regexes ficam exatamente como estão.

Escolhi `posix.join` em vez de `.replace(/\/g, "/")` porque no Linux `posix.join` **é** o `join` de hoje — o comportamento em CI não muda em nada, nem para o caso patológico de um nome de arquivo que contenha `\` literal (legal no Linux, que o `replace` corromperia). `readdirSync` e `readFileSync` aceitam `/` nos dois SOs.

Diff: 1 arquivo, +10/-2, sendo 6 linhas de comentário explicando o porquê.

## Como provei

Windows 10 Pro, Git Bash, Node 22, pnpm 9.15.9.

| passo | resultado |
|---|---|
| `pnpm lint:channels` **antes** | ❌ exit 1 — 74 "novos" + 53 "stale" |
| `pnpm lint:channels` **depois** | ✅ exit 0 — `lint-channels: ok (53 arquivos de dívida conhecida, nenhum novo)` |
| `pnpm typecheck` | ✅ exit 0 |
| `pnpm lint` | ✅ 0 errors (170 warnings pré-existentes, nenhum no arquivo tocado) |

Os 53 são exatamente `13+9+2+29`, o total das quatro categorias de `KNOWN_DEBT` — ou seja, o fix não afrouxou a catraca engolindo entrada nenhuma.

### Sabotagem — as duas direções da catraca continuam vivas

Verde de lint não prova que a catraca ainda morde. Sabotei nas duas direções que ela existe para pegar:

**A. arquivo novo com nome de provider fora de `lib/channels/`** — criei `lib/sabotagem-catraca.ts` com `"http://localhost:3000/api/waha/session"`:

```
Nome de provider fora de lib/channels/ (doutrina restricao-de-canal, invariante 1):
  lib/sabotagem-catraca.ts
EXIT=1
```

Acusou só o arquivo novo, com a barra certa. (Arquivo removido em seguida.)

**B. arquivo limpo esquecido no `KNOWN_DEBT`** — acrescentei `lib/api/wrappers.ts` (que não tem nome de provider) à lista:

```
Entradas de KNOWN_DEBT que já não vazam (ou o arquivo sumiu) — apague-as de
scripts/lint-channels.ts para a catraca não afrouxar:
  lib/api/wrappers.ts
EXIT=1
```

A regra de "a lista só pode encolher" continua valendo. (Entrada revertida em seguida.)

## NÃO MEDIDO

- **Não deixei teste automatizado**, de propósito. A CI roda em Linux, onde `join` e `posix.join` são a mesma função — qualquer teste que afirmasse "o `walk()` devolve `/`" passaria **antes e depois** do fix na CI. Seria uma sonda verde-sempre, medindo caminho diferente do que quebra, que é justamente a falha-em-verde que a doutrina proíbe. Para valer alguma coisa o teste teria que injetar um `path` falso no `walk()`, o que exige exportar a função e parametrizar o módulo — mais máquina do que o próprio fix. A prova aqui é a sabotagem manual acima, rodada no SO onde o defeito existe.
- **Não rodei em macOS.** Testado só em Windows (onde estava quebrado) — no Linux a mudança é semanticamente nula por construção, e a CI cobre isso.
- **`pnpm test:unit` fica em 1890/1891.** A única falha é `tests/unit/import-puro-sem-env.test.ts` com `spawnSync npx ENOENT`, que é outro problema de portabilidade Windows (`execFileSync("npx")` não resolve em Node 18.20+ por causa do CVE-2024-27980) e já está sendo tratado em separado. Não tem relação com separador de path em script de lint, e é pré-existente na `main`.
- **Não toquei em schema, RLS, rota, env var nem UI** — os itens 4–12 da Definition of Done não se aplicam a este diff.

Mesmo tema do #134 (portabilidade Windows do harness), mas arquivo e mecanismo diferentes — por isso saiu em PR próprio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
