### PR TITLE
feat(anti-ban): declarar desde quando o número é usado — e poder pular o aquecimento

### DIFF
--- a/app/api/v1/ai/pacing/route.ts
+++ b/app/api/v1/ai/pacing/route.ts
@@ -19,6 +19,7 @@ import {
   knobsView,
   effectiveKnobs,
   windowIsValid,
+  WARMUP_PULADO,
   type ChannelKnobsRow,
 } from "@/lib/ai/pacing-knobs";
 
@@ -80,7 +81,16 @@ export async function PUT(req: NextRequest): Promise<Response> {
       details: parsed.error.flatten(),
     });
   }
-  const { channel_session_id, daily_message_limit, ...knobFields } = parsed.data;
+  const { channel_session_id, daily_message_limit, skip_warmup, ...camposDiretos } = parsed.data;
+  // `skip_warmup` é pergunta da TELA; a coluna guarda a forma que o motor lê.
+  // A tradução mora aqui, num lugar só: a tela não deveria precisar conhecer o
+  // formato dos degraus para dizer "este número já está aquecido".
+  const knobFields = {
+    ...camposDiretos,
+    ...(skip_warmup !== undefined
+      ? { warmup_daily_caps: skip_warmup ? [...WARMUP_PULADO] : null }
+      : {}),
+  };
 
   const admin = createAdminClient();
   const { data: session } = await admin

--- a/components/connections/AntiBanSheet.tsx
+++ b/components/connections/AntiBanSheet.tsx
@@ -37,6 +37,9 @@ interface FormState {
   daily_message_limit: string;
   allow_sunday: boolean;
   timezone: string;
+  /** `yyyy-mm-dd` do input date; '' = não declarado (o motor trata como idade 0). */
+  numero_em_uso_desde: string;
+  pular_aquecimento: boolean;
 }
 
 function fromItem(item: PacingKnobsItem): FormState {
@@ -52,6 +55,10 @@ function fromItem(item: PacingKnobsItem): FormState {
         : "",
     allow_sunday: o?.allow_sunday ?? item.defaults.allowSunday,
     timezone: o?.timezone ?? "",
+    numero_em_uso_desde: item.warmup.number_activated_at
+      ? item.warmup.number_activated_at.slice(0, 10)
+      : "",
+    pular_aquecimento: item.warmup.skipped,
   };
 }
 
@@ -90,6 +97,14 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
         ...(form.daily_message_limit.trim() !== ""
           ? { daily_message_limit: Math.round(Number(form.daily_message_limit)) }
           : {}),
+        // Meio-dia UTC, não meia-noite: a data é um DIA declarado pelo operador, e
+        // meia-noite vira o dia anterior em qualquer fuso a oeste — o número
+        // envelheceria um dia a menos do que ele informou.
+        number_activated_at:
+          form.numero_em_uso_desde.trim() === ""
+            ? null
+            : new Date(`${form.numero_em_uso_desde}T12:00:00.000Z`).toISOString(),
+        skip_warmup: form.pular_aquecimento,
       });
       toast.success("Proteção de envio atualizada.");
       onClose();
@@ -110,6 +125,43 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
         </SheetHeader>
 
         <div className="flex flex-col gap-5 px-4 py-2" data-testid="anti-ban-form">
+          <fieldset className="flex flex-col gap-2" data-testid="aquecimento">
+            <Label htmlFor="numero-em-uso-desde">Este número é usado desde</Label>
+            <Input
+              id="numero-em-uso-desde"
+              type="date"
+              max={new Date().toISOString().slice(0, 10)}
+              value={form.numero_em_uso_desde}
+              onChange={(e) => set({ numero_em_uso_desde: e.target.value })}
+              disabled={!canWrite || form.pular_aquecimento}
+              className="w-48"
+            />
+            <p className="text-xs text-muted-foreground">
+              A conexão pode ser nova sem que o número seja. O aquecimento conta a idade do
+              NÚMERO — se você deixar em branco, ele é tratado como recém-criado e começa
+              liberando pouco por dia.
+            </p>
+
+            <div className="mt-1 flex items-center gap-2">
+              <Switch
+                id="pular-aquecimento"
+                checked={form.pular_aquecimento}
+                onCheckedChange={(v) => set({ pular_aquecimento: v })}
+                disabled={!canWrite}
+              />
+              <Label htmlFor="pular-aquecimento" className="font-normal">
+                Este número já está aquecido — pular o aquecimento
+              </Label>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {form.pular_aquecimento
+                ? "Vale só o teto diário abaixo. Use apenas se o número já envia há semanas: pular o aquecimento num número novo é o caminho mais rápido para o bloqueio."
+                : item.warmup.cap_today === null
+                  ? `Número com ${item.warmup.age_days} dia(s) de uso — já formado. Vale só o teto diário abaixo.`
+                  : `Hoje o aquecimento libera ${item.warmup.cap_today} envio(s) — o número tem ${item.warmup.age_days} dia(s) de uso. Enquanto esse número for menor que o teto diário, é ELE que limita, e mexer no teto diário não muda nada.`}
+            </p>
+          </fieldset>
+
           <fieldset className="flex flex-col gap-2">
             <Label>Janela de envio (horário local)</Label>
             <div className="flex items-center gap-2">

--- a/hooks/channels/usePacingKnobs.ts
+++ b/hooks/channels/usePacingKnobs.ts
@@ -13,9 +13,19 @@ export interface PacingSessionLite {
   daily_message_limit: number | null;
 }
 
+/** Estado do aquecimento, já calculado no servidor (a tela não recalcula a regra). */
+export interface PacingWarmupView {
+  number_activated_at: string | null;
+  age_days: number;
+  skipped: boolean;
+  /** Teto de HOJE pelo aquecimento; null = sem teto (número formado ou aquecimento pulado). */
+  cap_today: number | null;
+}
+
 export interface PacingKnobsItem {
   channel_session: PacingSessionLite;
   effective: PacingKnobs;
+  warmup: PacingWarmupView;
   overrides: ChannelKnobsRow | null;
   defaults: PacingKnobs;
   bounds: {

--- a/lib/agent-engine/pacing/engine.ts
+++ b/lib/agent-engine/pacing/engine.ts
@@ -112,8 +112,12 @@ export function decidePacing(input: PacingInput): PacingDecision {
  * Degrau vigente para a idade (degraus ordenados por minAgeDays crescente).
  * Falha FECHADO: idade aquém do primeiro degrau usa o cap do PRIMEIRO degrau
  * (o mais conservador) — configuração com furo nunca vira "sem cap".
+ *
+ * Exportada para a TELA poder dizer ao operador qual é o teto de hoje. A regra
+ * tem de ser esta mesma função: uma segunda cópia na UI é a receita para a tela
+ * prometer um número e o motor aplicar outro.
  */
-function warmupCapFor(ageDays: number, steps: WarmupStep[]): number | null {
+export function warmupCapFor(ageDays: number, steps: WarmupStep[]): number | null {
   let cap: number | null = steps[0]?.cap ?? null;
   for (const step of steps) {
     if (ageDays >= step.minAgeDays) cap = step.cap;

--- a/lib/ai/pacing-knobs.ts
+++ b/lib/ai/pacing-knobs.ts
@@ -12,6 +12,7 @@ import {
   PACING_DEFAULTS,
   type PacingKnobs,
 } from "@/lib/agent-engine/pacing/defaults";
+import { warmupCapFor } from "@/lib/agent-engine/pacing/engine";
 import { parseWarmupCaps } from "@/lib/agent-engine/pacing/store";
 
 function isValidTimezone(tz: string): boolean {
@@ -50,6 +51,28 @@ export const pacingKnobsUpdateSchema = z
       .min(DAILY_LIMIT_BOUNDS.min)
       .max(DAILY_LIMIT_BOUNDS.max)
       .optional(),
+    /**
+     * Desde quando o NÚMERO é usado — não desde quando esta conexão existe.
+     *
+     * O warm-up mede idade, e a idade nascia do instante em que o número era
+     * pareado aqui: reconectar um número usado há meses o rebaixava a
+     * recém-nascido (teto de 20 envios/dia) sem nenhum caminho para corrigir.
+     * Data futura é recusada — ela ADIANTARIA o aquecimento, que é o oposto de
+     * proteger.
+     */
+    number_activated_at: z
+      .string()
+      .datetime({ offset: true })
+      .refine((iso) => new Date(iso).getTime() <= Date.now(), "a data não pode estar no futuro")
+      .nullable()
+      .optional(),
+    /**
+     * "Este número já está aquecido" — pula os degraus por completo, gravando um
+     * único degrau sem teto. Existe ao lado da data porque são perguntas
+     * diferentes: a data é um FATO que o dono conhece; isto é uma DECISÃO dele,
+     * assumindo o risco de banimento de um número que talvez não esteja pronto.
+     */
+    skip_warmup: z.boolean().optional(),
   })
   .strict();
 
@@ -89,12 +112,46 @@ export function effectiveKnobs(row: ChannelKnobsRow | null): PacingKnobs {
   };
 }
 
-/** Payload de GET para a tela: efetivo + o que é override + limites de edição. */
-export function knobsView(row: ChannelKnobsRow | null) {
+/** Forma gravada em `warmup_daily_caps` quando o dono declara o número já aquecido. */
+export const WARMUP_PULADO = [{ minAgeDays: 0, cap: null }] as const;
+
+/** A configuração de warm-up desta conexão é a de "já aquecido"? */
+export function warmupEstaPulado(row: ChannelKnobsRow | null): boolean {
+  const caps = parseWarmupCaps(row?.warmup_daily_caps);
+  return caps?.length === 1 && caps[0]?.minAgeDays === 0 && caps[0]?.cap === null;
+}
+
+/** Dias completos desde a ativação do número. Sem data = 0 (o motor é conservador). */
+export function idadeEmDias(row: ChannelKnobsRow | null, agora: Date = new Date()): number {
+  const iso = row?.number_activated_at;
+  if (!iso) return 0;
+  const ms = agora.getTime() - new Date(iso).getTime();
+  return Number.isFinite(ms) ? Math.max(0, Math.floor(ms / 86_400_000)) : 0;
+}
+
+/**
+ * Payload de GET para a tela: efetivo + o que é override + limites de edição.
+ *
+ * `warmup` vai junto porque a tela precisava explicar um veto que ela não sabia
+ * calcular: o operador lia "número em aquecimento, limite atingido", subia o teto
+ * diário — o único campo que a tela oferecia — e nada mudava, porque quem barrava
+ * era o teto por IDADE. Agora o número que decide aparece ao lado do que o
+ * decide.
+ */
+export function knobsView(row: ChannelKnobsRow | null, agora: Date = new Date()) {
+  const efetivo = effectiveKnobs(row);
+  const dias = idadeEmDias(row, agora);
   return {
-    effective: effectiveKnobs(row),
+    effective: efetivo,
     overrides: row,
     defaults: PACING_DEFAULTS,
     bounds: { ...KNOB_BOUNDS, daily_limit: DAILY_LIMIT_BOUNDS },
+    warmup: {
+      number_activated_at: row?.number_activated_at ?? null,
+      age_days: dias,
+      skipped: warmupEstaPulado(row),
+      /** Teto de HOJE pelo aquecimento. null = sem teto (formado ou pulado). */
+      cap_today: warmupCapFor(dias, efetivo.warmupDailyCaps),
+    },
   };
 }

--- a/tests/unit/aquecimento-idade-do-numero.test.ts
+++ b/tests/unit/aquecimento-idade-do-numero.test.ts
@@ -1,0 +1,132 @@
+/**
+ * O aquecimento mede a idade do NÚMERO, e essa idade nascia do instante em que o
+ * número era pareado. Reconectar um número usado há meses o rebaixava a
+ * recém-nascido — teto de 20 envios/dia — e não havia caminho nenhum para
+ * corrigir: o contrato da API era `.strict()` e não aceitava nem a data de
+ * ativação nem os degraus.
+ *
+ * Pior: a tela oferecia o teto DIÁRIO, que é outro gate. O operador subia o teto
+ * para 1000, nada mudava, e a mensagem seguia falando de aquecimento.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  WARMUP_PULADO,
+  idadeEmDias,
+  knobsView,
+  pacingKnobsUpdateSchema,
+  warmupEstaPulado,
+  type ChannelKnobsRow,
+} from "@/lib/ai/pacing-knobs";
+
+const SESSAO = "11111111-1111-4111-8111-111111111111";
+const VAZIO: ChannelKnobsRow = {
+  throttle_ms: null,
+  jitter_max_ms: null,
+  window_start_hour: null,
+  window_end_hour: null,
+  allow_sunday: null,
+  timezone: null,
+  warmup_daily_caps: null,
+  number_activated_at: null,
+};
+
+describe("contrato da API — os campos que faltavam", () => {
+  it("aceita a data de ativação do número", () => {
+    const r = pacingKnobsUpdateSchema.safeParse({
+      channel_session_id: SESSAO,
+      number_activated_at: "2026-04-29T02:15:52.000Z",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("recusa data no FUTURO — adiantar o aquecimento é o oposto de proteger", () => {
+    const amanha = new Date(Date.now() + 86_400_000).toISOString();
+    const r = pacingKnobsUpdateSchema.safeParse({
+      channel_session_id: SESSAO,
+      number_activated_at: amanha,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("aceita null — volta a tratar o número como recém-criado", () => {
+    const r = pacingKnobsUpdateSchema.safeParse({
+      channel_session_id: SESSAO,
+      number_activated_at: null,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("aceita a decisão de pular o aquecimento", () => {
+    const r = pacingKnobsUpdateSchema.safeParse({ channel_session_id: SESSAO, skip_warmup: true });
+    expect(r.success).toBe(true);
+  });
+
+  it("continua estrito: campo desconhecido é recusado", () => {
+    const r = pacingKnobsUpdateSchema.safeParse({ channel_session_id: SESSAO, inventado: 1 });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("idade do número", () => {
+  it("conta dias completos desde a ativação", () => {
+    const row = { ...VAZIO, number_activated_at: "2026-04-29T02:00:00.000Z" };
+    expect(idadeEmDias(row, new Date("2026-08-06T02:00:00.000Z"))).toBe(99);
+  });
+
+  it("sem data = idade 0 — o motor falha fechado, e a view não inventa idade", () => {
+    expect(idadeEmDias(VAZIO)).toBe(0);
+  });
+
+  it("data no futuro não vira idade negativa", () => {
+    const row = { ...VAZIO, number_activated_at: "2030-01-01T00:00:00.000Z" };
+    expect(idadeEmDias(row, new Date("2026-08-06T00:00:00.000Z"))).toBe(0);
+  });
+});
+
+describe("knobsView.warmup — o número que a tela precisava mostrar", () => {
+  it("número recém-pareado: teto de hoje é o do primeiro degrau, NÃO o teto diário", () => {
+    const hoje = new Date("2026-08-06T20:00:00.000Z");
+    const row = { ...VAZIO, number_activated_at: "2026-08-06T19:00:00.000Z" };
+    const v = knobsView(row, hoje);
+    expect(v.warmup.age_days).toBe(0);
+    expect(v.warmup.cap_today).toBe(20);
+    expect(v.warmup.skipped).toBe(false);
+  });
+
+  it("número com mais de 31 dias: sem teto de aquecimento", () => {
+    const v = knobsView(
+      { ...VAZIO, number_activated_at: "2026-04-29T02:00:00.000Z" },
+      new Date("2026-08-06T02:00:00.000Z"),
+    );
+    expect(v.warmup.cap_today).toBeNull();
+  });
+
+  it("aquecimento pulado: sem teto mesmo com o número nascido hoje", () => {
+    const hoje = new Date("2026-08-06T20:00:00.000Z");
+    const row = {
+      ...VAZIO,
+      number_activated_at: "2026-08-06T19:00:00.000Z",
+      warmup_daily_caps: [...WARMUP_PULADO],
+    };
+    const v = knobsView(row, hoje);
+    expect(v.warmup.age_days).toBe(0);
+    expect(v.warmup.skipped).toBe(true);
+    expect(v.warmup.cap_today).toBeNull();
+  });
+});
+
+describe("warmupEstaPulado", () => {
+  it("reconhece a forma gravada por skip_warmup", () => {
+    expect(warmupEstaPulado({ ...VAZIO, warmup_daily_caps: [...WARMUP_PULADO] })).toBe(true);
+  });
+
+  it("os degraus padrão NÃO são 'pulado'", () => {
+    expect(warmupEstaPulado(VAZIO)).toBe(false);
+  });
+
+  it("degraus customizados com teto não contam como pulado", () => {
+    const row = { ...VAZIO, warmup_daily_caps: [{ minAgeDays: 0, cap: 500 }] };
+    expect(warmupEstaPulado(row)).toBe(false);
+  });
+});


### PR DESCRIPTION
Pedido do dono de uma instalação, depois de bater na trava sem ter como sair dela.

## O problema

**A conexão pode ser nova sem que o número seja.** O aquecimento mede idade, e essa idade nascia do instante do pareamento — então reconectar um número usado há meses o rebaixava a recém-nascido: teto de **20 envios/dia**.

E não havia saída. O contrato da API é `.strict()` e aceitava intervalo, jitter, janela, domingo, fuso e teto diário — **nem a data de ativação, nem os degraus de aquecimento**.

Pior: a tela oferecia o **teto diário**, que é outro gate. O operador subia para 1000, nada mudava, e a mensagem continuava falando de aquecimento. Medido em produção: número com 296 mensagens de histórico desde abril, marcado como idade 0, barrado no 20º envio do dia — com o teto diário em 1000.

O produto avisava sobre uma trava, oferecia um botão que não a controlava, e escondia o que a controlava.

## O que muda

Duas entradas, porque são perguntas diferentes:

- **"Este número é usado desde"** — um FATO que o dono conhece. Data futura é recusada: adiantar o aquecimento é o oposto de proteger.
- **"Já está aquecido — pular"** — uma DECISÃO dele, com o risco escrito ao lado.

A tela passa a mostrar **o teto de hoje** junto do que o decide, e diz explicitamente que, enquanto ele for menor que o teto diário, é ele que limita — que era a informação que faltava para o operador não mexer no lugar errado.

O cálculo vem de `warmupCapFor`, a mesma função do motor, agora exportada. Uma segunda cópia na UI faria a tela prometer um número e o motor aplicar outro.

## Verificação

- `tsc --noEmit`: 0 · `eslint`: 0 erros · `lint:channels`: ok · 74 testes de pacing/knobs passando
- Sabotagem, com a contagem prevista antes de rodar:
  - schema volta a recusar os campos → **3 reprovações** (previstas: 3)
  - data futura passa a ser aceita → **1 reprovação** (prevista: 1)

## Achado lateral

`scripts/lint-pacing.ts` **não existe**. O cabeçalho de `pacing/defaults.ts` afirma que ele "reprova literal de pacing em qualquer outro arquivo de daemon/src", e ele não está no repositório, no `package.json` nem no CI. A doutrina de números de pacing como fonte única não tem gate — está escrita, não vigiada. Fora do escopo deste PR, mas vale abrir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186uhSjxkjwHgMzbkbytbSq