### PR TITLE
fix(ia): a chave da OpenAI do .env nunca chegava ao agente

### DIFF
--- a/lib/agent-engine/edge/llm/credentials.test.ts
+++ b/lib/agent-engine/edge/llm/credentials.test.ts
@@ -5,7 +5,12 @@ vi.mock("@/lib/crypto/aes_gcm", () => ({
   decryptKey: () => "chave-byok-da-org",
 }));
 
-import { resolveOrgLlmConfig, LlmNotConfiguredError, type LlmEdgeConfig } from "./credentials";
+import {
+  llmEdgeConfigFromEnv,
+  resolveOrgLlmConfig,
+  LlmNotConfiguredError,
+  type LlmEdgeConfig,
+} from "./credentials";
 
 /** Pool falso: 1ª query devolve settings->'llm', 2ª devolve credenciais BYOK. */
 function poolFake(settingsLlm: unknown, credenciais: unknown[]) {
@@ -62,5 +67,47 @@ describe("resolveOrgLlmConfig — chave de plataforma por provider", () => {
     await expect(
       resolveOrgLlmConfig(poolFake({ provider: "openai" }, SEM_BYOK), {}, "org-1"),
     ).rejects.toBeInstanceOf(LlmNotConfiguredError);
+  });
+});
+
+/**
+ * A ponte que faltava. Os testes acima provam que `resolveOrgLlmConfig` USA
+ * `openaiApiKey` — e passavam. Só que nenhum caminho do agente PREENCHIA o campo:
+ * `llmEdgeConfigFromEnv` montava apenas a chave da Anthropic, e o único lugar que
+ * preenchia a da OpenAI era o worker de transcrição, na mão.
+ *
+ * Guardar a função de consumo não guarda o call site: a instalação tinha a chave
+ * no `.env`, o teste do consumidor estava verde, e o agente OpenAI morria com
+ * "org sem credencial LLM utilizável".
+ */
+describe("llmEdgeConfigFromEnv — o que sai do .env chega ao turno", () => {
+  it("leva a chave da OpenAI, não só a da Anthropic", () => {
+    const cfg = llmEdgeConfigFromEnv({
+      ANTHROPIC_API_KEY: "sk-ant-x",
+      OPENAI_API_KEY: "sk-proj-y",
+    });
+    expect(cfg.anthropicApiKey).toBe("sk-ant-x");
+    expect(cfg.openaiApiKey).toBe("sk-proj-y");
+  });
+
+  it("chave ausente continua ausente — string vazia não vira credencial", () => {
+    const cfg = llmEdgeConfigFromEnv({ ANTHROPIC_API_KEY: "sk-ant-x", OPENAI_API_KEY: "" });
+    expect(cfg).not.toHaveProperty("openaiApiKey");
+  });
+
+  it("só OpenAI configurada: a config sai utilizável mesmo sem a Anthropic", () => {
+    const cfg = llmEdgeConfigFromEnv({ OPENAI_API_KEY: "sk-proj-y" });
+    expect(cfg).not.toHaveProperty("anthropicApiKey");
+    expect(cfg.openaiApiKey).toBe("sk-proj-y");
+  });
+
+  it("o caminho inteiro: chave do .env resolve um modelo OpenAI numa org sem BYOK", async () => {
+    const cfg = llmEdgeConfigFromEnv({ OPENAI_API_KEY: "sk-proj-do-env" });
+    const out = await resolveOrgLlmConfig(
+      poolFake({ provider: "openai", default_model: "gpt-5-mini" }, SEM_BYOK),
+      cfg,
+      "org1",
+    );
+    expect(out.apiKey).toBe("sk-proj-do-env");
   });
 });

--- a/lib/agent-engine/edge/llm/credentials.ts
+++ b/lib/agent-engine/edge/llm/credentials.ts
@@ -3,7 +3,7 @@
  * `ai_provider_credentials` do CRM (AES-256-GCM via lib/crypto/aes_gcm — colunas
  * api_key_encrypted/api_key_iv/api_key_tag) e os knobs de modelo/params/teto vivem
  * em `organizations.settings->'llm'`. Sem BYOK, o fallback é a chave de plataforma
- * do env (ANTHROPIC_API_KEY) — só para provider anthropic. O plaintext da chave
+ * do env (ANTHROPIC_API_KEY ou OPENAI_API_KEY, conforme o provider). O plaintext da chave
  * existe apenas em memória do processo no instante da chamada; nunca em log.
  *
  * A config é lida do DB A CADA chamada (resolveOrgLlmConfig) — trocar modelo/
@@ -34,8 +34,19 @@ export interface LlmEdgeConfig {
   cacheTtl?: CacheTtl;
 }
 
+/**
+ * ⚠️ `OPENAI_API_KEY` entra aqui, e não entrava antes — o campo `openaiApiKey`
+ * existia no tipo e era lido em `resolveOrgLlmConfig`, mas NENHUM caminho do
+ * agente o preenchia (só o worker de transcrição de áudio montava a config na
+ * mão). O efeito: numa instalação com a chave da OpenAI no `.env`, um agente com
+ * modelo OpenAI caía em `LlmNotConfiguredError` — a chave estava lá, coletada
+ * pelo instalador, e o turno morria como se não estivesse. Um campo declarado que
+ * ninguém preenche é pior que um campo ausente: faz quem lê o código concluir que
+ * o caminho existe.
+ */
 export function llmEdgeConfigFromEnv(env: {
   ANTHROPIC_API_KEY?: string;
+  OPENAI_API_KEY?: string;
   LLM_CACHE_TTL?: string;
 }): LlmEdgeConfig {
   const ttl = env.LLM_CACHE_TTL ?? '1h';
@@ -44,6 +55,7 @@ export function llmEdgeConfigFromEnv(env: {
   }
   return {
     ...(env.ANTHROPIC_API_KEY ? { anthropicApiKey: env.ANTHROPIC_API_KEY } : {}),
+    ...(env.OPENAI_API_KEY ? { openaiApiKey: env.OPENAI_API_KEY } : {}),
     cacheTtl: ttl,
   };
 }
@@ -53,7 +65,7 @@ export class LlmNotConfiguredError extends Error {
   override readonly name = 'llm_not_configured';
   constructor() {
     super(
-      'org sem credencial LLM utilizável — cadastre uma chave BYOK ativa/validada em ai_provider_credentials ou defina ANTHROPIC_API_KEY (fallback de plataforma, só provider anthropic)',
+      'org sem credencial LLM utilizável — cadastre uma chave BYOK ativa/validada em ai_provider_credentials ou defina ANTHROPIC_API_KEY / OPENAI_API_KEY (fallback de plataforma, conforme o provider do modelo)',
     );
   }
 }

--- a/lib/agent-engine/env.test.ts
+++ b/lib/agent-engine/env.test.ts
@@ -38,3 +38,22 @@ describe("loadEnv — vazio é ausente (contrato BYOK do README)", () => {
     expect(() => loadEnv(rest)).toThrowError(/SUPABASE_DB_URL/);
   });
 });
+
+/**
+ * A metade que NADA guardava. Medido: remover `OPENAI_API_KEY` deste schema não
+ * reprova nenhum teste E passa no `tsc` — o parâmetro de `llmEdgeConfigFromEnv`
+ * declara a chave como opcional, então um env sem ela é um tipo válido. O
+ * resultado seria o bug de origem voltando em silêncio: chave no `.env`, worker
+ * subindo, agente OpenAI morrendo com "org sem credencial LLM utilizável".
+ */
+describe("loadEnv — a chave da OpenAI existe no contrato do worker", () => {
+  it("OPENAI_API_KEY é reconhecida e chega ao env do worker", () => {
+    const env = loadEnv({ ...REQUIRED, OPENAI_API_KEY: "sk-proj-abc" });
+    expect(env.OPENAI_API_KEY).toBe("sk-proj-abc");
+  });
+
+  it("vazia continua sendo ausente — mesmo contrato BYOK das demais", () => {
+    const env = loadEnv({ ...REQUIRED, OPENAI_API_KEY: "" });
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+  });
+});

--- a/lib/agent-engine/env.ts
+++ b/lib/agent-engine/env.ts
@@ -24,6 +24,11 @@ const envSchema = z.object({
   // ai_provider_credentials). Opcional no boot: sem ela e sem BYOK, o turno
   // falha com erro instrutivo — nunca silêncio.
   ANTHROPIC_API_KEY: z.string().min(1).optional(),
+  // A irmã da de cima, e ela faltava aqui. O instalador coleta OPENAI_API_KEY, mas
+  // sem esta linha ela nunca chegava ao turno do agente: uma organização com agente
+  // OpenAI e a chave no `.env` continuava sem credencial utilizável, e a única
+  // saída era cadastrar BYOK pela tela — sem nada dizendo isso.
+  OPENAI_API_KEY: z.string().min(1).optional(),
   // Modelo default do agente quando a org não define o dela (knob, nunca constante).
   AGENT_DEFAULT_MODEL: z.string().min(1).default('claude-sonnet-4-5'),
   // Teto de conexões por pool do pg. Sem valor = pg decide (default 10).

--- a/scripts/smoke-llm.ts
+++ b/scripts/smoke-llm.ts
@@ -84,7 +84,11 @@ async function main(): Promise<void> {
     [ORG, MODEL],
   );
 
-  const cfg = llmEdgeConfigFromEnv({ ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY, LLM_CACHE_TTL: '1h' });
+  const cfg = llmEdgeConfigFromEnv({
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    LLM_CACHE_TTL: '1h',
+  });
   const system = bigSystem();
   const tools = {
     consultar_catalogo: tool({


### PR DESCRIPTION
Encontrado diagnosticando um agente que não respondia numa VPS: modelo `gpt-5-mini`, `OPENAI_API_KEY` presente no `.env`, e nenhum turno respondido.

## O defeito

`LlmEdgeConfig` declara `openaiApiKey`, e `resolveOrgLlmConfig` **lê** esse campo para escolher a chave de plataforma quando o provedor é OpenAI. Só que **nenhum caminho do agente preenchia**: `llmEdgeConfigFromEnv` montava apenas a da Anthropic, e o único lugar que preenchia a da OpenAI era o worker de transcrição de áudio, na mão.

Efeito no self-host: o instalador coleta `OPENAI_API_KEY`, o dono põe a chave no `.env`, e o agente OpenAI morre com *"org sem credencial LLM utilizável"* — a chave está lá, e o sistema age como se não estivesse. A única saída era cadastrar BYOK pela tela, sem nada dizendo isso.

Duas linhas faltavam: o schema de env do worker não declarava `OPENAI_API_KEY`, e a função de montagem não a lia.

## O teste que faltava era o da ponte

Os casos existentes provavam que `resolveOrgLlmConfig` **usa** `openaiApiKey` — e passavam, com o produto quebrado. Guardar a função de consumo não guarda quem preenche.

E a metade do worker não tinha guarda **nenhuma**: medi que removê-la não reprova teste e **passa no `tsc`** (o parâmetro declara a chave como opcional, então um env sem ela é um tipo válido). Fechei com teste próprio.

## Verificação

- `tsc --noEmit`: 0 · `eslint`: 0 · 14 testes das áreas tocadas passando
- Sabotagem, com a contagem prevista antes de rodar:
  - montagem volta a ignorar a OpenAI → **3 reprovações** (previstas: 3)
  - schema de env do worker perde a chave → previ *"0 nos testes, mas o typecheck cai"*; **medi: o typecheck NÃO cai**. Com o teste novo, passa a reprovar **1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186uhSjxkjwHgMzbkbytbSq