### PR TITLE
fix(capacidades): pacote prometia uma escolha que o teto impedia (#162)

### DIFF
--- a/app/app/ai/agents/[id]/_components/ToolPicker.tsx
+++ b/app/app/ai/agents/[id]/_components/ToolPicker.tsx
@@ -34,6 +34,7 @@ import {
   desligarPacote,
   estadoDoPacote,
   ligarPacote,
+  vagasExigidasPeloPacote,
   textoDaContagem,
   vagasRestantes,
   type CapacidadeSelecionavel,
@@ -168,7 +169,12 @@ export function ToolPicker({ value, onChange, disabled }: Props) {
   function alternarPacote(pacote: ToolBundle, ligar: boolean) {
     if (ligar) {
       const proximo = ligarPacote(value, catalogo, pacote);
-      const excedente = proximo.length - TETO_TOOLS_POR_AGENTE;
+      // O excedente conta as CRÍTICAS do pacote junto (issue #162): ligar o
+      // pacote e deixar a crítica dele sem vaga é prometer uma escolha que o
+      // produto não permite fazer — o checkbox nasce desabilitado, sem dizer
+      // por quê. Ou cabe inteiro, com a vaga da crítica guardada, ou não liga
+      // e a tela diz quantas faltam.
+      const excedente = vagasExigidasPeloPacote(value, catalogo, pacote) - TETO_TOOLS_POR_AGENTE;
       aplicar(
         proximo,
         `Ligar este pacote passaria de ${TETO_TOOLS_POR_AGENTE} capacidades (faltam ${excedente} ${

--- a/lib/mcp/tools/selecao-por-pacote.ts
+++ b/lib/mcp/tools/selecao-por-pacote.ts
@@ -120,6 +120,41 @@ export function desligarPacote(
   return selecionadas.filter((n) => !aRemover.has(n) || sobrevivem.has(n));
 }
 
+/**
+ * Quantas vagas ligar este pacote REALMENTE exige — contando as críticas dele.
+ *
+ * ## Por que as críticas entram na conta (issue #162)
+ *
+ * O contrato do pacote é "eu ligo as seguras e DEIXO as críticas para você
+ * marcar à mão" — a tela diz isso com todas as letras ("o pacote não liga por
+ * você"). Se as automáticas do pacote encostam no teto, a crítica que ele
+ * deliberadamente deixou de fora fica com o checkbox **desabilitado**: o pacote
+ * prometeu uma escolha que o produto não permite fazer.
+ *
+ * Medido em 2026-08-06, catálogo de 51 capacidades, teto 20:
+ *
+ *   atender    17 automáticas + 1 crítica = 18
+ *   organizar  14 automáticas + 4 críticas = 18
+ *   escalar    10 automáticas + 2 críticas = 12
+ *
+ * Nenhum estoura sozinho. O que estourava era o pacote SOMADO ao que já estava
+ * ligado: 3 pré-selecionadas + atender = 20 exatas, teto cheio, crítica morta.
+ *
+ * Reservar é o que mantém o contrato de pé: ou o pacote cabe inteiro — com a
+ * vaga da crítica guardada — ou ele não liga, e a tela diz quantas vagas faltam.
+ * A alternativa era ligar e deixar um checkbox morto sem explicação, que é o
+ * defeito que a #162 nomeia.
+ */
+export function vagasExigidasPeloPacote(
+  selecionadas: ReadonlyArray<string>,
+  catalogo: ReadonlyArray<CapacidadeSelecionavel>,
+  pacote: ToolBundle,
+): number {
+  const depois = new Set(ligarPacote(selecionadas, catalogo, pacote));
+  for (const name of capacidadesCriticasDoPacote(catalogo, pacote)) depois.add(name);
+  return depois.size;
+}
+
 export function vagasRestantes(selecionadas: ReadonlyArray<string>): number {
   return TETO_TOOLS_POR_AGENTE - selecionadas.length;
 }

--- a/scripts/seed-e2e-capacidades.ts
+++ b/scripts/seed-e2e-capacidades.ts
@@ -100,6 +100,27 @@ async function main(): Promise<void> {
 
   const TOOLS_LIGADAS = ["crm_get_lead", "crm_move_lead_stage", "crm_list_leads"];
 
+  // REPÕE TODAS AS VERSÕES DRAFT DESTE AGENTE, não só a de maior número.
+  //
+  // A tela SALVA criando draft novo. Depois de uma rodada do e2e o agente fica
+  // com vários drafts, e o seed — que buscava só o de `version_number` mais
+  // alto — repunha um enquanto a tela editava outro. Resultado: a segunda
+  // execução media o resto da primeira. Foi assim que a jornada do teto (issue
+  // #162) apareceu passando num banco onde o pacote já estava ligado de antes:
+  // as 3 capacidades do cenário eram na verdade 17.
+  {
+    const { error } = await admin
+      .from("ai_agent_versions")
+      .update({
+        tool_ids: TOOLS_LIGADAS,
+        created_at: new Date(Date.now() - 60 * 86_400_000).toISOString(),
+      })
+      .eq("organization_id", orgId)
+      .eq("agent_id", agentId)
+      .eq("status", "draft");
+    if (error) throw error;
+  }
+
   let versionId = versaoExistente?.id as string | undefined;
   if (versionId) {
     // Repõe o estado conhecido. O E2E mexe na configuração pela tela (é o que

--- a/tests/unit/pacote-reserva-vaga-da-critica.test.ts
+++ b/tests/unit/pacote-reserva-vaga-da-critica.test.ts
@@ -1,0 +1,97 @@
+/**
+ * O PACOTE NÃO PROMETE UMA ESCOLHA QUE O TETO IMPEDE (issue #162).
+ *
+ * ## O defeito
+ *
+ * A regra deliberada de `selecao-por-pacote.ts` é que **capacidade `critico`
+ * nunca entra por pacote** — o humano tem de marcar à mão, e a tela diz isso
+ * ("o pacote não liga por você"). O teto de 20 (`TETO_TOOLS_POR_AGENTE`) existe
+ * por outro motivo, também escrito: prompt com capacidade demais degrada a
+ * escolha do modelo.
+ *
+ * As duas regras se cancelavam. Ligar "Atender" traz 17 automáticas; somadas ao
+ * que já estivesse ligado, o teto era atingido — e aí o checkbox da crítica
+ * ficava `disabled`. O pacote prometia uma escolha que o produto não permitia
+ * fazer, e o único sinal era um checkbox morto com `opacity-60`.
+ *
+ * Achado ao trazer as specs do épico IA 360 para o CI (issue #63): a spec que
+ * cobre exatamente essa jornada reprovava por timeout de clique. Ela não rodava
+ * em gate nenhum desde que foi escrita, e o catálogo cresceu no meio.
+ *
+ * ## O que se guarda
+ *
+ * A CONTA, não a mensagem: quantas vagas ligar um pacote realmente exige. Sem
+ * as críticas nessa conta, o pacote cabe "por pouco" e a crítica morre.
+ */
+import { describe, expect, it } from "vitest";
+
+import { TOOL_CATALOG } from "@/lib/mcp/tools/catalogo";
+import {
+  TETO_TOOLS_POR_AGENTE,
+  capacidadesAutomaticasDoPacote,
+  capacidadesCriticasDoPacote,
+  ligarPacote,
+  vagasExigidasPeloPacote,
+} from "@/lib/mcp/tools/selecao-por-pacote";
+
+const CATALOGO = TOOL_CATALOG.map((t) => ({
+  name: t.name,
+  risco: t.risco,
+  pacotes: t.pacotes,
+}));
+
+/** Pacotes que realmente têm crítica — os únicos onde a reserva muda algo. */
+const COM_CRITICA = [...new Set(CATALOGO.flatMap((c) => c.pacotes as string[]))].filter(
+  (p) => capacidadesCriticasDoPacote(CATALOGO as never, p as never).length > 0,
+);
+
+describe("ligar pacote reserva a vaga das próprias críticas", () => {
+  it("existem pacotes com crítica (guarda de vacuidade)", () => {
+    // Sem isto, um catálogo que perdesse o conceito de `critico` faria os casos
+    // abaixo passarem por ausência de dado — verde sobre nada.
+    expect(COM_CRITICA.length).toBeGreaterThan(0);
+  });
+
+  it.each(COM_CRITICA)("%s: a conta inclui as críticas, não só as automáticas", (pacote) => {
+    const auto = capacidadesAutomaticasDoPacote(CATALOGO as never, pacote as never);
+    const crit = capacidadesCriticasDoPacote(CATALOGO as never, pacote as never);
+
+    const soAutomaticas = ligarPacote([], CATALOGO as never, pacote as never).length;
+    const exigido = vagasExigidasPeloPacote([], CATALOGO as never, pacote as never);
+
+    expect(soAutomaticas).toBe(auto.length);
+    expect(
+      exigido,
+      "sem as críticas na conta, o pacote cabe 'por pouco' e a crítica dele nasce com o checkbox morto",
+    ).toBe(auto.length + crit.length);
+  });
+
+  it("o que já está ligado entra na conta", () => {
+    const pacote = COM_CRITICA[0]!;
+    const fora = CATALOGO.find((c) => !(c.pacotes as string[]).includes(pacote))!;
+    const semNada = vagasExigidasPeloPacote([], CATALOGO as never, pacote as never);
+    const comUma = vagasExigidasPeloPacote([fora.name], CATALOGO as never, pacote as never);
+    expect(comUma).toBe(semNada + 1);
+  });
+
+  it("capacidade do pacote já ligada não é contada duas vezes", () => {
+    const pacote = COM_CRITICA[0]!;
+    const jaLigada = capacidadesAutomaticasDoPacote(CATALOGO as never, pacote as never)[0]!;
+    expect(vagasExigidasPeloPacote([jaLigada], CATALOGO as never, pacote as never)).toBe(
+      vagasExigidasPeloPacote([], CATALOGO as never, pacote as never),
+    );
+  });
+
+  it("nenhum pacote sozinho estoura o teto (senão a reserva o tornaria inatingível)", () => {
+    // Se um pacote exigisse mais que o teto por si só, reservar apenas trocaria
+    // "crítica morta" por "pacote que nunca liga". Medido em 2026-08-06: o maior
+    // é 18 (atender 17+1, organizar 14+4) contra teto 20. Este caso é o alarme
+    // para quem acrescentar capacidade ao catálogo sem olhar o teto.
+    for (const pacote of COM_CRITICA) {
+      expect(
+        vagasExigidasPeloPacote([], CATALOGO as never, pacote as never),
+        `o pacote ${pacote} sozinho já não cabe em ${TETO_TOOLS_POR_AGENTE} — reservar não resolve, o teto é que precisa de decisão`,
+      ).toBeLessThanOrEqual(TETO_TOOLS_POR_AGENTE);
+    }
+  });
+});


### PR DESCRIPTION
O desenho diz que capacidade `critico` NUNCA entra por pacote — a tela escreve
"o pacote não liga por você" e espera que o humano marque à mão. O teto de 20
existe por outro motivo, também escrito: prompt com capacidade demais degrada a
escolha do modelo.

As duas regras se cancelavam. Ligar "Atender" traz 17 automáticas; somadas ao que
já estivesse ligado, o teto era atingido — e aí o checkbox da crítica ficava
`disabled`, com `opacity-60` e nenhuma explicação. O pacote prometia uma escolha
que o produto não permitia fazer.

Medido em 2026-08-06, catálogo de 51 capacidades, teto 20:

  atender    17 automáticas + 1 crítica = 18
  organizar  14 automáticas + 4 críticas = 18
  escalar    10 automáticas + 2 críticas = 12

Nenhum estoura sozinho — o que estourava era o pacote SOMADO ao que já estava
ligado. Por isso a conta de "cabe?" passa a incluir as críticas do próprio
pacote: ou ele liga inteiro, com a vaga da crítica guardada, ou não liga e a tela
diz quantas vagas faltam (o caminho de recusa já existia). Trocar um checkbox
morto por um número é o ponto.

O teto NÃO subiu: 20 tem razão escrita, e mexer nele para acomodar um pacote é
decisão de produto com efeito na qualidade da escolha do modelo — fica com o
dono, agora com a medição na mão.

`scripts/seed-e2e-capacidades.ts` repõe TODOS os drafts do agente, não só o de
maior `version_number`: a tela salva criando draft novo, então depois de uma
rodada o seed repunha um enquanto o e2e editava outro, e a segunda execução media
o resto da primeira. Foi o que me fez, aqui, medir 17 capacidades onde o cenário
diz 3.

NÃO MEDIDO, e por isso a issue não fecha: a jornada pela TELA. O `ToolPicker` lê
o catálogo SERVIDO (`/api/v1/mcp/tools`, que junta catálogo com handlers), não o
`TOOL_CATALOG` que os unitários usam — e não consegui medir o servido fora do
Next. Se o servido for menor, a jornada cabe no teto e o sintoma não reproduz
localmente. A spec `capacidades-do-agente` segue fora do CI (issue #63), e eu
reverti a mudança que tinha feito nela: publicar spec que não provei é o defeito
que estou consertando, na outra ponta.

Refs #162

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HstH7nNmrTvCtZsasppeHj