### PR TITLE
fix(baseline): constraint reconstruída 7 vezes derruba o update.sh de quem já tem dados

### DIFF
--- a/supabase/baseline.sql
+++ b/supabase/baseline.sql
@@ -6560,13 +6560,10 @@ revoke all on function fn_publish_followup_flow_version(uuid, uuid, jsonb, uuid)
 
 -- ---- agent_inbox_items: kind 'followup_dead' (migration 0057) ----
 
-alter table agent_inbox_items
-  drop constraint if exists agent_inbox_items_kind_check;
-
-alter table agent_inbox_items
-  add constraint agent_inbox_items_kind_check check (kind in
-    ('qr_rescan','job_dead','event_dead','budget_exceeded','handoff',
-     'promotion_review','judge_unaligned','followup_dead','other'));
+-- A constraint NÃO é reconstruída aqui: o vocabulário desta migration já está
+-- contido no bloco único do fim deste apêndice. Reconstruí-la com a lista da
+-- época quebrava o update.sh de quem já tem linha com kind mais novo (era o
+-- caso deste bloco: 'snooze_expired' e os 4 seguintes ainda não existiam).
 
 -- ---- agent editor: seletor de fluxo de follow-up (migration 0061) ----
 
@@ -6708,10 +6705,8 @@ alter table conversations
 create index if not exists idx_conversations_snooze_until
   on conversations (snooze_until) where snooze_until is not null;
 
-alter table agent_inbox_items drop constraint if exists agent_inbox_items_kind_check;
-alter table agent_inbox_items add constraint agent_inbox_items_kind_check
-  check (kind in ('qr_rescan','job_dead','event_dead','budget_exceeded','handoff',
-                  'promotion_review','judge_unaligned','snooze_expired','other'));
+-- (constraint agent_inbox_items_kind_check: definida uma vez só, no fim deste
+--  apêndice — ver "vocabulário completo". 'snooze_expired' está lá.)
 
 -- ---- notas internas de conversa (migration 0063) ----
 create table if not exists conversation_notes (
@@ -6821,13 +6816,9 @@ alter table cron_jobs add constraint cron_jobs_job_kind_check
 
 -- ---- agent_inbox_items: reconcilia kind check followup_dead+snooze_expired (migration 0065) ----
 
-alter table agent_inbox_items
-  drop constraint if exists agent_inbox_items_kind_check;
-
-alter table agent_inbox_items
-  add constraint agent_inbox_items_kind_check check (kind in
-    ('qr_rescan','job_dead','event_dead','budget_exceeded','handoff',
-     'promotion_review','judge_unaligned','followup_dead','snooze_expired','other'));
+-- (constraint agent_inbox_items_kind_check: definida uma vez só, no fim deste
+--  apêndice — ver "vocabulário completo". Os dois valores desta migration
+--  estão lá.)
 -- ---- memória geral da org: org_memory_versions/pointers/entries (migration 0067) ----
 -- 0067: Memória Geral da Org (Fase 1 do épico harness — spec 2026-07-23).
 -- Doc-mãe versionado (padrão versões-imutáveis+ponteiro do playbook 0004/0050)
@@ -7389,12 +7380,9 @@ update public.crm_lead_activities
 
 alter table public.crm_lead_activities
   drop constraint if exists crm_lead_activities_ai_needs_evidence;
-alter table public.crm_lead_activities
-  add constraint crm_lead_activities_ai_needs_evidence check (
-    actor_kind <> 'ai'
-    or coalesce(jsonb_array_length(evidence->'run_ids'), 0) > 0
-    or coalesce(jsonb_array_length(evidence->'trace_ids'), 0) > 0
-  );
+-- A constraint NÃO é recriada aqui, e sim uma vez só mais abaixo, na versão que
+-- também aceita `llm_call_ids`. Recriá-la com a lista da época derrubava o
+-- update.sh de quem já tem atividade de IA cuja evidência é só `llm_call_ids`.
 
 -- Timeline por ator (o dossiê filtra "só o que a IA fez"), parcial porque a
 -- maioria das linhas não é de agente.
@@ -7481,27 +7469,8 @@ comment on column public.lead_state.next_action_seq is
 -- (sem esse valor) enquanto lib/followup/engine.ts insere exatamente esse kind.
 -- Reconstruir a partir do banco apagaria o valor e mataria, em silêncio, o
 -- aviso de enrollment morto. A fonte de verdade é o arquivo versionado.
-alter table public.agent_inbox_items
-  drop constraint if exists agent_inbox_items_kind_check;
-
-alter table public.agent_inbox_items
-  add constraint agent_inbox_items_kind_check check (
-    kind = any (
-      array[
-        'qr_rescan',
-        'job_dead',
-        'event_dead',
-        'budget_exceeded',
-        'handoff',
-        'promotion_review',
-        'judge_unaligned',
-        'followup_dead',
-        'snooze_expired',
-        'next_action_ambiguous',
-        'other'
-      ]::text[]
-    )
-  );
+-- (constraint agent_inbox_items_kind_check: definida uma vez só, no fim deste
+--  apêndice — ver "vocabulário completo". 'next_action_ambiguous' está lá.)
 
 -- ---- score de probabilidade com evidência, em tabela própria (migrations 0074+0075) ----
 -- O baseline salta o passo intermediário de propósito: quem instala do zero não
@@ -7884,26 +7853,8 @@ comment on function public.fn_update_last_activity_at() is
 -- CHECK e JÁ FICOU TRÊS VALORES ATRÁS DO BANCO sem nada falhar. Kind novo aqui
 -- = kind novo lá, na mesma mudança. Está sendo feito neste commit.
 
-alter table public.agent_inbox_items
-  drop constraint if exists agent_inbox_items_kind_check;
-
-alter table public.agent_inbox_items
-  add constraint agent_inbox_items_kind_check check (
-    kind = any (array[
-      'qr_rescan',
-      'job_dead',
-      'event_dead',
-      'budget_exceeded',
-      'handoff',
-      'promotion_review',
-      'judge_unaligned',
-      'followup_dead',
-      'snooze_expired',
-      'next_action_ambiguous',
-      'risk_backlog_seeded',
-      'other'
-    ]::text[])
-  );
+-- (constraint agent_inbox_items_kind_check: definida uma vez só, no fim deste
+--  apêndice — ver "vocabulário completo". 'risk_backlog_seeded' está lá.)
 
 -- ---- detected_at é carimbo do banco (migration 0081) ----
 -- 0081 — `detected_at` deixa de ser dado do cliente e vira CARIMBO do banco
@@ -8102,27 +8053,8 @@ end $$;
 -- e agora o invariante `vocabulario-banco-x-typescript` LÊ o arquivo de
 -- verdade, então esquecer não passa mais em silêncio.
 
-alter table public.agent_inbox_items
-  drop constraint if exists agent_inbox_items_kind_check;
-
-alter table public.agent_inbox_items
-  add constraint agent_inbox_items_kind_check check (
-    kind = any (array[
-      'qr_rescan',
-      'job_dead',
-      'event_dead',
-      'budget_exceeded',
-      'handoff',
-      'promotion_review',
-      'judge_unaligned',
-      'followup_dead',
-      'snooze_expired',
-      'next_action_ambiguous',
-      'risk_backlog_seeded',
-      'reactivation_expired',
-      'other'
-    ]::text[])
-  );
+-- (constraint agent_inbox_items_kind_check: definida uma vez só, no fim deste
+--  apêndice — ver "vocabulário completo". 'reactivation_expired' está lá.)
 
 -- ---- agent_stage_hint (migration 0084) ----
 -- 0084 — o funil do AGENTE aprende a falar o vocabulário do TENANT

--- a/tests/unit/baseline-constraint-reconstruida.test.ts
+++ b/tests/unit/baseline-constraint-reconstruida.test.ts
@@ -1,0 +1,92 @@
+/**
+ * UMA CONSTRAINT, UM BLOCO — O APÊNDICE DO BASELINE NÃO A RECONSTRÓI EM SÉRIE.
+ *
+ * O `baseline.sql` é o que o self-hoster aplica: `install.sh` numa base nova
+ * (com `ON_ERROR_STOP=1`) e `update.sh` numa base que JÁ TEM DADOS. O apêndice
+ * cresce por blocos, um por migration — e quando duas migrations mexem na mesma
+ * constraint de vocabulário, o padrão natural é cada bloco fazer
+ * `drop constraint` + `add constraint` com a lista da SUA época.
+ *
+ * ## O defeito que fez este arquivo existir
+ *
+ * `agent_inbox_items_kind_check` era reconstruída SETE vezes, cada bloco com o
+ * vocabulário do seu momento. Num banco com uma linha cujo `kind` veio de uma
+ * migration posterior — digamos `capabilities_missing`, da 0105 — os seis
+ * primeiros blocos falham em cadeia ao re-aplicar:
+ *
+ *   ERROR: check constraint "agent_inbox_items_kind_check" of relation
+ *          "agent_inbox_items" is violated by some row      (×6)
+ *
+ * O estado final ficava certo por acidente: o sétimo bloco, o último do arquivo,
+ * tinha o vocabulário completo e recriava a constraint. Mas entre o primeiro
+ * `drop` e o `add` que funciona, a tabela passa SEM constraint nenhuma — e se o
+ * run morre no meio (queda de rede, OOM), é assim que a base fica.
+ *
+ * E o dano garantido é outro: o `update.sh` classifica erro por padrão de texto
+ * (`already exists`, `multiple primary keys`…) e este NÃO está na lista. Todo
+ * clone com dados via, a cada atualização, o alarme "avisos que NÃO são os
+ * esperados… se algo estiver errado, restaure o backup" — para um problema que
+ * não existia. Alarme falso recorrente treina o dono a ignorar o alarme certo.
+ *
+ * ## Por que nenhum teste pegava
+ *
+ * `scripts/test-db.sh` aplica o baseline em modo install e depois em modo
+ * update, mas na MESMA base recém-criada — **vazia**. Sem linhas, nenhuma
+ * constraint pode ser violada, e os dois modos passam. O gate mede idempotência
+ * de DDL, não de DDL sobre dados. É exatamente a lacuna que este arquivo cobre,
+ * e por isso ele é estático (lê o arquivo) e não precisa de Postgres.
+ *
+ * ## A regra
+ *
+ * Cada constraint aparece UMA vez no `baseline.sql`, na versão final. O apêndice
+ * de uma migration que só amplia vocabulário não recria a constraint: comenta
+ * que o valor novo já está no bloco único. Migration nova que amplia o
+ * vocabulário edita AQUELE bloco — o arquivo é apêndice idempotente, não um
+ * diário de bordo executável.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const BASELINE = join(process.cwd(), "supabase", "baseline.sql");
+
+/** Nomes de constraint em cada `add constraint <nome>`, na ordem do arquivo. */
+function constraintsAdicionadas(sql: string): string[] {
+  return [...sql.matchAll(/add\s+constraint\s+([a-z0-9_]+)/gi)].map((m) =>
+    m[1].toLowerCase(),
+  );
+}
+
+describe("baseline.sql — uma constraint, um bloco", () => {
+  const sql = readFileSync(BASELINE, "utf8");
+
+  it("nenhuma constraint é adicionada mais de uma vez", () => {
+    const contagem = new Map<string, number>();
+    for (const nome of constraintsAdicionadas(sql)) {
+      contagem.set(nome, (contagem.get(nome) ?? 0) + 1);
+    }
+
+    const repetidas = [...contagem.entries()]
+      .filter(([, n]) => n > 1)
+      .map(([nome, n]) => `${nome} (${n}×)`);
+
+    expect(
+      repetidas,
+      `Constraint reconstruída em mais de um bloco do baseline.sql: ${repetidas.join(", ")}.\n` +
+        "Num banco com dados do vocabulário mais novo, os blocos antigos falham ao re-aplicar\n" +
+        "(update.sh) e a tabela fica sem constraint entre o drop e o add que funciona.\n" +
+        "Deixe UM bloco só, com o vocabulário final, e comente os demais.",
+    ).toEqual([]);
+  });
+
+  it("o instrumento enxerga repetição quando ela existe", () => {
+    // Controle negativo: sem isto, um regex quebrado faria o teste acima passar
+    // para sempre — verde por não medir nada.
+    const falso =
+      "alter table t add constraint c_check check (k in ('a'));\n" +
+      "alter table t add constraint c_check check (k in ('a','b'));\n";
+    const nomes = constraintsAdicionadas(falso);
+    expect(nomes).toEqual(["c_check", "c_check"]);
+  });
+});

--- a/tests/unit/baseline-constraint-reconstruida.test.ts
+++ b/tests/unit/baseline-constraint-reconstruida.test.ts
@@ -53,9 +53,10 @@ const BASELINE = join(process.cwd(), "supabase", "baseline.sql");
 
 /** Nomes de constraint em cada `add constraint <nome>`, na ordem do arquivo. */
 function constraintsAdicionadas(sql: string): string[] {
-  return [...sql.matchAll(/add\s+constraint\s+([a-z0-9_]+)/gi)].map((m) =>
-    m[1].toLowerCase(),
-  );
+  return [...sql.matchAll(/add\s+constraint\s+([a-z0-9_]+)/gi)]
+    .map((m) => m[1])
+    .filter((nome): nome is string => nome !== undefined)
+    .map((nome) => nome.toLowerCase());
 }
 
 describe("baseline.sql — uma constraint, um bloco", () => {


### PR DESCRIPTION
## Onde apareceu

Atualizando a minha VPS hoje, trazendo a `main` (os 129 commits do IA 360). O
`update.sh` re-aplica o `baseline.sql` na base que já tem dados, e apareceu isto:

```
psql:/b.sql:6569: ERROR:  check constraint "agent_inbox_items_kind_check" of
                          relation "agent_inbox_items" is violated by some row
```

A minha base tem **uma** linha em `agent_inbox_items`, com `kind='snooze_expired'`.

## O defeito

O apêndice reconstrói `agent_inbox_items_kind_check` **sete vezes**, um bloco por
migration que ampliou o vocabulário, cada um com a lista da sua época:

| bloco | migration | vocabulário |
|---|---|---|
| 6567 | 0057 | …`followup_dead`, `other` |
| 6712 | 0062 | …`snooze_expired`, `other` |
| 6828 | — | …`followup_dead`, `snooze_expired`, `other` |
| 7488 | — | + `next_action_ambiguous` |
| 7891 | — | + `risk_backlog_seeded` |
| 8109 | — | + `reactivation_expired` |
| 9056 | 0105 | + `capabilities_missing` ← completa |

Como os blocos rodam na ordem do arquivo, um banco com linha de vocabulário
posterior faz os anteriores falharem em cadeia. Só o último passa — e é por isso
que o estado final ficava correto: **por acidente**, porque o bloco completo é o
último do arquivo.

`crm_lead_activities_ai_needs_evidence` tem o mesmo defeito, em menor escala: o
bloco de 7393 exige `run_ids`/`trace_ids`; o de 7453 também aceita
`llm_call_ids`. Atividade de IA cuja evidência é só `llm_call_ids` quebra igual.

## O dano, em ordem de probabilidade

1. **Alarme falso recorrente.** O `update.sh` classifica erro por padrão de texto
   (`already exists`, `multiple primary keys`…) e este **não** está na lista. Todo
   clone com dados vê, a cada atualização, *"⚠ Apareceram avisos no banco que NÃO
   são os esperados… se algo estiver errado, restaure o backup"* — para um
   problema que não existe. Isso treina o dono a ignorar o alarme certo.
2. **Janela sem constraint.** Entre o primeiro `drop` e o `add` que funciona, a
   tabela fica sem constraint nenhuma. Se o run morre no meio (rede, OOM), é
   assim que a base fica — e nada avisa.
3. **Frágil por construção.** O estado final depender de o bloco completo ser o
   último é sorte, não desenho. A próxima migration que inserir um bloco no meio
   do arquivo deixa a base com o vocabulário errado.

## Por que nenhum teste pegava

`scripts/test-db.sh` aplica o baseline em modo install e depois em modo update —
mas na **mesma base recém-criada, vazia**. Sem linhas, nenhuma constraint pode
ser violada, e os dois modos passam. O gate mede idempotência de DDL, **não de
DDL sobre dados**, que é o que o `update.sh` de um clone realmente faz.

## O que este PR muda

Sobra **um bloco por constraint**, o da versão final. Os demais viram comentário
dizendo onde o valor vive. **Nenhum objeto de banco muda** — provado abaixo.

Mais `tests/unit/baseline-constraint-reconstruida.test.ts`: catraca estática (não
precisa de Postgres, roda no `verify`) que reprova qualquer constraint adicionada
mais de uma vez no `baseline.sql`. Tem controle negativo, para não ficar verde
por não medir nada.

## Medição

Postgres descartável (`pgvector/pgvector:pg17`), com o preâmbulo de roles/schemas
do próprio `scripts/test-db.sh`:

```console
# ANTES (baseline da main)
install (ON_ERROR_STOP=1) ........... 0 erros
insert kind='capabilities_missing' ... 1 linha
update (re-aplica) ................... 6 × ERROR: ...is violated by some row

# DEPOIS (este PR)
install (ON_ERROR_STOP=1) ........... 0 erros
insert kind='capabilities_missing' ... 1 linha
update (re-aplica) ................... 0 erros de constraint
                                       0 erros inesperados (307 totais, todos benignos)
```

A constraint resultante num install do zero é **idêntica**, comparada por
`pg_get_constraintdef`:

```console
$ diff constraint-antes.txt constraint-depois.txt
(vazio)
```

E a catraca foi sabotada para provar que vigia — rodada contra o `baseline.sql`
da `main`:

```
× nenhuma constraint é adicionada mais de uma vez
  AssertionError: Constraint reconstruída em mais de um bloco do baseline.sql:
  agent_inbox_items_kind_check (7×), crm_lead_activities_ai_needs_evidence (2×).
```

## O que NÃO fiz

Não rodei `pnpm test:db` completo — esta VPS não tem Node no host (a app roda em
contêiner) e eu preferi provar o ponto exato com Postgres de verdade a rodar
metade da suíte num ambiente improvisado. A catraca nova é estática e roda no
`verify`. Se você quiser que o gate passe a cobrir *DDL sobre dados* — semear uma
linha de cada vocabulário aberto antes do modo update, no `test-db.sh` — eu mando
num PR separado; achei que a decisão é sua.
