### PR TITLE
fix(capacidades): a reserva contava certo e não decidia nada (#162)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -200,7 +200,8 @@ jobs:
             qa-agente-usa-as-maos.spec.ts qa-selo-no-funil-usado.spec.ts \
             qa-telas-descobertas-w4.spec.ts retorno-anti-morte.spec.ts \
             followup-builder.spec.ts followup-queue.spec.ts \
-            distribuicao-atendimento.spec.ts followup-journey.spec.ts
+            distribuicao-atendimento.spec.ts followup-journey.spec.ts \
+            capacidades-do-agente.spec.ts
         env:
           INTERNAL_SECRET: ci-placeholder-nao-e-segredo
           CPF_ENCRYPTION_KEY: ci-placeholder-nao-e-segredo
@@ -222,7 +223,7 @@ jobs:
           {
             echo "## E2E — cobertura deste job"
             echo ""
-            echo "**Rodou (30 de 33 specs):** smoke, auth, error-pages, password-recovery,"
+            echo "**Rodou (31 de 33 specs):** smoke, auth, error-pages, password-recovery,"
             echo "signup-journey, rbac-roles, inbox-scope, reset-password-mfa,"
             echo "degradacao-silenciosa, vps-webhook-outbound-ssrf, kanban-owner-filter,"
             echo "queue-assign, risk-radar, invite-lifecycle, system-update,"
@@ -230,22 +231,15 @@ jobs:
             echo "escalacao-ciclo, navegacao, olhar-telas-do-epico, pipelines-gestao,"
             echo "qa-agente-usa-as-maos, qa-selo-no-funil-usado, qa-telas-descobertas-w4,"
             echo "retorno-anti-morte, followup-builder, followup-queue,"
-            echo "distribuicao-atendimento, followup-journey."
+            echo "distribuicao-atendimento, followup-journey, capacidades-do-agente."
             echo ""
-            echo "**Não rodou (3):**"
+            echo "**Não rodou (2):**"
             echo "- webhooks: a automação não aplica a tag no card do lead neste"
             echo "  ambiente — reproduzido localmente, ainda sem causa. NÃO é falta"
             echo "  de WAHA: a followup-journey estava na mesma categoria e passa"
             echo "  sem WAHA nenhum (ela dubla o webhook chamando a mesma função"
             echo "  que o receiver real chama)."
             echo "- precisa de WAHA + Redis + Resend + Nuvemshop: vps-fresh-onboarding (P0)"
-            echo "- **capacidades-do-agente: fora porque REPROVA, e o vermelho está certo.**"
-            echo "  Ligar o pacote 'Atender' enche o teto de 20 capacidades, e aí a UI"
-            echo "  DESABILITA o checkbox da capacidade crítica que o próprio desenho"
-            echo "  manda o humano marcar à mão ('o pacote não liga por você'). O seed"
-            echo "  liga 3; o pacote traz >=17 automáticas. Não é dado sujo: é o catálogo"
-            echo "  ter crescido depois que a spec foi escrita — e ninguém soube porque"
-            echo "  ela nunca rodou no gate, que é a tese desta issue."
             echo ""
             echo "Expandir é trabalho de seguimento — issue #63."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/app/app/ai/agents/[id]/_components/ToolPicker.tsx
+++ b/app/app/ai/agents/[id]/_components/ToolPicker.tsx
@@ -157,8 +157,19 @@ export function ToolPicker({ value, onChange, disabled }: Props) {
   /** Ids salvos que o servidor não oferece mais — some da tela seria mentir. */
   const orfas = value.filter((id) => !porNome.has(id));
 
-  function aplicar(proximo: string[], motivoSeRecusar: string) {
-    if (proximo.length > TETO_TOOLS_POR_AGENTE) {
+  /**
+   * `vagasExigidas` é o que DECIDE, e por padrão é o tamanho do resultado.
+   *
+   * Ele existe separado porque ligar um pacote exige mais vagas do que o
+   * resultado ocupa: as críticas do pacote não entram por ele, mas o humano
+   * precisa poder marcá-las depois (issue #162). A primeira versão desta
+   * correção contava as críticas só na MENSAGEM de recusa e deixava a decisão
+   * em `proximo.length` — o número certo aparecia no texto e não mudava nada.
+   * Medido na tela: com 3 ligadas, "Atender" (17 automáticas + 1 crítica)
+   * chegava a 20, passava, e a crítica nascia desabilitada.
+   */
+  function aplicar(proximo: string[], motivoSeRecusar: string, vagasExigidas = proximo.length) {
+    if (vagasExigidas > TETO_TOOLS_POR_AGENTE) {
       setRecusa(motivoSeRecusar);
       return;
     }
@@ -174,12 +185,14 @@ export function ToolPicker({ value, onChange, disabled }: Props) {
       // produto não permite fazer — o checkbox nasce desabilitado, sem dizer
       // por quê. Ou cabe inteiro, com a vaga da crítica guardada, ou não liga
       // e a tela diz quantas faltam.
-      const excedente = vagasExigidasPeloPacote(value, catalogo, pacote) - TETO_TOOLS_POR_AGENTE;
+      const exigidas = vagasExigidasPeloPacote(value, catalogo, pacote);
+      const excedente = exigidas - TETO_TOOLS_POR_AGENTE;
       aplicar(
         proximo,
         `Ligar este pacote passaria de ${TETO_TOOLS_POR_AGENTE} capacidades (faltam ${excedente} ${
           excedente === 1 ? "vaga" : "vagas"
         }). Desligue um pacote que você usa menos antes.`,
+        exigidas,
       );
     } else {
       setRecusa(null);

--- a/tests/e2e/capacidades-do-agente.spec.ts
+++ b/tests/e2e/capacidades-do-agente.spec.ts
@@ -180,6 +180,32 @@ test.describe("Configurar o que o agente pode fazer", () => {
     const antes = await consumo(page);
     expect(antes).toMatch(/de 20$/);
 
+    // O TETO ENTRA NA JORNADA (issue #162), e entra antes do clique.
+    //
+    // Medido pela API servida em 2026-08-06: o catálogo tem 51 capacidades e
+    // "Atender" exige 18 vagas (17 automáticas + a crítica que o pacote
+    // deliberadamente NÃO liga). Com as 3 do seed dá 21, num teto de 20.
+    //
+    // Antes da correção a tela aceitava o pacote, chegava a 20 exatas e deixava
+    // o checkbox da crítica DESABILITADO — prometia uma escolha que o produto
+    // não permitia fazer, sem dizer por quê. Agora recusa e diz quantas vagas
+    // faltam, e o operador faz o que a própria tela manda.
+    await page.getByTestId("switch-pacote-atender").click();
+    await expect(page.getByTestId("aviso-teto")).toContainText(/faltam? 1 vaga/);
+    await expect(
+      page.getByTestId("pacote-atender"),
+      "recusar significa NÃO aplicar: pacote meio-ligado seria o pior dos dois mundos",
+    ).not.toHaveAttribute("data-estado", "ligado");
+
+    // Libera a vaga desligando uma capacidade que o seed tinha ligado.
+    await page.getByTestId("toggle-avancado").click();
+    await page.getByTestId("lista-avancada").waitFor({ state: "visible" });
+    await page
+      .getByTestId(`capacidade-${TOOLS_DO_SEED[2]}`)
+      .locator("input[type=checkbox]")
+      .click();
+    await page.getByTestId("toggle-avancado").click();
+
     await page.getByTestId("switch-pacote-atender").click();
 
     // As capacidades da jornada entraram…


### PR DESCRIPTION
Correção da minha própria correção. No #170 eu passei a contar as críticas do
pacote ao calcular quantas vagas ele exige — mas usei esse número **só na
mensagem de recusa** e deixei a decisão em `proximo.length`. O texto ficava
certo e o comportamento não mudava: com 3 capacidades ligadas, "Atender" (17
automáticas) chegava a 20, passava no teto, e a crítica que o pacote não liga
nascia com o checkbox DESABILITADO — exatamente o defeito da issue.

`aplicar()` passa a receber as vagas EXIGIDAS (default: o tamanho do resultado,
que é o caso de todas as outras chamadas) e a decidir por elas.

A premissa que faltava está medida agora, pela API que a tela consome:
`GET /api/v1/mcp/tools` devolve **51 capacidades** — o mesmo número do
`TOOL_CATALOG`, não um subconjunto. `atender` = 17 automáticas + 1 crítica.
Era essa dúvida que me fez, no #170, não fechar a issue e reverter a mudança na
spec; ela caiu.

Com a premissa provada, `capacidades-do-agente.spec.ts` volta a modelar o teto
como um operador o vive: liga o pacote → recusa dizendo que falta 1 vaga →
desliga uma capacidade → liga → marca a crítica à mão. **As 5 passam** contra
Supabase local com o baseline aplicado. Sabotado: devolver a decisão para
`proximo.length` deixa a spec vermelha.

A spec entra no CI (31 das 33). Sobram 2: `webhooks` (defeito próprio, sem causa
achada) e `vps-fresh-onboarding` (P0, 4 serviços externos).

Closes #162

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HstH7nNmrTvCtZsasppeHj