### PR TITLE
fix(lint-channels): a fronteira \b não fechava antes de _ e 7 arquivos escapavam (#118)

### DIFF
--- a/docs/doctrine/restricao-de-canal.md
+++ b/docs/doctrine/restricao-de-canal.md
@@ -46,7 +46,11 @@ if (!caps.freeformOutsideWindow) { /* ... */ }
 - **Por quê:** cada `if (provider === ...)` é uma chance de alguém escrever o ramo novo e
   esquecer o antigo. É assim que uma implementação regride a outra.
 - **Verificação:** `scripts/lint-channels.ts` reprova o vazamento no `gov:verify`. Provider
-  novo não exige tocar em feature nenhuma.
+  novo não exige tocar em feature nenhuma. O reconhecimento do nome mora em
+  `scripts/lint-channels.pattern.ts` — separado justamente para poder ser testado, porque o
+  lint em si varre disco e chama `process.exit` ao ser importado. São **duas** fronteiras,
+  uma por grafia (`waha_session_name` / `WAHA_API_KEY` vs. `WahaClient`); a #118 mostrou que
+  uma catraca que enxerga só uma delas dá verde afirmando o que não verificou.
 
 ### 2. Toda restrição declara ORIGEM e FÍSICA
 

--- a/scripts/lint-channels.pattern.ts
+++ b/scripts/lint-channels.pattern.ts
@@ -1,0 +1,62 @@
+/**
+ * O padrão que reconhece "nome de provider" para o invariante 1 da doutrina de
+ * restrição de canal (`docs/doctrine/restricao-de-canal.md`).
+ *
+ * Mora num módulo separado de `lint-channels.ts` por um motivo só: o script é
+ * uma casca que varre o disco e chama `process.exit` no topo do módulo, então
+ * importá-lo de um teste RODARIA o lint. Sem separar, o mecanismo do
+ * reconhecimento fica sem como ser vigiado — e foi exatamente o que deixou o
+ * furo abaixo viver.
+ *
+ * ─── O furo (issue #118) ────────────────────────────────────────────────────
+ *
+ * A primeira versão era `/\b(waha|WAHA|meta_cloud|graph\.facebook\.com)\b/`.
+ * `_` é *word character* em regex, então `\b` NÃO fecha entre `WAHA` e `_`:
+ * `WAHA_API_KEY` e `waha_session_name` — os nomes de provider mais comuns do
+ * código — passavam invisíveis pela catraca, que está no `gov:verify` e é
+ * catraca de merge. Uma catraca com furo é pior que catraca nenhuma: o verde
+ * afirma que a doutrina está sendo respeitada.
+ *
+ * ─── Por que DUAS fronteiras, e não uma ─────────────────────────────────────
+ *
+ * Um provider vira identificador em TypeScript de dois jeitos, e cada um pede
+ * uma fronteira diferente. Uma regex só não expressa os dois sem virar ilegível
+ * ou frouxa:
+ *
+ *   `waha_session_name`, `WAHA_API_KEY`, `@/lib/waha/x`  → separador não-alfanumérico
+ *   `WahaClient`, `createWahaSession`                    → transição de caixa
+ *
+ * Consertar só a primeira deixaria a segunda como álibi para o próximo caso —
+ * é o mesmo furo (uma grafia do provider que a catraca não vê), na outra
+ * dimensão. Medido na main de 2026-08-05: a regra PascalCase custa **zero**
+ * arquivo ofensor a mais (hoje todo arquivo que a tem também importa de
+ * `lib/waha/`), então fechar a classe inteira aqui não cria dívida nova.
+ */
+
+/**
+ * Grafia separada por não-alfanumérico: `waha`, `WAHA_API_KEY`,
+ * `waha_session_name`, `lib/waha/client`, `meta_cloud`, `graph.facebook.com`.
+ *
+ * A fronteira é "não colado em alfanumérico" — deixa `_`, `/`, `.` e `-` serem
+ * separadores de verdade (que `\b` não deixava) e continua ignorando `wahax` /
+ * `xwaha`, onde `waha` é pedaço de outra palavra e não menção ao provider.
+ */
+const SEPARADO = /(?<![a-zA-Z0-9])(waha|meta_cloud|graph\.facebook\.com)(?![a-zA-Z0-9])/i;
+
+/**
+ * Grafia PascalCase dentro de identificador: `WahaClient`,
+ * `WahaChannelAdapter`, `createWahaSession`.
+ *
+ * Case-SENSITIVE de propósito: é a transição de caixa que marca a fronteira do
+ * segmento. Não seguido de minúscula/dígito exclui `Wahalla` — onde `Waha` é
+ * começo de outra palavra, não segmento próprio.
+ */
+const PASCAL = /Waha(?![a-z0-9])/;
+
+/** Um trecho de código/prosa nomeia um provider de canal? */
+export function nomeiaProvider(texto: string): boolean {
+  return SEPARADO.test(texto) || PASCAL.test(texto);
+}
+
+/** Exportadas para o teste de fronteira poder vigiar cada uma isoladamente. */
+export const PADROES = { SEPARADO, PASCAL } as const;

--- a/scripts/lint-channels.ts
+++ b/scripts/lint-channels.ts
@@ -31,7 +31,10 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-const FORBIDDEN = /\b(waha|WAHA|meta_cloud|graph\.facebook\.com)\b/;
+// O padrão vive em módulo próprio para poder ser testado sem executar o lint —
+// ver a justificativa das duas fronteiras (issue #118) lá.
+import { nomeiaProvider } from "./lint-channels.pattern";
+
 const ROOTS = ["app", "lib", "components", "workers"];
 const ALLOWED = [
   /^lib\/channels\//,
@@ -42,7 +45,16 @@ const ALLOWED = [
 ];
 
 /**
- * Dívida conhecida, medida em 2026-07-27 (Task 7 do plano de seam de canais).
+ * Dívida conhecida, medida em 2026-07-27 (Task 7 do plano de seam de canais) e
+ * RE-medida em 2026-08-05 ao consertar a fronteira do padrão (issue #118).
+ *
+ * As 7 entradas marcadas `(#118)` não são dívida nova: elas já violavam o
+ * invariante desde sempre e a catraca é que não as enxergava, porque `\b` não
+ * fecha antes de `_`. Entram DECLARADAS em vez de consertadas no mesmo passo —
+ * congelar o que já existia e reprovar só o novo é o que deixa o gate nascer
+ * verde; limpá-las exige renomear coluna de banco e campo de API pública, que é
+ * mudança de comportamento e trabalho da Fase 3 do seam.
+ *
  * Ordem alfabética dentro de cada grupo, para o diff ficar legível.
  */
 const KNOWN_DEBT: { reason: string; files: string[] }[] = [
@@ -67,6 +79,10 @@ const KNOWN_DEBT: { reason: string; files: string[] }[] = [
       "app/api/v1/onboarding/whatsapp/session/route.ts",
       "app/api/v1/webhooks/waha/[token]/route.ts",
       "app/api/v1/webhooks/waha/route.ts",
+      // (#118) Lê `process.env.WAHA_API_BASE_URL`/`WAHA_API_KEY` só para
+      // decidir se o transporte está configurado — o nome está no ENV, não
+      // numa pergunta de identidade. Sai quando o env virar config de canal.
+      "app/app/connections/page.tsx",
       "app/onboarding/connect-whatsapp/page.tsx",
       "lib/agent-engine/edge/crm/session-reconciler.ts",
       "workers/media-persist-worker.ts",
@@ -75,20 +91,44 @@ const KNOWN_DEBT: { reason: string; files: string[] }[] = [
   {
     reason:
       "Texto VISÍVEL ao usuário (cópia de tela) ou nome de campo de resposta de " +
-      "API pública (`checks.waha`, `waha_ban`, `waha_sessions_count`). Trocar é " +
-      "mudança de comportamento observável — proibida nas Fases 0–2. A cópia " +
-      "neutra de canal entra junto com o seletor de canal da Fase 3a, que é " +
-      "quando o usuário passa a ter mais de um canal para distinguir.",
+      "API pública (`checks.waha`, `waha_ban`, `waha_sessions_count`, o código " +
+      "de erro `waha_error`). Trocar é mudança de comportamento observável — " +
+      "proibida nas Fases 0–2, e no caso do código de erro quebraria cliente de " +
+      "API de terceiro. A cópia neutra de canal entra junto com o seletor de " +
+      "canal da Fase 3a, que é quando o usuário passa a ter mais de um canal " +
+      "para distinguir.",
     files: [
       "app/api/v1/admin/dashboard/kpis/route.ts",
       "app/api/v1/admin/tenants/[id]/health/route.ts",
+      // (#118) Emite `waha_sessions_count` na resposta do admin.
+      "app/api/v1/admin/tenants/[id]/route.ts",
       "app/design/sections/SectionPatterns.tsx",
       "app/onboarding/connect-whatsapp/_client.tsx",
       "components/admin/dashboard/AlertItem.tsx",
       "components/admin/dashboard/KPICards.tsx",
       "components/admin/tenants/HealthGrid.tsx",
+      // (#118) Fixture do teste do componente logo abaixo, que já é dívida:
+      // sai junto com ele, pelo mesmo motivo.
+      "components/admin/tenants/TenantOverview.test.tsx",
       "components/admin/tenants/TenantOverview.tsx",
       "components/connections/ConnectionsClient.tsx",
+      // (#118) `waha_error` no catálogo de códigos de erro da API pública.
+      "lib/api/errors.ts",
+    ],
+  },
+  {
+    reason:
+      "(#118) Leem a COLUNA `channel_sessions.waha_session_name`. Aqui o nome do " +
+      "provider está no SCHEMA, não na feature: nenhum destes pergunta 'é WAHA?' " +
+      "— só leem o identificador da sessão pelo nome que a coluna tem hoje. " +
+      "Limpar é renomear a coluna (migration + apêndice no baseline + toda a " +
+      "leitura), que é a mesma mudança de schema que a Fase 3 do seam já prevê " +
+      "ao absorver `lib/waha/`. Consertar aqui, antes disso, espalharia um " +
+      "alias por 3 arquivos sem tirar o nome de lugar nenhum.",
+    files: [
+      "app/api/v1/ai/pacing/route.ts",
+      "app/api/v1/cron/contact-avatars/route.ts",
+      "components/connections/AntiBanSheet.tsx",
     ],
   },
   {
@@ -152,7 +192,7 @@ function walk(dir: string): string[] {
 
 const offenders = ROOTS.flatMap(walk)
   .filter((f) => !ALLOWED.some((re) => re.test(f)))
-  .filter((f) => FORBIDDEN.test(readFileSync(f, "utf8")));
+  .filter((f) => nomeiaProvider(readFileSync(f, "utf8")));
 
 const novos = offenders.filter((f) => !DEBT.has(f));
 const stale = [...DEBT].filter((f) => !offenders.includes(f)).sort();

--- a/tests/unit/lint-channels-fronteira.test.ts
+++ b/tests/unit/lint-channels-fronteira.test.ts
@@ -1,0 +1,79 @@
+/**
+ * A FRONTEIRA do padrão do `lint:channels` (issue #118).
+ *
+ * ## O defeito que fez este arquivo existir
+ *
+ * `scripts/lint-channels.ts` é catraca de merge (está no `gov:verify`) para o
+ * invariante 1 da doutrina de restrição de canal. O padrão dele usava `\b` como
+ * fronteira. `_` é *word character*, então `\b` não fecha entre `WAHA` e `_`: a
+ * catraca não enxergava **nenhum** identificador da família `WAHA_*`/`waha_*` —
+ * justamente os nomes mais comuns de provider no código. Sete arquivos violavam
+ * o invariante com o gate verde, e nenhum estava declarado como dívida.
+ *
+ * Nada acusou, e nada podia acusar: o único teste possível seria sobre o padrão,
+ * e o padrão morava dentro de um script que varre o disco e chama `process.exit`
+ * no topo do módulo — importá-lo de um teste rodaria o lint. Por isso o padrão
+ * saiu para `scripts/lint-channels.pattern.ts`.
+ *
+ * ## O que se guarda aqui
+ *
+ * O RECONHECIMENTO, não a lista de ofensores (essa é do próprio lint, e muda a
+ * cada arquivo novo). Cada caso abaixo é uma grafia que já escapou ou que
+ * escaparia; voltar a fronteira para `\b`, ou a alternação para
+ * case-sensitive, deixa este arquivo vermelho.
+ *
+ * Os casos negativos não são enfeite: um padrão frouxo demais (ex.: sem
+ * fronteira nenhuma) passaria em todos os positivos e transformaria a catraca
+ * num gerador de falso positivo, que é o outro jeito de matá-la.
+ */
+import { describe, expect, it } from "vitest";
+
+import { PADROES, nomeiaProvider } from "../../scripts/lint-channels.pattern";
+
+describe("fronteira do padrão de nome de provider", () => {
+  it.each([
+    // Os que o `\b` deixava passar — o defeito da #118, em suas duas pontas.
+    ["WAHA_API_KEY", "env var: `_` depois do nome não fechava a fronteira"],
+    ["WAHA_API_BASE_URL", "env var"],
+    ["waha_session_name", "coluna de banco — a grafia mais frequente no repo"],
+    ["waha_sessions_count", "campo de resposta de API"],
+    ["waha_error", "código de erro"],
+    ["X_WAHA", "`_` antes do nome também não abria a fronteira"],
+    // A outra dimensão do mesmo furo: a grafia PascalCase, que a alternação
+    // `(waha|WAHA)` não reconhecia — e que a fronteira "não-alfanumérico"
+    // sozinha também não pega, porque a letra seguinte é alfanumérica.
+    ["WahaChannelAdapter", "identificador PascalCase"],
+    ["WahaClient", "identificador PascalCase"],
+    ["createWahaSession", "segmento PascalCase no meio do identificador"],
+    // Os que já funcionavam — ficam para o conserto não regredir o que servia.
+    ["waha", "menção nua"],
+    ["WAHA", "menção nua em caixa alta"],
+    ["import { x } from '@/lib/waha/client'", "caminho de import"],
+    ["meta_cloud", "outro provider do vocabulário"],
+    ["graph.facebook.com", "host de provider"],
+  ])("reconhece %s (%s)", (texto) => {
+    expect(nomeiaProvider(texto)).toBe(true);
+  });
+
+  it.each([
+    ["wahax", "`waha` como prefixo de outra palavra"],
+    ["xwaha", "`waha` como sufixo de outra palavra"],
+    ["wahalla", "palavra que apenas começa igual"],
+    ["Wahalla", "idem, em PascalCase — `Waha` seguido de minúscula não é segmento"],
+    ["metacloud", "sem o separador, não é o termo do vocabulário"],
+    ["graphxfacebookxcom", "o ponto do host é literal, não coringa"],
+  ])("NÃO reconhece %s (%s)", (texto) => {
+    expect(nomeiaProvider(texto)).toBe(false);
+  });
+
+  it("as duas fronteiras são independentes (guarda de vacuidade)", () => {
+    // Sem isto, uma das duas podendo cobrir sozinha todos os casos acima
+    // deixaria a outra virar código morto sem ninguém notar — e o dia em que
+    // ela fosse apagada por "simplificação" o teste seguiria verde.
+    expect(PADROES.SEPARADO.test("WahaClient")).toBe(false);
+    expect(PADROES.PASCAL.test("waha_session_name")).toBe(false);
+    // E nenhuma delas pode voltar a usar `\b`, que é o defeito da #118.
+    expect(PADROES.SEPARADO.source).not.toContain("\\b");
+    expect(PADROES.PASCAL.source).not.toContain("\\b");
+  });
+});


### PR DESCRIPTION
`_` é word character, então `\b` não fecha entre `WAHA` e `_`. A catraca do
`gov:verify` não enxergava nenhum identificador da família `waha_*`/`WAHA_*` —
justamente os nomes de provider mais comuns do código. Verde afirmando que a
doutrina estava sendo respeitada, que é pior que catraca nenhuma.

Medido com o lint REAL (não réplica), trocando só o padrão: 54 → 61 ofensores.
Os 7 já violavam o invariante desde sempre; entram como dívida DECLARADA, com
razão escrita por grupo, porque limpá-los é renomear coluna de banco e campo de
API pública — mudança de comportamento que é trabalho da Fase 3 do seam. Gate
que nasce vermelho não é gate: congela o que existia, reprova só o novo.

Duas fronteiras em vez de uma: um provider vira identificador por separador
(`waha_session_name`) ou por caixa (`WahaClient`), e a segunda grafia escapava
pelo mesmo motivo — consertar só uma daria álibi à irmã. Medido: a regra
PascalCase custa zero ofensor a mais hoje.

O padrão saiu para módulo próprio para poder ser testado — antes era impossível,
porque importar o lint o executava, e é por isso que o furo viveu sem ninguém
notar. `tests/unit/lint-channels-fronteira.test.ts` guarda o RECONHECIMENTO, não
a lista de ofensores. Sabotado nos dois sentidos: voltar o `\b` reprova 7 casos,
apagar a regra PascalCase reprova 3.

gov:verify verde: 257 arquivos, 2393 testes.

Closes #118

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HstH7nNmrTvCtZsasppeHj

---

Independente das outras branches desta leva — não toca em nenhum arquivo compartilhado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HstH7nNmrTvCtZsasppeHj