### PR TITLE
feat(inbox): colar imagem no composer com Ctrl+V

### DIFF
--- a/components/inbox/Composer.tsx
+++ b/components/inbox/Composer.tsx
@@ -1,5 +1,12 @@
 "use client";
-import { forwardRef, useImperativeHandle, useRef, useState, type KeyboardEvent } from "react";
+import {
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type ClipboardEvent,
+  type KeyboardEvent,
+} from "react";
 import { PaperPlaneTilt } from "@/lib/ui/icons";
 import { Button } from "@/components/ui/button";
 import { AttachMenu } from "@/components/inbox/composer/AttachMenu";
@@ -12,6 +19,7 @@ import { useCreateNote } from "@/hooks/inbox/useCreateNote";
 import { useMessageTemplates, type MessageTemplate } from "@/hooks/inbox/useMessageTemplates";
 import { useSendMessage } from "@/hooks/inbox/useSendMessage";
 import { useUploadMedia } from "@/hooks/inbox/useUploadMedia";
+import { imagemDoClipboard } from "@/lib/inbox/clipboard-image";
 import { interpolateTemplate } from "@/lib/inbox/template-vars";
 import { cn } from "@/lib/utils";
 
@@ -108,6 +116,25 @@ export const Composer = forwardRef<ComposerHandle, Props>(function Composer(
     });
   }
 
+  /**
+   * Ctrl/Cmd+V com imagem no clipboard cai no MESMO caminho do menu "+":
+   * abre o preview com legenda e envia por ali. Nada de atalho paralelo — a
+   * validação, o toast de erro e o retry já vivem lá.
+   *
+   * As três guardas antes de olhar o clipboard não são zelo: em "Nota interna"
+   * não existe anexo (a nota é só texto e o envio nem passa pelo upload), com
+   * um anexo já em preview a colagem substituiria em silêncio o que o operador
+   * escolheu, e desabilitado é desabilitado. Em qualquer um desses casos o
+   * Ctrl+V precisa continuar sendo o Ctrl+V de sempre.
+   */
+  function onPaste(e: ClipboardEvent<HTMLTextAreaElement>) {
+    if (mode !== "reply" || isDisabled || pendingFile) return;
+    const imagem = imagemDoClipboard(e.clipboardData, new Date());
+    if (!imagem) return; // colagem de texto segue o caminho normal do browser
+    e.preventDefault();
+    setPendingFile(imagem);
+  }
+
   function onKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key === "Escape" && menuOpen) {
       setMenuDismissed(true);
@@ -202,6 +229,7 @@ export const Composer = forwardRef<ComposerHandle, Props>(function Composer(
               autoresize();
             }}
             onKeyDown={onKeyDown}
+            onPaste={onPaste}
             rows={1}
             placeholder={
               mode === "note"

--- a/lib/inbox/clipboard-image.ts
+++ b/lib/inbox/clipboard-image.ts
@@ -1,0 +1,77 @@
+/**
+ * Imagem colada no composer (Ctrl/Cmd+V), padrão WhatsApp.
+ *
+ * A decisão de "isto é uma colagem de imagem ou de texto?" vive aqui, fora do
+ * componente, porque é a parte que erra: um handler que intercepta cedo demais
+ * quebra o Ctrl+V de texto — que é o uso comum do campo — e o defeito só
+ * aparece em produção, com o vendedor no meio de um atendimento.
+ *
+ * Regra: só é colagem de imagem quando existe MESMO um arquivo de imagem no
+ * clipboard. Copiar texto nunca produz arquivo, então texto continua passando
+ * direto pro browser.
+ */
+
+/** Extensão canônica por mime — espelha o mapa de `lib/messaging/media/types`. */
+const EXT_POR_MIME: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/gif": "gif",
+};
+
+function ehImagem(tipo: string | undefined): boolean {
+  return !!tipo && tipo.split(";")[0]!.trim().toLowerCase().startsWith("image/");
+}
+
+/**
+ * Extrai a imagem de um clipboard, ou `null` se não houver uma.
+ *
+ * Lê `files` E `items`: nem todo browser popula os dois. Chrome preenche
+ * `files` num print de tela; Firefox, em alguns casos, só expõe o `item` do
+ * tipo `file`. Ler apenas um deles faz a colagem "não funcionar" num browser
+ * e funcionar no outro — o tipo de bug que ninguém reproduz.
+ *
+ * @param carimbo instante usado para nomear o arquivo. Entra por parâmetro
+ *   para o teste ser determinístico: um print colado chega sem nome útil
+ *   ("image.png" em toda colagem), e um nome com horário é o que deixa o
+ *   anexo rastreável depois, na lista de mídia da conversa.
+ */
+export function imagemDoClipboard(dados: DataTransfer | null, carimbo: Date): File | null {
+  if (!dados) return null;
+
+  const daLista = Array.from(dados.files ?? []).find((f) => ehImagem(f.type));
+  const dosItens = daLista
+    ? null
+    : Array.from(dados.items ?? [])
+        .filter((i) => i.kind === "file" && ehImagem(i.type))
+        .map((i) => i.getAsFile())
+        .find((f): f is File => f !== null);
+
+  const arquivo = daLista ?? dosItens ?? null;
+  // Arquivo de 0 byte existe (colagem de uma referência que o browser não
+  // conseguiu materializar) e subiria só para o servidor recusar com
+  // "Arquivo vazio" — melhor tratar como "não havia imagem" e deixar o
+  // Ctrl+V seguir seu caminho normal.
+  if (!arquivo || arquivo.size <= 0) return null;
+
+  return new File([arquivo], nomeDaColagem(arquivo, carimbo), {
+    type: arquivo.type,
+    lastModified: arquivo.lastModified,
+  });
+}
+
+/**
+ * Nome para o arquivo colado.
+ *
+ * Preserva o nome quando ele existe e é real (arrastar/copiar um arquivo do
+ * sistema traz "orcamento.png"); só inventa quando o browser entregou o nome
+ * genérico de print de tela, que é o caso de toda colagem de captura.
+ */
+function nomeDaColagem(arquivo: File, carimbo: Date): string {
+  const generico = !arquivo.name || /^image\.[a-z0-9]+$/i.test(arquivo.name);
+  if (!generico) return arquivo.name;
+
+  const ext = EXT_POR_MIME[arquivo.type.split(";")[0]!.trim().toLowerCase()] ?? "png";
+  const iso = carimbo.toISOString().slice(0, 19).replace(/[:T]/g, "-");
+  return `imagem-colada-${iso}.${ext}`;
+}

--- a/tests/unit/composer-colar-imagem.test.tsx
+++ b/tests/unit/composer-colar-imagem.test.tsx
@@ -1,0 +1,168 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Colar imagem no composer (Ctrl/Cmd+V), padrão WhatsApp.
+ *
+ * A propriedade em disputa NÃO é "abre o preview" — é "abre o preview SEM
+ * quebrar o Ctrl+V de texto". Um handler que intercepta cedo demais transforma
+ * o campo de mensagem num campo onde colar texto não funciona, e isso é pior
+ * que não ter a funcionalidade. Por isso metade destes casos prova o que o
+ * handler tem que DEIXAR passar.
+ */
+
+const uploadResult = {
+  storage_path: "org/conv/out-1.png",
+  media_mime: "image/png",
+  media_size_bytes: 3,
+  kind: "image" as const,
+};
+const uploadMock = vi.fn(async () => uploadResult);
+const sendMock = vi.fn();
+
+vi.mock("@/hooks/inbox/useUploadMedia", () => ({
+  useUploadMedia: () => ({ mutateAsync: uploadMock, isPending: false }),
+}));
+vi.mock("@/hooks/inbox/useSendMessage", () => ({
+  useSendMessage: () => ({ mutate: sendMock, isPending: false }),
+}));
+
+import { Composer } from "@/components/inbox/Composer";
+import { imagemDoClipboard } from "@/lib/inbox/clipboard-image";
+
+const CARIMBO = new Date("2026-08-07T19:26:03.000Z");
+
+function png(nome = "image.png", bytes = [1, 2, 3], tipo = "image/png") {
+  return new File([new Uint8Array(bytes)], nome, { type: tipo });
+}
+
+/** Clipboard falso: só o que o handler lê. `files`/`items` são iteráveis. */
+function clipboard(opts: { files?: File[]; items?: unknown[]; texto?: string }) {
+  return {
+    files: opts.files ?? [],
+    items:
+      opts.items ??
+      (opts.texto !== undefined ? [{ kind: "string", type: "text/plain", getAsFile: () => null }] : []),
+    getData: () => opts.texto ?? "",
+  } as unknown as DataTransfer;
+}
+
+function renderComposer(props: Partial<React.ComponentProps<typeof Composer>> = {}) {
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <Composer conversationId="conv-1" {...props} />
+    </QueryClientProvider>,
+  );
+}
+
+const campo = () => screen.getByLabelText("Mensagem");
+
+describe("imagemDoClipboard", () => {
+  it("acha a imagem em `files` (Chrome num print de tela)", () => {
+    const r = imagemDoClipboard(clipboard({ files: [png()] }), CARIMBO);
+    expect(r).not.toBeNull();
+    expect(r!.type).toBe("image/png");
+  });
+
+  it("acha a imagem em `items` quando `files` vem vazio (Firefox)", () => {
+    const f = png();
+    const dt = clipboard({ items: [{ kind: "file", type: "image/png", getAsFile: () => f }] });
+    expect(imagemDoClipboard(dt, CARIMBO)).not.toBeNull();
+  });
+
+  it("devolve null para colagem de texto — é o que preserva o Ctrl+V normal", () => {
+    expect(imagemDoClipboard(clipboard({ texto: "orçamento 300 mil" }), CARIMBO)).toBeNull();
+  });
+
+  it("devolve null para arquivo que não é imagem", () => {
+    const pdf = new File([new Uint8Array([1])], "contrato.pdf", { type: "application/pdf" });
+    expect(imagemDoClipboard(clipboard({ files: [pdf] }), CARIMBO)).toBeNull();
+  });
+
+  it("devolve null para arquivo de 0 byte em vez de subir um vazio", () => {
+    expect(imagemDoClipboard(clipboard({ files: [png("image.png", [])] }), CARIMBO)).toBeNull();
+  });
+
+  it("devolve null quando não há clipboard", () => {
+    expect(imagemDoClipboard(null, CARIMBO)).toBeNull();
+  });
+
+  it("batiza o print com horário — todo print chega como 'image.png'", () => {
+    const r = imagemDoClipboard(clipboard({ files: [png("image.png")] }), CARIMBO);
+    expect(r!.name).toBe("imagem-colada-2026-08-07-19-26-03.png");
+  });
+
+  it("preserva o nome real quando o arquivo tem um", () => {
+    const r = imagemDoClipboard(clipboard({ files: [png("orcamento-final.png")] }), CARIMBO);
+    expect(r!.name).toBe("orcamento-final.png");
+  });
+
+  it("entende mime com parâmetro (image/png;charset=binary)", () => {
+    const r = imagemDoClipboard(clipboard({ files: [png("image.png", [1], "image/png;charset=binary")] }), CARIMBO);
+    expect(r).not.toBeNull();
+  });
+});
+
+describe("Composer — colar imagem", () => {
+  beforeEach(() => {
+    uploadMock.mockClear();
+    sendMock.mockClear();
+  });
+
+  it("colar imagem abre o preview e enviar dispara upload + send", async () => {
+    renderComposer();
+    fireEvent.paste(campo(), { clipboardData: clipboard({ files: [png()] }) });
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/legenda/i), { target: { value: "mirá esto" } });
+    fireEvent.click(screen.getByRole("button", { name: /^enviar$/i }));
+
+    await waitFor(() => expect(uploadMock).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(sendMock).toHaveBeenCalledWith(
+        expect.objectContaining({ conversation_id: "conv-1", type: "image", body: "mirá esto" }),
+        expect.anything(),
+      ),
+    );
+  });
+
+  it("colar TEXTO não abre preview e não cancela o paste do browser", () => {
+    renderComposer();
+    const seguiu = fireEvent.paste(campo(), { clipboardData: clipboard({ texto: "bom dia" }) });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(seguiu, "preventDefault aqui quebraria o Ctrl+V de texto").toBe(true);
+  });
+
+  it("em 'Nota interna' colar imagem não vira anexo — nota é só texto", () => {
+    renderComposer();
+    fireEvent.click(screen.getByRole("button", { name: /nota interna/i }));
+    const seguiu = fireEvent.paste(campo(), { clipboardData: clipboard({ files: [png()] }) });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(seguiu).toBe(true);
+  });
+
+  it("com anexo já em preview, colar não substitui em silêncio o que o operador escolheu", async () => {
+    renderComposer();
+    fireEvent.click(screen.getByRole("button", { name: /anexar/i }));
+    const inputDoc = document.querySelector('input[accept^=".pdf"]') as HTMLInputElement;
+    const doc = new File([new Uint8Array([1])], "contrato-assinado.pdf", { type: "application/pdf" });
+    fireEvent.change(inputDoc, { target: { files: [doc] } });
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("contrato-assinado.pdf")).toBeInTheDocument();
+
+    fireEvent.paste(campo(), { clipboardData: clipboard({ files: [png()] }) });
+
+    expect(screen.getByText("contrato-assinado.pdf")).toBeInTheDocument();
+  });
+
+  it("composer desabilitado ignora a colagem", () => {
+    renderComposer({ disabled: true });
+    fireEvent.paste(campo(), { clipboardData: clipboard({ files: [png()] }) });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Quem atende no WhatsApp tira print e cola. No composer não dava: era preciso salvar o arquivo, abrir o menu "+", achar a pasta e escolher — quatro passos para o que no WhatsApp é um atalho.

`Ctrl/Cmd+V` com imagem no clipboard passa a cair no **mesmo caminho do menu "+"**: abre o `AttachmentPreviewDialog` com legenda e envia por ali. Nada de atalho paralelo — validação, toast de erro e retry já vivem nesse caminho, e duplicá-los seria criar um segundo lugar para o mesmo defeito aparecer.

## A parte que erra não é abrir o preview

É **não quebrar o Ctrl+V de texto**, que é o uso comum do campo. Um handler afobado transforma a caixa de mensagem numa caixa onde colar texto não funciona, e isso é pior que não ter a funcionalidade.

Por isso a decisão de "isto é imagem ou texto?" saiu do componente para `lib/inbox/clipboard-image.ts`, onde dá pra testar sem DOM, e só intercepta quando existe **mesmo** um arquivo de imagem — copiar texto nunca produz arquivo.

Quatro detalhes que não são zelo:

- **Lê `files` E `items`.** Nem todo browser popula os dois: Chrome preenche `files` num print de tela; Firefox, em alguns casos, só expõe o item de `kind: "file"`. Ler um só faz a colagem "não funcionar" num browser e funcionar no outro — o bug que ninguém reproduz.
- **Arquivo de 0 byte vira `null`** em vez de subir. O servidor recusaria com "Arquivo vazio", e o certo é deixar o Ctrl+V seguir seu caminho normal.
- **Em "Nota interna" não intercepta** — nota é só texto e o envio nem passa pelo upload.
- **Com um anexo já em preview não intercepta** — substituir em silêncio o que o operador escolheu é pior que ignorar a colagem.

Print chega sem nome útil (`image.png` em toda colagem), então ganha horário: `imagem-colada-2026-08-07-19-26-03.png`. Nome real de arquivo copiado do sistema é preservado.

## Prova

`tests/unit/composer-colar-imagem.test.tsx` — 14 casos, **metade provando o que o handler tem que DEIXAR passar**. Verde não prova nada sozinho, então sabotei cada propriedade:

| sabotagem | resultado |
|---|---|
| tirar a guarda de "Nota interna" | **falha** |
| tirar a guarda de anexo já em preview | **falha** |
| tirar a guarda de `disabled` | **falha** |
| `preventDefault` incondicional (quebra o Ctrl+V de texto) | **falha** |
| ler só `files`, ignorar `items` (quebra Firefox) | **falha** |
| aceitar arquivo de 0 byte | **falha** |
| restaurado | **14 passam** |

## Portões

```
typecheck       limpo
lint            0 erros
lint:channels   ok — nenhum arquivo novo sujo
test:unit       288 arquivos, 2964 testes
build           ok
```

Não toca schema — sem migration, sem apêndice no baseline. Sem env var nova.

## O que NÃO provei

**Não rodei num browser de verdade.** Os 14 casos dirigem o componente real e o handler real, mas em jsdom com um clipboard falso — e clipboard é justamente onde os browsers divergem (é o motivo de o código ler `files` e `items`). O que está provado é a lógica de decisão e o encanamento até o preview; o que falta é a colagem de verdade, com um print de verdade, em Chrome/Firefox/Safari.

Automatizar isso no Playwright exige CDP para injetar imagem no clipboard, então não entra barato no CI. Se preferir, valido à mão nos três browsers e mando a evidência antes do merge — ou fica como está e quem rodar numa instalação real fecha essa lacuna.

Escopo deliberadamente limitado a **imagens**, que é o pedido comum. Estender pra qualquer arquivo é trocar um `startsWith("image/")` por uma checagem de mime suportado, mas interceptar colagem de arquivo arbitrário surpreende mais do que ajuda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)