### PR TITLE
fix(inbox): a rota lê o `tag` da query string — o filtro da tela filtra

### DIFF
--- a/app/api/v1/conversations/route.ts
+++ b/app/api/v1/conversations/route.ts
@@ -37,6 +37,12 @@ export async function GET(req: NextRequest): Promise<Response> {
     status: url.searchParams.get("status") ?? undefined,
     exclude_finished: url.searchParams.get("exclude_finished") === "true" ? true : undefined,
     assigned_to: url.searchParams.get("assigned_to") ?? undefined,
+    // O `tag` era o único param que o schema aceitava, o hook serializava e o
+    // handler implementava — e que esta linha não lia. A cadeia rompia AQUI, no
+    // meio: `InboxFilters` mostra o select "Filtrar por tag" sempre que a org tem
+    // vocabulário, o browser manda `?tag=vip`, e a lista voltava inteira, sem erro.
+    // Achado por @jmpo, no cabeçalho do teste que ele escreveu no PR #199.
+    tag: url.searchParams.get("tag") ?? undefined,
     channel_session_id: url.searchParams.get("channel_session_id") ?? undefined,
     search: url.searchParams.get("search") ?? undefined,
     cursor: url.searchParams.get("cursor") ?? undefined,

--- a/tests/unit/inbox-filtro-de-tag.test.ts
+++ b/tests/unit/inbox-filtro-de-tag.test.ts
@@ -1,0 +1,90 @@
+/**
+ * O FILTRO POR TAG DO INBOX FILTRA.
+ *
+ * ## O defeito que fez este arquivo existir
+ *
+ * A cadeia do filtro por tag existia inteira e rompia num ponto só, no meio:
+ *
+ *   `components/inbox/InboxFilters.tsx`       mostra o select "Filtrar por tag"
+ *   `hooks/inbox/useConversationsRealtime.ts` faz `qs.set("tag", filters.tag)`
+ *   `app/api/v1/conversations/route.ts`       lia 6 params — e `tag` NÃO era um deles
+ *   `app/api/v1/conversations/_handler.ts`    `if (q.tag) query.contains("tags", [q.tag])`
+ *
+ * O usuário escolhia uma tag, o browser mandava `?tag=vip`, a rota descartava e a
+ * lista voltava inteira. **Sem erro** — que é o que torna esta classe cara: um
+ * controle visível que não faz nada não gera ticket, gera desconfiança na tela.
+ *
+ * Achado por @jmpo, que o documentou no cabeçalho de
+ * `tests/unit/inbox-aba-minhas-encanamento.test.tsx` do PR #199 e — corretamente —
+ * não o consertou, porque estava fora do escopo do PR dele.
+ *
+ * ## Por que o teste é da ROTA, e não do handler
+ *
+ * O handler já estava certo: `if (q.tag) query.contains(...)` está lá desde sempre.
+ * Um teste que chamasse `listConversationsHandler` com `{tag:"vip"}` passaria com o
+ * defeito VIVO — o elo quebrado era a leitura de `searchParams`, uma camada acima.
+ * Por isso aqui se chama `GET` com uma query string de verdade e se afere o que o
+ * handler RECEBEU.
+ *
+ * Sabotar a linha `tag:` de `route.ts` deixa `_handler.ts` intacto, o símbolo
+ * `q.tag` presente e todo `grep` verde. É a perda silenciosa que este arquivo vigia.
+ */
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const listConversationsHandler = vi.fn(async () => ({
+  conversations: [],
+  cursor: null,
+  has_more: false,
+}));
+
+vi.mock("@/app/api/v1/conversations/_handler", () => ({ listConversationsHandler }));
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: { id: "u-1" } }, error: null }) },
+  }),
+}));
+vi.mock("@/lib/auth/server", () => ({
+  loadAuthUser: async () => ({ id: "u-1" }),
+  resolveActiveOrg: async () => ({ orgId: "org-1", role: "agent" }),
+}));
+
+/** A query que o handler recebeu na última chamada. */
+async function queryRecebidaCom(qs: string): Promise<Record<string, unknown>> {
+  const { GET } = await import("@/app/api/v1/conversations/route");
+  await GET(new NextRequest(`http://x/api/v1/conversations${qs}`));
+  const chamada = listConversationsHandler.mock.calls.at(-1);
+  if (!chamada) throw new Error("o handler não foi chamado — a rota morreu antes");
+  return (chamada as unknown[])[2] as Record<string, unknown>;
+}
+
+describe("GET /api/v1/conversations — o `tag` da query string chega ao handler", () => {
+  beforeEach(() => listConversationsHandler.mockClear());
+
+  it("com `?tag=vip`, o handler recebe `tag: \"vip\"`", async () => {
+    expect((await queryRecebidaCom("?tag=vip")).tag).toBe("vip");
+  });
+
+  /**
+   * Guarda de vacuidade nº 1: sem `tag` na URL o campo tem de chegar `undefined`.
+   * Se a rota passasse a mandar `tag` sempre (um literal, um default), o caso acima
+   * ficaria verde sem provar que a leitura da query string existe.
+   */
+  it("sem `tag` na URL, o handler recebe `tag: undefined`", async () => {
+    expect((await queryRecebidaCom("")).tag).toBeUndefined();
+  });
+
+  /**
+   * Guarda de vacuidade nº 2: o instrumento está vivo? Um param que a rota SEMPRE
+   * leu tem de chegar. Se este caso reprovasse junto com o de cima, o defeito
+   * estaria no dublê e não na rota — é o controle positivo do arquivo.
+   */
+  it("controle positivo: `?status=open` continua chegando", async () => {
+    expect((await queryRecebidaCom("?status=open")).status).toBe("open");
+  });
+
+  it("os dois juntos convivem — `?status=open&tag=vip`", async () => {
+    const q = await queryRecebidaCom("?status=open&tag=vip");
+    expect([q.status, q.tag]).toEqual(["open", "vip"]);
+  });
+});


### PR DESCRIPTION
Achado por **@jmpo**, que o documentou no cabeçalho do teste que escreveu no #199 e — corretamente — não consertou, por estar fora do escopo dele.

A cadeia existia inteira e rompia num ponto só, no meio:

```
InboxFilters.tsx:138          aria-label="Filtrar por tag"        ← a tela oferece
useConversationsRealtime:63   qs.set("tag", filters.tag)          ← o hook manda
conversations/route.ts:37-42  status, assigned_to, channel_session_id, search, cursor, limit
                                                                  ← a rota lia 6 e descartava o tag
_handler.ts:103               if (q.tag) query.contains("tags",…) ← pronto e inalcançável
```

A pessoa escolhia uma tag, o browser mandava `?tag=vip`, a rota descartava e a lista voltava inteira — **sem erro**. Controle visível que não faz nada não gera ticket, gera desconfiança na tela.

**O teste é da ROTA, não do handler**: o handler já estava certo, então um teste sobre ele passaria com o defeito vivo. Sabotando a linha nova: previ 2 vermelhos, observei 2 — a guarda de vacuidade e o controle positivo seguiram verdes.

Co-authored-by: jmpo <jmpo@users.noreply.github.com>