### PR TITLE
fix(kit): bootstrap não troca senha de dono que já existe, e o instalador diz isso

### DIFF
--- a/.env.hostgator.example
+++ b/.env.hostgator.example
@@ -143,6 +143,10 @@ SENTRY_DSN=
 # -----------------------------------------------------------------------------
 # 12) Bootstrap do 1º dono (usado só uma vez pelo install.sh)
 # -----------------------------------------------------------------------------
+# "só uma vez" é literal: numa re-execução do install.sh, o Auth recusa (422) o
+# cadastro de um e-mail que já existe e a senha abaixo NÃO passa a valer — quem
+# entra continua sendo a senha da 1ª instalação. Trocar a senha do dono é
+# `bash hostgator-setup-kit/reset-password.sh <email>`, não editar esta linha.
 OWNER_EMAIL=voce@seudominio.com.br
 OWNER_PASSWORD=                          # senha forte do primeiro admin
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,8 @@ Ao mexer em schema, RLS, RBAC, atribuição, escopo, roteamento, follow-up, webh
 
 **O que "recurso real" significa (e o que NÃO conta):**
 - **Conta.** Prova pela tela, dirigindo o browser (Playwright), logando com conta de teste real. `curl`/chamada de API **não** provam UX — validam o backend, mas não o que o usuário vê, clica e entende. Use curl só como diagnóstico.
-- **Banco fresco estilo VPS.** Postgres limpo aplicado do `supabase/baseline.sql` (não das `migrations/` — a cadeia fresh não sobe) + `scripts/bootstrap-owner.ts` (o que o `install.sh` faz). O ambiente do teste = o que o clone recém-instalado tem: sem os seus dados, sem os seus envs opcionais.
+- **Banco fresco estilo VPS.** Postgres limpo aplicado do `supabase/baseline.sql` (não das `migrations/` — a cadeia fresh não sobe) + `scripts/bootstrap-owner.ts`. O ambiente do teste = o que o clone recém-instalado tem: sem os seus dados, sem os seus envs opcionais.
+  - ⚠️ **`bootstrap-owner.ts` ESPELHA o bootstrap do `install.sh`, mas não é chamado por ele.** O instalador refaz o passo em bash (`curl` na admin API + heredoc `psql`) — sempre foi assim. São duas implementações do mesmo contrato, e elas já divergiram calada na credencial do dono: até 2026-08-04 o script TS sobrescrevia a senha de um dono que já existia e o instalador não (ele leva 422 e preserva). **Ao mexer num, cheque o outro** — e, para saber o que a VPS faz, leia o `install.sh`, não o script.
 - **Dependências como na VPS.** WAHA local, Redis local (`redis` + `serverless-redis-http`), cron drain via endpoint. E **teste com os envs opcionais AUSENTES** (ex.: sem `RESEND_API_KEY`) — é o estado real de um primeiro deploy, e é onde moram os piores bugs de primeira impressão.
 - **Efeito colateral externo provado com receiver real.** Webhook outbound, envio — suba um receiver HTTP de verdade e prove o que chegou (ou que foi barrado). Mock não estressa o egress real (anti-SSRF, projeção de payload, https em prod).
 

--- a/docs/testing/HANDOFF-vps-qa.md
+++ b/docs/testing/HANDOFF-vps-qa.md
@@ -15,7 +15,8 @@ os bugs achados na causa raiz.
 
 - **Banco:** Supabase local **pg17** (`config.toml major_version = 17`) do
   `baseline.sql`; extensões `vector/pg_trgm/citext/uuid-ossp/pgcrypto` antes.
-- **Primeiro usuário:** `scripts/bootstrap-owner.ts` (como o `install.sh`):
+- **Primeiro usuário:** `scripts/bootstrap-owner.ts` (espelha o bootstrap do
+  `install.sh` — que **não** chama este script, refaz o passo em bash):
   `dono@qa.local` / `QaVps!2026#Dono`, org "Loja QA VPS".
 - **Deps:** WAHA Core local (`deskcomm-waha`, :3030), Redis + serverless-redis-http
   (`qa-redis`/`qa-srh`, :8079), cron drain via endpoint.

--- a/docs/testing/user-journey-map.md
+++ b/docs/testing/user-journey-map.md
@@ -6,7 +6,8 @@
 > real). Curl/API só como diagnóstico, nunca como prova de UX.
 >
 > Persona: **usuário leigo** que rodou o `install.sh` numa VPS e abriu o navegador.
-> Ambiente de referência: banco 100% zerado + `bootstrap-owner.ts` (o que o kit faz).
+> Ambiente de referência: banco 100% zerado + `bootstrap-owner.ts` (espelha o que o kit
+> faz — o `install.sh` refaz esse bootstrap em bash, não chama o script).
 
 ## Convenções
 
@@ -21,7 +22,8 @@
 ## J1 — Onboarding do primeiro usuário `[P0]`
 
 Contexto do código: sem signup público (`app/(public)/login`); primeiro usuário nasce
-do `scripts/bootstrap-owner.ts` (install.sh). Wizard: welcome → whatsapp → (nuvemshop
+do `scripts/bootstrap-owner.ts` (na VPS, do bootstrap equivalente dentro do `install.sh`).
+Wizard: welcome → whatsapp → (nuvemshop
 se `NUVEMSHOP_ENABLED`) → setup-ai → invite-team → done. Gate: `organizations.onboarded_at`.
 MFA obrigatório pra admin logo após o wizard (`MfaEnrollGate`).
 

--- a/hostgator-setup-kit/CLAUDE.md
+++ b/hostgator-setup-kit/CLAUDE.md
@@ -121,6 +121,14 @@ Se mesmo assim aparecerem, aqui está o diagnóstico pronto:
    `hiett/serverless-redis-http` (o compose já usa). Um nome antigo (`hjr265/...`) saiu do ar.
 6. **"usuário já existe" (422) no bootstrap do admin** — normal numa 2ª tentativa. O
    `install.sh` é idempotente: ignora o 422 e encontra o usuário pelo e-mail. Não trava.
+   **O 422 também quer dizer que a senha do dono NÃO mudou:** a admin API recusa o
+   cadastro inteiro, então o `OWNER_PASSWORD` que está no `.env` agora não vale — quem
+   entra continua sendo a senha da instalação anterior. Repare nisso quando você re-roda
+   o instalador para corrigir uma configuração (que é o caminho que este kit indica): se
+   a pessoa trocou a senha no `.env` esperando que ela passasse a valer, ela vai bater na
+   tela de login com a senha errada. O instalador avisa na hora e repete no fim, no lugar
+   da senha. Trocar a senha é outro comando, de propósito:
+   `bash reset-password.sh <email>`.
 7. **`/api/v1/health` diz "unhealthy" mas o site funciona** — versões antigas checavam
    rotas erradas (`/ping`, `/api/health`). A imagem atual já checa as rotas certas; se ver
    isso, garanta que a imagem do app está na tag `latest` mais nova (`bash update.sh`).

--- a/hostgator-setup-kit/README.md
+++ b/hostgator-setup-kit/README.md
@@ -115,7 +115,7 @@ painel dela. Se o seu Traefik usa nomes diferentes de `websecure`/`letsencrypt`,
 
 | Script | Função |
 |---|---|
-| `install.sh` | Instala tudo (idempotente) |
+| `install.sh` | Instala tudo (idempotente — re-rodar **não** troca a senha de um admin que já existe) |
 | `update.sh` | Atualiza pra versão nova |
 | `backup.sh` | Backup do banco + sessões WhatsApp |
 | `restore.sh` | Restaura um backup |

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -519,6 +519,33 @@ sb_carrega_credenciais() {
   done <<<"$1"
 }
 
+# Cria o dono no Supabase Auth (passo 8). Se esse e-mail JÁ tem usuário, a admin
+# API responde 422 `email_exists` e NÃO toca na senha dele — medido contra o
+# GoTrue: depois do 422, a senha antiga continua entrando e a do corpo não vale.
+# Ou seja, o instalador nunca troca a senha de ninguém, e re-rodar é seguro.
+#
+# O que faltava era DIZER isso. Sem a mensagem, quem re-roda o instalador para
+# corrigir uma config lê "senha: (a que você definiu)" no fim, tenta entrar com
+# a senha que acabou de pôr no .env, e não entra — a que vale é a da instalação
+# anterior. Nada quebrou, mas a última tela mentiu, que é o pior lugar.
+#
+# Sai 0 sempre (quem decide se o dono existe é o psql do passo seguinte, que
+# resolve o uid direto do auth.users); quem já existia fica em OWNER_JA_EXISTIA.
+OWNER_JA_EXISTIA=0
+criar_dono_no_auth() {
+  local code
+  code="$(curl -s -o /dev/null -w '%{http_code}' -X POST "${NEXT_PUBLIC_SUPABASE_URL}/auth/v1/admin/users" \
+    -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+    -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"${OWNER_EMAIL}\",\"password\":\"${OWNER_PASSWORD}\",\"email_confirm\":true}" 2>/dev/null || true)"
+  [ "$code" = "422" ] || return 0
+  OWNER_JA_EXISTIA=1
+  c_ylw "• esse e-mail já tinha usuário — a senha dele NÃO foi alterada."
+  c_dim "  continua valendo a senha anterior; para trocar:"
+  c_dim "    bash ${KIT_DIR}/reset-password.sh ${OWNER_EMAIL}"
+}
+
 # Carrega só as funções acima, sem instalar nada — é assim que
 # `test-validators.sh` exercita os validadores:  INSTALL_SH_LIB=1 . install.sh
 if [ "${INSTALL_SH_LIB:-}" = "1" ]; then trap - EXIT; return 0; fi
@@ -1075,20 +1102,15 @@ fi
 
 # ── 8. Bootstrap do 1º dono (cria no Auth + promove via psql) ───────────────
 step "Criando o primeiro admin (${OWNER_EMAIL})"
-# 1) Cria o usuário no Supabase Auth. Se já existe, a API responde 422 — ignoramos
-#    (|| true): a re-execução é idempotente, o passo seguinte encontra o usuário.
-curl -fsS -X POST "${NEXT_PUBLIC_SUPABASE_URL}/auth/v1/admin/users" \
-  -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
-  -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
-  -H "Content-Type: application/json" \
-  -d "{\"email\":\"${OWNER_EMAIL}\",\"password\":\"${OWNER_PASSWORD}\",\"email_confirm\":true}" \
-  >/dev/null 2>&1 || true
+# 1) Cria o usuário no Supabase Auth. Se já existe, a API responde 422, a senha
+#    dele fica intacta e a função avisa — ver o comentário na definição dela.
+criar_dono_no_auth
 
 # 2) Resolve o id direto do auth.users e cria org + membership + platform_admin.
 #    Resolver o uid DENTRO do SQL evita parsing frágil de JSON e funciona tanto para
 #    usuário recém-criado quanto para um que já existia (re-execução).
 docker run --rm -i postgres:17-alpine psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 <<SQL \
-  && c_grn "✓ dono criado e promovido a super-admin" \
+  && c_grn "✓ dono $([ "$OWNER_JA_EXISTIA" = 1 ] && printf 'confirmado' || printf 'criado') e promovido a super-admin" \
   || die "Não consegui promover o admin. Confira a service_role key, a URL e a connection string do Supabase."
 do \$\$
 declare v_org uuid; v_uid uuid;
@@ -1184,6 +1206,16 @@ INCOMPLETO
   exit 1
 fi
 
+# Numa reinstalação sobre um banco que já tinha esse dono, a senha que entra é a
+# antiga — o Auth recusou (422) a que está no .env. Dizer "a que você definiu"
+# aqui manda a pessoa tentar a senha errada na primeira tela que ela vê.
+if [ "$OWNER_JA_EXISTIA" = 1 ]; then
+  SENHA_LOGIN="a MESMA de antes (esse e-mail já tinha usuário; o instalador não troca senha)
+                trocar: bash ${KIT_DIR}/reset-password.sh ${OWNER_EMAIL}"
+else
+  SENHA_LOGIN="(a que você definiu)"
+fi
+
 cat <<DONE
 
 $(c_grn "═══════════════════════════════════════════════════════")
@@ -1195,7 +1227,7 @@ $(c_grn "═══════════════════════�
 
   2. Faça login com:
        e-mail: ${OWNER_EMAIL}
-       senha:  (a que você definiu)
+       senha:  ${SENHA_LOGIN}
 
   3. Conecte o WhatsApp (2º passo do onboarding):
        Deixe o WhatsApp JÁ ABERTO em Configurações → Aparelhos conectados

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -535,6 +535,49 @@ np_ok /root/_123         123
 np_ok /root/deskcomm.crm deskcommcrm
 np_ok /root/crm_cliente  crm_cliente
 
+echo "bootstrap do dono (o instalador não troca senha de quem já existe)"
+# Um `curl` de mentira devolve só o código HTTP, que é o que a função lê. Prova
+# a única coisa que ela decide: 422 = o e-mail já tinha usuário, então a senha
+# que entra é a ANTIGA e a pessoa precisa ouvir isso — senão ela sai da última
+# tela do instalador tentando a senha nova do .env, que o Auth recusou.
+FAKEBIN="$(mktemp -d)"
+trap 'rm -rf "$FAKEBIN"' EXIT
+cat > "$FAKEBIN/curl" <<'STUB'
+#!/usr/bin/env bash
+printf '%s' "${FAKE_HTTP_CODE:-000}"
+STUB
+chmod +x "$FAKEBIN/curl"
+PATH="$FAKEBIN:$PATH"
+NEXT_PUBLIC_SUPABASE_URL="https://x.supabase.co"
+SUPABASE_SERVICE_ROLE_KEY="service-role-de-mentira"
+OWNER_EMAIL="dono@empresa.com.br"
+OWNER_PASSWORD="SenhaNovaDoEnv!2026"
+KIT_DIR="hostgator-setup-kit"
+
+dono_ok() {  # dono_ok <descrição> <http> <ja_existia> [trecho esperado na saída]
+  local desc="$1" http="$2" esperado="$3" want="${4-}" out
+  OWNER_JA_EXISTIA=0
+  out="$(FAKE_HTTP_CODE="$http" criar_dono_no_auth 2>&1; printf '|%s' "$OWNER_JA_EXISTIA")"
+  local flag="${out##*|}"; out="${out%|*}"
+  if [ "$flag" != "$esperado" ]; then
+    printf '  ✗ %s  (OWNER_JA_EXISTIA=%s, esperava %s)\n' "$desc" "$flag" "$esperado"; fail=1; return
+  fi
+  if [ -n "$want" ] && ! printf '%s' "$out" | grep -qi -- "$want"; then
+    printf '  ✗ %s  (não avisou; esperava falar de: %s)\n     disse: %s\n' "$desc" "$want" "$out"; fail=1; return
+  fi
+  if [ -z "$want" ] && [ -n "$out" ]; then
+    printf '  ✗ %s  (falou de senha numa criação normal: %s)\n' "$desc" "$out"; fail=1; return
+  fi
+  printf '  ✓ %s\n' "$desc"
+}
+
+dono_ok "201 (usuário novo) → segue calado"                201 0
+dono_ok "422 (já existe) → marca e avisa que NÃO trocou"   422 1 "senha dele NÃO foi alterada"
+dono_ok "422 → ensina o caminho de trocar a senha"         422 1 "reset-password.sh"
+# Rede fora / URL errada não é "já existe": inventar o aviso aqui faria a pessoa
+# desconfiar de uma senha que está certa. Quem reprova de verdade é o psql adiante.
+dono_ok "000 (curl não chegou) → não inventa que já existia" 000 0
+
 echo
 if [ "$fail" = 0 ]; then echo "todos os validadores passaram"; else echo "FALHOU"; fi
 exit "$fail"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:journeys": "playwright test -c tests/journeys/playwright.config.ts",
     "test:unit": "vitest run",
     "test:db": "bash scripts/test-db.sh",
-    "test:shell": "bash tests/shell/update-guard.test.sh",
+    "test:shell": "bash tests/shell/update-guard.test.sh && bash hostgator-setup-kit/test-validators.sh",
     "test:invariants": "bash scripts/test-db.sh",
     "lint:channels": "tsx scripts/lint-channels.ts",
     "gov:verify": "pnpm typecheck && pnpm lint && pnpm lint:channels && pnpm test:unit",

--- a/scripts/bootstrap-owner.ts
+++ b/scripts/bootstrap-owner.ts
@@ -13,6 +13,15 @@
  * Uso (o install.sh exporta as vars; localmente lê .env/.env.local):
  *   OWNER_EMAIL=dono@empresa.com OWNER_PASSWORD='senha-forte' \
  *   OWNER_ORG_NAME='Minha Empresa' npx tsx scripts/bootstrap-owner.ts
+ *
+ * Sobre um banco que JÁ tem esse e-mail, a senha existente é PRESERVADA. Antes
+ * ela era sobrescrita em silêncio pelo OWNER_PASSWORD do .env — e este script é
+ * documentado como "o que o install.sh faz", que faz o oposto: o instalador
+ * manda um POST /auth/v1/admin/users, leva 422 `email_exists` e não toca na
+ * senha. Duas rotas que se anunciam iguais e divergem justamente na credencial
+ * do dono trancam quem re-roda o bootstrap com um .env de senha antiga.
+ * Redefinir agora é escolha explícita:
+ *   npx tsx scripts/bootstrap-owner.ts --reset-owner-password
  */
 
 import { createClient } from "@supabase/supabase-js";
@@ -40,6 +49,8 @@ const SERVICE_ROLE = env.SUPABASE_SERVICE_ROLE_KEY;
 const OWNER_EMAIL = env.OWNER_EMAIL;
 const OWNER_PASSWORD = env.OWNER_PASSWORD;
 const ORG_NAME = env.OWNER_ORG_NAME || "Minha Empresa";
+/** Só com esta flag o script mexe na senha de um dono que já existe. */
+const RESET_SENHA = process.argv.includes("--reset-owner-password");
 
 if (!SUPABASE_URL || !SERVICE_ROLE) {
   throw new Error("Faltam NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY.");
@@ -67,8 +78,21 @@ async function ensureOwnerUser(): Promise<string> {
   const { data: list } = await admin.auth.admin.listUsers({ perPage: 200 });
   const existing = list.users.find((u) => u.email === OWNER_EMAIL);
   if (existing) {
-    await admin.auth.admin.updateUserById(existing.id, { password: OWNER_PASSWORD });
-    console.log(`[bootstrap] dono já existia, senha atualizada: ${existing.id}`);
+    if (!RESET_SENHA) {
+      console.log(
+        `[bootstrap] dono já existia, senha PRESERVADA: ${existing.id}` +
+          ` (para redefinir: --reset-owner-password)`,
+      );
+      return existing.id;
+    }
+    // O erro era engolido: uma senha que a admin API recusou (política de
+    // tamanho, por ex.) saía como "senha atualizada" e a pessoa só descobria
+    // na tela de login.
+    const { error } = await admin.auth.admin.updateUserById(existing.id, {
+      password: OWNER_PASSWORD,
+    });
+    if (error) throw new Error(`redefinir senha do dono: ${error.message}`);
+    console.log(`[bootstrap] dono já existia, senha REDEFINIDA: ${existing.id}`);
     return existing.id;
   }
   const { data, error } = await admin.auth.admin.createUser({

--- a/tests/e2e/vps-fresh-onboarding.spec.ts
+++ b/tests/e2e/vps-fresh-onboarding.spec.ts
@@ -3,7 +3,8 @@
  *
  * Pré-condições (ambiente que simula o kit self-host):
  *   - banco zerado do baseline.sql (Supabase local pg17)
- *   - primeiro usuário criado via scripts/bootstrap-owner.ts (como o install.sh)
+ *   - primeiro usuário criado via scripts/bootstrap-owner.ts, que espelha o
+ *     bootstrap do install.sh (o instalador refaz o passo em bash, não chama o script)
  *   - WAHA ativo, Redis local, RESEND_API_KEY VAZIO (realidade da VPS fresca)
  *   - app em produção (next build + next start) na E2E_PORT
  *

--- a/tests/prova-org-fresca-clinica.ts
+++ b/tests/prova-org-fresca-clinica.ts
@@ -25,7 +25,8 @@
  *     Chamar `sincronizaEstagioDoAgente` direto passaria com a ponte desligada —
  *     por isso a ponte é o ponto de entrada.
  *   • a criação da organização é um INSERT em `organizations` com o service role,
- *     o mesmo que `scripts/bootstrap-owner.ts` (o que o `install.sh` roda) faz.
+ *     o mesmo que `scripts/bootstrap-owner.ts` — e que o bootstrap equivalente
+ *     dentro do próprio `install.sh`, que não chama o script — faz.
  *     Quem semeia é o GATILHO do banco, então qualquer caminho de criação passa
  *     por ele.
  *

--- a/tests/unit/bootstrap-owner-senha.test.ts
+++ b/tests/unit/bootstrap-owner-senha.test.ts
@@ -1,0 +1,112 @@
+/**
+ * `scripts/bootstrap-owner.ts` sobre um banco que JÁ tem o dono.
+ *
+ * O defeito que este teste guarda: o script sobrescrevia a senha do dono com o
+ * OWNER_PASSWORD do .env toda vez que rodava. Quem re-rodava o bootstrap com um
+ * .env de senha antiga (ou de placeholder) perdia o acesso que tinha — e sem
+ * aviso nenhum, porque o log dizia só "senha atualizada".
+ *
+ * O que faz disso um defeito, e não uma escolha: o script é documentado como
+ * "o que o install.sh faz" (CLAUDE.md, docs/testing/HANDOFF-vps-qa.md), e o
+ * install.sh faz o OPOSTO. Medido contra o GoTrue v2.194.0 local: o
+ * POST /auth/v1/admin/users do instalador responde 422 `email_exists` e a senha
+ * anterior continua entrando; só o PUT/updateUserById daqui trocava.
+ *
+ * A asserção é sobre a CHAMADA à admin API, não sobre o log: é o que o usuário
+ * sente. Sabote removendo o `if (!RESET_SENHA)` do script e o 1º caso reprova.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const OWNER_ID = "11111111-1111-4111-8111-111111111111";
+const OWNER_EMAIL = "dono@empresa.local";
+
+const updateUserById = vi.fn(async () => ({ data: {}, error: null }));
+const createUser = vi.fn(async () => ({
+  data: { user: { id: OWNER_ID } },
+  error: null,
+}));
+
+/**
+ * Encadeador preguiçoso: qualquer método devolve a si mesmo e o objeto é
+ * "thenable", então tanto `.select().eq().maybeSingle()` quanto o
+ * `await .update().eq().eq()` do script resolvem no mesmo resultado. Ele
+ * responde "a linha já existe" para org, membership e platform_admin — que é
+ * exatamente o cenário sob prova: a 2ª execução, num banco já povoado.
+ */
+function chainJaExiste(): unknown {
+  const linha = { data: { id: "org-1", user_id: OWNER_ID } };
+  const chain: unknown = new Proxy(
+    {},
+    {
+      get(_alvo, prop) {
+        if (prop === "then") {
+          return (ok: (v: unknown) => unknown, erro?: (e: unknown) => unknown) =>
+            Promise.resolve(linha).then(ok, erro);
+        }
+        return () => chain;
+      },
+    },
+  );
+  return chain;
+}
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    auth: {
+      admin: {
+        listUsers: async () => ({
+          data: { users: [{ id: OWNER_ID, email: OWNER_EMAIL }] },
+        }),
+        createUser,
+        updateUserById,
+      },
+    },
+    from: () => chainJaExiste(),
+  }),
+}));
+
+/** Roda o script inteiro (ele chama main() no import) e espera terminar. */
+async function rodarBootstrap(argv: string[]): Promise<void> {
+  const argvOriginal = process.argv;
+  process.argv = ["node", "scripts/bootstrap-owner.ts", ...argv];
+  const logs: string[] = [];
+  const log = vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+    logs.push(a.join(" "));
+  });
+  try {
+    vi.resetModules();
+    await import("../../scripts/bootstrap-owner");
+    // main() não é aguardado pelo módulo; o fim dele é a última linha do log.
+    await vi.waitFor(() =>
+      expect(logs.some((l) => l.includes("Bootstrap completo"))).toBe(true),
+    );
+  } finally {
+    log.mockRestore();
+    process.argv = argvOriginal;
+  }
+}
+
+describe("bootstrap-owner: dono que já existe", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "http://127.0.0.1:54321");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service-role-de-mentira");
+    vi.stubEnv("OWNER_EMAIL", OWNER_EMAIL);
+    vi.stubEnv("OWNER_PASSWORD", "SenhaNovaDoEnv!2026");
+    updateUserById.mockClear();
+    createUser.mockClear();
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("por padrão NÃO mexe na senha (igual ao install.sh)", async () => {
+    await rodarBootstrap([]);
+    expect(updateUserById).not.toHaveBeenCalled();
+    expect(createUser).not.toHaveBeenCalled();
+  });
+
+  it("só redefine com --reset-owner-password, e com a senha do .env", async () => {
+    await rodarBootstrap(["--reset-owner-password"]);
+    expect(updateUserById).toHaveBeenCalledWith(OWNER_ID, {
+      password: "SenhaNovaDoEnv!2026",
+    });
+  });
+});


### PR DESCRIPTION
## O que motivou

O item 6 das "Armadilhas já mapeadas" (`hostgator-setup-kit/CLAUDE.md`) dizia do 422 do bootstrap só que o `install.sh` "ignora e não trava". É verdade — mas falta a metade que muda o que a pessoa faz em seguida: **o 422 significa que a senha do dono NÃO mudou**. A admin API recusa o cadastro inteiro, então o `OWNER_PASSWORD` que está no `.env` agora não vale nada; quem entra continua sendo a senha da instalação anterior. E re-rodar o instalador é justamente o caminho que o kit indica para corrigir config.

## O que foi medido

GoTrue v2.194.0 (Supabase local), com login real antes e depois de cada rota:

| rota | quem usa | HTTP | senha antiga | senha do `.env` |
|---|---|---|---|---|
| `POST /auth/v1/admin/users` | `install.sh` | 422 `email_exists` | **200** (continua valendo) | 400 |
| `PUT /auth/v1/admin/users/<uid>` | `scripts/bootstrap-owner.ts` | 200 | 400 | **200** (trocou) |

Ou seja: **o instalador nunca trocou a senha de ninguém.** Quem trocava, em silêncio, era o `scripts/bootstrap-owner.ts` — que o `CLAUDE.md` da raiz e o `docs/testing/HANDOFF-vps-qa.md` descrevem como *"o que o `install.sh` faz"*. Duas rotas que se anunciam iguais e divergem exatamente na credencial do dono: quem re-roda o bootstrap com um `.env` de senha antiga ou de placeholder perde o acesso que tinha.

## O que muda

- **`scripts/bootstrap-owner.ts`** preserva a senha de um dono que já existe. Redefinir virou escolha explícita (`--reset-owner-password`). De quebra, o erro do `updateUserById` deixou de ser engolido — uma senha recusada pela política do Auth saía como "senha atualizada" e a pessoa só descobria na tela de login.
- **`install.sh`** lê o código HTTP em vez de descartá-lo (`|| true`) e avisa na hora que a senha não foi alterada, com o comando de trocar. A última tela deixa de dizer `senha: (a que você definiu)` numa reinstalação em que a senha que entra é a antiga — falso verde na única tela que a pessoa lê inteira. O `✓ dono criado` vira `✓ dono confirmado` quando ninguém foi criado.
- **Docs alinhados**: item 6 reescrito, `.env.hostgator.example` ("usado só uma vez" é literal) e a tabela de scripts do README.

## Provas

Ambas sabotadas antes de commitar, para confirmar que reprovam:

- `tests/unit/bootstrap-owner-senha.test.ts` — asserta a **chamada à admin API**, não o log. Sem a guarda, o 1º caso fica vermelho.
- 4 casos em `hostgator-setup-kit/test-validators.sh`, incluindo o `curl` que não chegou (`000`), que não pode virar "já existia" — inventar o aviso faria a pessoa desconfiar de uma senha que está certa.

E **`test-validators.sh` passa a rodar no CI** (`pnpm test:shell`): existia desde o 1º commit do kit e não era chamado por nada, então nenhum dos validadores do instalador segurava merge.

## NÃO MEDIDO

- O 422 foi medido no GoTrue **local** (v2.194.0), não contra o Supabase **hospedado** que a VPS usa.
- Nada aqui foi exercitado numa instalação HostGator de verdade — só o caminho de código, com dublês.
- A suíte shell tem 1 ✗ pré-existente no Windows (`.env continua 600`, sem permissão POSIX no Git Bash); reproduzido igual num checkout sem estas mudanças.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
