### PR TITLE
fix(e2e): o e2e reprovava por rate limit de login, e o sintoma não aparecia em log nenhum

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -182,3 +182,16 @@ META_SYSTEM_USER_TOKEN=
 META_WEBHOOK_VERIFY_TOKEN=
 # Versão da Graph API. Explícita de propósito: bump é decisão, não deriva.
 META_GRAPH_VERSION=v22.0
+
+# --- Teto de login por IP (SÓ para CI de e2e) ---
+# NÃO defina isto em produção nem numa VPS. O default (60 tentativas por IP a
+# cada 5 min) é o valor correto para uso real e já é folgado por causa de NAT.
+#
+# Existe porque no CI todos os testes saem de UM IP (o runner): 28 specs de e2e
+# estouram o teto e o login passa a responder "Muitas tentativas", reprovando
+# specs que não têm nada a ver com autenticação.
+#
+# O teto por CONTA (5 falhas na mesma conta em 5 min) NÃO é configurável de
+# propósito — é ele que barra brute force, inclusive distribuído por vários IPs.
+# Valor inválido ou ausente cai no default: a falha é fechada.
+# AUTH_RATE_LIMIT_LOGIN_IP=1000

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -187,6 +187,9 @@ jobs:
           WAHA_WEBHOOK_BASE_URL: http://127.0.0.1:3001
           UPSTASH_REDIS_REST_URL: http://127.0.0.1:3998
           UPSTASH_REDIS_REST_TOKEN: ci-placeholder-nao-e-segredo
+          # CI = 1 IP para todos os specs; o teto de produção (60/5min) é irreal aqui.
+          # O teto por CONTA (5 falhas) NÃO muda — é ele que barra brute force.
+          AUTH_RATE_LIMIT_LOGIN_IP: "1000"
 
       - name: E2E — parte 2 de 2 (processo novo, contador de login zerado)
         run: |
@@ -209,6 +212,9 @@ jobs:
           WAHA_WEBHOOK_BASE_URL: http://127.0.0.1:3001
           UPSTASH_REDIS_REST_URL: http://127.0.0.1:3998
           UPSTASH_REDIS_REST_TOKEN: ci-placeholder-nao-e-segredo
+          # CI = 1 IP para todos os specs; o teto de produção (60/5min) é irreal aqui.
+          # O teto por CONTA (5 falhas) NÃO muda — é ele que barra brute force.
+          AUTH_RATE_LIMIT_LOGIN_IP: "1000"
 
       - name: Declarar o que este job ainda NÃO cobre
         if: always()

--- a/lib/auth/rate-limit.ts
+++ b/lib/auth/rate-limit.ts
@@ -109,12 +109,38 @@ export async function authRateLimited(
  *    script; o teto por IP é mais folgado por causa de NAT corporativo.
  *  - signup e convite: fluxos raros por pessoa, teto baixo.
  */
+/** Teto de produção por IP no login. Congelado por teste — ver `LOGIN_IP_DEFAULT` abaixo. */
+const LOGIN_IP_DEFAULT = 60;
+
+/**
+ * O teto por IP do login é o ÚNICO limite configurável, e existe por um defeito
+ * de ambiente, não de produto: no CI todo teste sai do mesmo IP por construção
+ * (um runner), então 28 specs × vários logins estouram 60/5min e o e2e reprova
+ * com "Muitas tentativas" — foi o que derrubou `risk-radar` (13ª de 15 na parte 1).
+ *
+ * Por que afrouxar ISTO é seguro, e afrouxar o resto não seria: o limite que
+ * barra brute force é `id` (5 falhas na MESMA conta em 5 min), e ele NÃO é
+ * configurável — continua valendo inclusive para quem distribui as tentativas
+ * por muitos IPs. O teto por IP é anti-flood genérico, já folgado de propósito
+ * por causa de NAT corporativo; no CI o "NAT" é o runner inteiro.
+ *
+ * Valor inválido ou ausente cai no default de produção: a falha é fechada.
+ */
+function loginIpLimit(): number {
+  const bruto = process.env.AUTH_RATE_LIMIT_LOGIN_IP;
+  if (bruto === undefined) return LOGIN_IP_DEFAULT;
+  const n = Number.parseInt(bruto, 10);
+  return Number.isFinite(n) && n > 0 ? n : LOGIN_IP_DEFAULT;
+}
+
 export const AUTH_LIMITS = {
-  login: { ip: 60, id: 5, windowSec: 300 },
+  login: { ip: loginIpLimit(), id: 5, windowSec: 300 },
   signup: { ip: 20, windowSec: 3600 },
   reset: { ip: 30, id: 3, windowSec: 3600 },
   invite_accept: { ip: 60, windowSec: 3600 },
-} as const satisfies Record<string, AuthRateLimits>;
+} satisfies Record<string, AuthRateLimits>;
+
+export const __LOGIN_IP_DEFAULT_PARA_TESTE = LOGIN_IP_DEFAULT;
 
 /**
  * Bloqueio por FALHA, para o login.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,6 +39,12 @@ export default defineConfig({
     // false: reusar um server que já ocupa a porta pode ser OUTRO processo
     // (ex.: bundle do Remotion na 3000) — o teste precisa do NOSSO next start.
     reuseExistingServer: false,
+    // NÃO declare `env:` aqui sem espalhar `process.env` junto. O default do
+    // Playwright é herdar o ambiente, e o CI depende disso: o teto de login por
+    // IP (`AUTH_RATE_LIMIT_LOGIN_IP`) é definido no passo do workflow e precisa
+    // chegar ao `next start`, porque quem aplica o rate limit é o SERVIDOR.
+    // Declarar `env` aqui substitui o ambiente inteiro e o teto volta a 60 —
+    // o sintoma seria "Muitas tentativas" numa spec tardia, não um erro de config.
     timeout: 120_000,
   },
   projects: [{ name: "chromium", use: { browserName: "chromium" } }],

--- a/tests/unit/login-teto-por-ip-configuravel.test.ts
+++ b/tests/unit/login-teto-por-ip-configuravel.test.ts
@@ -1,0 +1,73 @@
+/**
+ * O teto por IP do login virou configurável — e isso precisa de guarda nos DOIS lados.
+ *
+ * Por que existe: no CI todo teste sai do mesmo IP (um runner). Com 28 specs, o e2e
+ * estourava 60 logins/5min e `risk-radar` (13ª de 15 na parte 1) reprovava com
+ * "Muitas tentativas. Aguarde alguns minutos." — visível só no `error-context` do
+ * Playwright, porque o bloqueio é RENDERIZADO na tela e não logado no servidor. Quem
+ * procurar `429` no log do CI acha zero e conclui, errado, que não houve rate limit.
+ *
+ * O risco de tornar algo configurável é o default vazar: alguém afrouxa produção e
+ * nenhum gate reclama, porque "passa" continua passando. Por isso a metade mais
+ * importante deste arquivo é a primeira — o valor SEM env.
+ *
+ * O que NÃO é configurável, de propósito: o teto por CONTA (`id`), que é quem barra
+ * brute force de verdade, inclusive contra quem distribui tentativas por muitos IPs.
+ * Se um dia alguém o tornar configurável, o teste do fim deste arquivo reprova.
+ */
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+const ENV = "AUTH_RATE_LIMIT_LOGIN_IP";
+
+/** Reimporta o módulo com o env corrente — `AUTH_LIMITS` é avaliado na carga. */
+async function carregaLimites(valor?: string) {
+  vi.resetModules();
+  if (valor === undefined) delete process.env[ENV];
+  else process.env[ENV] = valor;
+  return import("@/lib/auth/rate-limit");
+}
+
+describe("teto por IP do login", () => {
+  const original = process.env[ENV];
+  beforeEach(() => {
+    delete process.env[ENV];
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env[ENV];
+    else process.env[ENV] = original;
+    vi.resetModules();
+  });
+
+  it("SEM env, vale o default de produção (a guarda que impede o default vazar)", async () => {
+    const m = await carregaLimites(undefined);
+    expect(m.AUTH_LIMITS.login.ip).toBe(m.__LOGIN_IP_DEFAULT_PARA_TESTE);
+    expect(m.AUTH_LIMITS.login.ip, "o default de produção mudou sem alguém decidir").toBe(60);
+  });
+
+  it("COM env válida, o CI consegue afrouxar (senão o conserto não conserta nada)", async () => {
+    const m = await carregaLimites("500");
+    expect(m.AUTH_LIMITS.login.ip).toBe(500);
+  });
+
+  it.each([
+    ["texto", "muitos"],
+    ["zero", "0"],
+    ["negativo", "-1"],
+    ["vazio", ""],
+  ])("env inválida (%s) cai no default — falha FECHADA, não aberta", async (_n, v) => {
+    const m = await carregaLimites(v);
+    expect(m.AUTH_LIMITS.login.ip).toBe(60);
+  });
+
+  it("o teto por CONTA continua NÃO configurável (é ele que barra brute force)", async () => {
+    // Sabotagem futura provável: "já que o de IP é configurável, o de conta também".
+    // O de conta vale mesmo contra ataque distribuído por muitos IPs — afrouxá-lo por
+    // env transformaria uma variável de ambiente em desligar-proteção-de-senha.
+    const comEnv = await carregaLimites("500");
+    expect(comEnv.AUTH_LIMITS.login.id, "o teto por conta reagiu ao env de IP").toBe(5);
+
+    const semEnv = await carregaLimites(undefined);
+    expect(semEnv.AUTH_LIMITS.login.id).toBe(5);
+    expect(semEnv.AUTH_LIMITS.login.windowSec).toBe(300);
+  });
+});


### PR DESCRIPTION
`risk-radar.spec.ts` falhava as 2 specs no `waitForURL` do login — na `main` e em todo PR aberto depois do #157.

## A evidência que ninguém tinha olhado

A tela que o Playwright guarda no `error-context.md` diz, textualmente:

> **Muitas tentativas. Aguarde alguns minutos.**

`AUTH_LIMITS.login` é `{ ip: 60, id: 5, windowSec: 300 }`. O log do CI registrou **75** requisições no bucket `auth:login:ip` — todas do **mesmo IP**, porque no CI todo teste sai de um runner só. `risk-radar` é a **13ª de 15** specs da parte 1: quando ela roda, o orçamento acabou.

O #157 ampliou o e2e de 15 para 28 specs sem rebalancear a divisão em duas partes — que existia exatamente para isto, como diz o nome do passo: *"parte 2 de 2 (processo novo, contador de login zerado)"*.

## Por que passou despercebido — e por que eu também errei

**O bloqueio é renderizado na tela e nunca logado no servidor.** Procurar `429` ou "muitas tentativas" no log do CI devolve **zero**. Esse zero parece ausência do fenômeno, mas é ausência de sinal *naquele lugar*.

Eu declarei esta hipótese **refutada** com essa medição, antes de abrir o `error-context`. Registro porque a sonda cega para a categoria do objeto é o erro reproduzível aqui, não o rate limit.

## Conserto

O teto por IP passa a ser configurável (`AUTH_RATE_LIMIT_LOGIN_IP`); o CI usa `1000` nas duas partes. Não é esconder comportamento — é **modelar o ambiente**: em produção os IPs variam, no CI há um só por construção.

**O que NÃO mudou, de propósito:** o teto por **conta** (`id: 5` falhas na mesma conta em 5 min), que é quem barra brute force — inclusive contra quem distribui tentativas por muitos IPs. Afrouxar o de IP não abre buraco; afrouxar o de conta abriria. Env ausente ou inválida cai no default de produção: **falha fechada**.

Rebalancear as partes consertaria hoje e quebraria no próximo PR que adicionasse spec. Por isso o conserto é no limite, não na divisão.

## Guarda

`tests/unit/login-teto-por-ip-configuravel.test.ts` congela o default (60) para o valor de produção não vazar em silêncio, cobre env inválida, e afirma que o teto por conta segue **não** configurável.

**Sabotado nos dois sentidos:**
- default afrouxado para 5000 → **5 casos reprovam**
- env inválida virando permissiva → **4 casos reprovam**

## Medido em `0a85d251` + estas mudanças

`typecheck` 0 · `lint` 0 · `lint:channels` 0 · `test:unit` **2594 passed** em 270 files

**A prova de ponta a ponta é o `e2e` deste PR** — o defeito só aparece com 15 specs logando em sequência do mesmo IP, então nenhum teste unitário pode demonstrá-lo.