### PR TITLE
fix(kit): install.sh lê os entrypoints do Traefik em vez de assumir web/websecure

### DIFF
--- a/.env.hostgator.example
+++ b/.env.hostgator.example
@@ -37,6 +37,13 @@ ACME_EMAIL=voce@seudominio.com.br          # e-mail do Let's Encrypt (avisos de 
 # TRAEFIK_NETWORK é a rede do Traefik DA HOSPEDAGEM (o app é anexado a ela), não a
 # rede do projeto — o nome varia por painel: `coolify`, `dokploy-network`, `traefik`.
 # O install.sh descobre inspecionando o contêiner do Traefik.
+#
+# Os três de baixo são os NOMES que os labels citam, e também variam por painel:
+# Dokploy usa `web`/`websecure`, Easypanel usa `http`/`https`. O install.sh lê os
+# nomes reais da config do contêiner do Traefik (casando quem escuta `:80` e
+# `:443`). DEIXE COMENTADO, pelo mesmo motivo do REVERSE_PROXY: valor preenchido
+# aqui manda, e um nome que não existe naquele proxy falha em SILÊNCIO — o
+# Traefik não cria a rota e o domínio responde o 404 dele.
 #TRAEFIK_NETWORK=traefik
 #TRAEFIK_ENTRYPOINT=websecure
 #TRAEFIK_ENTRYPOINT_HTTP=web

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -33,9 +33,15 @@
 #
 # PRÉ-REQUISITOS NO TRAEFIK DA HOSPEDAGEM
 # ---------------------------------------
-# Espera-se um entrypoint `websecure` (443) e um certresolver `letsencrypt` —
-# os nomes padrão dessas instalações. Se a sua usa outros nomes, ajuste
-# TRAEFIK_ENTRYPOINT e TRAEFIK_CERTRESOLVER no .env.
+# Um entrypoint na 443 e outro na 80, mais um certresolver ACME. Os NOMES deles
+# não são padronizados — Dokploy chama de `web`/`websecure`, Easypanel de
+# `http`/`https` — e citar um nome que não existe naquele proxy falha CALADO: o
+# Traefik não reclama do label, só não cria a rota, e o domínio cai no 404
+# catch-all. Por isso o install.sh não assume: ele lê os nomes da config
+# estática do contêiner do Traefik (env vars e argumentos) e grava
+# TRAEFIK_ENTRYPOINT_HTTP / TRAEFIK_ENTRYPOINT / TRAEFIK_CERTRESOLVER no .env.
+# Os defaults abaixo são o fallback de quando não dá para ler (config por
+# traefik.yml montado, por exemplo) — aí é ajuste manual no .env.
 #
 # O Traefik precisa enxergar a rede deste projeto. O nome dela é
 # "<projeto>_internal", e <projeto> é o nome da pasta onde o compose roda — ou

--- a/hostgator-setup-kit/CLAUDE.md
+++ b/hostgator-setup-kit/CLAUDE.md
@@ -96,8 +96,8 @@ Estes pontos já foram descobertos e corrigidos no `install.sh` / `docker-compos
 Se mesmo assim aparecerem, aqui está o diagnóstico pronto:
 
 0. **O VPS já tem um proxy (Traefik) nas portas 80/443** — acontece na Hostinger, Coolify,
-   Dokploy e afins: o painel entrega a VPS com um Traefik próprio, que é quem dá o HTTPS
-   automático a tudo que ele instala. O Caddy do kit quer as MESMAS portas, então o
+   Dokploy, Easypanel e afins: o painel entrega a VPS com um Traefik próprio, que é quem dá
+   o HTTPS automático a tudo que ele instala. O Caddy do kit quer as MESMAS portas, então o
    `up -d` falha no bind e a instalação morre no meio. O `install.sh` **detecta isso
    sozinho** (procura um contêiner Traefik rodando), grava `REVERSE_PROXY=traefik` no
    `.env` e passa a subir com o override `docker-compose.traefik.yml` — que desliga o
@@ -105,6 +105,17 @@ Se mesmo assim aparecerem, aqui está o diagnóstico pronto:
    para "liberar" as portas: isso quebra as automações do painel dela. Se precisar rodar
    compose na mão nessa instalação, inclua sempre os dois arquivos:
    `docker compose -f docker-compose.prod.yml -f docker-compose.traefik.yml ...`
+0b. **Instalou por Traefik, os contêineres subiram, mas o site responde 404** — é o nome do
+   entrypoint. Ele muda por painel (Dokploy: `web`/`websecure`; Easypanel: `http`/`https`),
+   e o erro é MUDO: label citando entrypoint inexistente não faz o Traefik reclamar, ele só
+   não cria a rota — o domínio cai no 404 catch-all e o `up -d` diz "Started". O
+   `install.sh` atual **lê os nomes** da config do contêiner do Traefik (env e argumentos,
+   casando `:80` e `:443`) e ainda confere a rota no fim, batendo na porta 80 do proxy com
+   o Host do domínio. Numa instalação FEITA ANTES disso o `.env` já tem `websecure`
+   gravado, e valor existente não é sobrescrito: rode `bash install.sh` de novo — ele é
+   idempotente e avisa a divergência ("o Traefik desta VPS usa 'https'"), ou troque
+   `TRAEFIK_ENTRYPOINT_HTTP`/`TRAEFIK_ENTRYPOINT` no `.env` à mão e suba de novo. Para ver
+   os nomes reais: `docker inspect <contêiner do traefik> | grep -i entrypoints`.
 1. **Firewall te tranca fora do VPS** — o `ufw` padrão libera a porta **22**, mas alguns
    VPS da HostGator usam SSH em porta **custom** (ex.: `22022`). SEMPRE confira a porta do
    SSH atual (`ss -tlnp | grep sshd` ou o número que você usou pra conectar) e libere ELA

--- a/hostgator-setup-kit/README.md
+++ b/hostgator-setup-kit/README.md
@@ -95,7 +95,7 @@ Owner/Admin. Não dá para hospedar vários clientes numa conta só.
 - Portas **80** e **443** abertas (`ufw allow 80,443,22/tcp`).
 - Docker + Docker Compose v2 — o `install.sh` instala o Docker sozinho se faltar (ver acima).
 
-### VPS que já vem com proxy próprio (Hostinger, Coolify, Dokploy…)
+### VPS que já vem com proxy próprio (Hostinger, Coolify, Dokploy, Easypanel…)
 
 Algumas hospedagens entregam a VPS com um **Traefik** já ocupando as portas 80/443 — é ele
 que dá HTTPS automático ao que o painel instala. O Caddy do kit quer as mesmas portas e não
@@ -108,7 +108,17 @@ docker compose -f docker-compose.prod.yml -f docker-compose.traefik.yml up -d
 ```
 
 Não desligue o Traefik da hospedagem para liberar as portas — isso quebra as automações do
-painel dela. Se o seu Traefik usa nomes diferentes de `websecure`/`letsencrypt`, ajuste
+painel dela.
+
+Os **nomes** dos entrypoints também são descobertos, não presumidos: o instalador lê a
+configuração do contêiner do Traefik (variáveis de ambiente e argumentos) e casa pelo
+endereço — quem escuta `:80` vira o `TRAEFIK_ENTRYPOINT_HTTP`, quem escuta `:443` vira o
+`TRAEFIK_ENTRYPOINT`, e o certresolver ACME sai do mesmo lugar. Isso importa porque os
+nomes variam por painel (Dokploy usa `web`/`websecure`, Easypanel usa `http`/`https`) e
+errar o nome falha **em silêncio**: o Traefik não reclama do label, apenas não cria a rota
+— o site responde o 404 do proxy e o `up -d` diz que subiu. Quando não dá para ler a
+configuração (Traefik com `traefik.yml` montado), o instalador avisa, usa
+`web`/`websecure`/`letsencrypt` e você ajusta `TRAEFIK_ENTRYPOINT_HTTP`,
 `TRAEFIK_ENTRYPOINT` e `TRAEFIK_CERTRESOLVER` no `.env`.
 
 ## Scripts do kit

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -490,6 +490,77 @@ eh_traefik() {  # eh_traefik <imagem> <nome>
   return 1
 }
 
+# Os nomes que os labels do docker-compose.traefik.yml precisam CITAR, lidos da
+# configuração estática do Traefik da hospedagem. Não são convenção: Easypanel
+# (comum em VPS BR) chama os entrypoints de `http`/`https`, Dokploy de
+# `web`/`websecure`. Assumir um par é aposta — e a aposta errada falha CALADA: o
+# Traefik não reclama de label apontando para entrypoint inexistente, ele só não
+# cria a rota. O `up -d` diz "Started", o domínio cai no 404 catch-all do proxy e
+# não há uma linha de log dizendo por quê. Medido em produção: Easypanel com
+# Traefik 3.6.7, exatamente esse 404.
+#
+# Duas regras vieram de medir um Traefik v3.6 de verdade, não da documentação —
+# e as duas mudam o resultado:
+#   1. nome vindo de env vira MINÚSCULA (TRAEFIK_ENTRYPOINTS_HTTP_ADDRESS → `http`);
+#      nome vindo de argumento mantém a caixa (--entryPoints.WebSecure → `WebSecure`).
+#   2. argumento não se SOMA ao ambiente, SUBSTITUI: um único
+#      `--entrypoints.X.address` apaga o mapa inteiro que veio das env vars.
+#      Ler as duas fontes juntas inventaria um entrypoint que não existe.
+#
+# Ecoa "<entrypoint da 80>|<entrypoint da 443>|<certresolver>"; campo vazio = não
+# achei, e aí quem chama fica com o default de hoje.
+traefik_nomes() {  # traefik_nomes <linhas "cmd <arg>" e "env <VAR=valor>">
+  printf '%s\n' "${1:-}" | awk '
+    # ":80", "0.0.0.0:80", "[::]:80/tcp" → 80. O /udp é o QUIC, que NÃO é o
+    # entrypoint TCP que a rota do CRM usa.
+    function porta(v) {
+      gsub(/^"|"$/, "", v)
+      if (v ~ /\/udp$/) return ""
+      sub(/\/tcp$/, "", v); sub(/^.*:/, "", v)
+      return (v ~ /^[0-9]+$/) ? v : ""
+    }
+    { fonte = $1; par = substr($0, length($1) + 2)
+      chave = par; sub(/=.*/, "", chave)
+      valor = index(par, "=") ? substr(par, index(par, "=") + 1) : ""
+      k = tolower(chave) }
+    # --entrypoints.<nome>.address=:80  (a caixa do nome é preservada)
+    fonte == "cmd" && k ~ /^--?entrypoints\.[^.]+\.address$/ {
+      nome = chave; sub(/^--?[^.]*\./, "", nome); sub(/\.[^.]*$/, "", nome)
+      p = porta(valor); if (p != "") { ep["cmd" p] = nome; tem_ep_cmd = 1 } }
+    # TRAEFIK_ENTRYPOINTS_<NOME>_ADDRESS=:80  (o Traefik minúscula o nome)
+    fonte == "env" && k ~ /^traefik_entrypoints_.+_address$/ {
+      nome = k; sub(/^[^_]*_[^_]*_/, "", nome); sub(/_[^_]*$/, "", nome)
+      p = porta(valor); if (p != "") ep["env" p] = nome }
+    # --certificatesresolvers.<nome>.acme.…
+    fonte == "cmd" && k ~ /^--?certificatesresolvers\.[^.]+\.acme\./ {
+      nome = chave; sub(/^--?[^.]*\./, "", nome); sub(/\..*/, "", nome)
+      if (cr["cmd"] == "") cr["cmd"] = nome }
+    # TRAEFIK_CERTIFICATESRESOLVERS_<NOME>_ACME_…
+    fonte == "env" && k ~ /^traefik_certificatesresolvers_.+_acme_/ {
+      nome = k; sub(/^[^_]*_[^_]*_/, "", nome); sub(/_acme_.*$/, "", nome)
+      if (cr["env"] == "") cr["env"] = nome }
+    END {
+      f = tem_ep_cmd ? "cmd" : "env"
+      printf "%s|%s|%s\n", ep[f "80"], ep[f "443"], (cr["cmd"] != "" ? cr["cmd"] : cr["env"])
+    }
+  '
+}
+
+# Aplica um nome detectado. O valor que já está no .env é do dono e MANDA — mas
+# divergir do que o proxy tem de verdade é o sintoma exato do 404 mudo, e quem
+# instalou antes desta detecção tem `websecure` gravado sem nunca ter escolhido
+# isso. Avisar é o que transforma "não abre e não sei por quê" numa linha.
+tk_nome() {  # tk_nome <NOME_DA_VAR> <detectado>
+  local var="$1" achado="${2:-}" atual="${!1:-}"
+  [ -z "$achado" ] && return 0
+  if [ -z "$atual" ]; then
+    printf -v "$var" '%s' "$achado"
+  elif [ "$atual" != "$achado" ]; then
+    c_ylw "⚠ $var='$atual' no .env, mas o Traefik desta VPS usa '$achado'."
+    c_ylw "  Mantive o seu valor. Se o site não abrir, é aqui: troque para '$achado'."
+  fi
+}
+
 # Esconde o miolo de um segredo para a tela de conferência.
 mask() {
   local v="$1"
@@ -855,6 +926,49 @@ identifique a rede dele e ponha TRAEFIK_NETWORK=<nome> no .env antes de tentar d
 fi
 TRAEFIK_NETWORK="${TRAEFIK_NETWORK:-traefik}"
 
+# Os NOMES dos entrypoints e do certresolver, pela mesma via da rede: perguntar
+# ao proxy em vez de assumir. Ver o cabeçalho de traefik_nomes para o porquê de
+# assumir ser caro aqui (o erro é mudo) e para as duas regras medidas.
+#
+# Numa re-execução com REVERSE_PROXY já no .env a detecção de proxy não roda e
+# `traefik_container` fica vazio — mas o dono das portas foi levantado assim
+# mesmo lá em cima, e é ele que interessa. É o caso de quem já instalou: é essa
+# rodada que aponta o `websecure` errado que ficou gravado.
+_tk_ct="$traefik_container"
+if [ "$REVERSE_PROXY" = "traefik" ] && [ -z "$_tk_ct" ] && eh_traefik "$dono_imagem" "$dono_portas"; then
+  _tk_ct="$dono_portas"
+fi
+if [ "$REVERSE_PROXY" = "traefik" ] && [ -n "$_tk_ct" ]; then
+  # `.Config.Cmd` traz os argumentos (inclusive num contêiner de serviço Swarm,
+  # que é como o Easypanel roda o dele) e `.Config.Env`, a config por ambiente.
+  # "|| true" pelo mesmo motivo do bloco da rede: numa atribuição o status do
+  # pipeline vira o do script. Aqui não achar nada é caso PREVISTO — Traefik
+  # configurado por traefik.yml montado não expõe nada disso, e o default cobre.
+  _tk_conf="$(docker inspect \
+    -f '{{range .Config.Cmd}}cmd {{println .}}{{end}}{{range .Config.Env}}env {{println .}}{{end}}' \
+    "$_tk_ct" 2>/dev/null || true)"
+  _tk="$(traefik_nomes "$_tk_conf" || true)"
+  _tk_resto="${_tk#*|}"
+  tk_nome TRAEFIK_ENTRYPOINT_HTTP "${_tk%%|*}"
+  tk_nome TRAEFIK_ENTRYPOINT      "${_tk_resto%%|*}"
+  tk_nome TRAEFIK_CERTRESOLVER    "${_tk_resto##*|}"
+  # Sem as barras não sobra nada = nenhum dos três nomes saiu. Comparar com "||"
+  # dava verde falso no caso em que o próprio traefik_nomes não ecoa (awk fora do
+  # PATH): a mensagem diria "detectei" mostrando os defaults.
+  if [ -z "${_tk//|/}" ]; then
+    c_ylw "⚠ Não consegui ler os entrypoints do Traefik de '$_tk_ct' (config por arquivo?)."
+    c_ylw "  Vou usar os nomes padrão. Se o site responder 404 depois de instalado,"
+    c_ylw "  o nome certo está no traefik.yml da hospedagem (ou em"
+    c_ylw "  'docker inspect $_tk_ct | grep -i entrypoints'): ponha em"
+    c_ylw "  TRAEFIK_ENTRYPOINT_HTTP / TRAEFIK_ENTRYPOINT no .env e rode de novo."
+  else
+    c_grn "✓ Traefik: entrypoints ${TRAEFIK_ENTRYPOINT_HTTP:-web}/${TRAEFIK_ENTRYPOINT:-websecure}, certresolver ${TRAEFIK_CERTRESOLVER:-letsencrypt}"
+  fi
+  unset _tk_conf _tk _tk_resto
+fi
+# `_tk_ct` sobrevive de propósito: a conferência da rota, lá no fim, nomeia esse
+# contêiner no comando que a pessoa vai copiar.
+
 # ── Telemetria: perguntar, não presumir ─────────────────────────────────────
 # Issue #100. Antes, quem não definisse SENTRY_DSN mandava relatório de erro pro
 # Sentry da comunidade sem ter decidido nada — e só ficava sabendo na mensagem
@@ -1135,6 +1249,37 @@ else
   # "|| true": mesma família do pipe que matava o supabase-provision.sh — o
   # corpo passa de 200 bytes, o head fecha o pipe e o printf leva SIGPIPE.
   [ -n "$health_body" ] && c_dim "  última resposta: $(printf '%s' "$health_body" | head -c 200 || true)"
+fi
+
+# O healthcheck acima pergunta ao app DENTRO do contêiner (127.0.0.1:3000), então
+# ele é verde mesmo quando o proxy não roteia nada — e é por isso que o entrypoint
+# errado passava despercebido até a pessoa abrir o site. Aqui a pergunta é feita
+# pelo caminho do usuário: bate na porta 80 do próprio proxy com o Host do
+# domínio. Sem DNS e sem TLS no meio, então isto não depende de propagação nem de
+# certificado — só responde se o Traefik encontrou (ou não) a rota do CRM.
+# Avisa, nunca bloqueia: uma hospedagem pode ter razões próprias para não ter
+# entrypoint na 80, e reprovar uma instalação boa por isso é pior que o aviso.
+if [ "$REVERSE_PROXY" = "traefik" ]; then
+  step "Conferindo a rota no Traefik da hospedagem"
+  _rota=""
+  for _i in 1 2 3; do
+    # O provider do Docker leva um instante para ver o contêiner novo.
+    _rota="$(curl -s -o /dev/null -m 5 -w '%{http_code}' -H "Host: ${DOMAIN}" http://127.0.0.1/ 2>/dev/null || true)"
+    case "$_rota" in 000|''|404) sleep 3;; *) break;; esac
+  done
+  case "$_rota" in
+    000|'')
+      c_dim "  (a porta 80 não respondeu aqui dentro — não deu para conferir)" ;;
+    404)
+      c_ylw "⚠ O Traefik respondeu 404 para ${DOMAIN}: ele NÃO está roteando o CRM."
+      c_ylw "  Quase sempre é o nome do entrypoint. Os desta VPS estão em:"
+      c_ylw "      docker inspect ${_tk_ct:-<contêiner do traefik>} | grep -i entrypoints"
+      c_ylw "  Ajuste TRAEFIK_ENTRYPOINT_HTTP / TRAEFIK_ENTRYPOINT no .env e rode:"
+      c_ylw "      docker compose $(dc_files) up -d" ;;
+    *)
+      c_grn "✓ o Traefik está roteando ${DOMAIN} para o CRM (HTTP ${_rota})" ;;
+  esac
+  unset _rota _i
 fi
 
 # ── 11. Automações (cron do drain de eventos) ───────────────────────────────

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -516,6 +516,69 @@ dec_ok "Traefik da hospedagem → por ele"    traefik  "80 e 443" "coolify"   "c
 dec_ok "ocupante não identificado → bloqueia" bloqueia "80"     ""          "crm" ""              ""
 dec_ok "projeto vazio não casa projeto vazio" bloqueia "80"     ""          ""    "nginx"         "web"
 
+echo "proxy reverso: os nomes dos entrypoints do Traefik"
+# Os defaults `web`/`websecure` são os do Dokploy, não uma convenção. Easypanel
+# usa `http`/`https`, e o erro é MUDO: o Traefik não reclama de label apontando
+# para entrypoint inexistente, só não cria a rota — o domínio cai no 404
+# catch-all e o `up -d` termina dizendo "Started". Medido em produção (Easypanel,
+# Traefik 3.6.7).
+#
+# Os dois casos que decidem o resultado saíram de medir um Traefik v3.6 real,
+# não da documentação — e um deles é contra-intuitivo (argumento SUBSTITUI o
+# ambiente em vez de somar). Estão marcados abaixo.
+tn_ok() {  # tn_ok <descrição> <esperado "http|https|cert"> <blob>
+  local desc="$1" esperado="$2" real
+  real="$(traefik_nomes "$3")"
+  if [ "$real" = "$esperado" ]; then printf '  ✓ %s\n' "$desc"
+  else printf '  ✗ %s\n     deu:      [%s]\n     esperava: [%s]\n' "$desc" "$real" "$esperado"; fail=1; fi
+}
+
+# Easypanel, copiado da VPS de produção onde o bug apareceu.
+tn_ok "Easypanel (env): http/https" 'http|https|letsencrypt' 'env TRAEFIK_ENTRYPOINTS_HTTP_ADDRESS=:80
+env TRAEFIK_ENTRYPOINTS_HTTPS_ADDRESS=:443
+env TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL=dono@exemplo.com.br
+env TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_STORAGE=/etc/traefik/acme.json
+env PATH=/usr/local/bin:/usr/bin'
+
+# Dokploy — o par que o kit já assumia. Detectar não pode mudar o que já
+# funciona: aqui a detecção precisa CONFIRMAR o default, não substituí-lo.
+tn_ok "Dokploy (args): web/websecure" 'web|websecure|letsencrypt' 'cmd --providers.docker=true
+cmd --entrypoints.web.address=:80
+cmd --entrypoints.websecure.address=:443
+cmd --certificatesresolvers.letsencrypt.acme.httpchallenge=true'
+
+# MEDIDO em traefik:v3.6 — a linha de comando não SOMA ao ambiente, SUBSTITUI o
+# mapa inteiro. Com env http/https + arg `outro`, a API do Traefik lista só
+# `outro`: os entrypoints do ambiente somem. Ler as duas fontes juntas daria
+# `http`, um entrypoint que naquele proxy não existe mais.
+tn_ok "argumento apaga o mapa que veio do ambiente" '|outro|' 'env TRAEFIK_ENTRYPOINTS_HTTP_ADDRESS=:80
+env TRAEFIK_ENTRYPOINTS_HTTPS_ADDRESS=:443
+cmd --entrypoints.outro.address=:443'
+
+# MEDIDO em traefik:v3.6 — o nome vindo do ambiente vira minúscula
+# (TRAEFIK_ENTRYPOINTS_HTTP_ADDRESS → `http`), o vindo de argumento mantém a
+# caixa (--entryPoints.WebSecure → `WebSecure`). O label cita o nome exato, e
+# nomear `websecure` um entrypoint que se chama `WebSecure` é o mesmo 404.
+tn_ok "argumento preserva a caixa do nome" '|WebSecure|' 'cmd --entryPoints.WebSecure.address=:443'
+tn_ok "ambiente minúscula o nome"          '|websecure|' 'env TRAEFIK_ENTRYPOINTS_WEBSECURE_ADDRESS=:443'
+
+tn_ok "endereço com host explícito"    'web|websecure|' 'cmd --entrypoints.web.address=0.0.0.0:80
+cmd --entrypoints.websecure.address=[::]:443'
+# QUIC/HTTP3 declara :443/udp num entrypoint separado. Ele não serve rota HTTP —
+# escolhê-lo é o mesmo 404, com o agravante de parecer certo.
+tn_ok "entrypoint /udp (QUIC) não é o da rota" '|websecure|' 'cmd --entrypoints.websecure.address=:443
+cmd --entrypoints.quic.address=:443/udp'
+tn_ok "porta que não é 80/443 é ignorada" '||' 'cmd --entrypoints.traefik.address=:8080'
+# Traefik configurado por traefik.yml montado não expõe nada em env nem em args.
+# Nada detectado tem de sair vazio: é o que faz o chamador cair no default de
+# hoje, em vez de gravar um nome inventado.
+tn_ok "config por arquivo → nada detectado" '||' 'env PATH=/usr/bin
+cmd --configfile=/etc/traefik/traefik.yml'
+tn_ok "entrada vazia não inventa nome" '||' ''
+# Só a 443 configurada: cada porta se resolve sozinha, e a que faltou volta ao
+# default. Um campo vazio não pode arrastar o outro.
+tn_ok "detecção parcial não contamina a outra" '|https|' 'env TRAEFIK_ENTRYPOINTS_HTTPS_ADDRESS=:443'
+
 echo "nome do projeto que o docker compose usa"
 # O compose faz TrimLeft("_-") no basename. Sem isso, uma pasta /root/_deskcomm
 # faz o kit calcular "_deskcomm" enquanto os contêineres carregam "deskcomm" — a


### PR DESCRIPTION
## O defeito

Numa VPS **Easypanel** o CRM instala "com sucesso" e o site não abre.

Os labels do `docker-compose.traefik.yml` citam `web`/`websecure` — os defaults fixos do `install.sh`. No Easypanel os entrypoints se chamam **`http`/`https`**. O Traefik não reclama de label apontando para entrypoint que não existe: ele simplesmente não cria a rota. O `up -d` diz "Started", o domínio cai no 404 catch-all do proxy, e não há uma linha de log dizendo por quê. Medido em produção, Traefik 3.6.7.

O instalador já descobria o proxy e a rede dele inspecionando o contêiner — faltava fazer o mesmo com os nomes, que é a única parte ainda chutada.

## O que muda

- **Detecção**: lê a config estática do contêiner do Traefik (`.Config.Env` + `.Config.Cmd`) e casa pelo endereço — quem escuta `:80` vira `TRAEFIK_ENTRYPOINT_HTTP`, quem escuta `:443` vira `TRAEFIK_ENTRYPOINT`, e o certresolver ACME sai do mesmo lugar.
- **Fallback intacto**: não achou nada (Traefik com `traefik.yml` montado) → os defaults de hoje, mais um aviso dizendo onde olhar. Coolify/Dokploy não mudam de comportamento.
- **Divergência avisa**: valor já no `.env` continua mandando, mas se ele discorda do proxy o instalador aponta. É o caso de quem instalou antes disto e tem `websecure` gravado sem nunca ter escolhido — re-rodar o `install.sh` (idempotente) mostra o problema.
- **Conferência pelo caminho do usuário**: o healthcheck do fim pergunta ao app DENTRO do contêiner (`127.0.0.1:3000`), então fica verde com o proxy roteando nada — a falha-em-verde que deixou esse bug invisível. Em modo traefik agora também bate na porta 80 do proxy com o `Host` do domínio (sem DNS e sem TLS no meio) e, no 404, diz qual variável ajustar. Avisa, nunca bloqueia.

## Duas regras que vieram de medir, não da documentação

Um `traefik:v3.6` real, porque as duas mudam o resultado:

1. Nome vindo de **env** vira minúscula (`TRAEFIK_ENTRYPOINTS_HTTP_ADDRESS` → `http`); nome vindo de **argumento** mantém a caixa (`--entryPoints.WebSecure` → `WebSecure`). O label cita o nome exato.
2. Argumento **não soma** ao ambiente, **substitui**: um único `--entrypoints.X.address` apaga o mapa inteiro que veio das env vars. Ler as duas fontes juntas inventaria um entrypoint que não existe.

## Prova

Traefik real, com os labels renderizados pelo `docker compose config` dos arquivos de verdade (nada transcrito à mão) e um backend respondendo:

| cenário | resultado |
|---|---|
| proxy `http/https` + labels `web/websecure` (hoje) | **HTTP 404** — o bug |
| proxy `http/https` + labels detectados | **301** na 80, **200** no https, **403** no webhook global do WAHA |
| proxy `web/websecure` + labels `web/websecure` | **HTTP 200** — Dokploy/Coolify seguem como antes |
| app direto, sem proxy, durante todos eles | **200** — o 404 era roteamento, não o app |

A detecção também foi medida num contêiner de **serviço Swarm**, que é como o Easypanel roda o dele: `[http|https|letsencrypt]`.

## Testes

11 casos novos em `hostgator-setup-kit/test-validators.sh` (Easypanel, Dokploy, precedência argumento-vs-env, caixa do nome, QUIC `/udp`, config por arquivo, detecção parcial). Sabotar cada um dos dois comportamentos medidos deixa a suíte vermelha — verificado.

Docs atualizadas junto: cabeçalho do `docker-compose.traefik.yml`, README e CLAUDE.md do kit (nova armadilha "subiu mas responde 404"), e `.env.hostgator.example`.

**Não medido**: VPS Easypanel de verdade ponta a ponta (a reprodução é local, com Traefik e Swarm reais); Traefik configurado por `traefik.yml` montado cai no fallback por construção, sem instalação real que exercite esse caminho.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
