### PR TITLE
fix(inbox): foto do contato refaz a rota inteira a cada render

### DIFF
--- a/app/api/v1/contacts/[id]/avatar/route.ts
+++ b/app/api/v1/contacts/[id]/avatar/route.ts
@@ -25,6 +25,25 @@ export const dynamic = "force-dynamic";
 /** Vida da URL assinada. Curta de propósito: se vazar, expira sozinha. */
 const SIGNED_TTL_SECONDS = 300;
 
+/**
+ * Quanto o browser guarda o próprio redirect.
+ *
+ * Sem isto a lista de conversas refazia a rota inteira — sessão, organização
+ * ativa, SELECT em `contacts` e `createSignedUrl` — uma vez por foto, a cada
+ * render. Com 39 contatos com foto numa instalação pequena isso é ~3s de
+ * trabalho de servidor por carga de lista, e o Realtime invalida a lista a cada
+ * mensagem que chega.
+ *
+ * `private` é obrigatório e não é detalhe: a autorização desta rota é por
+ * organização da sessão, então um cache compartilhado (CDN, proxy) que
+ * guardasse a resposta serviria o rosto de um contato para outro tenant.
+ *
+ * Tem que ser MENOR que SIGNED_TTL_SECONDS, senão o browser reusa um redirect
+ * que aponta para uma assinatura já vencida e a foto some. A folga de 60s cobre
+ * o caso de o redirect ser seguido no último instante da janela.
+ */
+const BROWSER_CACHE_SECONDS = 240;
+
 export async function GET(
   _req: NextRequest,
   ctx: { params: Promise<{ id: string }> },
@@ -63,5 +82,13 @@ export async function GET(
     return new Response(null, { status: 404 });
   }
 
-  return Response.redirect(signed.signedUrl, 307);
+  // Response.redirect() devolve headers imutáveis — não dá pra anexar o
+  // Cache-Control depois. Por isso o 307 é montado à mão.
+  return new Response(null, {
+    status: 307,
+    headers: {
+      Location: signed.signedUrl,
+      "Cache-Control": `private, max-age=${BROWSER_CACHE_SECONDS}`,
+    },
+  });
 }

--- a/tests/unit/contato-avatar-cache.test.ts
+++ b/tests/unit/contato-avatar-cache.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Cache do redirect da foto de perfil — GET /api/v1/contacts/{id}/avatar.
+ *
+ * A rota é chamada uma vez por contato COM foto a cada render da lista de
+ * conversas, e cada chamada custa sessão + organização ativa + SELECT em
+ * `contacts` + `createSignedUrl`. Sem `Cache-Control` o browser não guarda nada
+ * e a cadeia inteira se repete a cada refresh — medido em ~73ms de servidor por
+ * foto, ~3s por carga numa instalação com 39 contatos com foto.
+ *
+ * O que se prova aqui:
+ *  - o 307 carrega `Cache-Control` com `private` e um `max-age` positivo;
+ *  - `max-age` é MENOR que a vida da assinatura (senão o browser reusa um
+ *    redirect que aponta pra URL vencida e a foto some);
+ *  - `private` está presente — a autorização é por organização da sessão, e um
+ *    cache compartilhado serviria o rosto de um contato a outro tenant;
+ *  - o 404 de "sem foto"/anonimizado NÃO é cacheado: anonimização é irreversível
+ *    por contrato e não pode ficar presa num cache que a antecede.
+ *
+ * O client é falsificado; o handler roda de verdade.
+ */
+
+const SIGNED_URL = "https://storage.example/assinada?token=abc";
+
+let contatoRow: { avatar_storage_path: string | null; is_anonimizado: boolean } | null = null;
+let orgAtiva: { orgId: string } | null = { orgId: "org-1" };
+let erroDeAssinatura: { message: string } | null = null;
+
+// A assinatura tipada importa: o teste do TTL lê o 2º argumento que o handler
+// passou, e com `vi.fn(async () => ...)` esse índice não existe no tipo.
+const createSignedUrl = vi.fn(async (_caminho: string, _ttlSegundos: number) =>
+  erroDeAssinatura
+    ? { data: null, error: erroDeAssinatura }
+    : { data: { signedUrl: SIGNED_URL }, error: null },
+);
+
+/** Imita o query builder do PostgREST: encadeável, resolve no `maybeSingle()`. */
+function chain(): Record<string, unknown> {
+  const proxy: Record<string, unknown> = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === "maybeSingle" || prop === "single") {
+          return async () => ({
+            data: contatoRow
+              ? {
+                  avatar_storage_path: contatoRow.avatar_storage_path,
+                  is_anonymized: contatoRow.is_anonimizado,
+                }
+              : null,
+            error: null,
+          });
+        }
+        return () => proxy;
+      },
+    },
+  ) as Record<string, unknown>;
+  return proxy;
+}
+
+vi.mock("@/lib/auth/server", () => ({
+  loadAuthUser: async () => ({ id: "user-1" }),
+  resolveActiveOrg: async () => orgAtiva,
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: () => ({ select: () => chain() }),
+    storage: { from: () => ({ createSignedUrl }) },
+  }),
+}));
+
+const { GET } = await import("@/app/api/v1/contacts/[id]/avatar/route");
+
+function chamar(id = "contato-1") {
+  return GET({} as never, { params: Promise.resolve({ id }) });
+}
+
+describe("GET /api/v1/contacts/{id}/avatar — cache do redirect", () => {
+  beforeEach(() => {
+    contatoRow = { avatar_storage_path: "org-1/avatars/contato-1.jpg", is_anonimizado: false };
+    orgAtiva = { orgId: "org-1" };
+    erroDeAssinatura = null;
+    createSignedUrl.mockClear();
+  });
+
+  it("responde 307 para a URL assinada", async () => {
+    const res = await chamar();
+    expect(res.status).toBe(307);
+    expect(res.headers.get("Location")).toBe(SIGNED_URL);
+  });
+
+  it("manda Cache-Control — sem isso a lista refaz a rota inteira por foto a cada render", async () => {
+    const res = await chamar();
+    const cc = res.headers.get("Cache-Control");
+
+    expect(cc, "o 307 precisa de Cache-Control ou o browser não guarda nada").toBeTruthy();
+    expect(cc).toMatch(/max-age=\d+/);
+    expect(Number(/max-age=(\d+)/.exec(cc ?? "")?.[1])).toBeGreaterThan(0);
+  });
+
+  it("marca o cache como private — a autorização é por organização da sessão", async () => {
+    const res = await chamar();
+    const cc = res.headers.get("Cache-Control") ?? "";
+
+    expect(cc, "cache compartilhado serviria a foto de um tenant a outro").toContain("private");
+    expect(cc).not.toContain("public");
+  });
+
+  it("expira o cache ANTES da assinatura, senão o redirect guardado aponta pra URL vencida", async () => {
+    const res = await chamar();
+    const maxAge = Number(/max-age=(\d+)/.exec(res.headers.get("Cache-Control") ?? "")?.[1]);
+
+    // A vida da assinatura é o argumento passado ao createSignedUrl pelo próprio
+    // handler — lido dele, não copiado, para o teste não descolar da constante.
+    const ttlAssinatura = createSignedUrl.mock.calls[0]?.[1];
+
+    expect(ttlAssinatura, "o handler precisa ter assinado a URL").toBeDefined();
+    expect(ttlAssinatura ?? 0).toBeGreaterThan(0);
+    expect(maxAge).toBeLessThan(ttlAssinatura ?? 0);
+  });
+
+  it("não cacheia o 404 de contato sem foto", async () => {
+    contatoRow = { avatar_storage_path: null, is_anonimizado: false };
+    const res = await chamar();
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Cache-Control") ?? "").not.toMatch(/max-age=[1-9]/);
+  });
+
+  it("não cacheia o 404 de contato anonimizado — anonimização é irreversível", async () => {
+    contatoRow = { avatar_storage_path: "org-1/avatars/contato-1.jpg", is_anonimizado: true };
+    const res = await chamar();
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Cache-Control") ?? "").not.toMatch(/max-age=[1-9]/);
+  });
+
+  it("não cacheia quando a assinatura falha", async () => {
+    erroDeAssinatura = { message: "storage indisponível" };
+    const res = await chamar();
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Cache-Control") ?? "").not.toMatch(/max-age=[1-9]/);
+  });
+});


### PR DESCRIPTION
A rota do avatar (`GET /api/v1/contacts/{id}/avatar`, do #113) responde um 307 para a URL assinada — o desenho está certo: o browser baixa a imagem direto do Storage e o app não vira proxy de imagem na rolagem.

O que faltava é o redirect **em si** poder ser guardado. Ele saía sem `Cache-Control`, e com `dynamic = "force-dynamic"` o browser não guarda nada. Então a cada render da lista de conversas, **cada contato COM foto refaz a cadeia inteira**: sessão → organização ativa → `SELECT` em `contacts` → `createSignedUrl` → 307.

## Medido numa instalação real

```
custo de servidor por avatar: 235 73 52 80 56 73 115 222 49 71 60 48 ms   → mediana 73ms
39 contatos com foto  →  ~3s de trabalho de servidor acumulado por carga de lista
```

E o `useConversationsRealtime` invalida a lista inteira a cada mensagem que chega, então isso se repete o dia todo, não só no F5.

## A mudança

O 307 passa a levar `Cache-Control: private, max-age=240`.

Três decisões que o número esconde, e que ficaram documentadas na constante:

- **`private` não é detalhe.** A autorização desta rota é por organização da sessão. Um cache compartilhado (CDN, proxy da hospedagem — comum no self-host atrás de Traefik) que guardasse a resposta serviria o rosto de um contato para outro tenant.
- **240 < `SIGNED_TTL_SECONDS` (300) de propósito.** Se o `max-age` passasse da vida da assinatura, o browser reusaria um redirect apontando para uma URL já vencida e a foto sumiria. A folga de 60s cobre o redirect seguido no último instante da janela.
- **Os 404 continuam sem cache** — sem foto, anonimizado, e falha ao assinar. Anonimização é irreversível por contrato e não pode ficar presa atrás de um cache que a antecede.

`Response.redirect()` devolve headers imutáveis, então o 307 passa a ser montado à mão.

## Prova

`tests/unit/contato-avatar-cache.test.ts` — 7 casos. Verde não prova nada sozinho, então sabotei as três propriedades e confirmei vermelho:

| sabotagem | resultado |
|---|---|
| voltar ao `Response.redirect()` sem cache | **3 falham** |
| `public` no lugar de `private` | **1 falha** |
| `max-age=600` (acima do TTL da assinatura) | **1 falha** |
| restaurado | **7 passam** |

O teste do TTL lê o argumento que o handler passou ao `createSignedUrl` em vez de copiar a constante, para não descolar se ela mudar.

## Portões

```
typecheck       limpo
lint            0 erros
lint:channels   ok — nenhum arquivo novo sujo
test:unit       289 arquivos, 2962 testes
test:shell      ok
build           ok
```

Não toca schema — sem migration, sem apêndice no baseline.

## O que NÃO medi

O efeito no browser de verdade. O que está provado aqui é o contrato do header, não a melhora percebida com o Chrome carregando a lista. Quem rodar numa instalação com muitos contatos com foto vai ver melhor que eu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)