### PR TITLE
fix: aux classifiers borrow model without provider/credential, causing 404 on agents with non-default provider

### DIFF
--- a/lib/agent-engine/agent/aux-model-args.ts
+++ b/lib/agent-engine/agent/aux-model-args.ts
@@ -1,0 +1,61 @@
+/**
+ * De ONDE o classificador auxiliar tira modelo, provider e credencial.
+ *
+ * ## O defeito que fez esta função existir (PR #151, @Gervanno)
+ *
+ * Os classificadores auxiliares (estágio, jailbreak, promessa) não têm modelo
+ * próprio quando o knob de env está vazio, e então pegam emprestado o do agente
+ * publicado. Emprestavam **só a string do modelo** — o provider e a credencial
+ * continuavam sendo o default da organização.
+ *
+ * Num tenant cujo default é Anthropic com um `mcp_agent` publicado em OpenAI, o
+ * classificador mandava `gpt-5-mini` para o endpoint da Anthropic, tomava 404
+ * `not_found_error`, e o **turno inteiro** morria (`status='dead'`) antes de o
+ * agente responder. Sintoma para quem instalou: o agente simplesmente não
+ * responde no WhatsApp, sem erro na tela. E o dry-run passava, porque ele não
+ * chama classificador — o caminho que funciona não é o caminho que quebra.
+ *
+ * ## A regra, em uma frase
+ *
+ * **Modelo e provider/credencial vêm sempre do MESMO lugar.**
+ *
+ * - knob de env preenchido ⇒ é escolha consciente do operador, e ela já
+ *   pressupõe o provider default da org. Sem override.
+ * - knob vazio ⇒ herda do agente publicado, e aí provider e credencial vêm
+ *   JUNTO com o modelo, nunca soltos.
+ *
+ * ## Por que módulo separado
+ *
+ * A lógica nasceu como função interna de `runAgentTurn`, que precisa de banco,
+ * job e registry para rodar — ou seja, a regra ficava sem como ser exercitada
+ * por unit. Mesmo motivo de `lib/routing/decide.ts` existir fora do worker: a
+ * decisão é pura, o resto é I/O.
+ */
+import type { LlmResolveOverride } from "../edge/llm/credentials";
+
+/** O que o turno sabe do agente publicado — só o que esta decisão consulta. */
+export interface AgenteParaAux {
+  model?: string | undefined;
+  provider: string;
+  credentialId: string | null;
+}
+
+export interface AuxModelArgs {
+  model?: string;
+  llmOverride?: LlmResolveOverride;
+}
+
+export function auxModelArgs(
+  configuredModel: string | undefined,
+  agente: AgenteParaAux | null,
+): AuxModelArgs {
+  if (configuredModel !== undefined) return { model: configuredModel };
+  const agentModel = agente?.model;
+  if (agentModel === undefined) return {};
+  return {
+    model: agentModel,
+    ...(agente !== null
+      ? { llmOverride: { provider: agente.provider, credentialId: agente.credentialId } }
+      : {}),
+  };
+}

--- a/lib/agent-engine/agent/compaction.ts
+++ b/lib/agent-engine/agent/compaction.ts
@@ -27,6 +27,7 @@ import type pg from 'pg';
 
 import type { Logger } from '../obs/logger';
 import type { ProviderRegistry } from '../edge/llm/providers';
+import type { LlmResolveOverride } from '../edge/llm/credentials';
 import { runModelCall, type LlmEdgeConfig } from '../edge/llm/run-model-call';
 import { countPayloadTokens, type LeadContext, type LeadContextMessage } from '../edge/crm/get-lead-context';
 import { applySaveLeadNote } from './lead-notes';
@@ -190,7 +191,12 @@ export async function maybeCompact(
   db: pg.Pool,
   cfg: LlmEdgeConfig,
   ids: { tenantId: string; leadId: string; jobId?: string },
-  args: { context: LeadContext; previousSummary: string; knobs: CompactionKnobs; notesIndexMaxTokens: number },
+  args: {
+    context: LeadContext;
+    previousSummary: string;
+    knobs: CompactionKnobs & { llmOverride?: LlmResolveOverride };
+    notesIndexMaxTokens: number;
+  },
   deps: { registry?: ProviderRegistry; log: Logger },
 ): Promise<CompactionOutput | null> {
   if (args.context.messages.length < args.knobs.triggerMessages) {
@@ -221,6 +227,9 @@ export async function maybeCompact(
       ...(ids.jobId !== undefined ? { jobId: ids.jobId } : {}),
       purpose: 'compaction',
       ...(args.knobs.model !== undefined ? { model: args.knobs.model } : {}),
+      // Provider/credencial vêm JUNTO do modelo quando ele foi herdado do agente
+      // publicado — ver `aux-model-args.ts`.
+      ...(args.knobs.llmOverride !== undefined ? { llmOverride: args.knobs.llmOverride } : {}),
       messages: [
         { role: 'user', content: buildTranscriptMessage(args.context, args.previousSummary, COMPACTION_INSTRUCTION) },
       ],

--- a/lib/agent-engine/agent/inbound-turn.ts
+++ b/lib/agent-engine/agent/inbound-turn.ts
@@ -29,6 +29,7 @@
  */
 import type pg from 'pg';
 import { z } from 'zod';
+import { auxModelArgs, type AuxModelArgs } from './aux-model-args';
 import type { ChannelAdapter, ChannelSendResult } from '../channel-adapter';
 
 import { withFields, type Logger } from '../obs/logger';
@@ -704,28 +705,13 @@ export async function runAgentTurn(
   // knob de env → modelo do agente PUBLICADO na tela → organizations.settings.llm.
   // Sem isso, self-host que configurou tudo pela tela (que não preenche default_model)
   // morria no primeiro classificador: "modelo LLM não definido".
-  const agentModel = agentConfig?.model;
-  // Bug observado em prod (2026-08-05): quando o classificador auxiliar não tem
-  // model dedicado (env vazio) e cai no fallback `agentModel`, o `model` vinha do
-  // agente ativo mas o PROVIDER continuava o default da org — um agente mcp_agent
-  // em openai (ex.: gpt-5-mini) mandava o model id certo pro provider errado
-  // (anthropic), 404 "not_found_error", turno inteiro derrubado (não só o
-  // classificador). Model e provider/credencial têm que vir do MESMO lugar: se o
-  // knob de env está configurado, ele já pressupõe o provider default da org (uso
-  // consciente do operador) — sem override. Se caiu no fallback do agente, o
-  // provider/credencial do agente vêm JUNTO, nunca soltos.
-  function auxModelArgs(
-    configuredModel: string | undefined,
-  ): { model?: string; llmOverride?: { provider: string; credentialId: string | null } } {
-    if (configuredModel !== undefined) return { model: configuredModel };
-    if (agentModel === undefined) return {};
-    return {
-      model: agentModel,
-      ...(agentConfig !== null
-        ? { llmOverride: { provider: agentConfig.provider, credentialId: agentConfig.credentialId } }
-        : {}),
-    };
-  }
+  // A regra de ONDE o classificador auxiliar tira modelo + provider + credencial
+  // mora em `aux-model-args.ts`, fora daqui, para poder ser exercitada por unit:
+  // esta função precisa de banco, job e registry para rodar. Ver o defeito que a
+  // originou (PR #151) no cabeçalho de lá.
+  const argsAux = (configuredModel: string | undefined): AuxModelArgs =>
+    auxModelArgs(configuredModel, agentConfig);
+
   const turnContextKnobs =
     agentConfig !== null
       ? { historyLimit: agentConfig.historyMessageWindow, maxTokens: deps.knobs.maxContextTokens }
@@ -832,12 +818,11 @@ export async function runAgentTurn(
       {
         context: openingContext.context,
         previousSummary: previous?.rolling_summary ?? '',
-        knobs: {
-          ...deps.knobs.compaction,
-          ...(deps.knobs.compaction.model === undefined && agentModel !== undefined
-            ? { model: agentModel }
-            : {}),
-        },
+        // A compactação é o QUARTO call site da mesma regra, e o #151 só cobriu
+        // três: ela também pedia o modelo do agente ao provider default da org.
+        // Mesmo 404, mesma morte de turno — só que num caminho que roda quando a
+        // conversa já é longa, ou seja, mais tarde e com menos gente olhando.
+        knobs: { ...deps.knobs.compaction, ...argsAux(deps.knobs.compaction.model) },
         notesIndexMaxTokens: deps.knobs.notesIndexMaxTokens,
       },
       { registry: deps.registry, log: runLog },
@@ -937,7 +922,7 @@ export async function runAgentTurn(
             { tenantId, leadId, jobId: job.id },
             {
               candidate,
-              ...auxModelArgs(deps.knobs.promiseSemantic?.model),
+              ...argsAux(deps.knobs.promiseSemantic?.model),
             },
             { ...(deps.registry !== undefined ? { registry: deps.registry } : {}), log: runLog },
           )
@@ -1651,7 +1636,7 @@ export async function runAgentTurn(
       {
         context: effectiveContext,
         currentStage,
-        ...auxModelArgs(deps.knobs.stageClassifier.model),
+        ...argsAux(deps.knobs.stageClassifier.model),
       },
       { registry: deps.registry, log: runLog },
     );
@@ -1672,7 +1657,7 @@ export async function runAgentTurn(
       { tenantId, leadId, jobId: job.id },
       {
         message: skillSignal,
-        ...auxModelArgs(deps.knobs.jailbreak.model),
+        ...argsAux(deps.knobs.jailbreak.model),
       },
       { registry: deps.registry, log: runLog },
     );

--- a/lib/agent-engine/agent/inbound-turn.ts
+++ b/lib/agent-engine/agent/inbound-turn.ts
@@ -705,6 +705,27 @@ export async function runAgentTurn(
   // Sem isso, self-host que configurou tudo pela tela (que não preenche default_model)
   // morria no primeiro classificador: "modelo LLM não definido".
   const agentModel = agentConfig?.model;
+  // Bug observado em prod (2026-08-05): quando o classificador auxiliar não tem
+  // model dedicado (env vazio) e cai no fallback `agentModel`, o `model` vinha do
+  // agente ativo mas o PROVIDER continuava o default da org — um agente mcp_agent
+  // em openai (ex.: gpt-5-mini) mandava o model id certo pro provider errado
+  // (anthropic), 404 "not_found_error", turno inteiro derrubado (não só o
+  // classificador). Model e provider/credencial têm que vir do MESMO lugar: se o
+  // knob de env está configurado, ele já pressupõe o provider default da org (uso
+  // consciente do operador) — sem override. Se caiu no fallback do agente, o
+  // provider/credencial do agente vêm JUNTO, nunca soltos.
+  function auxModelArgs(
+    configuredModel: string | undefined,
+  ): { model?: string; llmOverride?: { provider: string; credentialId: string | null } } {
+    if (configuredModel !== undefined) return { model: configuredModel };
+    if (agentModel === undefined) return {};
+    return {
+      model: agentModel,
+      ...(agentConfig !== null
+        ? { llmOverride: { provider: agentConfig.provider, credentialId: agentConfig.credentialId } }
+        : {}),
+    };
+  }
   const turnContextKnobs =
     agentConfig !== null
       ? { historyLimit: agentConfig.historyMessageWindow, maxTokens: deps.knobs.maxContextTokens }
@@ -916,9 +937,7 @@ export async function runAgentTurn(
             { tenantId, leadId, jobId: job.id },
             {
               candidate,
-              ...((deps.knobs.promiseSemantic?.model ?? agentModel) !== undefined
-                ? { model: (deps.knobs.promiseSemantic?.model ?? agentModel) as string }
-                : {}),
+              ...auxModelArgs(deps.knobs.promiseSemantic?.model),
             },
             { ...(deps.registry !== undefined ? { registry: deps.registry } : {}), log: runLog },
           )
@@ -1632,9 +1651,7 @@ export async function runAgentTurn(
       {
         context: effectiveContext,
         currentStage,
-        ...((deps.knobs.stageClassifier.model ?? agentModel) !== undefined
-          ? { model: (deps.knobs.stageClassifier.model ?? agentModel) as string }
-          : {}),
+        ...auxModelArgs(deps.knobs.stageClassifier.model),
       },
       { registry: deps.registry, log: runLog },
     );
@@ -1655,9 +1672,7 @@ export async function runAgentTurn(
       { tenantId, leadId, jobId: job.id },
       {
         message: skillSignal,
-        ...((deps.knobs.jailbreak.model ?? agentModel) !== undefined
-          ? { model: (deps.knobs.jailbreak.model ?? agentModel) as string }
-          : {}),
+        ...auxModelArgs(deps.knobs.jailbreak.model),
       },
       { registry: deps.registry, log: runLog },
     );

--- a/lib/agent-engine/agent/stage-classifier.ts
+++ b/lib/agent-engine/agent/stage-classifier.ts
@@ -29,6 +29,7 @@ import type pg from 'pg';
 import type { Logger } from '../obs/logger';
 import type { ProviderRegistry } from '../edge/llm/providers';
 import { runModelCall, type LlmEdgeConfig } from '../edge/llm/run-model-call';
+import type { LlmResolveOverride } from '../edge/llm/credentials';
 import type { LeadContext } from '../edge/crm/get-lead-context';
 import { LEAD_STAGES, type LeadStage } from './lead-state';
 
@@ -92,7 +93,7 @@ export async function classifyStage(
   db: pg.Pool,
   cfg: LlmEdgeConfig,
   ids: { tenantId: string; leadId: string; jobId?: string },
-  args: { context: LeadContext; currentStage: LeadStage; model?: string },
+  args: { context: LeadContext; currentStage: LeadStage; model?: string; llmOverride?: LlmResolveOverride },
   deps: { registry?: ProviderRegistry; log: Logger },
 ): Promise<LeadStage | null> {
   const call = await runModelCall(
@@ -104,6 +105,7 @@ export async function classifyStage(
       ...(ids.jobId !== undefined ? { jobId: ids.jobId } : {}),
       purpose: 'stage_classifier',
       ...(args.model !== undefined ? { model: args.model } : {}),
+      ...(args.llmOverride !== undefined ? { llmOverride: args.llmOverride } : {}),
       messages: [{ role: 'user', content: buildClassifierMessage(args.context, args.currentStage) }],
     },
     { registry: deps.registry, log: deps.log },

--- a/lib/agent-engine/guardrails/jailbreak/classifier.ts
+++ b/lib/agent-engine/guardrails/jailbreak/classifier.ts
@@ -20,6 +20,7 @@ import type pg from 'pg';
 import type { Logger } from '../../obs/logger';
 import type { ProviderRegistry } from '../../edge/llm/providers';
 import { runModelCall, type LlmEdgeConfig } from '../../edge/llm/run-model-call';
+import type { LlmResolveOverride } from '../../edge/llm/credentials';
 
 /** Severidade do sinal: none (limpo) < low (suspeito) < high (jailbreak/injeção claro). */
 export type JailbreakLevel = 'none' | 'low' | 'high';
@@ -100,7 +101,7 @@ export async function classifyJailbreak(
   db: pg.Pool,
   cfg: LlmEdgeConfig,
   ids: { tenantId: string; leadId?: string | null; jobId?: string },
-  args: { message: string; model?: string },
+  args: { message: string; model?: string; llmOverride?: LlmResolveOverride },
   deps: { registry?: ProviderRegistry; log: Logger },
 ): Promise<JailbreakClassification> {
   const call = await runModelCall(
@@ -112,6 +113,7 @@ export async function classifyJailbreak(
       ...(ids.jobId !== undefined ? { jobId: ids.jobId } : {}),
       purpose: 'jailbreak_detect',
       ...(args.model !== undefined ? { model: args.model } : {}),
+      ...(args.llmOverride !== undefined ? { llmOverride: args.llmOverride } : {}),
       messages: [{ role: 'user', content: buildJailbreakMessage(args.message) }],
     },
     { registry: deps.registry, log: deps.log },

--- a/lib/agent-engine/guardrails/promise/semantic.ts
+++ b/lib/agent-engine/guardrails/promise/semantic.ts
@@ -22,6 +22,7 @@ import type pg from 'pg';
 import type { Logger } from '../../obs/logger';
 import type { ProviderRegistry } from '../../edge/llm/providers';
 import { runModelCall, type LlmEdgeConfig } from '../../edge/llm/run-model-call';
+import type { LlmResolveOverride } from '../../edge/llm/credentials';
 
 /** Veredito binário do classificador. suspectPhrase = null quando isPromise = false. */
 export interface PromiseClassification {
@@ -99,7 +100,7 @@ export async function classifyPromise(
   db: pg.Pool,
   cfg: LlmEdgeConfig,
   ids: { tenantId: string; leadId?: string | null; jobId?: string },
-  args: { candidate: string; model?: string },
+  args: { candidate: string; model?: string; llmOverride?: LlmResolveOverride },
   deps: { registry?: ProviderRegistry; log: Logger },
 ): Promise<PromiseClassification> {
   const call = await runModelCall(
@@ -111,6 +112,7 @@ export async function classifyPromise(
       ...(ids.jobId !== undefined ? { jobId: ids.jobId } : {}),
       purpose: 'promise_semantic',
       ...(args.model !== undefined ? { model: args.model } : {}),
+      ...(args.llmOverride !== undefined ? { llmOverride: args.llmOverride } : {}),
       messages: [{ role: 'user', content: buildPromiseMessage(args.candidate) }],
     },
     { registry: deps.registry, log: deps.log },

--- a/tests/unit/aux-classificador-provider.test.ts
+++ b/tests/unit/aux-classificador-provider.test.ts
@@ -1,0 +1,74 @@
+/**
+ * MODELO E PROVIDER VÊM DO MESMO LUGAR (PR #151, @Gervanno).
+ *
+ * ## O defeito
+ *
+ * Os classificadores auxiliares (estágio, jailbreak, promessa) e a compactação
+ * pegam emprestado o modelo do agente publicado quando o knob de env está
+ * vazio. Emprestavam **só a string do modelo**: provider e credencial seguiam
+ * sendo o default da organização.
+ *
+ * Num tenant com default Anthropic e um `mcp_agent` publicado em OpenAI, o
+ * classificador mandava `gpt-5-mini` para o endpoint da Anthropic, tomava 404
+ * `not_found_error`, e o **turno inteiro** morria (`status='dead'`) antes de o
+ * agente responder. Para quem instalou, o sintoma é o pior possível: o agente
+ * simplesmente não responde no WhatsApp, sem erro em tela nenhuma.
+ *
+ * E o dry-run passava — ele não chama classificador. O caminho que funciona não
+ * era o caminho que quebrava, que é o que fez isso sobreviver até produção.
+ *
+ * ## Por que este teste existe, e não só a correção
+ *
+ * O PR chegou sem teste. O defeito é de ACOPLAMENTO — duas informações que
+ * precisam viajar juntas — e esse é justamente o tipo que volta na próxima
+ * refatoração, porque nada no tipo obriga. Aqui o par fica preso por asserção.
+ */
+import { describe, expect, it } from "vitest";
+
+import { auxModelArgs, type AgenteParaAux } from "@/lib/agent-engine/agent/aux-model-args";
+
+const AGENTE_OPENAI: AgenteParaAux = {
+  model: "openai/gpt-5-mini",
+  provider: "openai",
+  credentialId: "cred-openai-1",
+};
+
+describe("de onde o classificador auxiliar tira modelo e provider", () => {
+  it("herdando do agente, o provider e a credencial vêm JUNTO", () => {
+    const args = auxModelArgs(undefined, AGENTE_OPENAI);
+    expect(args.model).toBe("openai/gpt-5-mini");
+    expect(
+      args.llmOverride,
+      "modelo do agente sem o provider dele é o defeito: model id certo para o endpoint errado, 404, turno morto",
+    ).toEqual({ provider: "openai", credentialId: "cred-openai-1" });
+  });
+
+  it("com knob de env, NÃO força override — o operador escolheu, e a escolha pressupõe o default da org", () => {
+    const args = auxModelArgs("anthropic/claude-haiku-4-5", AGENTE_OPENAI);
+    expect(args.model).toBe("anthropic/claude-haiku-4-5");
+    expect(
+      args.llmOverride,
+      "carregar o provider do agente por cima de um modelo escolhido no env inverteria o defeito",
+    ).toBeUndefined();
+  });
+
+  it("sem knob e sem agente, não inventa modelo", () => {
+    expect(auxModelArgs(undefined, null)).toEqual({});
+  });
+
+  it("agente sem modelo publicado cai no default da org, sem override", () => {
+    // `model` ausente é o self-host que configurou tudo pela tela e nunca
+    // preencheu `default_model`. Herdar o provider sem o modelo apontaria o
+    // default da org para um provider que não é o dela.
+    const args = auxModelArgs(undefined, { provider: "openai", credentialId: null });
+    expect(args).toEqual({});
+  });
+
+  it("credencial nula viaja como nula, não some", () => {
+    // `credentialId: null` significa "use a credencial default deste provider" —
+    // é informação, não ausência. Se ela sumisse, o resolver cairia no provider
+    // da org de novo, que é o defeito com outra roupa.
+    const args = auxModelArgs(undefined, { model: "openai/gpt-5-mini", provider: "openai", credentialId: null });
+    expect(args.llmOverride).toEqual({ provider: "openai", credentialId: null });
+  });
+});


### PR DESCRIPTION
Problem — When an mcp_agent is published using a provider different from the org's default (e.g. openai/gpt-5-mini in an Anthropic-default org), the agent never responds on WhatsApp. The turn fails silently before the agent runs.

Root cause — The auxiliary classifiers (stage-classifier, jailbreak, promise/semantic) fall back to borrowing the active agent's model when their env knob isn't set, but borrow only the model string, without the matching provider and credential. The classifier then calls e.g. gpt-5-mini against the Anthropic endpoint, gets a 404, and the whole inbound job dies (status='dead') before the agent replies. This is why the dry-run works (bypasses classifiers) while the real WhatsApp flow fails.

Fix — classifyStage / classifyJailbreak / classifyPromise now accept an optional llmOverride. In inbound-turn.ts, when the env knob isn't configured, the classifier fallback borrows provider + credentialId together with the model from the active agent, instead of the bare model string. Behavior is unchanged when the env knob is set.

Files — stage-classifier.ts, jailbreak/classifier.ts, promise/semantic.ts, inbound-turn.ts

Testing — tsc --noEmit and eslint clean; rebuilt worker image; confirmed an mcp_agent on openai/gpt-5-mini now replies on WhatsApp end-to-end (previously the job died with a 404).