### PR TITLE
test(e2e): webhooks entra no CI — 32 das 33 specs (#63)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -201,6 +201,7 @@ jobs:
             qa-telas-descobertas-w4.spec.ts retorno-anti-morte.spec.ts \
             followup-builder.spec.ts followup-queue.spec.ts \
             distribuicao-atendimento.spec.ts followup-journey.spec.ts \
+            webhooks.spec.ts \
             capacidades-do-agente.spec.ts
         env:
           INTERNAL_SECRET: ci-placeholder-nao-e-segredo
@@ -223,7 +224,7 @@ jobs:
           {
             echo "## E2E — cobertura deste job"
             echo ""
-            echo "**Rodou (31 de 33 specs):** smoke, auth, error-pages, password-recovery,"
+            echo "**Rodou (32 de 33 specs):** smoke, auth, error-pages, password-recovery,"
             echo "signup-journey, rbac-roles, inbox-scope, reset-password-mfa,"
             echo "degradacao-silenciosa, vps-webhook-outbound-ssrf, kanban-owner-filter,"
             echo "queue-assign, risk-radar, invite-lifecycle, system-update,"
@@ -231,14 +232,9 @@ jobs:
             echo "escalacao-ciclo, navegacao, olhar-telas-do-epico, pipelines-gestao,"
             echo "qa-agente-usa-as-maos, qa-selo-no-funil-usado, qa-telas-descobertas-w4,"
             echo "retorno-anti-morte, followup-builder, followup-queue,"
-            echo "distribuicao-atendimento, followup-journey, capacidades-do-agente."
+            echo "distribuicao-atendimento, followup-journey, capacidades-do-agente, webhooks."
             echo ""
-            echo "**Não rodou (2):**"
-            echo "- webhooks: a automação não aplica a tag no card do lead neste"
-            echo "  ambiente — reproduzido localmente, ainda sem causa. NÃO é falta"
-            echo "  de WAHA: a followup-journey estava na mesma categoria e passa"
-            echo "  sem WAHA nenhum (ela dubla o webhook chamando a mesma função"
-            echo "  que o receiver real chama)."
+            echo "**Não rodou (1):**"
             echo "- precisa de WAHA + Redis + Resend + Nuvemshop: vps-fresh-onboarding (P0)"
             echo ""
             echo "Expandir é trabalho de seguimento — issue #63."

--- a/tests/e2e/webhooks.spec.ts
+++ b/tests/e2e/webhooks.spec.ts
@@ -232,10 +232,18 @@ test.describe("webhooks & automações — fluxo completo", () => {
       await page.goto(`${APP_URL}/app/pipelines/${pipelineId}`);
       const leadHeading = page.getByRole("heading", { name: LEAD_NAME });
       await expect(leadHeading).toBeVisible({ timeout: 15_000 });
+      // A TAG VIVE NO `title` DO CARD, não como texto visível.
+      //
+      // `KanbanCard.tsx` publica `title={`Tags: ...`}` com um comentário que
+      // declara a intenção: "Tags saem do card (Lei A): ficam a um hover, sem
+      // ocupar altura". Esta spec afirmava texto visível — ela é que envelheceu
+      // junto com o desenho, e ninguém soube porque ela nunca rodou em gate
+      // (issue #63). Afirmar o `title` mantém a garantia que importa: a tag que
+      // a automação aplicou CHEGOU ao card.
       const leadCard = leadHeading.locator(
-        "xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' border-border ')][1]",
+        "xpath=ancestor::div[@role='group'][1]",
       );
-      await expect(leadCard.getByText(TAG)).toBeVisible();
+      await expect(leadCard).toHaveAttribute("title", new RegExp(`Tags:.*${TAG}`));
 
       // --- Step 9: AGENT não vê "Webhooks" e é redirecionado ---
       const agentContext = await browser.newContext();


### PR DESCRIPTION
Última das três que faltavam ser investigadas. Ela reprovava afirmando que a tag
aplicada pela automação aparece como TEXTO no card do lead. Não aparece — e é
deliberado: `KanbanCard.tsx` publica `title={\`Tags: ...\`}` com o motivo escrito
ao lado ("Tags saem do card (Lei A): ficam a um hover, sem ocupar altura").

O run da automação chegava a "Sucesso" no passo anterior, ou seja, a tag ERA
aplicada. O que falhava era a spec descrevendo um desenho que mudou — e ninguém
soube porque ela nunca rodou em gate nenhum, que é a tese desta issue pela
terceira vez nesta rodada.

A asserção passa a ser sobre o `title`, que é o que a UI publica: mantém a
garantia que importa (a tag da automação CHEGOU ao card) sem inventar UI nova. O
seletor do card também sai do xpath por classe CSS (`border-border`, que muda com
o tema) para `[@role='group']`, que é contrato de acessibilidade.

Rodada localmente contra Supabase local com o baseline aplicado: **passa**.

**32 das 33 specs no CI.** Sobra uma: `vps-fresh-onboarding`, a P0, que precisa
de WAHA + Redis + Resend + Nuvemshop no runner — o resíduo legítimo e o mais
caro.

Refs #63

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HstH7nNmrTvCtZsasppeHj