### PR TITLE
fix(observabilidade): dois caminhos que somem sem deixar pergunta respondível

### DIFF
--- a/lib/followup/engine.ts
+++ b/lib/followup/engine.ts
@@ -11,6 +11,8 @@
  */
 import type { SupabaseClient } from "@supabase/supabase-js";
 
+import { logger } from "@/lib/logger";
+
 import { flowGraphSchema, type FlowGraph, type FlowNode } from "./graph-schema";
 import {
   ACTION_RECHECK_MS,
@@ -88,6 +90,11 @@ export interface TickDeps {
 }
 
 export interface TickSummary {
+  /**
+   * Distingue "o claim falhou" de "nada vencido" — os dois produzem
+   * `claimed: 0`, e sem esta marca o segundo esconde o primeiro para sempre.
+   */
+  claim_falhou?: boolean;
   claimed: number;
   advanced: number;
   scheduled: number;
@@ -406,8 +413,19 @@ export async function runFollowupTick(deps: TickDeps, opts?: { limit?: number })
   let claimed: EnrollmentRow[];
   try {
     claimed = await deps.db.claimDueEnrollments(opts?.limit ?? DEFAULT_CLAIM_LIMIT, CLAIM_LEASE_SECONDS);
-  } catch {
-    // claim falhando é infra (DB fora do ar) — o tick seguinte tenta de novo; nunca lança.
+  } catch (err) {
+    // Claim falhando é infra (DB fora do ar) — o tick seguinte tenta de novo, e
+    // NUNCA lança: derrubar o worker por isso pararia todos os follow-ups.
+    //
+    // Mas silenciar é o defeito: `claimed: 0` aqui é indistinguível de "nada
+    // vencido", que é o estado normal. Se o claim falhar SEMPRE, o follow-up
+    // morre inteiro e o sintoma é a ausência de sintoma — ninguém descobre.
+    // A doutrina já tem a regra escrita para o audit (`CLAUDE.md`: falha de
+    // write gera alerta, não bloqueia); aqui ela vale igual.
+    logger.error("followup: claim falhou — tick sem enrollments, NAO e 'nada vencido'", {
+      erro: err instanceof Error ? err.message : String(err),
+    });
+    summary.claim_falhou = true;
     return summary;
   }
   summary.claimed = claimed.length;

--- a/lib/waha/ingest.ts
+++ b/lib/waha/ingest.ts
@@ -15,6 +15,7 @@ import { audit } from "@/lib/audit";
 import type { createAdminClient } from "@/lib/supabase/admin";
 import { ackToStatus } from "@/lib/types/messaging";
 import { bareWaMessageId, chatIdFromWaMessageId } from "@/lib/waha/message-id";
+import { logger } from "@/lib/logger";
 
 type Admin = ReturnType<typeof createAdminClient>;
 
@@ -416,7 +417,23 @@ async function handleInbound(
     console.error("[waha.ingest] message insert failed", insertErr.message);
     return;
   }
-  if (insertErr?.code === "23505") return;
+  if (insertErr?.code === "23505") {
+    // O `return` está certo — reingerir duplicaria a mensagem do cliente. Mas
+    // sair MUDO era o defeito: "5 mensagens, 4 jobs" fica indistinguível entre
+    // dedup legítimo e mensagem perdida por outro caminho, e a pergunta "cadê o
+    // turno dessa?" passa a não ter resposta no log.
+    //
+    // Não é erro, é evento esperado — por isso `info` e não `error`. O que ele
+    // paga é a CONTAGEM: sem a linha, o silêncio de um dedup normal e o de uma
+    // perda têm a mesma cara.
+    logger.info("waha.ingest: inbound ja ingerido, dedup por external_id", {
+      organization_id: session.organization_id,
+      conversation_id: conversationId,
+      external_id: p.id,
+      direcao: "inbound",
+    });
+    return;
+  }
 
   await markConversation(admin, session.organization_id, conversationId, "inbound", previewFromMessage(p), now);
 
@@ -601,7 +618,15 @@ async function handleOutboundFromUserPhone(
     console.error("[waha.ingest] outbound insert failed", insertErr.message);
     return;
   }
-  if (insertErr?.code === "23505") return;
+  if (insertErr?.code === "23505") {
+    // Mesma razão do inbound: dedup é esperado, invisível não.
+    logger.info("waha.ingest: outbound ja ingerido, dedup por external_id", {
+      organization_id: session.organization_id,
+      external_id: p.id,
+      direcao: "outbound",
+    });
+    return;
+  }
 
   await markConversation(admin, session.organization_id, conversationId, "outbound", previewFromMessage(p), now);
 

--- a/tests/unit/claim-falhou-nao-e-nada-vencido.test.ts
+++ b/tests/unit/claim-falhou-nao-e-nada-vencido.test.ts
@@ -1,0 +1,66 @@
+/**
+ * "O claim falhou" e "nada vencido" produzem o MESMO `claimed: 0`.
+ *
+ * O `catch` do claim em `runFollowupTick` está certo em não lançar — derrubar o
+ * worker por falha de infra pararia todos os follow-ups da instalação. O defeito
+ * era ele sair **mudo**: se o claim falhar SEMPRE, o follow-up morre inteiro e o
+ * sintoma é a ausência de sintoma, porque `claimed: 0` é também o estado normal
+ * de um tick sem nada vencido.
+ *
+ * A doutrina do repo já tinha a regra escrita para o audit (`CLAUDE.md`: falha
+ * de write gera alerta, não bloqueia a mutação principal). O que faltava era
+ * levá-la para cá.
+ *
+ * Este teste guarda as DUAS metades, porque consertar uma sem a outra deixa o
+ * defeito de pé: o erro tem que deixar sinal, E o tick normal não pode passar a
+ * gritar (senão o alarme vira ruído e alguém o desliga).
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import { runFollowupTick } from "@/lib/followup/engine";
+import { logger } from "@/lib/logger";
+
+function deps(claim: () => Promise<never[]> | never) {
+  return {
+    db: {
+      claimDueEnrollments: claim,
+      loadFlowGraph: async () => null,
+      loadLeadFacts: async () => ({ lead_stage: null, tags: [] }),
+      updateEnrollment: async () => {},
+      insertEvent: async () => {},
+    },
+    clock: () => new Date("2026-08-05T12:00:00Z"),
+    enqueueJob: async () => {},
+  } as never;
+}
+
+describe("claim que falha não se disfarça de 'nada vencido'", () => {
+  let erro: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    erro = vi.spyOn(logger, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    erro.mockRestore();
+  });
+
+  it("claim falhando deixa sinal E marca o summary", async () => {
+    const s = await runFollowupTick(
+      deps(async () => {
+        throw new Error("connection refused");
+      }),
+    );
+
+    expect(s.claimed, "sem enrollments, como antes").toBe(0);
+    expect(s.claim_falhou, "o summary distingue os dois zeros").toBe(true);
+    expect(erro, "falha de infra sem sinal é follow-up morrendo em silêncio").toHaveBeenCalled();
+  });
+
+  it("tick normal sem nada vencido NÃO grita (alarme que sempre toca é desligado)", async () => {
+    const s = await runFollowupTick(deps(async () => []));
+
+    expect(s.claimed).toBe(0);
+    expect(s.claim_falhou, "nada vencido não é falha").toBeFalsy();
+    expect(erro, "o caminho normal precisa ficar quieto").not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/ingest-dedup-deixa-rastro.test.ts
+++ b/tests/unit/ingest-dedup-deixa-rastro.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Dedup na porta de entrada não pode ser invisível.
+ *
+ * Achado medindo turnos reais (W4): 5 mensagens do cliente produziram 4 jobs e
+ * NENHUM registro de dedup. A pergunta "cadê o turno da quinta?" não tinha
+ * resposta no log — e essa era a resposta.
+ *
+ * O `return` no `23505` está certo: reingerir duplicaria a mensagem do cliente.
+ * O defeito era sair MUDO, porque aí "dedup legítimo" e "mensagem perdida por
+ * outro caminho" produzem exatamente o mesmo silêncio, no lugar mais caro do
+ * sistema — a porta de entrada.
+ *
+ * Este teste guarda as duas metades: o dedup deixa rastro, E o caminho normal
+ * (mensagem nova) não polui o log. Alarme que toca sempre é alarme desligado.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import { logger } from "@/lib/logger";
+
+/** Reproduz a decisão exata do ingest, sem subir Supabase. */
+function trataInsert(
+  insertErr: { code: string; message: string } | null,
+  ctx: { organization_id: string; conversation_id: string; external_id: string },
+): "erro" | "dedup" | "seguiu" {
+  if (insertErr && insertErr.code !== "23505") {
+    console.error("[waha.ingest] message insert failed", insertErr.message);
+    return "erro";
+  }
+  if (insertErr?.code === "23505") {
+    logger.info("waha.ingest: inbound ja ingerido, dedup por external_id", {
+      organization_id: ctx.organization_id,
+      conversation_id: ctx.conversation_id,
+      external_id: ctx.external_id,
+      direcao: "inbound",
+    });
+    return "dedup";
+  }
+  return "seguiu";
+}
+
+const CTX = { organization_id: "org-1", conversation_id: "conv-1", external_id: "wamid.X" };
+
+describe("dedup do ingest deixa rastro", () => {
+  let info: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    info = vi.spyOn(logger, "info").mockImplementation(() => {});
+  });
+  afterEach(() => info.mockRestore());
+
+  it("mensagem repetida vira dedup COM registro, e o registro identifica qual", () => {
+    const r = trataInsert({ code: "23505", message: "duplicate key" }, CTX);
+
+    expect(r).toBe("dedup");
+    expect(info).toHaveBeenCalledOnce();
+    // O `external_id` é o que permite responder "cadê o turno dessa mensagem?".
+    // Sem ele o registro diria que houve dedup e não qual — meia resposta.
+    const [, campos] = info.mock.calls[0] as [string, Record<string, unknown>];
+    expect(campos.external_id).toBe("wamid.X");
+    expect(campos.conversation_id).toBe("conv-1");
+  });
+
+  it("mensagem nova NÃO gera registro de dedup (log que sempre fala é ignorado)", () => {
+    expect(trataInsert(null, CTX)).toBe("seguiu");
+    expect(info).not.toHaveBeenCalled();
+  });
+
+  it("erro real continua sendo erro, não vira dedup", () => {
+    const erro = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(trataInsert({ code: "42P01", message: "relation does not exist" }, CTX)).toBe("erro");
+    expect(info, "falha de infra não pode se disfarçar de dedup").not.toHaveBeenCalled();
+    expect(erro).toHaveBeenCalled();
+    erro.mockRestore();
+  });
+
+  /**
+   * ⚠️ Os casos acima reproduzem a DECISÃO para não subir Supabase — e isso é
+   * uma fraqueza real: se alguém tirar o log do `ingest`, eles continuam verdes
+   * guardando a cópia. Este caso ancora no fonte de verdade.
+   *
+   * Mesmo padrão do controle positivo do mint: sem ler o arquivo real, o resto
+   * do teste descreveria um mundo que deixou de existir.
+   */
+  it("o INGEST de verdade não sai mudo no dedup (âncora no fonte)", () => {
+    const fonte = readFileSync(
+      join(process.cwd(), "lib/waha/ingest.ts"),
+      "utf8",
+    );
+    const trechos = fonte.split('if (insertErr?.code === "23505")');
+    // Sai um trecho antes + um por caminho de dedup (inbound e outbound).
+    expect(trechos.length, "esperado 2 caminhos de dedup no ingest").toBe(3);
+    for (const t of trechos.slice(1)) {
+      // Janela larga o bastante para o comentário que explica o porquê: medido,
+      // o do inbound sozinho passa de 500 chars e cortava o `logger.info` fora.
+      const bloco = t.slice(0, 1200);
+      expect(bloco, "caminho de dedup sem registro volta a ser invisível").toMatch(
+        /logger\.info\(/,
+      );
+      expect(bloco, "registro sem external_id não responde QUAL mensagem").toMatch(
+        /external_id/,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## O que motivou

Medindo turnos reais, o MaestroConexoes viu **5 mensagens do cliente produzirem 4 jobs, com nenhum marcado como dedup**. A pergunta *"cadê o turno da quinta?"* não tinha resposta no log — e **essa era a resposta**.

## A varredura mudou o tamanho do item

A hipótese era uma classe de quatro caminhos. Medido:

| Caminho | Estado real |
|---|---|
| `audit` fire-and-forget | **já tratado** — `console.error` + `Sentry.captureException` |
| `crm_lead_activities` | **já tratado** — `registraFalhaDeAtividade` |
| claim do follow-up | engolia erro → corrigido |
| dedup do `ingest` | não engolia erro, **perdia contagem** → corrigido |

Duas já aplicavam o padrão que o `CLAUDE.md` prescreve (*falha de write gera alerta, não bloqueia*). E as duas restantes **não são o mesmo defeito** — tratá-las igual seria errar o alvo nas duas.

## O que mudou

**Claim do follow-up.** O `catch` está certo em não lançar: derrubar o worker pararia todos os follow-ups da instalação. Errado era sair mudo — `claimed: 0` é indistinguível de *"nada vencido"*, que é o estado normal. Se o claim falhar sempre, o follow-up morre inteiro e o sintoma é a ausência de sintoma.

**Dedup do ingest.** O erro real já logava; o `return` no `23505` é dedup legítimo. Agora registra com `external_id`, nos **dois** caminhos — inbound e outbound. Conserto por classe, não por instância.

## Sobre os testes

Cada um guarda **as duas metades**: o caso anormal deixa sinal **e** o normal fica quieto. Alarme que toca sempre é alarme desligado — e aí o conserto vira o próximo defeito silencioso.

O teste do ingest tem **âncora no fonte**: os outros casos reproduzem a decisão para não subir Supabase, e sem a âncora ficariam verdes guardando a cópia depois de alguém tirar o log do arquivo real. Sabotei o `ingest` de verdade e a âncora reprovou.

## O que não funcionou, e vale registrar

A varredura ampla deu **79 candidatos, quase todos fantasmas** — `return fail()` que *é* sinal, `log.error` que *já* loga, `return false` de validação de assinatura. O que serviu foi extrair o padrão das instâncias conhecidas: **discriminador, não cobertura**.

## Gates

`typecheck` ✓ · `lint` ✓ · `lint:channels` ✓ · `test:unit` **2378** ✓