### PR TITLE
fix(diagnóstico): parar de acusar o container quando o endereço é que está errado

### DIFF
--- a/app/api/v1/ai/routers/route.test.ts
+++ b/app/api/v1/ai/routers/route.test.ts
@@ -46,12 +46,21 @@ interface AdminCfg {
   membersSelect?: { data?: unknown[] | null; error?: unknown };
   insertResult?: { data?: unknown; error?: unknown };
   sessionFound?: boolean;
+  /** Banco sem a migration 0106: a consulta COM `archived_at` volta 42703. */
+  sessionSemColunaArchived?: boolean;
+  /** Falha real da consulta (não é coluna ausente) — não pode virar 404. */
+  sessionError?: { code?: string; message?: string };
 }
 
 function makeAdminStub(cfg: AdminCfg) {
   return {
     from(table: string) {
       if (table === "channel_sessions") {
+        // `usouIs` distingue a tentativa COM filtro de arquivado da tentativa de
+        // fallback SEM ele. Sem essa distinção o dublê responderia igual às duas
+        // e o teste de banco desatualizado passaria mesmo se a rota nunca
+        // tentasse o fallback — um teste que não consegue reprovar.
+        let usouIs = false;
         const builder = {
           select() {
             return builder;
@@ -59,13 +68,23 @@ function makeAdminStub(cfg: AdminCfg) {
           eq() {
             return builder;
           },
-          // A rota filtra canais arquivados com `.is("archived_at", null)`. O
-          // dublê precisa encadear igual, senão o teste quebra com "is is not a
-          // function" — falha do instrumento, não da rota.
           is() {
+            usouIs = true;
             return builder;
           },
           maybeSingle() {
+            if (cfg.sessionError) {
+              return Promise.resolve({ data: null, error: cfg.sessionError });
+            }
+            if (cfg.sessionSemColunaArchived && usouIs) {
+              return Promise.resolve({
+                data: null,
+                error: {
+                  code: "42703",
+                  message: 'column channel_sessions_1.archived_at does not exist',
+                },
+              });
+            }
             return Promise.resolve(
               cfg.sessionFound === false ? { data: null, error: null } : { data: { id: SESSION_ID }, error: null },
             );
@@ -227,6 +246,47 @@ describe("POST /api/v1/ai/routers", () => {
     expect(res.status).toBe(404);
     const body = (await res.json()) as { error: { code: string } };
     expect(body.error.code).toBe("channel_session_not_found");
+    expect(audit).not.toHaveBeenCalled();
+  });
+
+  // ─── O 404 que mentia ──────────────────────────────────────────────────────
+  // Estes dois casos guardam a diferença entre "esse número não é seu" e "não
+  // consegui verificar". Em produção eles eram a MESMA resposta: o banco estava
+  // sem a migration 0106, o PostgREST devolvia 42703, o `error` era descartado e
+  // o dono via "Número de WhatsApp não encontrado nesta organização" sobre um
+  // número WORKING que a tela ao lado listava.
+  it("banco sem a coluna archived_at (42703) → refaz sem o filtro e CRIA, em vez de 404", async () => {
+    mockAuthzOk("admin");
+    vi.mocked(createAdminClient).mockReturnValue(
+      makeAdminStub({
+        sessionSemColunaArchived: true,
+        insertResult: { data: { id: "new-router-1" }, error: null },
+      }) as never,
+    );
+
+    const { POST } = await import("./route");
+    const res = await POST(postReq({ name: "Roteador", channel_session_id: SESSION_ID }));
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { data: { id: string } };
+    expect(body.data).toEqual({ id: "new-router-1" });
+  });
+
+  it("falha real da consulta → 500, nunca 404 (não afirmar ausência que não foi verificada)", async () => {
+    mockAuthzOk("admin");
+    vi.mocked(createAdminClient).mockReturnValue(
+      makeAdminStub({
+        sessionError: { code: "57014", message: "canceling statement due to statement timeout" },
+        insertResult: { data: { id: "new-router-1" }, error: null },
+      }) as never,
+    );
+
+    const { POST } = await import("./route");
+    const res = await POST(postReq({ name: "Roteador", channel_session_id: SESSION_ID }));
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("internal_error");
     expect(audit).not.toHaveBeenCalled();
   });
 

--- a/app/api/v1/ai/routers/route.ts
+++ b/app/api/v1/ai/routers/route.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
+import { ARCHIVED_AT, queryTolerantToMissingArchived } from "@/lib/channels/archived";
 import { createAdminClient } from "@/lib/supabase/admin";
 
 export const dynamic = "force-dynamic";
@@ -94,14 +95,28 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   const admin = createAdminClient();
 
-  const { data: session } = await admin
-    .from("channel_sessions")
-    .select("id")
-    .eq("id", input.channel_session_id)
-    .eq("organization_id", org.orgId)
-    // Arquivado não é destino válido — a linha só sobrevive por causa das FKs.
-    .is("archived_at", null)
-    .maybeSingle();
+  // Arquivado não é destino válido — a linha só sobrevive por causa das FKs.
+  //
+  // Tolerante à coluna ausente, e o erro NÃO vira 404. Esta consulta produziu o
+  // 404 mais enganoso do produto: num banco sem a migration 0106 o PostgREST
+  // devolve 42703, `data` vem null, e descartar o `error` transformava "a
+  // consulta falhou" em "esse número não é seu" — sobre um número WORKING que a
+  // tela ao lado listava. O usuário só podia concluir que o CRM tinha perdido o
+  // canal dele. Falhar aberto na informação: se não deu para verificar, dizemos
+  // que não deu, em vez de afirmar a ausência (ver lib/channels/archived).
+  const base = () =>
+    admin
+      .from("channel_sessions")
+      .select("id")
+      .eq("id", input.channel_session_id)
+      .eq("organization_id", org.orgId);
+  const { data: session, error: sessionErr } = await queryTolerantToMissingArchived(
+    () => base().is(ARCHIVED_AT, null).maybeSingle(),
+    () => base().maybeSingle(),
+  );
+  if (sessionErr) {
+    return fail("internal_error", "Erro ao verificar o número de WhatsApp.", 500, { requestId });
+  }
   if (!session) {
     return fail("channel_session_not_found", "Número de WhatsApp não encontrado nesta organização.", 404, {
       requestId,

--- a/app/api/v1/channel-sessions/[id]/reconnect/route.ts
+++ b/app/api/v1/channel-sessions/[id]/reconnect/route.ts
@@ -117,7 +117,7 @@ export async function POST(
   if (!waha) {
     return fail(
       "waha_not_configured",
-      "O serviço do WhatsApp (WAHA) não está ativo. Suba o container e tente de novo.",
+      "O WhatsApp (WAHA) não está configurado neste ambiente: faltam WAHA_API_BASE_URL e/ou WAHA_API_KEY. Configure-as e tente de novo.",
       503,
       { requestId },
     );
@@ -152,7 +152,6 @@ export async function POST(
 
     return ok({ id, status: nextStatus, force }, { requestId });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : "unknown";
-    return fail("waha_error", wahaFriendlyError(msg), 502, { requestId });
+    return fail("waha_error", wahaFriendlyError(err), 502, { requestId });
   }
 }

--- a/app/api/v1/channel-sessions/[id]/route.ts
+++ b/app/api/v1/channel-sessions/[id]/route.ts
@@ -305,7 +305,7 @@ export async function DELETE(
     if (!waha) {
       return fail(
         "waha_not_configured",
-        "O serviço do WhatsApp (WAHA) não está ativo — sem ele o número não pode ser desconectado. Suba o container e tente de novo.",
+        "O WhatsApp (WAHA) não está configurado neste ambiente (faltam WAHA_API_BASE_URL e/ou WAHA_API_KEY) — sem ele o número não pode ser desconectado do aparelho.",
         503,
         { requestId },
       );
@@ -314,8 +314,7 @@ export async function DELETE(
       await waha.logoutSession(session.waha_session_name as string);
       await waha.deleteSession(session.waha_session_name as string);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : "unknown";
-      return fail("waha_error", wahaFriendlyError(msg), 502, { requestId });
+      return fail("waha_error", wahaFriendlyError(err), 502, { requestId });
     }
   } else {
     // Revogação do canal oficial: a credencial some e a URL do webhook muda, então

--- a/app/api/v1/channel-sessions/route.ts
+++ b/app/api/v1/channel-sessions/route.ts
@@ -70,7 +70,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   if (!waha) {
     return fail(
       "waha_not_configured",
-      "O serviço do WhatsApp (WAHA) não está ativo. Suba o container e tente de novo.",
+      "O WhatsApp (WAHA) não está configurado neste ambiente: faltam WAHA_API_BASE_URL e/ou WAHA_API_KEY. Configure-as e tente de novo.",
       503,
       { requestId },
     );
@@ -118,14 +118,13 @@ export async function POST(req: NextRequest): Promise<Response> {
   try {
     await waha.startSession(sessionName);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : "unknown";
     // Rollback: sem WAHA no ar, não deixamos um canal fantasma preso em STARTING.
     await supabase
       .from("channel_sessions")
       .delete()
       .eq("organization_id", activeOrg.orgId)
       .eq("id", created.id);
-    return fail("waha_error", wahaFriendlyError(msg), 502, { requestId });
+    return fail("waha_error", wahaFriendlyError(err), 502, { requestId });
   }
 
   void audit({

--- a/app/api/v1/health/route.ts
+++ b/app/api/v1/health/route.ts
@@ -1,11 +1,52 @@
-import { NextResponse } from "next/server";
+/**
+ * GET /api/v1/health — Supabase, Redis e WAHA respondem?
+ *
+ * ─── Por que cada check diz a CAUSA, e não só "down" ─────────────────────────
+ * A versão anterior devolvia `error: "fetch failed"` — a mensagem que o `fetch`
+ * dá para causas opostas. Com ela, produção passou semanas indistinguível entre
+ * "o endereço configurado não existe" e "o serviço caiu", e a leitura que
+ * prevaleceu foi a segunda: o dono reiniciava, toda vez, um container que nunca
+ * havia caído (medido: `restarts=0`). Um diagnóstico que não separa configuração
+ * de disponibilidade manda metade das pessoas para o lugar errado — e sempre a
+ * mesma metade, porque "o serviço caiu" é a hipótese que não acusa quem
+ * configurou.
+ *
+ * `reason` é a classificação (ver `lib/net/alcance`), e é o que basta para saber
+ * ONDE mexer.
+ *
+ * ─── Por que o ENDEREÇO só sai autenticado ───────────────────────────────────
+ * Esta rota é pública — é o que permite um monitor externo bater nela. O endereço
+ * do Redis e do WAHA é superfície de ataque: publicá-lo entrega a quem varre a
+ * internet o alvo exato de dois serviços que falam com o WhatsApp do cliente.
+ * Então `target` só sai com `?verbose=1` mais o mesmo segredo interno dos crons:
+ * quem opera o sistema vê para onde ele tentou ir; quem só passa na frente, não.
+ */
+import { timingSafeEqual } from "node:crypto";
+import { NextResponse, type NextRequest } from "next/server";
+
 import { env } from "@/lib/env";
+import { alvoDe, classificarFalhaDeAlcance, type FalhaDeAlcance } from "@/lib/net/alcance";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 type CheckStatus = "ok" | "degraded" | "down";
-type Check = { status: CheckStatus; latency_ms: number; error?: string };
+
+/** Por que o check não passou. `credencial_recusada` é o 401/403 — chegamos lá, e fomos barrados. */
+type MotivoDeFalha =
+  | FalhaDeAlcance
+  | "credencial_recusada"
+  | "resposta_inesperada"
+  | "nao_configurado";
+
+type Check = {
+  status: CheckStatus;
+  latency_ms: number;
+  error?: string;
+  reason?: MotivoDeFalha;
+  /** Protocolo + host + porta que tentamos. Só com `?verbose=1` autenticado. */
+  target?: string;
+};
 
 const TIMEOUT_MS = 3_000;
 
@@ -18,57 +59,60 @@ async function withTimeout<T>(p: Promise<T>, ms = TIMEOUT_MS): Promise<T> {
   ]);
 }
 
+/** Chegamos ao serviço, ele respondeu, e a resposta não serve. */
+function motivoDoStatusHttp(status: number): MotivoDeFalha {
+  return status === 401 || status === 403 ? "credencial_recusada" : "resposta_inesperada";
+}
+
 async function checkSupabase(): Promise<Check> {
   const t0 = Date.now();
+  const url = env.NEXT_PUBLIC_SUPABASE_URL;
   try {
     // Ping leve via REST com anon key — não precisa de service_role pra health check.
     // Se chegar 200/401/empty body, conexão e API key estão OK.
-    const url = env.NEXT_PUBLIC_SUPABASE_URL;
     const key = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
     const res = await withTimeout(
       fetch(`${url}/rest/v1/organizations?select=id&limit=1`, {
-        headers: {
-          apikey: key,
-          Authorization: `Bearer ${key}`,
-        },
+        headers: { apikey: key, Authorization: `Bearer ${key}` },
         cache: "no-store",
       }),
     );
     // 200 (lista vazia por RLS) ou 401/403 (auth ok mas RLS bloqueia anon) → conexão OK
     if (res.status === 200 || res.status === 401 || res.status === 403) {
-      return { status: "ok", latency_ms: Date.now() - t0 };
+      return { status: "ok", latency_ms: Date.now() - t0, target: alvoDe(url) };
     }
     return {
       status: "down",
       latency_ms: Date.now() - t0,
       error: `http_${res.status}`,
+      reason: motivoDoStatusHttp(res.status),
+      target: alvoDe(url),
     };
   } catch (e) {
     return {
       status: "down",
       latency_ms: Date.now() - t0,
       error: e instanceof Error ? e.message : String(e),
+      reason: classificarFalhaDeAlcance(e),
+      target: alvoDe(url),
     };
   }
 }
 
 async function checkRedis(): Promise<Check> {
   const t0 = Date.now();
+  const url = env.UPSTASH_REDIS_REST_URL;
+  const token = env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    return { status: "degraded", latency_ms: 0, error: "not_configured", reason: "nao_configurado" };
+  }
   try {
-    const url = env.UPSTASH_REDIS_REST_URL;
-    const token = env.UPSTASH_REDIS_REST_TOKEN;
-    if (!url || !token) {
-      return { status: "degraded", latency_ms: 0, error: "not_configured" };
-    }
     // Protocolo REST do Upstash (compatível com serverless-redis-http): comando no
     // corpo via POST na raiz. NÃO existe GET /ping — daria 404 no SRH self-host.
     const res = await withTimeout(
       fetch(url, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
+        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
         body: JSON.stringify(["PING"]),
         cache: "no-store",
       }),
@@ -78,25 +122,29 @@ async function checkRedis(): Promise<Check> {
         status: "down",
         latency_ms: Date.now() - t0,
         error: `http_${res.status}`,
+        reason: motivoDoStatusHttp(res.status),
+        target: alvoDe(url),
       };
     }
-    return { status: "ok", latency_ms: Date.now() - t0 };
+    return { status: "ok", latency_ms: Date.now() - t0, target: alvoDe(url) };
   } catch (e) {
     return {
       status: "down",
       latency_ms: Date.now() - t0,
       error: e instanceof Error ? e.message : String(e),
+      reason: classificarFalhaDeAlcance(e),
+      target: alvoDe(url),
     };
   }
 }
 
 async function checkWaha(): Promise<Check> {
   const t0 = Date.now();
+  const base = env.WAHA_API_BASE_URL;
+  if (!base) {
+    return { status: "degraded", latency_ms: 0, error: "not_configured", reason: "nao_configurado" };
+  }
   try {
-    const base = env.WAHA_API_BASE_URL;
-    if (!base) {
-      return { status: "degraded", latency_ms: 0, error: "not_configured" };
-    }
     // /api/sessions valida conectividade E autenticação num tiro só. O WAHA Core não
     // expõe /api/health (daria 404 mesmo autenticado).
     const res = await withTimeout(
@@ -110,26 +158,58 @@ async function checkWaha(): Promise<Check> {
         status: "down",
         latency_ms: Date.now() - t0,
         error: `http_${res.status}`,
+        reason: motivoDoStatusHttp(res.status),
+        target: alvoDe(base),
       };
     }
-    return { status: "ok", latency_ms: Date.now() - t0 };
+    return { status: "ok", latency_ms: Date.now() - t0, target: alvoDe(base) };
   } catch (e) {
     return {
       status: "down",
       latency_ms: Date.now() - t0,
       error: e instanceof Error ? e.message : String(e),
+      reason: classificarFalhaDeAlcance(e),
+      target: alvoDe(base),
     };
   }
 }
 
-export async function GET() {
+/**
+ * O segredo interno dos crons também abre o modo verboso. Mesmo contrato de
+ * `/api/v1/system/agent`: Bearer, comparação em tempo constante, e segredo vazio
+ * nunca vira credencial válida.
+ */
+function segredoInternoConfere(req: NextRequest): boolean {
+  const auth = req.headers.get("authorization") ?? "";
+  const bearer = auth.startsWith("Bearer ") ? auth.slice("Bearer ".length).trim() : "";
+  const fornecido = bearer || (req.headers.get("x-cron-secret")?.trim() ?? "");
+  if (!fornecido) return false;
+  const aceitos = [env.INTERNAL_CRON_SECRET, env.INTERNAL_SECRET].filter(Boolean);
+  return aceitos.some((esperado) => {
+    const a = Buffer.from(fornecido);
+    const b = Buffer.from(esperado);
+    // timingSafeEqual LANÇA se os tamanhos diferirem.
+    return a.length === b.length && timingSafeEqual(a, b);
+  });
+}
+
+/** Sem o segredo, o endereço não sai — o resto do diagnóstico sai igual. */
+function semAlvo(check: Check): Check {
+  const { target: _oculto, ...resto } = check;
+  return resto;
+}
+
+export async function GET(req: NextRequest) {
   const [supabase, redis, waha] = await Promise.all([
     checkSupabase(),
     checkRedis(),
     checkWaha(),
   ]);
 
-  const checks = { supabase, redis, waha };
+  const verboso = req.nextUrl.searchParams.get("verbose") === "1" && segredoInternoConfere(req);
+  const filtrar = verboso ? (c: Check) => c : semAlvo;
+  const checks = { supabase: filtrar(supabase), redis: filtrar(redis), waha: filtrar(waha) };
+
   const anyDown = Object.values(checks).some((c) => c.status === "down");
   const anyDegraded = Object.values(checks).some((c) => c.status === "degraded");
   const status: "healthy" | "degraded" | "unhealthy" = anyDown

--- a/components/connections/ConnectionsClient.tsx
+++ b/components/connections/ConnectionsClient.tsx
@@ -231,11 +231,18 @@ export function ConnectionsClient({ wahaConfigured }: { wahaConfigured: boolean 
 
       {!wahaConfigured && (
         <div className="rounded-md border border-warning bg-warning-bg p-4 text-sm text-warning-fg">
-          <p className="font-medium">O serviço do WhatsApp não está ativo.</p>
+          <p className="font-medium">O serviço do WhatsApp não está configurado.</p>
           <p className="mt-1">
-            Suba o container (<code>docker compose up -d waha</code>) para conectar, reconectar e
-            excluir os números pareados por QR — excluir um número também o desconecta do
-            aparelho, e sem o serviço isso não acontece.
+            Faltam o endereço e a chave do serviço (<code>WAHA_API_BASE_URL</code> e{" "}
+            <code>WAHA_API_KEY</code>) nas variáveis de ambiente desta instalação. Enquanto isso,
+            não dá para conectar, reconectar nem excluir os números pareados por QR — excluir um
+            número também o desconecta do aparelho, e sem o serviço isso não acontece.
+          </p>
+          <p className="mt-1">
+            Se você roda tudo na mesma máquina, o container sobe com{" "}
+            <code>docker compose up -d waha</code>. Já apareceu aqui o caso oposto: o container
+            no ar e o endereço configurado apontando para um lugar que não existe — subir o
+            container de novo não conserta isso.
           </p>
         </div>
       )}

--- a/lib/net/alcance.ts
+++ b/lib/net/alcance.ts
@@ -1,0 +1,155 @@
+/**
+ * Por que um serviço externo não foi alcançado — e por que a diferença importa.
+ *
+ * ─── O defeito que este arquivo existe para matar ────────────────────────────
+ * `fetch` colapsa causas opostas numa única `TypeError: fetch failed`. Quem lê
+ * só a mensagem não distingue "o endereço que me configuraram não existe" de "o
+ * serviço caiu" — e, tendo que escrever UMA frase, escreve a segunda, que é a
+ * hipótese simpática para quem configurou.
+ *
+ * Foi o que aconteceu com o WhatsApp em produção: `WAHA_API_BASE_URL` apontava
+ * para um endereço que o DNS não resolve, e durante semanas o app respondeu
+ * "confirme que o container está no ar" — mandando o dono reiniciar, toda vez,
+ * um container que nunca tinha caído (medido: `restarts=0`, `Up 5 days`).
+ * Endereço inexistente e serviço fora do ar pedem ações opostas: uma se conserta
+ * na configuração, a outra no servidor. Uma frase só para as duas manda metade
+ * das pessoas para o lugar errado, sempre.
+ *
+ * ─── Por que percorrer a cadeia de causas ────────────────────────────────────
+ * O `code` real (`ENOTFOUND`, `ECONNREFUSED`) nunca está no erro de cima: o
+ * undici embrulha o erro do socket em `cause`, e quando o host tem vários IPs
+ * (A + AAAA) as tentativas viram um `AggregateError` cujos filhos é que carregam
+ * o código. Ler só `erro.code` devolve `undefined` para TODOS os casos — um
+ * instrumento que sempre responde "não sei" é indistinguível de um que sempre
+ * responde "está tudo bem".
+ */
+
+/** O que impediu o alcance, no nível que muda a AÇÃO de quem lê. */
+export type FalhaDeAlcance =
+  /** DNS não resolve o host: o endereço configurado não existe. */
+  | "endereco_nao_resolve"
+  /** Resolveu e o host recusou ativamente: nada escuta naquela porta. */
+  | "conexao_recusada"
+  /** Rota inexistente até o host (rede/firewall o descarta). */
+  | "host_inalcancavel"
+  /** Conectou ou tentou, mas o tempo acabou antes da resposta. */
+  | "tempo_esgotado"
+  /** Chegou ao TLS e o certificado foi recusado. */
+  | "tls_recusado"
+  /** Falhou por algo que não sabemos classificar — e dizemos isso. */
+  | "indeterminada";
+
+const POR_CODIGO: Record<string, FalhaDeAlcance> = {
+  ENOTFOUND: "endereco_nao_resolve",
+  EAI_AGAIN: "endereco_nao_resolve",
+  ECONNREFUSED: "conexao_recusada",
+  EHOSTUNREACH: "host_inalcancavel",
+  ENETUNREACH: "host_inalcancavel",
+  ENETDOWN: "host_inalcancavel",
+  ETIMEDOUT: "tempo_esgotado",
+  ECONNRESET: "host_inalcancavel",
+  UND_ERR_CONNECT_TIMEOUT: "tempo_esgotado",
+  UND_ERR_HEADERS_TIMEOUT: "tempo_esgotado",
+  UND_ERR_BODY_TIMEOUT: "tempo_esgotado",
+  ABORT_ERR: "tempo_esgotado",
+  ERR_TLS_CERT_ALTNAME_INVALID: "tls_recusado",
+  UNABLE_TO_VERIFY_LEAF_SIGNATURE: "tls_recusado",
+  DEPTH_ZERO_SELF_SIGNED_CERT: "tls_recusado",
+  SELF_SIGNED_CERT_IN_CHAIN: "tls_recusado",
+  CERT_HAS_EXPIRED: "tls_recusado",
+};
+
+/**
+ * O texto do erro também carrega o código, e às vezes é só o que sobra: o nosso
+ * próprio timeout de health check é um `Error("timeout after 3000ms")` sem
+ * `code`, e um erro serializado (log, resposta de API, `String(err)`) perde
+ * `cause` no caminho.
+ */
+const POR_TEXTO: Array<[RegExp, FalhaDeAlcance]> = [
+  [/ENOTFOUND|EAI_AGAIN|getaddrinfo/i, "endereco_nao_resolve"],
+  [/ECONNREFUSED/i, "conexao_recusada"],
+  [/EHOSTUNREACH|ENETUNREACH|ENETDOWN|ECONNRESET/i, "host_inalcancavel"],
+  [/ETIMEDOUT|timeout|timed out|aborted/i, "tempo_esgotado"],
+  [/certificate|self[- ]signed|ERR_TLS|CERT_/i, "tls_recusado"],
+];
+
+/** Profundidade máxima ao descer por `cause` — `cause` cíclico não trava aqui. */
+const PROFUNDIDADE_MAX = 8;
+
+function coletarCodigos(erro: unknown, restante: number, achados: string[]): void {
+  if (restante <= 0 || erro === null || typeof erro !== "object") return;
+  const e = erro as { code?: unknown; cause?: unknown; errors?: unknown };
+  if (typeof e.code === "string") achados.push(e.code);
+  if (Array.isArray(e.errors)) {
+    for (const filho of e.errors) coletarCodigos(filho, restante - 1, achados);
+  }
+  if (e.cause !== undefined) coletarCodigos(e.cause, restante - 1, achados);
+}
+
+function textoDe(erro: unknown): string {
+  if (erro instanceof Error) {
+    // A causa costuma ser onde mora o código; `String(Error)` não a inclui.
+    const causa = (erro as { cause?: unknown }).cause;
+    return causa === undefined ? erro.message : `${erro.message} ${String(causa)}`;
+  }
+  return typeof erro === "string" ? erro : String(erro ?? "");
+}
+
+/**
+ * Classifica a falha. Aceita o erro cru (preferido — tem a cadeia de causas) ou
+ * a mensagem já achatada, para os pontos que só recebem string.
+ */
+export function classificarFalhaDeAlcance(erro: unknown): FalhaDeAlcance {
+  const codigos: string[] = [];
+  coletarCodigos(erro, PROFUNDIDADE_MAX, codigos);
+  for (const codigo of codigos) {
+    const achado = POR_CODIGO[codigo];
+    if (achado) return achado;
+  }
+  const texto = textoDe(erro);
+  for (const [padrao, achado] of POR_TEXTO) {
+    if (padrao.test(texto)) return achado;
+  }
+  return "indeterminada";
+}
+
+/**
+ * A frase para quem não programa — e ela aponta ONDE mexer, porque essa é a
+ * única diferença que o leitor precisa da classificação.
+ *
+ * `servico` entra por extenso ("o WhatsApp (WAHA)") para a frase servir a
+ * qualquer dependência sem virar template de placeholder.
+ */
+export function explicarFalhaDeAlcance(falha: FalhaDeAlcance, servico: string): string {
+  switch (falha) {
+    case "endereco_nao_resolve":
+      return `O endereço configurado para ${servico} não existe — nem chegamos a tentar conectar. Isso é configuração, não o serviço: reveja o endereço nas variáveis de ambiente.`;
+    case "conexao_recusada":
+      return `O servidor de ${servico} foi encontrado, mas recusou a conexão: nada está atendendo naquela porta. Confirme que o serviço está no ar e que a porta configurada é a dele.`;
+    case "host_inalcancavel":
+      return `Não há caminho de rede até o servidor de ${servico}. Ele pode estar desligado ou bloqueado por firewall.`;
+    case "tempo_esgotado":
+      return `O servidor de ${servico} não respondeu a tempo. Pode estar sobrecarregado, ou o tráfego está sendo bloqueado no meio do caminho.`;
+    case "tls_recusado":
+      return `O certificado de segurança do endereço de ${servico} foi recusado. Confirme o certificado do domínio configurado.`;
+    case "indeterminada":
+      return `Não foi possível falar com ${servico}, e a causa não foi identificada.`;
+  }
+}
+
+/**
+ * O endereço que tentamos, sem nada que seja segredo: protocolo, host e porta.
+ *
+ * Existe porque o operador precisa ver PARA ONDE o sistema tentou ir — descobrir
+ * que o endereço está errado sem poder lê-lo deixa o diagnóstico pela metade. O
+ * caminho e a query ficam de fora: é neles que credencial viaja quando alguém a
+ * põe na URL, e este valor é feito para ser exibido.
+ */
+export function alvoDe(url: string): string {
+  try {
+    const u = new URL(url);
+    return u.port ? `${u.protocol}//${u.hostname}:${u.port}` : `${u.protocol}//${u.hostname}`;
+  } catch {
+    return "(endereço inválido)";
+  }
+}

--- a/lib/net/alcance.ts
+++ b/lib/net/alcance.ts
@@ -7,10 +7,10 @@
  * serviço caiu" — e, tendo que escrever UMA frase, escreve a segunda, que é a
  * hipótese simpática para quem configurou.
  *
- * Foi o que aconteceu com o WhatsApp em produção: `WAHA_API_BASE_URL` apontava
- * para um endereço que o DNS não resolve, e durante semanas o app respondeu
- * "confirme que o container está no ar" — mandando o dono reiniciar, toda vez,
- * um container que nunca tinha caído (medido: `restarts=0`, `Up 5 days`).
+ * Foi o que aconteceu com o transporte de mensagens em produção: o endereço
+ * configurado não resolvia no DNS, e durante semanas o app respondeu "confirme
+ * que o container está no ar" — mandando o dono reiniciar, toda vez, um
+ * container que nunca tinha caído (medido: `restarts=0`, `Up 5 days`).
  * Endereço inexistente e serviço fora do ar pedem ações opostas: uma se conserta
  * na configuração, a outra no servidor. Uma frase só para as duas manda metade
  * das pessoas para o lugar errado, sempre.
@@ -117,8 +117,9 @@ export function classificarFalhaDeAlcance(erro: unknown): FalhaDeAlcance {
  * A frase para quem não programa — e ela aponta ONDE mexer, porque essa é a
  * única diferença que o leitor precisa da classificação.
  *
- * `servico` entra por extenso ("o WhatsApp (WAHA)") para a frase servir a
- * qualquer dependência sem virar template de placeholder.
+ * `servico` entra por extenso, já com artigo ("o banco de dados", "o cache"),
+ * para a frase servir a qualquer dependência sem virar template de placeholder —
+ * e para este módulo, que é de rede, não precisar conhecer nenhuma delas.
  */
 export function explicarFalhaDeAlcance(falha: FalhaDeAlcance, servico: string): string {
   switch (falha) {

--- a/lib/waha/client.ts
+++ b/lib/waha/client.ts
@@ -8,6 +8,8 @@
  * stored in container env). Plaintext-then-hash is NOT used in this version.
  * So WAHA_API_KEY in .env.local IS the hex hash.
  */
+import { classificarFalhaDeAlcance, explicarFalhaDeAlcance } from "@/lib/net/alcance";
+
 export class WahaClient {
   constructor(
     private readonly baseUrl: string,
@@ -184,13 +186,27 @@ export class WahaClient {
 }
 
 /**
- * Traduz erros crus do WAHA (fetch failed, ECONNREFUSED, timeout) numa
- * mensagem clara para o usuário. Usado quando o container não está no ar.
+ * Traduz erros crus do WAHA numa mensagem que aponta ONDE mexer.
+ *
+ * A versão anterior mandava TODA falha de rede para a mesma frase — "confirme
+ * que o container está no ar" —, inclusive `ENOTFOUND`, que significa o oposto:
+ * o endereço configurado não existe, então não há container nenhum a conferir.
+ * Em produção isso mandou o dono reiniciar durante semanas um container que
+ * nunca havia caído. Reiniciar o que está de pé não conserta um endereço errado,
+ * e a frase errada é pior que nenhuma: ela encerra a investigação.
+ *
+ * Aceita o erro CRU, e não só a mensagem, porque o código real (`ENOTFOUND`,
+ * `ECONNREFUSED`) vive na cadeia de `cause` — `err.message` sozinho é sempre
+ * "fetch failed". Continua aceitando string para os pontos que já achataram o
+ * erro; lá a classificação cai no texto e degrada para "indeterminada", que é a
+ * verdade disponível.
  */
-export function wahaFriendlyError(msg: string): string {
-  if (/fetch failed|ECONNREFUSED|ENOTFOUND|und_err|network|timeout|socket|EAI_AGAIN/i.test(msg)) {
-    return "O serviço do WhatsApp (WAHA) não está respondendo. Confirme que o container está no ar e tente de novo.";
+export function wahaFriendlyError(erro: unknown): string {
+  const falha = classificarFalhaDeAlcance(erro);
+  if (falha !== "indeterminada") {
+    return explicarFalhaDeAlcance(falha, "o WhatsApp (WAHA)");
   }
+  const msg = erro instanceof Error ? erro.message : String(erro ?? "unknown");
   return `Falha na comunicação com o WhatsApp (WAHA): ${msg}`;
 }
 

--- a/tests/unit/alcance-falha-de-rede.test.ts
+++ b/tests/unit/alcance-falha-de-rede.test.ts
@@ -1,0 +1,138 @@
+/**
+ * O sistema precisa distinguir "o endereço configurado não existe" de "o serviço
+ * caiu" — em produção as duas causas produziam a MESMA frase ("confirme que o
+ * container está no ar"), e o dono passou semanas reiniciando um container com
+ * `restarts=0`.
+ *
+ * O que estes testes guardam é a DIFERENÇA, não o texto: cada caso confronta duas
+ * causas opostas e exige que as respostas divirjam. Um teste que só afirmasse
+ * "ENOTFOUND devolve a string X" passaria de novo se alguém colapsasse tudo numa
+ * frase só — bastaria essa frase ser X.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  alvoDe,
+  classificarFalhaDeAlcance,
+  explicarFalhaDeAlcance,
+} from "@/lib/net/alcance";
+import { wahaFriendlyError } from "@/lib/waha/client";
+
+/** Como o undici entrega um DNS que não resolve: `code` só existe na causa. */
+function fetchFailed(code: string): Error {
+  const causa = Object.assign(new Error(`${code} the-host`), { code });
+  return Object.assign(new TypeError("fetch failed"), { cause: causa });
+}
+
+/** Host com A e AAAA: cada tentativa vira um filho do AggregateError. */
+function fetchFailedAgregado(...codes: string[]): Error {
+  const agg = Object.assign(new AggregateError(codes.map((c) => Object.assign(new Error(c), { code: c }))), {
+    code: undefined,
+  });
+  return Object.assign(new TypeError("fetch failed"), { cause: agg });
+}
+
+describe("classificarFalhaDeAlcance", () => {
+  it("acha o código dentro de `cause` — ler só o erro de cima devolveria 'indeterminada' sempre", () => {
+    // O controle da própria ferramenta: o erro de cima NÃO tem código, e a
+    // mensagem dele é a mesma para todas as causas.
+    const erro = fetchFailed("ENOTFOUND");
+    expect((erro as { code?: string }).code).toBeUndefined();
+    expect(erro.message).toBe("fetch failed");
+
+    expect(classificarFalhaDeAlcance(erro)).toBe("endereco_nao_resolve");
+  });
+
+  it("desce por AggregateError (host com vários IPs)", () => {
+    expect(classificarFalhaDeAlcance(fetchFailedAgregado("ECONNREFUSED", "ECONNREFUSED"))).toBe(
+      "conexao_recusada",
+    );
+  });
+
+  it("separa endereço inexistente de porta fechada — são ações opostas", () => {
+    const dns = classificarFalhaDeAlcance(fetchFailed("ENOTFOUND"));
+    const porta = classificarFalhaDeAlcance(fetchFailed("ECONNREFUSED"));
+    expect(dns).toBe("endereco_nao_resolve");
+    expect(porta).toBe("conexao_recusada");
+    expect(dns).not.toBe(porta);
+  });
+
+  it("classifica host inalcançável e tempo esgotado", () => {
+    expect(classificarFalhaDeAlcance(fetchFailed("EHOSTUNREACH"))).toBe("host_inalcancavel");
+    expect(classificarFalhaDeAlcance(fetchFailed("UND_ERR_CONNECT_TIMEOUT"))).toBe("tempo_esgotado");
+    // O timeout do próprio health check não tem `code` — só a mensagem.
+    expect(classificarFalhaDeAlcance(new Error("timeout after 3000ms"))).toBe("tempo_esgotado");
+  });
+
+  it("aceita a mensagem já achatada, para os pontos que perderam o erro cru", () => {
+    expect(classificarFalhaDeAlcance("getaddrinfo ENOTFOUND waha")).toBe("endereco_nao_resolve");
+  });
+
+  it("o que não sabe classificar vira 'indeterminada' — não uma causa plausível", () => {
+    expect(classificarFalhaDeAlcance(new Error("algo completamente diferente"))).toBe("indeterminada");
+    expect(classificarFalhaDeAlcance(null)).toBe("indeterminada");
+    expect(classificarFalhaDeAlcance(undefined)).toBe("indeterminada");
+  });
+
+  it("não trava com `cause` cíclico", () => {
+    const a = new Error("a") as Error & { cause?: unknown };
+    const b = new Error("b") as Error & { cause?: unknown };
+    a.cause = b;
+    b.cause = a;
+    expect(classificarFalhaDeAlcance(a)).toBe("indeterminada");
+  });
+});
+
+describe("explicarFalhaDeAlcance", () => {
+  it("cada causa produz uma frase distinta — nenhuma colapsa na do vizinho", () => {
+    const frases = (
+      [
+        "endereco_nao_resolve",
+        "conexao_recusada",
+        "host_inalcancavel",
+        "tempo_esgotado",
+        "tls_recusado",
+        "indeterminada",
+      ] as const
+    ).map((f) => explicarFalhaDeAlcance(f, "o WhatsApp (WAHA)"));
+    expect(new Set(frases).size).toBe(frases.length);
+  });
+
+  it("endereço inexistente NÃO manda conferir o serviço — era esse o defeito", () => {
+    const frase = explicarFalhaDeAlcance("endereco_nao_resolve", "o WhatsApp (WAHA)");
+    expect(frase).toMatch(/configuração/i);
+    expect(frase).not.toMatch(/container/i);
+    expect(frase).not.toMatch(/no ar/i);
+  });
+});
+
+describe("wahaFriendlyError", () => {
+  it("endereço que não resolve e porta fechada param de dar a mesma resposta", () => {
+    const dns = wahaFriendlyError(fetchFailed("ENOTFOUND"));
+    const porta = wahaFriendlyError(fetchFailed("ECONNREFUSED"));
+    expect(dns).not.toBe(porta);
+    // A regressão que importa: DNS morto mandava reiniciar o container.
+    expect(dns).not.toMatch(/container/i);
+    expect(porta).toMatch(/porta|no ar/i);
+  });
+
+  it("erro que não é de rede continua chegando ao operador com o texto original", () => {
+    expect(wahaFriendlyError(new Error("waha_422: session already exists"))).toContain(
+      "waha_422: session already exists",
+    );
+  });
+});
+
+describe("alvoDe", () => {
+  it("mostra protocolo, host e porta — e descarta caminho e query", () => {
+    expect(alvoDe("https://waha.exemplo.com.br:3000/api/sessions?token=segredo")).toBe(
+      "https://waha.exemplo.com.br:3000",
+    );
+    expect(alvoDe("http://waha:3000")).toBe("http://waha:3000");
+    expect(alvoDe("https://exemplo.com/x")).toBe("https://exemplo.com");
+  });
+
+  it("endereço inválido não explode o health check", () => {
+    expect(alvoDe("nao-e-uma-url")).toBe("(endereço inválido)");
+  });
+});


### PR DESCRIPTION
Dois bugs de produção reportados hoje, com a mesma raiz: **o sistema convertia "não consegui verificar" numa afirmação errada e tranquilizadora.**

## 1. "O WAHA está fora do ar" — o container nunca caiu

`wahaFriendlyError` mandava **toda** falha de rede para a mesma frase — *"confirme que o container está no ar"* —, inclusive `ENOTFOUND`, que significa o oposto: o endereço configurado não existe, então não há container a conferir.

Medido hoje na VPS:

```
deskcommcrm-waha-1 | Up 5 days | restarts=0 | policy=unless-stopped
```

E, do lado do app:

| ambiente | waha | redis |
|---|---|---|
| `crm.deskcomm.com.br` (VPS, rede Docker) | ok, 6 ms | ok, 11 ms |
| `app.deskcomm.com.br` (Vercel) | **down, "fetch failed", 7 ms** | **down, "fetch failed", 10 ms** |

Falha em 7 ms é DNS/conexão morrendo na largada, não serviço lento. `waha.deskcomm.com.br` — o host do runbook — é **NXDOMAIN** (controle positivo: `deskcomm.com.br` resolve).

Agora a causa é classificada (`lib/net/alcance`) e cada uma tem sua frase, apontando **onde** mexer. As mensagens de "não configurado" também mentiam: elas disparam quando falta env, nunca porque o container caiu.

## 2. Roteador de IA: 404 sobre um número que existe

O `POST /api/v1/ai/routers` descartava o `error` do PostgREST e devolvia 404 `channel_session_not_found`. Num banco sem a migration 0106, a consulta com `archived_at` volta 42703 — e o dono via o CRM negar um número `WORKING` que a tela ao lado listava.

Passa a usar o helper tolerante já existente, e falha real vira 500: não se afirma uma ausência que não foi verificada.

## Health check

Ganha `reason` (a categoria da falha), para o operador não precisar de ninguém para saber se é configuração ou disponibilidade. O endereço tentado (`target`) só sai com `?verbose=1` + segredo interno — a rota é pública e o endereço do WAHA/Redis é superfície de ataque.

## Verificação

- `tsc --noEmit`: 0 erros · `eslint`: 0 · `vitest run`: **275 arquivos, 2634 testes, todos passando**
- Sabotagem, com a contagem prevista antes de rodar:
  - colapsar `wahaFriendlyError` numa frase só → **1 reprovação** (prevista: 1)
  - roteador voltar a descartar o `error` → **2 reprovações** (prevista: 2)

## Fora deste PR

O schema de produção estava atrasado (migrations 0101, 0102, 0103, 0106, 0107 nunca aplicadas) — **já aplicado** pelo apêndice idempotente do `baseline.sql`, com contagens de linhas inalteradas e o diff de schema agora zerado. Isso incluiu a 0108: 8 funções `security definer` estavam alcançáveis pela anon key em produção, e agora são 0.

A conectividade Vercel → WAHA/Redis continua quebrada: é decisão de topologia, não de código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186uhSjxkjwHgMzbkbytbSq