### PR TITLE
test(e2e): 15 → 28 das 32 specs no CI, provadas rodando (#63)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -100,8 +100,37 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
           SUPABASE_SERVICE_ROLE_KEY=$SUPABASE_SERVICE_ROLE_KEY
           INTERNAL_SECRET=ci-placeholder-nao-e-segredo
+          SUPABASE_DB_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
           EOF
           pnpm exec tsx scripts/seed-e2e-credentials.ts
+
+      # `SUPABASE_DB_URL` no `.env.local` (e não só no `env:` do passo de teste):
+      # `seed-e2e-escalacao.ts` abre um `pg.Pool` direto, e o `.env.local` é a
+      # única fonte que ele lê. Sem a linha, o `pg` cai no default 5432 e morre
+      # com ECONNREFUSED — o stack local do Supabase publica o Postgres na 54322.
+      # Medido: foi exatamente assim que a primeira execução deste passo falhou.
+      #
+      # A maioria das specs roda o próprio seed num `beforeAll`. Estas TRÊS não
+      # — ou o cabeçalho manda rodar à mão, ou a fixture é de outra spec.
+      #
+      # `seed-e2e-followup-agent` (credencial de IA + sessão de canal) é o caso
+      # sutil: `followup-builder` o roda no próprio `beforeAll`, mas
+      # `agente-novo-e-uso` PRECISA das mesmas fixtures e vem ANTES na ordem
+      # alfabética — em banco fresco os comboboxes de credencial e canal abrem
+      # com a opção desabilitada e o clique estoura por timeout. Medido: o
+      # ensaio local passou porque o banco tinha as fixtures de uma rodada
+      # anterior; o CI, fresco, reprovou. Rodar aqui torna a precondição
+      # explícita em vez de depender da ordem dos arquivos.
+      #
+      # `--env-file` só na segunda, e a diferença não é capricho: o seed de
+      # capacidades importa `lib/env.ts` (via lib/ai/embed.ts), que lê
+      # `process.env`; o de escalação parseia o `.env.local` por conta própria.
+      # Sem a flag o de capacidades morre na validação Zod das 3 vars do Supabase.
+      - name: Semear as fixtures que as specs não semeiam sozinhas
+        run: |
+          pnpm exec tsx scripts/seed-e2e-escalacao.ts
+          pnpm exec tsx --env-file=.env.local scripts/seed-e2e-capacidades-ausentes.ts
+          pnpm exec tsx scripts/seed-e2e-followup-agent.ts
 
       # O que ficou DE FORA (e por quê) é declarado no passo de summary —
       # cobertura parcial silenciosa se lê como cobertura total.
@@ -124,7 +153,13 @@ jobs:
             rbac-roles.spec.ts inbox-scope.spec.ts reset-password-mfa.spec.ts \
             degradacao-silenciosa.spec.ts vps-webhook-outbound-ssrf.spec.ts \
             kanban-owner-filter.spec.ts queue-assign.spec.ts \
-            risk-radar.spec.ts invite-lifecycle.spec.ts system-update.spec.ts
+            risk-radar.spec.ts invite-lifecycle.spec.ts system-update.spec.ts \
+            agente-novo-e-uso.spec.ts agente-organiza-operacao.spec.ts \
+            central-de-avisos-capacidades.spec.ts escalacao-ciclo.spec.ts \
+            navegacao.spec.ts olhar-telas-do-epico.spec.ts pipelines-gestao.spec.ts \
+            qa-agente-usa-as-maos.spec.ts qa-selo-no-funil-usado.spec.ts \
+            qa-telas-descobertas-w4.spec.ts retorno-anti-morte.spec.ts \
+            followup-builder.spec.ts followup-queue.spec.ts
         env:
           INTERNAL_SECRET: ci-placeholder-nao-e-segredo
           CPF_ENCRYPTION_KEY: ci-placeholder-nao-e-segredo
@@ -143,17 +178,25 @@ jobs:
           {
             echo "## E2E — cobertura deste job"
             echo ""
-            echo "**Rodou (15 de 20 specs):** smoke, auth, error-pages, password-recovery,"
+            echo "**Rodou (28 de 32 specs):** smoke, auth, error-pages, password-recovery,"
             echo "signup-journey, rbac-roles, inbox-scope, reset-password-mfa,"
             echo "degradacao-silenciosa, vps-webhook-outbound-ssrf, kanban-owner-filter,"
-            echo "queue-assign, risk-radar, invite-lifecycle, system-update."
+            echo "queue-assign, risk-radar, invite-lifecycle, system-update,"
+            echo "agente-novo-e-uso, agente-organiza-operacao, central-de-avisos-capacidades,"
+            echo "escalacao-ciclo, navegacao, olhar-telas-do-epico, pipelines-gestao,"
+            echo "qa-agente-usa-as-maos, qa-selo-no-funil-usado, qa-telas-descobertas-w4,"
+            echo "retorno-anti-morte, followup-builder, followup-queue."
             echo ""
-            echo "**Não rodou (5):**"
+            echo "**Não rodou (4):**"
             echo "- precisa de WAHA: followup-journey, webhooks"
             echo "- precisa de WAHA + Redis + Resend + Nuvemshop: vps-fresh-onboarding (P0)"
-            echo "- seed próprio falha neste ambiente (medido): followup-builder"
-            echo "  (seed-e2e-followup-agent.ts não grava followup_agent_fixtures) e"
-            echo "  followup-queue (followup_promise ausente em .e2e-creds.json)."
+            echo "- **capacidades-do-agente: fora porque REPROVA, e o vermelho está certo.**"
+            echo "  Ligar o pacote 'Atender' enche o teto de 20 capacidades, e aí a UI"
+            echo "  DESABILITA o checkbox da capacidade crítica que o próprio desenho"
+            echo "  manda o humano marcar à mão ('o pacote não liga por você'). O seed"
+            echo "  liga 3; o pacote traz >=17 automáticas. Não é dado sujo: é o catálogo"
+            echo "  ter crescido depois que a spec foi escrita — e ninguém soube porque"
+            echo "  ela nunca rodou no gate, que é a tese desta issue."
             echo ""
             echo "Expandir é trabalho de seguimento — issue #63."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,11 +66,13 @@ mudança toca schema, RLS ou UI, `gov:verify` verde **não** é prova — rode `
 efêmero pg17). `.github/workflows/perf.yml`: `build-and-size` = `pnpm build`.
 **Os três são checks obrigatórios** na branch protection da `main`.
 
-`.github/workflows/e2e.yml` roda **10 das 20 specs** Playwright (`smoke`, `auth`,
-`error-pages`) contra um Supabase local de verdade com o `baseline.sql` aplicado — o mesmo
-banco que o self-hoster tem. **Não é obrigatório ainda** (falta dado de estabilidade) e as
-outras 16 continuam sem gate: se você mexeu em UI ou fluxo de usuário fora desse
-subconjunto, a prova é sua.
+`.github/workflows/e2e.yml` roda **28 das 32 specs** Playwright contra um Supabase local de
+verdade com o `baseline.sql` aplicado — o mesmo banco que o self-hoster tem. **Não é
+obrigatório ainda** (o conjunto de specs acabou de mudar, então execuções verdes anteriores
+eram de outro conjunto e não provam a estabilidade deste). As 4 de fora: `followup-journey` e
+`webhooks` (precisam de WAHA), `vps-fresh-onboarding` (WAHA + Redis + Resend + Nuvemshop; é a
+P0 da doutrina de QA) e `capacidades-do-agente`, que está fora porque REPROVA de verdade — ver
+o summary do job. Se você mexeu em UI fora desse subconjunto, a prova é sua.
 
 ## Padrões de código (observados no repo, não inventados)
 
@@ -115,18 +117,19 @@ subconjunto, a prova é sua.
 ## Testes existentes (CONFIRMADO)
 
 - **221** arquivos `*.test.ts(x)` unitários (rodam em `test:unit` e no CI)
-- **56** arquivos de invariante de banco em `tests/invariants/` — RLS/isolamento cross-tenant,
+- **67** arquivos de invariante de banco em `tests/invariants/` — RLS/isolamento cross-tenant,
   RBAC, governança (G1–G6). Excluídos do `test:unit` de propósito; rodam via `pnpm test:db`
   **e no job `invariants` do CI**.
-- **19** specs Playwright em `tests/e2e/`. **3 rodam no CI** (`smoke`, `auth`,
-  `error-pages`, via `e2e.yml`, não-obrigatório). As outras 16 — incluindo
-  `vps-fresh-onboarding` e `vps-webhook-outbound-ssrf` — ainda não: dependem de fixture
-  semeada ou de serviço externo. Ver issue #63.
+- **32** specs Playwright em `tests/e2e/`. **28 rodam no CI** (via `e2e.yml`,
+  não-obrigatório). As 4 de fora dependem de serviço externo (WAHA/Redis/Resend/Nuvemshop) —
+  incluindo `vps-fresh-onboarding` — ou reprovam legitimamente (`capacidades-do-agente`).
+  Ver issue #63.
 
 ## Limitações conhecidas (estado em 2026-07-29, contra `origin/main` @ 789dfa6)
 
-- **10 das 20 specs E2E seguem fora do CI.** Se você mexeu em UI ou fluxo de usuário fora
-  de `smoke`/`auth`/`error-pages`, a prova é sua — nenhum gate automático cobre.
+- **4 das 32 specs E2E seguem fora do CI**, e o `e2e` ainda não é check obrigatório: um PR
+  que o quebre entra na `main` assim mesmo. Se você mexeu em UI coberta só por essas 4, a
+  prova é sua.
 - Rate limit HTTP existe em **2** pontos do código (webhook de captação e dispatcher de IA);
   login, signup, aceite de convite, crons e MCP estão sem. Não há lockout por conta no login.
 - Fallback do rate limit é **em memória** — sem Upstash configurado o limite é por processo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ Checks **obrigatórios** na branch protection da `main` (verificado na configura
 
 Check **não-obrigatório** (roda, mas não segura merge):
 
-- **`e2e`** (`e2e.yml`) — sobe Supabase local, aplica o `baseline.sql` e roda **10 das 20 specs** Playwright (`smoke`, `auth`, `error-pages`, `password-recovery`, `signup-journey`, `rbac-roles`, `inbox-scope`, `reset-password-mfa`, `degradacao-silenciosa`, `vps-webhook-outbound-ssrf`). As outras 10 dependem de serviço externo (WAHA, Redis, Resend, Nuvemshop) e seguem sem gate (issue #63) — inclusive a `vps-fresh-onboarding`, que é P0.
+- **`e2e`** (`e2e.yml`) — sobe Supabase local, aplica o `baseline.sql` e roda **28 das 32 specs** Playwright. As 4 de fora: `followup-journey` e `webhooks` (precisam de WAHA), `vps-fresh-onboarding` (WAHA + Redis + Resend + Nuvemshop — é a P0 da doutrina de QA Visual) e `capacidades-do-agente`, que está fora porque **reprova de verdade**: ligar o pacote "Atender" enche o teto de 20 capacidades e a UI desabilita o checkbox da capacidade crítica que o próprio desenho manda marcar à mão. O `e2e` **ainda não é obrigatório** — o conjunto de specs mudou em 2026-08-05, então as execuções verdes anteriores eram de outro conjunto e não servem de prova de estabilidade deste (issue #63).
 
 Ao mexer em schema, RLS, RBAC, atribuição, escopo, roteamento, follow-up, webhooks ou automações: rode `pnpm test:db` **localmente** antes de abrir PR. É o único caminho que exercita o `baseline.sql` que o self-hoster realmente aplica.
 

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -120,17 +120,19 @@ Estes são achados de código/config verificados nesta auditoria, não relatos.
 
 ### 4.1 Os E2E quase não rodam no CI 🟠 — parcialmente resolvido em 2026-07-30
 
-> **Atualização (2026-08-03):** `e2e.yml` roda **10 das 20 specs** (`smoke`, `auth`,
-> `error-pages`) contra Supabase local com o `baseline.sql` aplicado. Não-obrigatório ainda.
-> A primeira execução real já pagou o job: achou a página `/500`, que `public-paths.ts`
-> declarava pública e **nunca havia sido criada**. As 16 restantes seguem sem gate — o texto
-> abaixo continua valendo para elas.
+> **Atualização (2026-08-05, issue #63):** `e2e.yml` roda **28 das 32 specs** contra Supabase
+> local com o `baseline.sql` aplicado. Não-obrigatório ainda. A primeira execução real já
+> pagou o job: achou a página `/500`, que `public-paths.ts` declarava pública e **nunca havia
+> sido criada**. A rodada de 2026-08-05 pagou de novo: as 12 specs do épico IA 360 nunca
+> tinham entrado no gate, e ao rodá-las apareceu um defeito de produto real
+> (`capacidades-do-agente` — o teto de 20 capacidades desabilita a crítica que o desenho manda
+> marcar à mão). As 4 restantes seguem sem gate — o texto abaixo continua valendo para elas.
 
 O gate de isolamento RLS **roda** — `ci.yml` tem o job `invariants` chamando `pnpm test:db`,
 que sobe `pgvector/pgvector:pg17`, aplica `baseline.sql` em modo install e update, e roda os
 56 arquivos de `tests/invariants/`. Esse buraco está fechado.
 
-O que continua fora: **10 das 20 specs Playwright**. A `vps-webhook-outbound-ssrf.spec.ts`,
+O que continua fora: **4 das 32 specs Playwright**. A `vps-webhook-outbound-ssrf.spec.ts`,
 única prova automatizada do guard de SSRF, **passou a rodar** no `e2e.yml`. Mas a
 `vps-fresh-onboarding.spec.ts` — a jornada que a doutrina de QA Visual classifica como o
 caminho mais crítico do produto — continua fora, porque exige WAHA + Redis + Resend +

--- a/docs/harness-audit.md
+++ b/docs/harness-audit.md
@@ -28,7 +28,7 @@ verificados por leitura de arquivo, config e workflow.
 | H2 — Reproduzível | ✅ | Quickstart no README, `docs/SETUP.md`, `.nvmrc` (22), `packageManager` fixo, `pnpm-lock.yaml`, `docker-compose.yml`, `install.sh` do kit self-host, `baseline.sql` |
 | H3 — Verificável | ✅ | `lint` + `typecheck` + `test:unit` + `build`; CI roda os 3 primeiros em PR |
 | H4 — Preparado para agentes | ✅ | `CLAUDE.md` doutrinal forte; `AGENTS.md` **criado nesta auditoria**; documentação técnica extensa; **e o CI roda o gate de isolamento RLS** (job `invariants` → `pnpm test:db`) |
-| H5 — Automação avançada | ⚠️ **parcial** | CI confiável e ambiente isolado ✅ (Postgres efêmero pg17, worktrees, gov-loop com maker≠checker e hash-check). Faltam: **10 das 20 specs E2E fora do CI** (10 rodam via `e2e.yml`, ainda não-obrigatório), `format:check` fora do CI, e o comando único local (`gov:verify`) não cobre `test:db`/`test:e2e` |
+| H5 — Automação avançada | ⚠️ **parcial** | CI confiável e ambiente isolado ✅ (Postgres efêmero pg17, worktrees, gov-loop com maker≠checker e hash-check). Faltam: **4 das 32 specs E2E fora do CI** (28 rodam via `e2e.yml`, ainda não-obrigatório — e enquanto for opcional um PR que o quebre entra na `main`), `format:check` fora do CI, e o comando único local (`gov:verify`) não cobre `test:db`/`test:e2e` |
 
 **Por que H4 e não H5:** a instrução da auditoria é explícita — não atribuir nível só
 porque os arquivos existem, avaliar se o processo está implementado. Aqui está: o gate de

--- a/tests/e2e/followup-builder.spec.ts
+++ b/tests/e2e/followup-builder.spec.ts
@@ -43,7 +43,7 @@ function loadCreds(): Creds {
   return JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
 }
 
-const creds = loadCreds();
+let creds = loadCreds();
 
 async function login(page: Page, email: string): Promise<void> {
   await page.goto("/login");
@@ -598,6 +598,12 @@ test.describe("followup flow builder — editor de condição de aresta / ai_cla
 test.describe("followup flow selector no editor do agente (Task 7.2)", () => {
   test.beforeAll(() => {
     execFileSync("npx", ["tsx", "scripts/seed-e2e-followup-agent.ts"], { stdio: "inherit" });
+  // O seed ESCREVE em .e2e-creds.json, e `creds` foi lido no carregamento do
+    // módulo — sem reler, o objeto em memória nunca vê o bloco que o seed
+    // acabou de gravar. Foi por isto que esta spec ficou fora do CI: a mensagem
+    // "o seed não grava X" descrevia o sintoma, e o seed gravava certo desde
+    // sempre. Mesmo idioma de queue-assign.spec.ts, que passa por isso.
+    creds = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
   });
 
   test("admin vincula um fluxo publicado ao agente, salva, e a persistência é provada via API", async ({

--- a/tests/e2e/followup-journey.spec.ts
+++ b/tests/e2e/followup-journey.spec.ts
@@ -73,7 +73,7 @@ function loadInternalSecret(): string {
   return secret;
 }
 
-const creds = loadCreds();
+let creds = loadCreds();
 const secret = loadInternalSecret();
 
 /** Roda 1 subcomando do helper de SQL cru e devolve o JSON impresso na última linha. */
@@ -188,6 +188,10 @@ test.describe("followup — jornada completa (Task 8.3)", () => {
 
   test.beforeAll(() => {
     execFileSync("npx", ["tsx", "scripts/seed-e2e-followup-agent.ts"], { stdio: "inherit" });
+    // O seed ESCREVE em .e2e-creds.json, e `creds` foi lido no carregamento do
+    // módulo — sem reler, o objeto em memória nunca vê o bloco que o seed
+    // acabou de gravar. Mesmo idioma de queue-assign.spec.ts, que passa por isso.
+    creds = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
   });
 
   test("silêncio → enroll → trigger→wait→action→classify → resposta → outcome → fila", async ({ page }) => {

--- a/tests/e2e/followup-queue.spec.ts
+++ b/tests/e2e/followup-queue.spec.ts
@@ -55,7 +55,7 @@ function loadCreds(): Creds {
   return JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
 }
 
-const creds = loadCreds();
+let creds = loadCreds();
 
 async function login(page: Page, email: string): Promise<void> {
   await page.goto("/login");
@@ -142,6 +142,12 @@ async function cleanupLiveEnrollment(page: Page, live: LiveEnrollment): Promise<
 test.describe("followup queue — fila unificada (Task 7.1)", () => {
   test.beforeAll(() => {
     execFileSync("npx", ["tsx", "scripts/seed-e2e-followup-promise.ts"], { stdio: "inherit" });
+  // O seed ESCREVE em .e2e-creds.json, e `creds` foi lido no carregamento do
+    // módulo — sem reler, o objeto em memória nunca vê o bloco que o seed
+    // acabou de gravar. Foi por isto que esta spec ficou fora do CI: a mensagem
+    // "o seed não grava X" descrevia o sintoma, e o seed gravava certo desde
+    // sempre. Mesmo idioma de queue-assign.spec.ts, que passa por isso.
+    creds = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
   });
 
   test("manager vê enrollment na fila, filtra por status/fluxo, cancela, e a promessa seedada aparece", async ({


### PR DESCRIPTION
Os números da issue e dos 5 docs tinham envelhecido DE NOVO: o épico IA 360
trouxe 12 specs e nenhuma entrou no gate. Eram 32 specs com 15 rodando, não
"10 das 20".

Não adicionei nada no escuro. Montei o ambiente do CI localmente (Supabase
local + baseline.sql aplicado + next build + next start) e rodei as candidatas:
**41 testes verdes em 13 specs**. Só entra o que passou.

DOIS DEFEITOS DE VERDADE, achados por rodar:

1. `followup-builder`, `followup-queue` e `followup-journey` liam
   `.e2e-creds.json` no CARREGAMENTO DO MÓDULO e só depois o `beforeAll` rodava
   o seed, que escreve no arquivo — o objeto em memória nunca via o bloco novo.
   O diagnóstico anterior ("o seed não grava followup_agent_fixtures") descrevia
   o sintoma; o seed sempre gravou certo. Varri as 32 specs atrás das irmãs: 3
   tinham o defeito, 3 já reliam (`queue-assign` é o controle positivo — ela
   passa no CI justamente por reler). Corrigidas as 3.

2. `escalacao-ciclo` e `central-de-avisos-capacidades` não semeiam sozinhas — o
   cabeçalho delas manda rodar o seed à mão, e o workflow não rodava. Agora roda.
   `--env-file=.env.local` só no de capacidades, e a assimetria tem motivo: ele
   importa `lib/env.ts`, que lê `process.env`; o de escalação parseia o
   `.env.local` sozinho. Sem a flag ele morre na validação Zod.

`capacidades-do-agente` fica de fora porque REPROVA, e o vermelho está certo:
ligar o pacote "Atender" enche o teto de 20 capacidades e a UI DESABILITA o
checkbox da capacidade crítica que o próprio desenho manda o humano marcar à mão
("o pacote não liga por você"). O seed liga 3, o pacote traz >=17 automáticas —
determinístico, não dado sujo. É o catálogo ter crescido depois que a spec foi
escrita, e ninguém soube porque ela nunca rodou no gate: a tese desta issue,
demonstrada. Fica declarado no summary do job, não escondido.

NÃO promovi o `e2e` a check obrigatório, embora a issue peça: eu ACABEI de mudar
o conjunto de specs, então as execuções verdes anteriores eram de outro conjunto
— usá-las como prova de estabilidade deste seria medir uma coisa e concluir
sobre outra, que é o erro que o dono do repo já pegou em si mesmo neste mesmo
item.

Ressalva medida: o ensaio local rodou num banco com dados acumulados de sessões
anteriores (schema idêntico — baseline re-aplicado —, dados não). Um banco fresco
do CI pode expor dependência de estado que aqui passou despercebida. Como o job
não é obrigatório, o pior caso é vermelho visível, não merge bloqueado.

gov:verify verde: 256 arquivos, 2372 testes.

Refs #63

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HstH7nNmrTvCtZsasppeHj

---

**Ordem de merge:** toca a lista de specs do `e2e.yml`, que #144 também toca (acrescentando `distribuicao-atendimento.spec.ts`). O conflito pede **combinação**, não escolha.

Não fecha a issue: sobram `vps-fresh-onboarding` (P0, precisa de 4 serviços externos), `followup-journey`/`webhooks` (WAHA), a promoção do `e2e` a check obrigatório e o defeito novo de `capacidades-do-agente`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HstH7nNmrTvCtZsasppeHj