### PR TITLE
test(e2e): followup-journey entra no CI — ela nunca precisou de WAHA (#63)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -200,7 +200,7 @@ jobs:
             qa-agente-usa-as-maos.spec.ts qa-selo-no-funil-usado.spec.ts \
             qa-telas-descobertas-w4.spec.ts retorno-anti-morte.spec.ts \
             followup-builder.spec.ts followup-queue.spec.ts \
-            distribuicao-atendimento.spec.ts
+            distribuicao-atendimento.spec.ts followup-journey.spec.ts
         env:
           INTERNAL_SECRET: ci-placeholder-nao-e-segredo
           CPF_ENCRYPTION_KEY: ci-placeholder-nao-e-segredo
@@ -222,7 +222,7 @@ jobs:
           {
             echo "## E2E — cobertura deste job"
             echo ""
-            echo "**Rodou (29 de 33 specs):** smoke, auth, error-pages, password-recovery,"
+            echo "**Rodou (30 de 33 specs):** smoke, auth, error-pages, password-recovery,"
             echo "signup-journey, rbac-roles, inbox-scope, reset-password-mfa,"
             echo "degradacao-silenciosa, vps-webhook-outbound-ssrf, kanban-owner-filter,"
             echo "queue-assign, risk-radar, invite-lifecycle, system-update,"
@@ -230,10 +230,14 @@ jobs:
             echo "escalacao-ciclo, navegacao, olhar-telas-do-epico, pipelines-gestao,"
             echo "qa-agente-usa-as-maos, qa-selo-no-funil-usado, qa-telas-descobertas-w4,"
             echo "retorno-anti-morte, followup-builder, followup-queue,"
-            echo "distribuicao-atendimento."
+            echo "distribuicao-atendimento, followup-journey."
             echo ""
-            echo "**Não rodou (4):**"
-            echo "- precisa de WAHA: followup-journey, webhooks"
+            echo "**Não rodou (3):**"
+            echo "- webhooks: a automação não aplica a tag no card do lead neste"
+            echo "  ambiente — reproduzido localmente, ainda sem causa. NÃO é falta"
+            echo "  de WAHA: a followup-journey estava na mesma categoria e passa"
+            echo "  sem WAHA nenhum (ela dubla o webhook chamando a mesma função"
+            echo "  que o receiver real chama)."
             echo "- precisa de WAHA + Redis + Resend + Nuvemshop: vps-fresh-onboarding (P0)"
             echo "- **capacidades-do-agente: fora porque REPROVA, e o vermelho está certo.**"
             echo "  Ligar o pacote 'Atender' enche o teto de 20 capacidades, e aí a UI"


### PR DESCRIPTION
A issue classificava `followup-journey` e `webhooks` como "precisa de WAHA".
Herdei essa classificação sem testar; ao testar, ela cai para a primeira: a spec
DUBLA o webhook chamando a mesma função que o receiver real chama, e o próprio
cabeçalho dela diz isso ("simular uma resposta inbound sem WAHA real").

Rodada num ambiente igual ao do CI (Supabase local + baseline + next start):
**passa**, sem WAHA em lugar nenhum. 30 das 33 specs agora.

`webhooks` continua fora, mas com o motivo CERTO no summary em vez do herdado:
ela reprova ao conferir a tag que a automação deveria pôr no card do lead —
reproduzido localmente, causa ainda não achada. Não é falta de WAHA.

Sobram 3: `webhooks` (defeito próprio), `vps-fresh-onboarding` (P0, precisa de
WAHA + Redis + Resend + Nuvemshop) e `capacidades-do-agente` (issue #162).

Refs #63

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HstH7nNmrTvCtZsasppeHj