### PR TITLE
fix(ia): dois runtimes respondiam a mesma mensagem — o engine passa a ser o dono (#129)

### DIFF
--- a/lib/ai/types.ts
+++ b/lib/ai/types.ts
@@ -42,7 +42,16 @@ export type SkipReason =
   | "handoff_recent"
   | "conversation_not_found"
   | "empty_inbound_body"
-  | "duplicate_outbound";
+  | "duplicate_outbound"
+  /**
+   * A organização tem agente PUBLICADO, e quem responde publicado é o
+   * agent-engine (issue #129). Este worker é o caminho pré-engine: ele não
+   * chega a enviar nada — insere a outbound como `sending` e emite
+   * `message.send_requested`, que NUNCA teve consumidor. Sem esta trava os dois
+   * rodam na mesma mensagem: o engine responde de verdade e este aqui gasta
+   * token à toa e deixa uma linha presa para sempre no inbox de quem instalou.
+   */
+  | "engine_owns_reply";
 
 export interface BotContext {
   organization_id: string;

--- a/tests/invariants/engine-dono-da-resposta.test.ts
+++ b/tests/invariants/engine-dono-da-resposta.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import { sql } from "./gov-helpers";
+
+/**
+ * UM DONO POR RESPOSTA — o engine ou o worker embutido, nunca os dois (#129).
+ *
+ * ## O defeito
+ *
+ * `lib/waha/ingest.ts` emite, para CADA mensagem inbound, os dois eventos,
+ * incondicionalmente: `ai_agent.dispatch_requested` (drenado pelo agent-engine,
+ * que responde de verdade) e `message.received` (drenado por
+ * `workers/ai-response-worker.ts`). Não havia trava nenhuma entre eles.
+ *
+ * Numa instalação padrão os dois agiam na mesma mensagem. `ai_agents.is_active`
+ * tem DEFAULT `true` e o onboarding o liga explicitamente, então o worker
+ * embutido achava agente e seguia: chamava o LLM (custo cobrado duas vezes) e
+ * inseria uma outbound `sending` que nunca saía, porque
+ * `message.send_requested` nunca teve consumidor. O cliente recebia uma
+ * resposta e o dono via duas linhas, uma delas "enviando" para sempre.
+ *
+ * ## O que se guarda aqui, e por que no banco
+ *
+ * O PREDICADO, não a mensagem: os dois runtimes têm de decidir por critérios
+ * complementares — nunca ambos verdadeiros, nunca ambos falsos para a mesma
+ * organização. O do engine é `published_version_id não nulo + não arquivado`
+ * (`lib/agent-engine/agent/agent-config.ts`); o do worker embutido passou a ser
+ * a negação disso.
+ *
+ * Isto vive num invariante de BANCO porque a pergunta é sobre linhas: um
+ * unitário com dublê provaria que o código consulta, não que a consulta
+ * particiona. Aqui as três situações reais são montadas como linhas e medidas.
+ */
+
+const ORG_PUB = "eeee0000-0000-4000-8000-000000000001";
+const ORG_SEM = "eeee0000-0000-4000-8000-000000000002";
+const ORG_ARQ = "eeee0000-0000-4000-8000-000000000003";
+
+/** Réplica FIEL do predicado do engine (agent-config.ts): join em published + não arquivado. */
+function engineTemDono(org: string): boolean {
+  return (
+    sql(`
+      select exists(
+        select 1 from public.ai_agents a
+         join public.ai_agent_versions v on v.id = a.published_version_id
+        where a.organization_id = '${org}' and a.archived_at is null
+      );
+    `) === "t"
+  );
+}
+
+/** Réplica FIEL do predicado novo do worker embutido (ai-response-worker.ts). */
+function embutidoCede(org: string): boolean {
+  return (
+    sql(`
+      select exists(
+        select 1 from public.ai_agents a
+        where a.organization_id = '${org}'
+          and a.published_version_id is not null
+          and a.archived_at is null
+      );
+    `) === "t"
+  );
+}
+
+function semear(): void {
+  sql(`
+    insert into public.organizations (id, slug, legal_name, display_name) values
+      ('${ORG_PUB}', 'eng-pub', 'Engine Publicado', 'Eng Pub'),
+      ('${ORG_SEM}', 'eng-sem', 'Engine Sem Publicacao', 'Eng Sem'),
+      ('${ORG_ARQ}', 'eng-arq', 'Engine Arquivado', 'Eng Arq')
+      on conflict do nothing;
+
+    insert into public.ai_agents (id, organization_id, name, system_prompt, is_active)
+      values
+        ('eeee1111-0000-4000-8000-000000000001', '${ORG_PUB}', 'Publicado', 'p', true),
+        ('eeee1111-0000-4000-8000-000000000002', '${ORG_SEM}', 'Só rascunho', 'p', true),
+        ('eeee1111-0000-4000-8000-000000000003', '${ORG_ARQ}', 'Arquivado', 'p', true)
+      on conflict do nothing;
+
+    -- ai_agent_versions.channel_session_id é NOT NULL: a versão publicada
+    -- carrega o canal por onde ela fala. O engine é justamente quem age por
+    -- canal, então o dublê tem de ter a linha de verdade.
+    do $eng$ begin
+      insert into public.channel_sessions (id, organization_id, waha_session_name, webhook_secret_encrypted)
+        values
+          ('eeee3333-0000-4000-8000-000000000001', '${ORG_PUB}', 'eng-pub-sess', '\\x00'::bytea),
+          ('eeee3333-0000-4000-8000-000000000003', '${ORG_ARQ}', 'eng-arq-sess', '\\x00'::bytea);
+    exception when unique_violation then null; end $eng$;
+
+    insert into public.ai_agent_versions
+      (id, organization_id, agent_id, version_number, system_prompt, provider, model, channel_session_id, status)
+      values
+        ('eeee2222-0000-4000-8000-000000000001', '${ORG_PUB}', 'eeee1111-0000-4000-8000-000000000001', 1, 'p', 'anthropic', 'claude-sonnet-4-6', 'eeee3333-0000-4000-8000-000000000001', 'published'),
+        ('eeee2222-0000-4000-8000-000000000003', '${ORG_ARQ}', 'eeee1111-0000-4000-8000-000000000003', 1, 'p', 'anthropic', 'claude-sonnet-4-6', 'eeee3333-0000-4000-8000-000000000003', 'published')
+      on conflict do nothing;
+
+    update public.ai_agents set published_version_id = 'eeee2222-0000-4000-8000-000000000001'
+      where id = 'eeee1111-0000-4000-8000-000000000001';
+    update public.ai_agents
+       set published_version_id = 'eeee2222-0000-4000-8000-000000000003',
+           archived_at = now()
+      where id = 'eeee1111-0000-4000-8000-000000000003';
+  `);
+}
+
+describe("#129 — um dono por resposta", () => {
+  it("o cenário foi semeado (guarda de vacuidade)", () => {
+    semear();
+    // Sem isto, um seed que falhasse em silêncio faria os três casos abaixo
+    // medirem organizações vazias — e "nenhum dos dois age" passaria como se
+    // fosse partição correta.
+    expect(sql(`select count(*) from public.ai_agents where organization_id in ('${ORG_PUB}','${ORG_SEM}','${ORG_ARQ}');`)).toBe("3");
+  });
+
+  it("org com versão publicada: o engine é dono e o embutido CEDE", () => {
+    semear();
+    expect(engineTemDono(ORG_PUB)).toBe(true);
+    expect(embutidoCede(ORG_PUB)).toBe(true);
+  });
+
+  it("org sem publicação: o engine NÃO é dono e o embutido segue respondendo", () => {
+    // O caso que impede a trava de silenciar a IA de quem nunca publicou — sem
+    // `published_version_id` o engine não seleciona agente nenhum.
+    semear();
+    expect(engineTemDono(ORG_SEM)).toBe(false);
+    expect(
+      embutidoCede(ORG_SEM),
+      "ceder aqui deixaria a organização sem NENHUM runtime respondendo",
+    ).toBe(false);
+  });
+
+  it("agente arquivado não conta para nenhum dos dois", () => {
+    semear();
+    expect(engineTemDono(ORG_ARQ)).toBe(false);
+    expect(embutidoCede(ORG_ARQ)).toBe(false);
+  });
+
+  it("os dois predicados PARTICIONAM: nunca ambos, nunca nenhum", () => {
+    // A propriedade que de fato importa, afirmada sobre as três situações de
+    // uma vez: `engineTemDono` e `!embutidoCede` têm de coincidir sempre. Se um
+    // dia alguém mexer num dos dois lados sem o outro, é aqui que aparece.
+    semear();
+    for (const org of [ORG_PUB, ORG_SEM, ORG_ARQ]) {
+      expect(engineTemDono(org), `org ${org}: os dois lados discordaram`).toBe(embutidoCede(org));
+    }
+  });
+});

--- a/tests/unit/ai-response-worker-model-routing.test.ts
+++ b/tests/unit/ai-response-worker-model-routing.test.ts
@@ -121,9 +121,17 @@ function makeAdminStub() {
     // query-builder que não seja terminal (.eq, .is, .in, .not, .gte…) devolve
     // o próprio chain. Sem isso o teste vira uma caçada a "X is not a function"
     // toda vez que o worker ganha um filtro novo.
+    // O dublê precisa DIZER em que mundo está (issue #129). O worker agora
+    // pergunta se a org tem agente com versão PUBLICADA — se tem, quem responde
+    // é o agent-engine e ele cede. Estes casos exercitam o caminho legado (sem
+    // publicação), então a consulta discriminada devolve `null`. Sem isto o
+    // Proxy devolveria a MESMA linha de agente para as duas perguntas, e o
+    // worker cederia sempre — os testes ficariam verdes medindo o skip.
+    let consultaDePublicado = false;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const terminais: any = {
-      maybeSingle: () => Promise.resolve({ data: single, error: null }),
+      maybeSingle: () =>
+        Promise.resolve({ data: consultaDePublicado ? null : single, error: null }),
       single: () => Promise.resolve({ data: single, error: null }),
       insert: (row: Record<string, unknown>) => {
         inserted.push({ table, row });
@@ -149,7 +157,13 @@ function makeAdminStub() {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const chain: any = new Proxy(terminais, {
-      get: (alvo, prop) => (prop in alvo ? alvo[prop as keyof typeof alvo] : () => chain),
+      get: (alvo, prop) =>
+        prop in alvo
+          ? alvo[prop as keyof typeof alvo]
+          : (...args: unknown[]) => {
+              if (prop === "not" && args[0] === "published_version_id") consultaDePublicado = true;
+              return chain;
+            },
     });
     return chain;
   };

--- a/tests/unit/ai-response-worker-sent-via.test.ts
+++ b/tests/unit/ai-response-worker-sent-via.test.ts
@@ -139,9 +139,17 @@ function makeAdminStub(confidenceThreshold: number) {
               }
             : null; // ai_budgets sem linha = sem throttle; crm_leads sem lead
 
+    // O dublê precisa DIZER em que mundo está (issue #129). O worker agora
+    // pergunta se a org tem agente com versão PUBLICADA — se tem, quem responde
+    // é o agent-engine e ele cede. Estes casos exercitam o caminho legado (sem
+    // publicação), então a consulta discriminada devolve `null`. Sem isto o
+    // Proxy devolveria a MESMA linha de agente para as duas perguntas, e o
+    // worker cederia sempre — os testes ficariam verdes medindo o skip.
+    let consultaDePublicado = false;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const terminais: any = {
-      maybeSingle: () => Promise.resolve({ data: single, error: null }),
+      maybeSingle: () =>
+        Promise.resolve({ data: consultaDePublicado ? null : single, error: null }),
       single: () => Promise.resolve({ data: single, error: null }),
       insert: (row: Record<string, unknown>) => {
         inserted.push({ table, row });
@@ -191,7 +199,13 @@ function makeAdminStub(confidenceThreshold: number) {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const chain: any = new Proxy(terminais, {
-      get: (alvo, prop) => (prop in alvo ? alvo[prop as keyof typeof alvo] : () => chain),
+      get: (alvo, prop) =>
+        prop in alvo
+          ? alvo[prop as keyof typeof alvo]
+          : (...args: unknown[]) => {
+              if (prop === "not" && args[0] === "published_version_id") consultaDePublicado = true;
+              return chain;
+            },
     });
     return chain;
   };

--- a/workers/ai-response-worker.ts
+++ b/workers/ai-response-worker.ts
@@ -356,6 +356,38 @@ async function buildContext(input: BuildContextInput): Promise<GuardDecision> {
     .maybeSingle();
 
   if (!agent) return skip("agent_inactive_or_missing");
+
+  // O ENGINE É O DONO DA RESPOSTA QUANDO HÁ VERSÃO PUBLICADA (issue #129).
+  //
+  // `lib/waha/ingest.ts` emite, para cada inbound, `ai_agent.dispatch_requested`
+  // (drenado pelo agent-engine) E `message.received` (drenado por este worker),
+  // incondicionalmente — e até aqui não havia trava nenhuma entre os dois. Numa
+  // instalação padrão os dois agiam na MESMA mensagem: o engine respondia de
+  // verdade, e este worker chamava o LLM (custo real, cobrado duas vezes) e
+  // inseria uma outbound `sending` que nunca saía, porque
+  // `message.send_requested` nunca teve consumidor.
+  //
+  // O critério é o MESMO que o engine usa para se considerar dono
+  // (`lib/agent-engine/agent/agent-config.ts`: join em `published_version_id`,
+  // não arquivado). Usar o mesmo predicado é o que garante que não existe buraco
+  // entre os dois: ou o engine responde, ou este worker responde — nunca
+  // nenhum, nunca os dois.
+  //
+  // Quem NÃO publicou versão nenhuma continua caindo aqui, como antes: sem
+  // `published_version_id` o engine não seleciona agente e não age. Por isso a
+  // trava não pode ser "existe engine rodando" — essa pergunta não é
+  // respondível daqui, e errá-la significaria silenciar a IA de quem depende
+  // deste caminho.
+  const { data: publicado } = await admin
+    .from("ai_agents")
+    .select("id")
+    .eq("organization_id", input.organizationId)
+    .not("published_version_id", "is", null)
+    .is("archived_at", null)
+    .limit(1)
+    .maybeSingle();
+  if (publicado) return skip("engine_owns_reply");
+
   if (!agent.active_kb_version_id) return skip("kb_version_missing");
 
   // Budget guard (IA-02)


### PR DESCRIPTION
A issue deixou como "não medido: os dois runtimes ao vivo com WAHA". Não liguei
os dois com WAHA, mas o acoplamento é decidível sem isso, e é pior que
"provável":

- `lib/waha/ingest.ts` emite, para CADA inbound, `ai_agent.dispatch_requested`
  (linha 467, drenado pelo agent-engine) E `message.received` (linha 486,
  drenado por `workers/ai-response-worker.ts`) — incondicionalmente;
- `ai-response-worker.ts` não tinha trava nenhuma contra o engine;
- `ai_agents.is_active` tem **DEFAULT true** e o onboarding o liga
  explicitamente, então o worker embutido ACHA agente numa instalação padrão.

Ou seja: os dois agiam na mesma mensagem. O engine respondia de verdade; o
worker embutido chamava o LLM (custo cobrado duas vezes) e inseria uma outbound
`sending` que nunca saía, porque `message.send_requested` nunca teve consumidor.
O cliente recebia uma resposta e o dono via duas linhas, uma "enviando" para
sempre. Com o cron do #156 em pé, essa linha vira `failed` + aviso critical —
ruído por resposta, em vez de anomalia.

A TRAVA USA O PREDICADO DO PRÓPRIO ENGINE: `published_version_id` não nulo e
agente não arquivado, que é exatamente o critério de seleção dele
(`lib/agent-engine/agent/agent-config.ts`, join em `published_version_id`). Usar
o mesmo predicado é o que garante que não sobra buraco: ou um responde, ou o
outro — nunca nenhum, nunca os dois.

Descartei as alternativas por medição, não por gosto: "existe engine rodando?"
não é respondível de dentro do app, e errá-la silencia a IA de quem depende do
caminho legado; e reusar `AGENT_DISPATCH_CONSUMER` juntaria numa chave só duas
decisões diferentes (quem consome o dispatch × quem responde).

Quem nunca publicou versão continua caindo no worker embutido, como antes — sem
`published_version_id` o engine não seleciona agente nenhum.

`tests/invariants/engine-dono-da-resposta.test.ts` guarda a PARTIÇÃO contra
Postgres real, com as três situações como linhas (publicado, só rascunho,
arquivado) e um caso que afirma a propriedade de uma vez: os dois predicados têm
de coincidir sempre. Sabotado: fazer um lado ignorar `archived_at` deixa 2 casos
vermelhos.

Os dublês de `ai-response-worker-{sent-via,model-routing}` passaram a DIZER em
que mundo estão: eles exercitam o caminho legado, e o Proxy devolvia a mesma
linha de agente para as duas perguntas — sem isso os testes ficariam verdes
medindo o skip.

typecheck, lint e lint:channels limpos; test:db verde. Uma falha em
`ai-response-worker-model-routing` ("model como STRING nem emite requisição")
persiste NESTA MÁQUINA com as minhas mudanças guardadas e o `ci` da main está
verde — é ambiental, não deste commit.

Refs #129

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HstH7nNmrTvCtZsasppeHj