### PR TITLE
fix(kit): instalador aceita Supabase self-hosted e overlay do Swarm (reconciliação do #188)

### DIFF
--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -75,6 +75,11 @@ veredito_rede_do_proxy() {  # veredito_rede_do_proxy <driver encontrado> <rede> 
     printf 'inexistente'; return 0
   fi
   [ "$drv" = bridge ] && { printf 'ok'; return 0; }
+  # $4 = "true" quando a rede é uma overlay attachable (Swarm). Contêiner de
+  # compose comum entra numa dessas, então ela serve tão bem quanto uma bridge.
+  # Sem o attachable a recusa continua: ali o `up` morreria em
+  # "could not attach to network".
+  [ "$drv" = overlay ] && [ "${4:-}" = true ] && { printf 'ok'; return 0; }
   printf 'driver_errado'
 }
 
@@ -93,7 +98,9 @@ garantir_rede_do_proxy() {
   nossa="$(rede_reservada_do_proxy)"
   TRAEFIK_NETWORK="${TRAEFIK_NETWORK:-traefik}"
   drv="$(docker network inspect -f '{{.Driver}}' "$TRAEFIK_NETWORK" 2>/dev/null || true)"
-  case "$(veredito_rede_do_proxy "$drv" "$TRAEFIK_NETWORK" "$nossa")" in
+  local att
+  att="$(docker network inspect -f '{{.Attachable}}' "$TRAEFIK_NETWORK" 2>/dev/null || true)"
+  case "$(veredito_rede_do_proxy "$drv" "$TRAEFIK_NETWORK" "$nossa" "$att")" in
   ok) : ;;
   criar)
     # O motivo vai junto porque aqui NÃO se sabe qual é: o comando está certo, e
@@ -120,7 +127,9 @@ TRAEFIK_NETWORK=<nome> no .env antes de tentar de novo."
 de uma bridge para o Traefik alcançar o contêiner. Se o seu Traefik roda em modo
 host (é o caso quando 'docker ps' não mostra porta publicada nele), APAGUE a linha
 TRAEFIK_NETWORK do .env: o kit cria e usa a rede '$nossa'.
-Senão, rode 'docker network ls' e ponha a bridge certa em TRAEFIK_NETWORK no .env."
+Senão, rode 'docker network ls' e ponha a bridge certa em TRAEFIK_NETWORK no .env.
+Se for uma overlay do Swarm, ela precisa ter sido criada com --attachable —
+sem isso um contêiner de compose comum não consegue entrar nela."
     ;;
   esac
 }

--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -68,7 +68,7 @@ rede_reservada_do_proxy() { printf '%s_proxy' "$(nome_do_projeto_atual)"; }
 # instalação nova, ou alguém que rodou `docker network prune`. Aí a resposta é
 # criar, não morrer: o nome é nosso e sabemos a forma dele.
 # Ecoa: ok | criar | inexistente | driver_errado
-veredito_rede_do_proxy() {  # veredito_rede_do_proxy <driver encontrado> <rede> <bridge do projeto>
+veredito_rede_do_proxy() {  # veredito_rede_do_proxy <driver encontrado> <rede> <bridge do projeto> [attachable]
   local drv="${1:-}" rede="${2:-}" nossa="${3:-}"
   if [ -z "$drv" ]; then
     [ -n "$nossa" ] && [ "$rede" = "$nossa" ] && { printf 'criar'; return 0; }

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -188,8 +188,12 @@ v_email() {
 v_supabase_url() {
   case "$1" in
     https://*.supabase.co) ;;
+    # Supabase SELF-HOSTED (ex.: https://db-crm.exemplo.com.br). A prova é a
+    # chamada a /auth/v1/health logo abaixo, que vale para qualquer host — o
+    # que se dispensa aqui é só a suposição de que todo Supabase é o da nuvem.
+    https://*) ;;
     *supabase.co*) echo "Cole a URL completa, começando com https:// — ex.: https://abcdefgh.supabase.co"; return 1;;
-    *) echo "Essa não é a URL do projeto Supabase. Ela termina em .supabase.co e fica em Settings > API > Project URL."; return 1;;
+    *) echo "A URL precisa começar com https://. Na nuvem ela fica em Settings > API > Project URL (termina em .supabase.co); num Supabase próprio, é o endereço do seu servidor."; return 1;;
   esac
   local code
   code="$(curl -s -o /dev/null -w '%{http_code}' -m 15 "$1/auth/v1/health" 2>/dev/null || echo 000)"
@@ -261,11 +265,14 @@ v_db_url() {
   esac
   # Mesma família de projeto? (usuário do pooler é 'postgres.<ref>')
   local dbref="${1#*://}"; dbref="${dbref%%:*}"; dbref="${dbref#postgres.}"
-  if [ -n "${NEXT_PUBLIC_SUPABASE_URL:-}" ] && [ "$dbref" != "postgres" ] \
-     && [ "$dbref" != "$(sb_ref "$NEXT_PUBLIC_SUPABASE_URL")" ]; then
-    echo "Essa connection string é do projeto '${dbref}', mas a URL que você deu é do projeto '$(sb_ref "$NEXT_PUBLIC_SUPABASE_URL")'. Precisam ser o mesmo projeto."
-    return 1
-  fi
+  case "${NEXT_PUBLIC_SUPABASE_URL:-}" in
+    *.supabase.co)
+      if [ "$dbref" != "postgres" ] \
+         && [ "$dbref" != "$(sb_ref "$NEXT_PUBLIC_SUPABASE_URL")" ]; then
+        echo "Essa connection string é do projeto '${dbref}', mas a URL que você deu é do projeto '$(sb_ref "$NEXT_PUBLIC_SUPABASE_URL")'. Precisam ser o mesmo projeto."
+        return 1
+      fi;;
+  esac
   local out
   if out="$(docker run --rm postgres:17-alpine psql "$1" -tAc 'select 1' 2>&1)"; then
     return 0

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -265,7 +265,16 @@ v_db_url() {
   esac
   # Mesma família de projeto? (usuário do pooler é 'postgres.<ref>')
   local dbref="${1#*://}"; dbref="${dbref%%:*}"; dbref="${dbref#postgres.}"
-  case "${NEXT_PUBLIC_SUPABASE_URL:-}" in
+  # Só a NUVEM tem <ref> a comparar. E a decisão é pelo HOST, nunca pela string
+  # inteira: `case "$url" in *.supabase.co)` só casa quando a URL TERMINA nisso, e
+  # ela chega com barra final, caminho ou espaço colado — é o que o address bar do
+  # navegador entrega. Medido: com `https://<ref>.supabase.co/` a comparação era
+  # pulada e uma connection string de OUTRO projeto passava, o que instala o
+  # baseline.sql num banco e deixa o app falando com outro.
+  local sbhost="${NEXT_PUBLIC_SUPABASE_URL:-}"
+  sbhost="${sbhost#*://}"; sbhost="${sbhost%%/*}"
+  sbhost="${sbhost%%[[:space:]]*}"; sbhost="${sbhost%%:*}"
+  case "$sbhost" in
     *.supabase.co)
       if [ "$dbref" != "postgres" ] \
          && [ "$dbref" != "$(sb_ref "$NEXT_PUBLIC_SUPABASE_URL")" ]; then

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -80,6 +80,54 @@ echo "e-mail"
 ok "aceita e-mail válido"     pass   v_email "voce@empresa.com.br"
 ok "rejeita sem @"            reject v_email "voce.empresa.com.br"          "inválido"
 
+echo "URL do Supabase: a da nuvem E a de um Supabase próprio"
+# O gate de formato exigia `.supabase.co` e matava quem roda Supabase
+# self-hosted com a frase "Ela termina em .supabase.co" — recusa do dado CERTO, e
+# sem saída nenhuma: não existe o que digitar que passe. Agora o formato só exige
+# https://, e a mensagem de recusa precisa ensinar os DOIS casos, senão ela
+# recria o mesmo beco em prosa.
+#
+# FRONTEIRA (o cabeçalho deste arquivo): aqui se mede só o `case` de formato. A
+# chamada a /auth/v1/health é dublada, porque prender esta suíte a DNS é trocar
+# um teste por um oráculo. O que aquela chamada prova de fato — e o que ela NÃO
+# prova — é medição de instalação real; ver o relatório da triagem.
+sburl_ok() {  # sburl_ok <descrição> <pass|reject> <url> [trecho esperado]...
+  local desc="$1" expect="$2" url="$3" out rc want
+  shift 3
+  out="$(bash -c '
+      INSTALL_SH_LIB=1 . ./install.sh
+      set +e
+      # Só o formato está sob teste: para o dublê, a rede responde 200 a todos.
+      curl() { printf 200; }
+      v_supabase_url "$1"' _ "$url" 2>&1)"; rc=$?
+  if [ "$expect" = pass ]; then
+    if [ $rc -eq 0 ]; then printf '  ✓ %s\n' "$desc"
+    else printf '  ✗ %s  (esperava aceitar, rejeitou: %s)\n' "$desc" "$(printf '%s' "$out" | head -1)"; fail=1; fi
+    return
+  fi
+  if [ $rc -eq 0 ]; then printf '  ✗ %s  (esperava rejeitar, aceitou)\n' "$desc"; fail=1; return; fi
+  for want in "$@"; do
+    if ! printf '%s' "$out" | grep -qi -- "$want"; then
+      printf '  ✗ %s  (rejeitou, mas a mensagem não fala de: %s)\n     disse: %s\n' \
+        "$desc" "$want" "$(printf '%s' "$out" | head -1)"; fail=1; return
+    fi
+  done
+  printf '  ✓ %s\n' "$desc"
+}
+sburl_ok "aceita a URL da nuvem"                pass   "https://abcdefghijklmnop.supabase.co"
+# ESTE é o caso que não existia: Supabase próprio, host que não tem .supabase.co.
+sburl_ok "aceita Supabase próprio (self-hosted)" pass  "https://db-crm.exemplo.com.br"
+sburl_ok "aceita host sem ponto (Supabase na rede interna)" pass "https://supabase-interno"
+# Sem https:// continua sendo recusa — é o que quebra o curl logo abaixo, e o
+# caso do `.supabase.co` colado sem esquema tem mensagem própria, mais específica.
+sburl_ok "rejeita .supabase.co colado sem esquema" reject "abcdefghijklmnop.supabase.co" "https://"
+sburl_ok "rejeita http:// (sem TLS)"               reject "http://db-crm.exemplo.com.br" "https://"
+# A mensagem tem de nomear os DOIS mundos. Uma recusa que só fala da nuvem
+# devolve o self-hoster ao beco de onde esta correção o tirou — o defeito
+# migraria do `case` para a prosa, onde não há catraca nenhuma.
+sburl_ok "a recusa ensina o caso da NUVEM"         reject "meu-supabase" "supabase.co"
+sburl_ok "a recusa ensina o caso do Supabase PRÓPRIO" reject "meu-supabase" "servidor"
+
 echo "chaves do Supabase (formato/papel/projeto)"
 ok "rejeita service_role no campo anon" reject v_anon    "$(mkjwt service_role abcdefghijklmnop)" "preciso da 'anon'"
 ok "rejeita anon no campo service_role" reject v_service "$(mkjwt anon abcdefghijklmnop)"         "preciso da 'service_role'"
@@ -91,6 +139,74 @@ ok "rejeita [YOUR-PASSWORD] não trocado" reject v_db_url "postgresql://postgres
 ok "rejeita Direct connection (IPv6)"    reject v_db_url "postgresql://postgres:senha@db.abcdefghijklmnop.supabase.co:5432/postgres"                                "Session pooler"
 ok "rejeita string de outro projeto"     reject v_db_url "postgresql://postgres.zzzzzzzzzzzzzzzz:senha@aws-1-us-west-2.pooler.supabase.com:5432/postgres"          "mesmo projeto"
 ok "rejeita o que não é URL de Postgres" reject v_db_url "aws-1-us-west-2.pooler.supabase.com"                                                                     "começa com postgresql"
+
+echo "connection string: Supabase PRÓPRIO não tem <ref> de projeto"
+# A comparação de projeto lê o `postgres.<ref>` do pooler DA NUVEM. Num Supabase
+# self-hosted não existe <ref> e a role pode ser qualquer uma, então a checagem
+# acusava "a string é do projeto 'crmuser', mas a URL é do projeto 'db-crm'" —
+# frase sobre duas coisas que não existem, e sem saída. Agora ela só roda quando
+# a URL é mesmo da nuvem.
+#
+# O caso da nuvem está aqui de novo (já existe acima) porque a asserção é OUTRA:
+# lá se mede a mensagem, aqui se mede que a recusa acontece ANTES de encostar no
+# banco. É essa fronteira que o `case` novo poderia ter movido sem ninguém ver.
+#
+# O que sobra barrando o dado errado no caminho self-hosted é SÓ o `select 1`, e
+# ele prova que o banco RESPONDE, não que é o banco certo: medido, uma string
+# apontando para o banco de outra pessoa passa. Isto está no relatório da
+# triagem como achado — não é um teste vermelho aqui de propósito.
+db_ok() {  # db_ok <descrição> <pass|reject> <NEXT_PUBLIC_SUPABASE_URL> <string> [trecho esperado]
+  local desc="$1" expect="$2" sburl="$3" conn="$4" want="${5-}" dir out rc tocou
+  dir="$(mktemp -d)"; mkdir -p "$dir/bin"
+  # O `select 1` roda via `docker run postgres:17-alpine`. O dublê não é
+  # conveniência: sem ele um caso de ACEITE baixaria imagem e abriria conexão de
+  # rede, que é justamente o que o cabeçalho deste arquivo promete não fazer.
+  # Ele deixa um rastro para a asserção de vacuidade logo abaixo.
+  printf '#!/usr/bin/env bash\ntouch "%s/tocou-no-banco"\nprintf 1\n' "$dir" > "$dir/bin/docker"
+  chmod +x "$dir/bin/docker"
+  out="$(env PATH="$dir/bin:$PATH" NEXT_PUBLIC_SUPABASE_URL="$sburl" bash -c '
+      INSTALL_SH_LIB=1 . ./install.sh
+      set +e
+      v_db_url "$1"' _ "$conn" 2>&1)"; rc=$?
+  tocou=nao; [ -e "$dir/tocou-no-banco" ] && tocou=sim
+  rm -rf "$dir"
+  if [ "$expect" = pass ]; then
+    if [ $rc -ne 0 ]; then
+      printf '  ✗ %s  (esperava aceitar, rejeitou: %s)\n' "$desc" "$(printf '%s' "$out" | head -1)"; fail=1
+    elif [ "$tocou" != sim ]; then
+      # Vacuidade: aceitar SEM chegar ao psql é outro defeito com a mesma cara de
+      # verde — seria um `return 0` antecipado, e a instalação seguiria com uma
+      # connection string que ninguém testou.
+      printf '  ✗ %s  (aceitou sem nunca tentar conectar — return 0 antecipado?)\n' "$desc"; fail=1
+    else printf '  ✓ %s\n' "$desc"; fi
+    return
+  fi
+  if [ $rc -eq 0 ]; then printf '  ✗ %s  (esperava rejeitar, aceitou)\n' "$desc"; fail=1; return; fi
+  if [ -n "$want" ] && ! printf '%s' "$out" | grep -qi -- "$want"; then
+    printf '  ✗ %s  (rejeitou, mas pelo motivo errado)\n     disse: %s\n' "$desc" "$(printf '%s' "$out" | head -1)"; fail=1; return
+  fi
+  if [ "$tocou" = sim ]; then
+    printf '  ✗ %s  (recusou só DEPOIS de tentar conectar — a guarda é de formulário)\n' "$desc"; fail=1; return
+  fi
+  printf '  ✓ %s\n' "$desc"
+}
+db_ok "próprio: role arbitrária deixa de virar 'projeto'" pass \
+  "https://db-crm.exemplo.com.br" "postgresql://crmuser:senha@db-crm.exemplo.com.br:5432/postgres"
+db_ok "próprio: role 'postgres' segue passando"           pass \
+  "https://db-crm.exemplo.com.br" "postgresql://postgres:senha@db-crm.exemplo.com.br:5432/postgres"
+# A regressão que importa: afrouxar o self-hosted não podia afrouxar a NUVEM,
+# onde o <ref> existe e apontar para o projeto errado é o erro clássico.
+db_ok "NUVEM: projeto cruzado continua barrado antes do banco" reject \
+  "https://abcdefghijklmnop.supabase.co" \
+  "postgresql://postgres.zzzzzzzzzzzzzzzz:senha@aws-1-us-west-2.pooler.supabase.com:5432/postgres" \
+  "mesmo projeto"
+db_ok "NUVEM: mesmo projeto passa"                        pass \
+  "https://abcdefghijklmnop.supabase.co" \
+  "postgresql://postgres.abcdefghijklmnop:senha@aws-1-us-west-2.pooler.supabase.com:5432/postgres"
+# Quem responde a connection string ANTES da URL (ou pula a URL) não tem com o
+# que comparar — e não pode ser barrado por isso.
+db_ok "sem URL respondida ainda: não há o que comparar"   pass \
+  "" "postgresql://postgres.zzzzzzzzzzzzzzzz:senha@aws-1-us-west-2.pooler.supabase.com:5432/postgres"
 
 echo "chaves de IA e senha"
 ok "rejeita chave Anthropic com prefixo errado" reject v_anthropic "sk-proj-abc123" "começa com 'sk-ant-'"
@@ -592,9 +708,15 @@ rt_ok "Traefik em 2 redes → a primeira"          coolify    coolify    "coolif
 rt_ok "modo host NÃO grava a pseudo-rede 'host'" crm_proxy  host       "host "           crm_proxy
 
 echo "proxy reverso: a rede externa existe e serve?"
-vr_ok() {  # vr_ok <descrição> <esperado> <driver encontrado> <rede> <bridge do projeto>
+vr_ok() {  # vr_ok <descrição> <esperado> <driver encontrado> <rede> <bridge do projeto> [attachable]
   local desc="$1" esperado="$2" real
-  real="$(veredito_rede_do_proxy "${3:-}" "${4:-}" "${5:-}")"
+  # O attachable só é passado quando o caso o declara, e isso NÃO é firula de
+  # assinatura: a chamada de 3 argumentos é o call site de antes do Swarm, e ela
+  # tem de continuar recusando overlay. Passar "" sempre apagaria essa medição em
+  # silêncio — a função trata ausente e vazio igual, então os dois casos ficariam
+  # verdes pelo mesmo caminho e o de compatibilidade deixaria de existir.
+  if [ $# -ge 6 ]; then real="$(veredito_rede_do_proxy "${3:-}" "${4:-}" "${5:-}" "$6")"
+  else                  real="$(veredito_rede_do_proxy "${3:-}" "${4:-}" "${5:-}")"; fi
   if [ "$real" = "$esperado" ]; then printf '  ✓ %s\n' "$desc"
   else printf '  ✗ %s  (deu %s, esperava %s)\n' "$desc" "$real" "$esperado"; fail=1; fi
 }
@@ -606,9 +728,83 @@ vr_ok "a bridge do PROJETO ainda não existe → cria" criar       ""      crm_p
 vr_ok "rede de outro que não existe → morre"      inexistente   ""      coolify    crm_proxy
 # TRAEFIK_NETWORK=host escrito à mão: existe, mas não aceita contêiner de bridge.
 vr_ok "driver host → morre"                       driver_errado host    host       crm_proxy
-vr_ok "driver overlay → morre"                    driver_errado overlay traefik    crm_proxy
+# Chamada com 3 argumentos DE PROPÓSITO: é o call site de antes do attachable.
+# Sem este caso, apagar o `att` de garantir_rede_do_proxy (deixando a função
+# intacta e o símbolo presente) não seria pego por teste nenhum.
+vr_ok "driver overlay, chamada de 3 args → morre" driver_errado overlay traefik    crm_proxy
 # Sem bridge do projeto conhecida (chamada defensiva), ausência volta a ser morte.
 vr_ok "sem rede nossa declarada → não inventa"    inexistente   ""      crm_proxy  ""
+
+# ── Overlay do Swarm ────────────────────────────────────────────────────────
+# Numa VPS com Docker Swarm o Traefik vive numa overlay, e a recusa por driver
+# matava a instalação com "ponha a bridge certa em TRAEFIK_NETWORK" — instrução
+# impossível de seguir, porque ali bridge do Traefik não existe. O que separa a
+# overlay que SERVE da que não serve é o --attachable: sem ele um contêiner de
+# compose comum não entra na rede e o `up -d` morre em "could not attach to
+# network". Por isso o veredito lê os DOIS campos, nunca só o driver.
+#
+# Os valores abaixo são o que `docker network inspect -f '{{.Attachable}}'`
+# imprime DE VERDADE (medido no docker 28.3.2): `true` ou `false`, minúsculo e
+# sem aspas, e VAZIO quando a rede não existe (aí o inspect sai != 0). Um teste
+# escrito com "True" ou "1" guardaria um formato que o Docker não emite.
+vr_ok "overlay attachable → serve como bridge"     ok            overlay traefik crm_proxy true
+vr_ok "overlay SEM attachable → morre"             driver_errado overlay traefik crm_proxy false
+# Vazio é a resposta de quem não sabe, não um "pode entrar". Tratar ausência de
+# resposta como permissão é exatamente o falhar-em-verde que este arquivo existe
+# para impedir.
+vr_ok "overlay com attachable vazio → morre"       driver_errado overlay traefik crm_proxy ""
+# O attachable NÃO pode virar critério único: a bridge default do Docker e as que
+# os painéis criam reportam Attachable=false (medido no docker 28.3.2, inclusive
+# na rede `bridge`). Exigi-lo de todo mundo quebraria toda instalação com Traefik
+# em bridge que hoje funciona — que é a maioria.
+vr_ok "bridge com attachable=false segue ok"       ok            bridge  coolify crm_proxy false
+# E o driver continua mandando: attachable=true numa rede `host` não muda que
+# contêiner de bridge não entra nela.
+vr_ok "host com attachable=true continua morrendo" driver_errado host    host    crm_proxy true
+
+echo "proxy reverso: o CALL SITE pergunta o attachable ao Docker"
+# Guardar a função não guarda a correção. Apagar o `att=` e o 4º argumento de
+# `garantir_rede_do_proxy` deixa `veredito_rede_do_proxy` intacta, o símbolo
+# presente e todo grep verde — e a VPS com Swarm volta a morrer, no update.sh
+# que o agent.sh roda sozinho a cada 5 minutos, sem ninguém lendo a tela. É o
+# call site que precisa de rede, e aqui o _common.sh roda de verdade contra um
+# `docker` dublê que responde como um Swarm responderia.
+rede_e2e() {  # rede_e2e <descrição> <segue|morre> <driver> <attachable>
+  local desc="$1" esperado="$2" drv="$3" att="$4" dir real perguntou kit="$PWD"
+  dir="$(mktemp -d)"; mkdir -p "$dir/bin"
+  cat > "$dir/bin/docker" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$dir/chamadas.log"
+if [ "\$1" = network ] && [ "\$2" = inspect ]; then
+  case "\$*" in
+    *Driver*)     printf '$drv\n'; exit 0 ;;
+    *Attachable*) printf '$att\n'; exit 0 ;;
+  esac
+fi
+exit 0
+STUB
+  chmod +x "$dir/bin/docker"
+  # O kit é capturado ANTES do cd: dentro do subshell o \$PWD já é o temporário,
+  # e o _common.sh não seria encontrado — o teste "morreria" por não achar o
+  # arquivo, indistinguível de uma recusa legítima.
+  if (cd "$dir" && env PATH="$dir/bin:$PATH" REVERSE_PROXY=traefik \
+        TRAEFIK_NETWORK=traefik PROJECT_DIR="$dir" \
+        bash -c '. "$1/_common.sh"; garantir_rede_do_proxy' _ "$kit") >/dev/null 2>&1
+  then real=segue; else real=morre; fi
+  # Vacuidade: "segue" só significa alguma coisa se o call site TIVER perguntado
+  # o attachable ao Docker. Sem esta checagem, um call site que parasse de
+  # perguntar — e um veredito que aceitasse overlay de olhos fechados — passaria
+  # com a mesma cara de aprovado.
+  perguntou=nao
+  grep -q 'Attachable' "$dir/chamadas.log" 2>/dev/null && perguntou=sim
+  rm -rf "$dir"
+  if [ "$perguntou" != sim ]; then
+    printf '  ✗ %s  (o call site não perguntou o attachable ao Docker)\n' "$desc"; fail=1
+  elif [ "$real" = "$esperado" ]; then printf '  ✓ %s\n' "$desc"
+  else printf '  ✗ %s  (deu %s, esperava %s)\n' "$desc" "$real" "$esperado"; fail=1; fi
+}
+rede_e2e "overlay attachable: install/update seguem" segue overlay true
+rede_e2e "overlay sem attachable: morre explicando"  morre overlay false
 
 echo "proxy reverso: quanta confiança a eleição merece"
 # A eleição por porta publicada traz a evidência (a coluna Ports diz ':80->'); a

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -203,6 +203,24 @@ db_ok "NUVEM: projeto cruzado continua barrado antes do banco" reject \
 db_ok "NUVEM: mesmo projeto passa"                        pass \
   "https://abcdefghijklmnop.supabase.co" \
   "postgresql://postgres.abcdefghijklmnop:senha@aws-1-us-west-2.pooler.supabase.com:5432/postgres"
+# A URL da nuvem NÃO chega sempre terminando em '.supabase.co'. O address bar do
+# navegador entrega barra final; quem copia da documentação traz caminho; quem
+# cola com o mouse traz espaço. Decidir "é nuvem?" pela string inteira desliga a
+# comparação de projeto em silêncio nesses três casos — e o desfecho é o pior
+# possível: o baseline.sql vai para um banco e o app fala com outro, cada um de
+# um projeto. Estes três casos guardam a extração de HOST que impede isso.
+for _sufixo in "/" "/rest/v1" " "; do
+  db_ok "NUVEM com '${_sufixo}' na URL: projeto cruzado continua barrado" reject \
+    "https://abcdefghijklmnop.supabase.co${_sufixo}" \
+    "postgresql://postgres.zzzzzzzzzzzzzzzz:senha@aws-1-us-west-2.pooler.supabase.com:5432/postgres" \
+    "mesmo projeto"
+done
+unset _sufixo
+# E o outro lado da mesma extração: Supabase próprio com barra final continua
+# sendo Supabase próprio — a correção acima não pode reintroduzir a recusa do
+# dado certo que este PR veio tirar.
+db_ok "próprio com barra final segue sem comparar projeto" pass \
+  "https://db-crm.exemplo.com.br/" "postgresql://crmuser:senha@db-crm.exemplo.com.br:5432/postgres"
 # Quem responde a connection string ANTES da URL (ou pula a URL) não tem com o
 # que comparar — e não pode ser barrado por isso.
 db_ok "sem URL respondida ainda: não há o que comparar"   pass \


### PR DESCRIPTION
Reconciliação do #188, de @ygorebos. O PR original fechou porque o fork foi apagado — os dois commits dele estão aqui com **autoria preservada**.

O que veio dele: os três afrouxamentos de validador (URL de Supabase próprio, `v_db_url` sem `<ref>`, overlay attachable do Swarm). Medidos na triagem: as três recusas existem na `main` e somem com o patch; a correção do Swarm alcança `install.sh` **e** `update.sh`.

O que a triagem acrescentou:
- **23 testes** (133 → 156). O comportamento novo tinha cobertura **zero**: o helper `vr_ok` chamava a função com 3 argumentos, então o caso `driver overlay` exercitava só a permanência da recusa.
- Um caso que guarda o **call site**, não a função: apagar o `att=` de `garantir_rede_do_proxy` deixa a função intacta e todo `grep` verde. Sabotado: as 11 asserções de unidade ficam verdes e só os 2 de call site pegam.
- **Conserto de uma regressão colateral**: `case "$URL" in *.supabase.co)` só casa quando a URL TERMINA nisso. Com barra final — o que o address bar entrega — a guarda de projeto cruzado **desligava**, e uma connection string de outro projeto passava. Medido; passa a decidir pelo host.

Achados que viraram issue: #190 (o sentinela `000` do curl é código morto em 5 sítios), #191 (a suíte do kit não roda em CI nenhum), #192 e #193 (achados dele).

Todos os gates verdes localmente: typecheck, lint, lint:channels, test:unit (287 arquivos), test:shell, test:db (71 arquivos), build, e a suíte do kit em 156 ✓.

Co-authored-by: ygorebos <ygor2013elisson@gmail.com>