### PR TITLE
fix(inbox): aba Minhas mostra tudo que o atendente já fechou

### DIFF
--- a/app/api/v1/conversations/_handler.ts
+++ b/app/api/v1/conversations/_handler.ts
@@ -8,6 +8,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { ApiError } from "@/lib/api/types";
 import type { Actor, HandlerCtx } from "@/lib/api/handlers/types";
 import { audit } from "@/lib/audit";
+import { CONVERSATION_TERMINAL_STATUSES } from "@/lib/schemas";
 import type {
   ListConversationsQuery,
   PatchConversationInput,
@@ -99,6 +100,12 @@ export async function listConversationsHandler(
     .limit(q.limit + 1);
 
   if (q.status) query = query.eq("status", q.status);
+  // Depois do `status` de propósito: pedir um status terminal E `exclude_finished`
+  // é contradição, e a resposta certa para uma contradição é lista vazia — não
+  // um dos dois lados escolhido em silêncio.
+  if (q.exclude_finished) {
+    query = query.not("status", "in", `(${CONVERSATION_TERMINAL_STATUSES.join(",")})`);
+  }
   if (q.channel_session_id) query = query.eq("channel_session_id", q.channel_session_id);
   if (q.tag) query = query.contains("tags", [q.tag]); // tags @> array[tag] (GIN)
 

--- a/app/api/v1/conversations/counts/route.ts
+++ b/app/api/v1/conversations/counts/route.ts
@@ -10,6 +10,7 @@ import { randomUUID } from "node:crypto";
 
 import { fail, ok } from "@/lib/api/wrappers";
 import { loadAuthUser, resolveActiveOrg } from "@/lib/auth/server";
+import { CONVERSATION_TERMINAL_STATUSES } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -40,10 +41,16 @@ export async function GET(): Promise<Response> {
       .eq("organization_id", org);
 
   // Espelha tabToFilter (InboxLayout): unassigned = fila aberta sem dono;
-  // mine = atribuídas a mim; all = tudo que o usuário VÊ (RLS-scoped).
+  // mine = atribuídas a mim e ainda ABERTAS; all = tudo que o usuário VÊ.
+  //
+  // O `not in (terminais)` do `mine` espelha o `exclude_finished` da aba, e o
+  // espelhamento é o ponto: um badge que conta o que a aba não mostra é pior
+  // que badge nenhum — manda o atendente procurar um trabalho que não existe.
   const [unassigned, mine, all] = await Promise.all([
     countExact().is("assigned_to_user_id", null).eq("status", "open"),
-    countExact().eq("assigned_to_user_id", user.id),
+    countExact()
+      .eq("assigned_to_user_id", user.id)
+      .not("status", "in", `(${CONVERSATION_TERMINAL_STATUSES.join(",")})`),
     countExact(),
   ]);
 

--- a/app/api/v1/conversations/route.ts
+++ b/app/api/v1/conversations/route.ts
@@ -35,6 +35,7 @@ export async function GET(req: NextRequest): Promise<Response> {
   const url = new URL(req.url);
   const qsParsed = listConversationsQuerySchema.safeParse({
     status: url.searchParams.get("status") ?? undefined,
+    exclude_finished: url.searchParams.get("exclude_finished") === "true" ? true : undefined,
     assigned_to: url.searchParams.get("assigned_to") ?? undefined,
     channel_session_id: url.searchParams.get("channel_session_id") ?? undefined,
     search: url.searchParams.get("search") ?? undefined,

--- a/components/inbox/InboxLayout.tsx
+++ b/components/inbox/InboxLayout.tsx
@@ -20,12 +20,20 @@ import { CRMSidePanel } from "./CRMSidePanel";
 import { InboxKeyboardShortcuts } from "./InboxKeyboardShortcuts";
 import { ShortcutsHelpDialog } from "./ShortcutsHelpDialog";
 
-function tabToFilter(tab: InboxFiltersValue["tab"]): Partial<ConversationsFilters> {
+/**
+ * O QUE CADA ABA SIGNIFICA. Exportada porque é a definição em si — o defeito
+ * que este mapa já teve (Minhas mostrando tudo que o atendente fechou) não
+ * aparece em nenhuma tela até alguém reclamar, então vale prender por teste.
+ */
+export function tabToFilter(tab: InboxFiltersValue["tab"]): Partial<ConversationsFilters> {
   switch (tab) {
     case "unassigned":
       return { assigned_to: "unassigned", status: "open" };
     case "mine":
-      return { assigned_to: "me" };
+      // Sem `exclude_finished` a aba mostra tudo que o atendente JÁ atendeu —
+      // `Fechar` muda o status mas não solta o dono (de propósito: quem atendeu
+      // é histórico). O lugar de "minhas fechadas" é a aba Fechadas.
+      return { assigned_to: "me", exclude_finished: true };
     case "closed":
       return { status: "closed" };
     case "ai":

--- a/hooks/inbox/useConversationsRealtime.ts
+++ b/hooks/inbox/useConversationsRealtime.ts
@@ -33,6 +33,8 @@ export type ConversationWithContact = Conversation & {
 
 export interface ConversationsFilters {
   status?: "open" | "claimed" | "ai_handling" | "closed" | "archived";
+  /** Esconde fechadas/arquivadas — ver `exclude_finished` no schema da rota. */
+  exclude_finished?: boolean;
   assigned_to?: "me" | "unassigned" | string;
   search?: string;
   channel_session_id?: string;
@@ -57,6 +59,7 @@ export function useConversationsRealtime(
     queryFn: async ({ pageParam }) => {
       const qs = new URLSearchParams();
       if (filters.status) qs.set("status", filters.status);
+      if (filters.exclude_finished) qs.set("exclude_finished", "true");
       if (filters.assigned_to) qs.set("assigned_to", filters.assigned_to);
       if (filters.search) qs.set("search", filters.search);
       if (filters.channel_session_id) qs.set("channel_session_id", filters.channel_session_id);

--- a/lib/schemas/messaging.ts
+++ b/lib/schemas/messaging.ts
@@ -115,8 +115,26 @@ export const patchConversationSchema = z
 
 export type PatchConversationInput = z.infer<typeof patchConversationSchema>;
 
+/**
+ * Estados TERMINAIS: a conversa acabou e não volta sozinha.
+ *
+ * Vive aqui, e não espalhado em cada `.not(...)`, porque "acabou" é uma decisão
+ * de produto — se um dia `resolved` deixar de ser legado e passar a valer, o
+ * lugar de dizer isso é um só.
+ */
+export const CONVERSATION_TERMINAL_STATUSES = ["closed", "archived"] as const;
+
 export const listConversationsQuerySchema = z.object({
   status: conversationStatusSchema.optional(),
+  /**
+   * Esconde as conversas terminais (fechada/arquivada).
+   *
+   * Existe porque "Minhas" filtrava SÓ por dono e `Fechar` não solta o dono
+   * (de propósito: quem atendeu é histórico que vale). Sem isto, tudo que o
+   * atendente já fechou ficava na aba dele para sempre, e ela deixava de
+   * significar "meu trabalho" para virar "tudo que já toquei".
+   */
+  exclude_finished: z.boolean().optional(),
   assigned_to: z.union([z.string().uuid(), z.literal("me"), z.literal("unassigned")]).optional(),
   channel_session_id: z.string().uuid().optional(),
   tag: conversationTagSchema.optional(),

--- a/tests/unit/inbox-aba-minhas-encanamento.test.tsx
+++ b/tests/unit/inbox-aba-minhas-encanamento.test.tsx
@@ -1,0 +1,105 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * O encanamento de `exclude_finished`, ponta a ponta.
+ *
+ * `inbox-aba-minhas-sem-fechadas.test.ts` prova as duas pontas — o significado
+ * da aba e o predicado SQL. Este arquivo prova os dois elos DO MEIO, que são os
+ * que somem sem barulho: o hook precisa mandar o parâmetro na query string, e a
+ * rota precisa lê-lo da URL.
+ *
+ * Não é zelo: a rota já tem um caso vivo desse esquecimento — o filtro por
+ * `tag` é serializado pelo hook e implementado pelo handler, mas a rota nunca o
+ * lê de `searchParams`, então escolher uma tag na tela não filtra nada. Um
+ * parâmetro que atravessa três arquivos precisa de teste nos três.
+ */
+
+// Tipado com a URL: o teste lê o 1º argumento, e `(...a: unknown[])` o esconde.
+const getSpy = vi.fn(async (_url: string) => ({ data: [], meta: { has_more: false, cursor: null } }));
+vi.mock("@/lib/api/client", () => ({ apiClient: { get: (url: string) => getSpy(url) } }));
+vi.mock("@/components/feedback/ApiErrorToast", () => ({ showApiError: vi.fn() }));
+vi.mock("@/lib/supabase/browser", () => ({
+  createClient: () => ({
+    channel: () => ({ on: () => ({ subscribe: () => ({}) }), subscribe: () => ({}) }),
+    removeChannel: () => {},
+  }),
+}));
+
+import { useConversationsRealtime } from "@/hooks/inbox/useConversationsRealtime";
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+/** A URL que o hook pediu. */
+async function urlPedida(filtros: Parameters<typeof useConversationsRealtime>[0]) {
+  renderHook(() => useConversationsRealtime(filtros, "org-1"), { wrapper });
+  await waitFor(() => expect(getSpy).toHaveBeenCalled());
+  return getSpy.mock.calls.at(-1)?.[0] ?? "";
+}
+
+describe("elo do meio 1 — o hook serializa", () => {
+  beforeEach(() => getSpy.mockClear());
+
+  it("manda exclude_finished=true quando a aba pede", async () => {
+    expect(await urlPedida({ assigned_to: "me", exclude_finished: true })).toContain(
+      "exclude_finished=true",
+    );
+  });
+
+  it("NÃO manda nada quando a aba não pede", async () => {
+    expect(await urlPedida({ assigned_to: "me" })).not.toContain("exclude_finished");
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+// Tipado com os 3 parâmetros reais: o teste lê o 3º (o `q` montado pela rota),
+// e com `(...a: unknown[])` esse índice não existe no tipo.
+const handlerSpy = vi.fn(
+  async (_sb: unknown, _ctx: unknown, _q: Record<string, unknown>) => ({
+    conversations: [],
+    cursor: null,
+    has_more: false,
+  }),
+);
+vi.mock("@/app/api/v1/conversations/_handler", () => ({
+  listConversationsHandler: (sb: unknown, ctx: unknown, q: Record<string, unknown>) =>
+    handlerSpy(sb, ctx, q),
+}));
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: { id: "user-1" } }, error: null }) },
+  }),
+}));
+vi.mock("@/lib/auth/server", () => ({
+  loadAuthUser: async () => ({ id: "user-1" }),
+  resolveActiveOrg: async () => ({ orgId: "org-1" }),
+}));
+
+const { GET } = await import("@/app/api/v1/conversations/route");
+
+/** O `q` com que a rota chamou o handler. */
+async function queryRecebida(qs: string) {
+  handlerSpy.mockClear();
+  await GET(new Request(`http://localhost/api/v1/conversations?${qs}`) as never);
+  return handlerSpy.mock.calls.at(-1)?.[2] ?? {};
+}
+
+describe("elo do meio 2 — a rota lê da URL", () => {
+  it("exclude_finished=true chega ao handler", async () => {
+    expect((await queryRecebida("assigned_to=me&exclude_finished=true")).exclude_finished).toBe(true);
+  });
+
+  it("sem o parâmetro, o handler não recebe o filtro", async () => {
+    expect((await queryRecebida("assigned_to=me")).exclude_finished).toBeUndefined();
+  });
+
+  it("só a string 'true' liga — 'false' não pode ligar por ser não-vazia", async () => {
+    expect((await queryRecebida("exclude_finished=false")).exclude_finished).toBeUndefined();
+    expect((await queryRecebida("exclude_finished=0")).exclude_finished).toBeUndefined();
+  });
+});

--- a/tests/unit/inbox-aba-minhas-sem-fechadas.test.ts
+++ b/tests/unit/inbox-aba-minhas-sem-fechadas.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * A aba "Minhas" não pode mostrar o que o atendente já fechou.
+ *
+ * O defeito era a soma de duas decisões que, isoladas, estão certas: a aba
+ * filtrava SÓ por dono, e `Fechar` muda o status mas não solta o dono — de
+ * propósito, porque quem atendeu é histórico que vale para auditoria e métrica.
+ * Juntas, faziam a aba acumular para sempre tudo que a pessoa já atendeu, e o
+ * badge contar um trabalho que não existe mais.
+ *
+ * A correção é na VISTA, não no dado: `exclude_finished` esconde os estados
+ * terminais. As fechadas continuam existindo, com dono, na aba Fechadas.
+ *
+ * Os três elos da corrente são provados separados porque quebram separados:
+ * o significado da aba, a serialização para a query string, e o predicado SQL.
+ */
+
+import { listConversationsHandler } from "@/app/api/v1/conversations/_handler";
+import { tabToFilter } from "@/components/inbox/InboxLayout";
+import { CONVERSATION_TERMINAL_STATUSES, listConversationsQuerySchema } from "@/lib/schemas";
+
+// ---------------------------------------------------------------------------
+// elo 1 — o significado da aba
+// ---------------------------------------------------------------------------
+
+describe("tabToFilter — o que cada aba significa", () => {
+  it("Minhas pede as minhas SEM as terminais", () => {
+    expect(tabToFilter("mine")).toEqual({ assigned_to: "me", exclude_finished: true });
+  });
+
+  it("Fechadas continua mostrando as fechadas — senão não sobra onde vê-las", () => {
+    expect(tabToFilter("closed")).toEqual({ status: "closed" });
+  });
+
+  it("as outras abas não ganham o filtro de tabela", () => {
+    expect(tabToFilter("unassigned").exclude_finished).toBeUndefined();
+    expect(tabToFilter("all").exclude_finished).toBeUndefined();
+    expect(tabToFilter("ai").exclude_finished).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// elo 2 — a query string
+// ---------------------------------------------------------------------------
+
+describe("schema da rota", () => {
+  it("aceita exclude_finished", () => {
+    const r = listConversationsQuerySchema.safeParse({ exclude_finished: true });
+    expect(r.success).toBe(true);
+    expect(r.success && r.data.exclude_finished).toBe(true);
+  });
+
+  it("sem o parâmetro, fica indefinido — nenhuma aba herda o filtro sem pedir", () => {
+    const r = listConversationsQuerySchema.safeParse({});
+    expect(r.success && r.data.exclude_finished).toBeUndefined();
+  });
+
+  it("os estados terminais são fechada e arquivada", () => {
+    expect([...CONVERSATION_TERMINAL_STATUSES]).toEqual(["closed", "archived"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// elo 3 — o predicado SQL
+// ---------------------------------------------------------------------------
+
+/** Registra a cadeia do PostgREST; resolve como lista vazia no `await`. */
+function fakeSupabase() {
+  const chamadas: { metodo: string; args: unknown[] }[] = [];
+  const proxy: Record<string, unknown> = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === "then") {
+          return (ok: (v: unknown) => unknown) => ok({ data: [], error: null });
+        }
+        return (...args: unknown[]) => {
+          chamadas.push({ metodo: String(prop), args });
+          return proxy;
+        };
+      },
+    },
+  ) as Record<string, unknown>;
+  return { client: { from: () => proxy } as never, chamadas };
+}
+
+const ctx = {
+  organization_id: "org-1",
+  requestId: "req-1",
+  actor: { type: "user" as const, id: "user-1" },
+} as never;
+
+async function rodar(q: Record<string, unknown>) {
+  const { client, chamadas } = fakeSupabase();
+  await listConversationsHandler(client, ctx, { limit: 50, ...q } as never);
+  return chamadas;
+}
+
+/** O `.not("status","in","(closed,archived)")` que esconde as terminais. */
+const temNotTerminal = (chamadas: { metodo: string; args: unknown[] }[]) =>
+  chamadas.some(
+    (c) =>
+      c.metodo === "not" &&
+      c.args[0] === "status" &&
+      c.args[1] === "in" &&
+      String(c.args[2]).includes("closed") &&
+      String(c.args[2]).includes("archived"),
+  );
+
+describe("listConversationsHandler — predicado", () => {
+  it("com exclude_finished, exclui as terminais no BANCO (não na tela)", async () => {
+    expect(temNotTerminal(await rodar({ assigned_to: "me", exclude_finished: true }))).toBe(true);
+  });
+
+  it("sem exclude_finished, NÃO exclui nada — Todas e Fechadas seguem inteiras", async () => {
+    expect(temNotTerminal(await rodar({ assigned_to: "me" }))).toBe(false);
+    expect(temNotTerminal(await rodar({ status: "closed" }))).toBe(false);
+  });
+
+  it("status terminal + exclude_finished aplica os DOIS: contradição devolve vazio", async () => {
+    const chamadas = await rodar({ status: "closed", exclude_finished: true });
+    expect(chamadas.some((c) => c.metodo === "eq" && c.args[0] === "status")).toBe(true);
+    expect(temNotTerminal(chamadas)).toBe(true);
+  });
+
+  it("continua filtrando por organização — o filtro novo não desloca o de tenant", async () => {
+    const chamadas = await rodar({ assigned_to: "me", exclude_finished: true });
+    expect(
+      chamadas.some((c) => c.metodo === "eq" && c.args[0] === "organization_id" && c.args[1] === "org-1"),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// o badge tem que espelhar a aba
+// ---------------------------------------------------------------------------
+
+describe("contador de Minhas", () => {
+  it("usa o mesmo conjunto de estados terminais que a aba", async () => {
+    // Lê a fonte da rota de counts em vez de repetir a string: o que quebra
+    // aqui é o badge e a aba discordarem, e um literal duplicado no teste
+    // esconderia exatamente isso.
+    const { readFileSync } = await import("node:fs");
+    const fonte = readFileSync("app/api/v1/conversations/counts/route.ts", "utf8");
+
+    expect(fonte).toContain("CONVERSATION_TERMINAL_STATUSES");
+    expect(fonte).toMatch(/assigned_to_user_id[\s\S]{0,200}not\(\s*"status"\s*,\s*"in"/);
+  });
+});
+
+vi.resetModules();


### PR DESCRIPTION
A aba "Minhas" filtra **só por dono** ([`InboxLayout.tsx`](https://github.com/melgarafael/DeskcommCRM/blob/main/components/inbox/InboxLayout.tsx#L29)), e `Fechar` muda o status **sem soltar o dono** ([`close/route.ts`](https://github.com/melgarafael/DeskcommCRM/blob/main/app/api/v1/conversations/%5Bid%5D/close/route.ts#L42)).

Isoladas, as duas decisões estão certas — quem atendeu é histórico que vale para auditoria e métrica por atendente. Juntas, fazem a aba acumular para sempre tudo que a pessoa já atendeu: ela deixa de significar *meu trabalho* e vira *tudo que já toquei*.

## Numa instalação real

```
👀                | status: closed  | dono: eu
Diego Pani        | status: closed  | dono: eu
Silvia Martinez   | status: claimed | dono: eu
Patty             | status: claimed | dono: eu
```

Badge **"Minhas 4"** com 2 conversas vivas. O atendente abre a aba procurando o que fazer e encontra conversas encerradas misturadas com as abertas, sem nada na tela dizendo por quê. Foi assim que apareceu: *"por que essa conversa fechada continua aí?"*

## A correção é na VISTA, não no dado

`exclude_finished` esconde os estados terminais, e a aba Minhas passa a pedi-lo. `Fechar` continua sem soltar o dono. As fechadas continuam existindo, com dono, na aba Fechadas — que é onde a pessoa espera achá-las.

O **contador de `/counts` ganha o mesmo predicado**. O espelhamento é o ponto: badge que conta o que a aba não mostra é pior que badge nenhum, porque manda o atendente procurar um trabalho que não existe.

`CONVERSATION_TERMINAL_STATUSES` vive no schema, e não espalhado em cada `.not(...)`: "acabou" é decisão de produto, e se um dia `resolved` deixar de ser legado, o lugar de dizer isso é um só.

Ordem importa: o `exclude_finished` é aplicado **depois** do `status`. Pedir um status terminal E `exclude_finished` é contradição, e a resposta certa para contradição é lista vazia — não um dos dois lados escolhido em silêncio.

## Por que teste nos QUATRO elos

O parâmetro atravessa aba → hook → rota → handler. A rota já tem um caso vivo desse esquecimento: **o filtro por `tag` é serializado pelo hook e implementado pelo handler, mas nunca lido de `searchParams`** — então escolher uma tag na tela não filtra nada, e o React Query refaz o fetch, o que faz parecer que funcionou. Não quis repetir o mesmo buraco.

`tabToFilter` passa a ser exportada: é a definição do que cada aba significa, e um defeito nesse mapa não aparece em tela nenhuma até alguém reclamar.

## Prova

16 casos em dois arquivos. Verde não prova nada sozinho, então sabotei cada elo:

| sabotagem | resultado |
|---|---|
| aba Minhas deixa de pedir o filtro | **falha** |
| hook deixa de serializar o parâmetro | **falha** |
| rota deixa de ler da URL (o bug que `tag` já tem) | **falha** |
| handler deixa de aplicar o predicado SQL | **falha** |
| contador deixa de espelhar a aba | **falha** |
| restaurado | **16 passam** |

## Portões

```
typecheck       limpo
lint            0 erros
lint:channels   ok — nenhum arquivo novo sujo
test:unit       289 arquivos, 2966 testes
build           ok
```

Não toca schema — sem migration, sem apêndice no baseline. Sem env var nova.

## O que NÃO provei

**Não rodei `pnpm test:db`** — não tenho Docker nesta máquina. A mudança não toca schema nem RLS, então não deveria alcançá-lo, mas é um portão que não passei e prefiro dizer.

Também não validei pela tela depois da correção: o número acima (`Minhas 4` com 2 vivas) é de ANTES, medido no banco. O que está provado é o predicado e o encanamento.

## Fica em aberto

O filtro por `tag` continua quebrado — mesma rota, mesma classe de defeito. Não entrou aqui para o PR não virar duas coisas, mas mando em seguida se fizer sentido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)