### PR TITLE
fix(kit): instalador aceita Supabase self-hosted e overlay do Swarm

### DIFF
--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -75,6 +75,11 @@ veredito_rede_do_proxy() {  # veredito_rede_do_proxy <driver encontrado> <rede> 
     printf 'inexistente'; return 0
   fi
   [ "$drv" = bridge ] && { printf 'ok'; return 0; }
+  # $4 = "true" quando a rede é uma overlay attachable (Swarm). Contêiner de
+  # compose comum entra numa dessas, então ela serve tão bem quanto uma bridge.
+  # Sem o attachable a recusa continua: ali o `up` morreria em
+  # "could not attach to network".
+  [ "$drv" = overlay ] && [ "${4:-}" = true ] && { printf 'ok'; return 0; }
   printf 'driver_errado'
 }
 
@@ -93,7 +98,9 @@ garantir_rede_do_proxy() {
   nossa="$(rede_reservada_do_proxy)"
   TRAEFIK_NETWORK="${TRAEFIK_NETWORK:-traefik}"
   drv="$(docker network inspect -f '{{.Driver}}' "$TRAEFIK_NETWORK" 2>/dev/null || true)"
-  case "$(veredito_rede_do_proxy "$drv" "$TRAEFIK_NETWORK" "$nossa")" in
+  local att
+  att="$(docker network inspect -f '{{.Attachable}}' "$TRAEFIK_NETWORK" 2>/dev/null || true)"
+  case "$(veredito_rede_do_proxy "$drv" "$TRAEFIK_NETWORK" "$nossa" "$att")" in
   ok) : ;;
   criar)
     # O motivo vai junto porque aqui NÃO se sabe qual é: o comando está certo, e
@@ -120,7 +127,9 @@ TRAEFIK_NETWORK=<nome> no .env antes de tentar de novo."
 de uma bridge para o Traefik alcançar o contêiner. Se o seu Traefik roda em modo
 host (é o caso quando 'docker ps' não mostra porta publicada nele), APAGUE a linha
 TRAEFIK_NETWORK do .env: o kit cria e usa a rede '$nossa'.
-Senão, rode 'docker network ls' e ponha a bridge certa em TRAEFIK_NETWORK no .env."
+Senão, rode 'docker network ls' e ponha a bridge certa em TRAEFIK_NETWORK no .env.
+Se for uma overlay do Swarm, ela precisa ter sido criada com --attachable —
+sem isso um contêiner de compose comum não consegue entrar nela."
     ;;
   esac
 }

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -188,8 +188,12 @@ v_email() {
 v_supabase_url() {
   case "$1" in
     https://*.supabase.co) ;;
+    # Supabase SELF-HOSTED (ex.: https://db-crm.exemplo.com.br). A prova é a
+    # chamada a /auth/v1/health logo abaixo, que vale para qualquer host — o
+    # que se dispensa aqui é só a suposição de que todo Supabase é o da nuvem.
+    https://*) ;;
     *supabase.co*) echo "Cole a URL completa, começando com https:// — ex.: https://abcdefgh.supabase.co"; return 1;;
-    *) echo "Essa não é a URL do projeto Supabase. Ela termina em .supabase.co e fica em Settings > API > Project URL."; return 1;;
+    *) echo "A URL precisa começar com https://. Na nuvem ela fica em Settings > API > Project URL (termina em .supabase.co); num Supabase próprio, é o endereço do seu servidor."; return 1;;
   esac
   local code
   code="$(curl -s -o /dev/null -w '%{http_code}' -m 15 "$1/auth/v1/health" 2>/dev/null || echo 000)"
@@ -261,11 +265,14 @@ v_db_url() {
   esac
   # Mesma família de projeto? (usuário do pooler é 'postgres.<ref>')
   local dbref="${1#*://}"; dbref="${dbref%%:*}"; dbref="${dbref#postgres.}"
-  if [ -n "${NEXT_PUBLIC_SUPABASE_URL:-}" ] && [ "$dbref" != "postgres" ] \
-     && [ "$dbref" != "$(sb_ref "$NEXT_PUBLIC_SUPABASE_URL")" ]; then
-    echo "Essa connection string é do projeto '${dbref}', mas a URL que você deu é do projeto '$(sb_ref "$NEXT_PUBLIC_SUPABASE_URL")'. Precisam ser o mesmo projeto."
-    return 1
-  fi
+  case "${NEXT_PUBLIC_SUPABASE_URL:-}" in
+    *.supabase.co)
+      if [ "$dbref" != "postgres" ] \
+         && [ "$dbref" != "$(sb_ref "$NEXT_PUBLIC_SUPABASE_URL")" ]; then
+        echo "Essa connection string é do projeto '${dbref}', mas a URL que você deu é do projeto '$(sb_ref "$NEXT_PUBLIC_SUPABASE_URL")'. Precisam ser o mesmo projeto."
+        return 1
+      fi;;
+  esac
   local out
   if out="$(docker run --rm postgres:17-alpine psql "$1" -tAc 'select 1' 2>&1)"; then
     return 0


### PR DESCRIPTION
## O que é

Três recusas do `hostgator-setup-kit` que reprovam o dado **certo** quando a VPS
não é a do caso padrão (HostGator simples + Supabase da nuvem).

Encontradas instalando numa VPS com **Supabase self-hosted** e **Docker Swarm**.
Instalação foi até o fim depois destas mudanças: schema aplicado, primeiro dono
criado, app saudável, WAHA no ar.

**Nenhuma prova foi removida.** Em cada caso o que caiu foi uma suposição sobre
a nuvem; o teste que realmente prova a coisa continua rodando.

| Onde | Suposição que caiu | Prova que continua |
|---|---|---|
| `v_supabase_url` | "toda URL de Supabase termina em `.supabase.co`" | a chamada a `/auth/v1/health` |
| `v_db_url` | "o usuário é `postgres.<ref>` e o `<ref>` bate com o da URL" | o `select 1` real na connection string |
| `veredito_rede_do_proxy` | "a rede do Traefik é sempre uma bridge" | overlay **não**-attachable segue recusada |

## Detalhe de cada uma

**1. `v_supabase_url` exigia `.supabase.co`.** Os docs de self-host do próprio
projeto dizem que Supabase próprio serve, mas o instalador respondia
`Essa não é a URL do projeto Supabase. Ela termina em .supabase.co`. URL sem
`https://` continua recusada — e a mensagem dessa recusa agora fala dos dois
casos, em vez de mandar procurar um `.supabase.co` que não existe.

**2. `v_db_url` comparava o `<ref>` do projeto.** Isso só existe na nuvem, onde
o usuário do pooler é `postgres.<ref>`. Num Supabase próprio não há `<ref>`, e o
usuário pode ser qualquer role — inclusive a role dedicada que
`docs/deploy-selfhost/README.md` recomenda para o worker. A comparação passa a
acontecer só quando a URL é de fato da nuvem.

`v_sb_key` já era compatível e não foi tocada: a comparação de `<ref>` ali é
guardada por `[ -n "$ref" ]`, e chave de Supabase próprio não traz essa claim.

**3. `veredito_rede_do_proxy` só aprovava `bridge`.** Com Swarm, o Traefik é
serviço do Swarm e vive numa overlay. Uma overlay criada com `--attachable`
aceita contêiner de `docker compose` comum, que é o que a stack do CRM é. Sem o
`--attachable` a recusa continua, e continua certa: ali o `up` morreria em
`could not attach to network`. A mensagem de erro ganhou essa distinção, que é
acionável.

## Como foi testado

VPS Ubuntu 24.04, Swarm de nó único, Traefik como serviço do Swarm numa overlay
attachable, Supabase self-hosted (`supabase/docker-compose.yml`, v0.7.2) na
mesma máquina. `install.sh --yes` completo: 97 tabelas no schema, dono criado e
promovido, os 6 contêineres de pé, `/login` respondendo.

## Fora do escopo deste PR

Duas coisas que apareceram na mesma instalação e merecem tratamento próprio:

- **`install.sh` e `update.sh` usam o mesmo `SUPABASE_DB_URL` para instalar
  schema e para o app rodar.** São necessidades diferentes: `create extension` e
  o `baseline.sql` exigem o dono do banco, enquanto o app quer a role menor. Num
  Supabase da nuvem isso não aparece porque a connection string do pooler já é
  privilegiada; self-hosted obriga a trocar a role antes e depois, na mão.
- **O link do e-mail de redefinir senha aponta para `0.0.0.0:3000`.**
  `app/auth/confirm/route.ts` usa `new URL(path, url.origin)`, e em Next.js
  standalone `origin` é o endereço de bind, não o host público — acontece com
  qualquer proxy reverso na frente. Uma linha resolve
  (`process.env.NEXT_PUBLIC_APP_URL || url.origin`). Abro em separado se fizer
  sentido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)