### PR TITLE
docs(deploy): os dois -f do compose numa VPS com proxy próprio — e por que esquecer um derruba o site

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,13 @@ subconjunto, a prova é sua.
 - **`lib/auth/public-paths.ts`** — adicionar path aqui remove a checagem de auth de borda.
   Só com guard próprio dentro da rota.
 - **`.env*`** — não abra, não copie valor, não logue. Só `.env.example` é template.
+- **`docker-compose.traefik.yml`** — numa VPS que já tem proxy reverso próprio
+  (Hostinger, Coolify, Dokploy…), é o único lugar que dá ao contêiner `app` as labels
+  de roteamento. Todo `up -d` leva os **dois** arquivos de compose:
+  `docker compose -f docker-compose.prod.yml -f docker-compose.traefik.yml --env-file .env up -d app`.
+  Esquecer o segundo `-f` recria o contêiner sem labels: o proxy deixa de enxergá-lo e o
+  domínio inteiro responde `404`, com o contêiner `healthy` — o healthcheck é um probe TCP
+  interno e não sabe nada de roteamento. Runbook: `docs/runbooks/deploy.md`.
 
 ## Arquivos GERADOS — não editar à mão
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,32 @@ DeskcommCRM é um sistema operacional de vendas open source com agentes de IA na
 | `lib/supabase/{browser,server,admin}.ts` | Clients canônicos |
 | `app/api/v1/health/route.ts` | Health check (Supabase + Redis + WAHA) |
 | `supabase/migrations/` | Schema versionado |
+| `docs/runbooks/deploy.md` | **Deploy em produção — leia ANTES de mexer na VPS** |
+
+---
+
+## Deploy em produção (NÃO NEGOCIÁVEL)
+
+**Numa VPS que já tem proxy reverso próprio (Hostinger, Coolify, Dokploy…), todo
+`up -d` leva os DOIS arquivos de compose:**
+
+```bash
+docker compose -f docker-compose.prod.yml -f docker-compose.traefik.yml --env-file .env up -d app
+```
+
+Omitir `-f docker-compose.traefik.yml` recria o contêiner sem as labels de
+roteamento; o Traefik da hospedagem deixa de enxergá-lo e **o domínio inteiro
+responde `404 page not found`** — com o contêiner `healthy`, porque o
+healthcheck é um probe TCP interno e não sabe nada de roteamento.
+
+Depois de qualquer deploy, confirme que o domínio responde **307** (redireciona
+pro login) e não 404. Verificações e o caso de build local em
+`docs/runbooks/deploy.md`.
+
+O caminho normal **não constrói nada na VPS**: commit → push → PR → merge na
+`main` → o CI publica no GHCR → a VPS puxa. Imagem construída na VPS é exceção
+de emergência e é dívida: existe só naquele disco e qualquer `up -d` sem
+`APP_PULL_POLICY=never` a substitui em silêncio.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,6 +101,7 @@ acessibilidade).
 | [`deploy-hostgator/README.md`](deploy-hostgator/README.md) | VPS HostGator (`install.sh`, `backup.sh`, `reset-mfa.sh`) |
 | [`DEPLOY-CHECKLIST.md`](DEPLOY-CHECKLIST.md) | Checklist de deploy |
 | [`ATUALIZANDO.md`](ATUALIZANDO.md) | `update.sh`, `restore.sh`, `healthcheck.sh` |
+| [`runbooks/deploy.md`](runbooks/deploy.md) | **Deploy em produção — os dois `-f` do compose, verificação pós-deploy** |
 | [`runbooks/waha-hostgator.md`](runbooks/waha-hostgator.md) | Runbook do WAHA em produção |
 | [`runbooks/ai-credentials-rotation.md`](runbooks/ai-credentials-rotation.md) | Rotação de credenciais de IA |
 | [`../SECURITY.md`](../SECURITY.md) | Política de reporte de vulnerabilidade |

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -1,0 +1,92 @@
+# Runbook — Deploy em produção (VPS)
+
+O caminho normal de deploy **não constrói nada na VPS**: o CI publica a imagem no
+GHCR e a VPS só puxa. Construir localmente é exceção de emergência, e tem custo —
+está documentado no fim.
+
+---
+
+## 1. O comando
+
+```bash
+cd /var/www/crm
+docker compose -f docker-compose.prod.yml -f docker-compose.traefik.yml --env-file .env up -d app
+```
+
+### Os DOIS `-f` são obrigatórios. Sempre.
+
+Esta é a pegadinha que já derrubou o site inteiro em produção (2026-08-05).
+
+A VPS (Hostinger) vem com um **Traefik próprio** ocupando as portas 80/443.
+`docker-compose.traefik.yml` é o ÚNICO lugar que:
+
+- coloca no contêiner `app` as labels de roteamento
+  (`traefik.http.routers.deskcomm.rule=Host(...)`);
+- associa o contêiner à rede que o Traefik enxerga (`TRAEFIK_DOCKER_NETWORK`);
+- desliga o `caddy` do compose base por profile (senão dois processos brigam
+  pela mesma porta).
+
+Rodar só com `-f docker-compose.prod.yml` recria o contêiner **sem labels
+nenhuma**. O Traefik deixa de enxergá-lo e o domínio inteiro passa a responder
+`404 page not found` — não é erro do Next, é o 404 genérico do Traefik. A app
+está no ar, saudável, e inalcançável.
+
+---
+
+## 2. Verificação pós-deploy (não pule)
+
+`healthy` no `docker ps` **não prova que o site está acessível** — o healthcheck
+é um probe TCP interno e passa mesmo com o roteamento quebrado. Verifique as
+duas coisas:
+
+```bash
+# 1) as labels do Traefik existem?
+docker inspect crm-app-1 --format '{{.Config.Labels}}' | grep -o 'traefik.enable:[^ ]*'
+# esperado: traefik.enable:true   (vazio = roteamento quebrado)
+
+# 2) o domínio responde?
+curl -s -o /dev/null -w "%{http_code}\n" https://<DOMAIN>/
+# esperado: 307 (redireciona pro login)
+# 404      = labels perdidas, refaça o deploy com os dois -f
+```
+
+---
+
+## 3. Fluxo completo (do código à produção)
+
+```
+commit → push → PR → merge na main → CI publica imagem → VPS puxa
+```
+
+1. **Commit + push** numa branch de feature. Trabalho que fica só no disco da
+   VPS não existe: o CI não o vê, some se a VPS for reconstruída, e é invisível
+   pra qualquer outra pessoa.
+2. **PR e merge na `main`.** `publish-image.yml` dispara em push na `main` (ou
+   tag `v*`) e publica `ghcr.io/<repo>:latest`. O build pesado (~6min) roda nos
+   runners do GitHub, nunca na VPS do usuário.
+3. **Deploy na VPS** com o comando da seção 1. Como o `.env` tem
+   `APP_PULL_POLICY='always'`, o `up -d` já puxa a imagem nova sozinho.
+
+---
+
+## 4. Exceção: imagem construída na VPS
+
+Só quando é preciso validar algo em produção **antes** de a imagem oficial
+existir (ex.: CI ainda rodando e um bug bloqueando o usuário).
+
+```bash
+APP_IMAGE=deskcomm-app:local docker compose \
+  -f docker-compose.prod.yml -f docker-compose.build.yml --env-file .env build app
+
+APP_IMAGE=deskcomm-app:local APP_PULL_POLICY=never docker compose \
+  -f docker-compose.prod.yml -f docker-compose.traefik.yml --env-file .env up -d app
+```
+
+**Isto é dívida, não um caminho paralelo.** A imagem existe só no disco daquela
+VPS: não está no registry, não está no git, e qualquer `docker compose up -d`
+sem `APP_PULL_POLICY=never` a substitui pela do GHCR — silenciosamente, sem erro
+nenhum, revertendo o que você acabou de subir.
+
+Requisitos: >= 4 GB de RAM **ou** swap (medido: ~4min num VPS de 3.8 GB com 4 GB
+de swap). Ao terminar, feche o ciclo — merge na `main` e volte a VPS pra imagem
+oficial.

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -41,7 +41,12 @@ duas coisas:
 
 ```bash
 # 1) as labels do Traefik existem?
-docker inspect crm-app-1 --format '{{.Config.Labels}}' | grep -o 'traefik.enable:[^ ]*'
+#    O nome do contêiner é <pasta-do-projeto>-app-1, então pergunte ao compose
+#    em vez de chutar. Aqui um -f só basta: o `ps -q` resolve pelo nome do
+#    projeto + serviço, não pelo conteúdo do arquivo (medido: com um -f ou com
+#    os dois, devolve o MESMO contêiner). Quem precisa dos dois é o `up -d`.
+docker inspect "$(docker compose -f docker-compose.prod.yml ps -q app)" \
+  --format '{{.Config.Labels}}' | grep -o 'traefik.enable:[^ ]*'
 # esperado: traefik.enable:true   (vazio = roteamento quebrado)
 
 # 2) o domínio responde?


### PR DESCRIPTION
## O que aconteceu

Fiz deploy na minha VPS Hostinger com

```bash
docker compose -f docker-compose.prod.yml --env-file .env up -d app
```

e o domínio inteiro passou a responder `404 page not found`. O contêiner subiu
`healthy`, a app respondia normalmente por dentro, e o `docker ps` não tinha nada
de errado — o healthcheck é um probe TCP interno e não sabe nada de roteamento.

O que faltou foi o segundo `-f`. Sem `docker-compose.traefik.yml`, o contêiner é
recriado **sem as labels de roteamento**, o Traefik da hospedagem deixa de
enxergá-lo, e quem responde o 404 é o proxy, não o Next.

Nada no repo dizia isso. O comando correto existia num comentário **dentro do
próprio `docker-compose.traefik.yml`** — arquivo que quem vai fazer deploy não
abre, porque só passa o nome dele na linha de comando. Os scripts do kit montam
os dois `-f` sozinhos (`dc()` no `_common.sh`), então o buraco só aparece pra
quem roda compose na mão: eu, e qualquer um debugando a VPS.

## O que este PR faz

Só documentação. **Nenhuma linha de configuração ou código muda.**

1. **`docs/runbooks/deploy.md`** (novo) — o comando, por que os dois `-f`, a
   verificação pós-deploy, o fluxo commit → CI → GHCR → VPS, e a exceção de
   build local com o custo dela.
2. **`CLAUDE.md`** — seção curta de deploy + linha na tabela de paths.
3. **`docs/index.md`** — o runbook entra no índice. Doc fora do índice existe e
   não é encontrado; é o mesmo defeito do item 14 da DoD (tela sem porta),
   aplicado a documentação.
4. **`AGENTS.md`** — o CLAUDE.md manda verificá-lo quando a doutrina muda, e ele
   não tinha uma linha sobre deploy, compose ou proxy reverso. Um agente lendo só
   o AGENTS.md derrubaria o site do mesmo jeito.

## A verificação que o runbook ensina

O ponto que eu queria deixar registrado é que **`healthy` não prova acessível**:

```bash
docker inspect "$(docker compose -f docker-compose.prod.yml ps -q app)" \
  --format '{{.Config.Labels}}' | grep -o 'traefik.enable:[^ ]*'
# traefik.enable:true

curl -s -o /dev/null -w "%{http_code}\n" https://<DOMAIN>/
# 307 = ok (redireciona pro login) · 404 = labels perdidas, refaça com os dois -f
```

## Uma coisa que escrevi errado e corrigi medindo

Na primeira versão eu afirmei que a inspeção também precisava dos dois `-f`,
senão o `ps -q` responderia sobre outro contêiner. **É falso.** `docker compose
ps -q app` resolve pelo nome do projeto + serviço, não pelo conteúdo do arquivo:
com um `-f` ou com os dois, devolve o mesmo id. Medido nesta VPS antes de
mandar. Quem precisa dos dois é o `up -d`. A afirmação foi corrigida no texto em
vez de removida, porque o "por quê" é o que evita o erro seguinte.

## Onde isto foi medido

VPS Hostinger (`hvps`, Ubuntu, Docker 27), Traefik da hospedagem em modo host,
instalação real seguindo a `main` deste repo. O 404 aconteceu de verdade em
2026-08-05 (~2 min de queda) e o 307 voltou com o comando dos dois `-f`. Rodei
hoje de novo, depois de trazer os 129 commits da `main`: `307` na raiz, `200` em
`/login`, `403` no webhook público do WAHA, health com `supabase ok · redis ok ·
waha ok`.

`tests/unit/agents-md-versoes.test.ts` (8 casos) verde.

## O que este PR NÃO faz

Não mexe no `install.sh`/`update.sh` nem nos compose. Se você achar que o lugar
certo pra parte do `CLAUDE.md` é outro — ou que o runbook devia viver em
`docs/deploy-hostgator/` em vez de `docs/runbooks/` — me diz e eu movo.
