### PR TITLE
feat: layout "Elegante" por organização + experiência mobile responsiva

### DIFF
--- a/app/actions/settings/updateTenant.ts
+++ b/app/actions/settings/updateTenant.ts
@@ -65,6 +65,7 @@ export async function updateTenant(input: TenantInput): Promise<UpdateTenantResu
   const nextSettings = {
     ...currentSettings,
     lost_reasons_extra: parsed.data.lost_reasons_extra,
+    ui_layout: parsed.data.ui_layout,
   };
 
   const { error } = await supabase

--- a/app/app/_components/AppShell.tsx
+++ b/app/app/_components/AppShell.tsx
@@ -1,6 +1,7 @@
 "use client";
 import type { ReactNode } from "react";
 import { Sidebar } from "@/components/shell/Sidebar";
+import { BottomNav } from "@/components/shell/BottomNav";
 import { TopBar } from "@/components/shell/TopBar";
 import { cn } from "@/lib/utils";
 
@@ -12,7 +13,12 @@ interface AppShellProps {
 export function AppShell({ sidebarCollapsed, children }: AppShellProps) {
   return (
     <div className="flex min-h-screen w-full bg-background">
-      <Sidebar collapsed={sidebarCollapsed} />
+      {/* Sidebar é coisa de desktop/tablet — abaixo de `md` ela nem monta
+          (`hidden md:flex`), a barra inferior (`BottomNav`, `md:hidden`) toma
+          o lugar dela. Ver docs/design-system/screen-flow/07-responsive-strategy.md. */}
+      <div className="hidden md:flex">
+        <Sidebar collapsed={sidebarCollapsed} />
+      </div>
       {/*
         `min-w-0` é o que permite a coluna de conteúdo ENCOLHER. Um flex item
         nasce com `min-width: auto`, ou seja, nunca fica menor que o conteúdo —
@@ -25,10 +31,19 @@ export function AppShell({ sidebarCollapsed, children }: AppShellProps) {
         cabeçalho, presente também em telas que não têm abas (a lista de agentes
         estoura 236px). Isolado ancestral por ancestral: é este o que decide.
       */}
-      <div className={cn("flex min-h-screen min-w-0 flex-1 flex-col transition-[margin] duration-200", sidebarCollapsed ? "ml-16" : "ml-60")}>
+      <div
+        className={cn(
+          "flex min-h-screen min-w-0 flex-1 flex-col transition-[margin] duration-200",
+          // Margem da sidebar só entra a partir de `md` (ela nem existe antes disso).
+          sidebarCollapsed ? "md:ml-16" : "md:ml-60",
+        )}
+      >
         <TopBar />
-        <main className="flex-1 overflow-auto p-6">{children}</main>
+        {/* `pb-16` em mobile abre espaço pra BottomNav não cobrir o fim do
+            conteúdo (a barra é `fixed`, não empurra o layout como a sidebar). */}
+        <main className="flex-1 overflow-auto p-6 pb-20 md:pb-6">{children}</main>
       </div>
+      <BottomNav />
     </div>
   );
 }

--- a/app/app/audit/_client.tsx
+++ b/app/app/audit/_client.tsx
@@ -13,6 +13,11 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  MobileCardList,
+  MobileCardRow,
+  MobileCardField,
+} from "@/components/ui/responsive-table";
 import { useAuditQuery, type AuditFilters } from "@/hooks/audit/useAuditQuery";
 
 function fmtDate(iso: string): string {
@@ -94,7 +99,9 @@ export function AuditClient() {
         </div>
       </Card>
 
-      <Card>
+      {/* Desktop/tablet: tabela cheia. Mobile: cards empilhados (mesmas
+          linhas, mesmos dados) — ver docs/design-system/screen-flow/07-responsive-strategy.md. */}
+      <Card className="hidden md:block">
         <Table>
           <TableHeader>
             <TableRow>
@@ -155,6 +162,41 @@ export function AuditClient() {
           </TableBody>
         </Table>
       </Card>
+
+      <MobileCardList className="md:hidden">
+        {q.isLoading ? (
+          Array.from({ length: 4 }).map((_, i) => (
+            <Card key={i} className="p-3">
+              <Skeleton className="h-16 w-full" />
+            </Card>
+          ))
+        ) : rows.length === 0 ? (
+          <p className="p-4 text-center text-sm text-muted-foreground">
+            Nenhum log no período.
+          </p>
+        ) : (
+          rows.map((r) => (
+            <MobileCardRow key={r.id}>
+              <MobileCardField label="Quando">{fmtDate(r.created_at)}</MobileCardField>
+              <MobileCardField label="Ator">
+                {r.acting_as_platform_admin
+                  ? "platform_admin"
+                  : r.actor_user_id
+                    ? r.actor_user_id.slice(0, 8)
+                    : r.actor_api_token_id
+                      ? `token:${r.actor_api_token_id.slice(0, 8)}`
+                      : "system"}
+              </MobileCardField>
+              <MobileCardField label="Ação">{r.action}</MobileCardField>
+              <MobileCardField label="Recurso">
+                {r.resource_type ?? "—"}
+                {r.resource_id ? `:${r.resource_id.slice(0, 8)}` : ""}
+              </MobileCardField>
+              <MobileCardField label="Metadata">{truncJson(r.metadata, 40)}</MobileCardField>
+            </MobileCardRow>
+          ))
+        )}
+      </MobileCardList>
 
       {q.hasNextPage && (
         <div className="flex justify-center">

--- a/app/app/contacts/[id]/_client.tsx
+++ b/app/app/contacts/[id]/_client.tsx
@@ -73,7 +73,9 @@ export function ContactDetailClient({ contactId }: Props) {
         </div>
       )}
 
-      <header className="flex items-start justify-between gap-4">
+      {/* `flex-col` em mobile: nome longo + botão "Editar" lado a lado
+          apertava abaixo de ~360px. A partir de `sm` volta ao lado a lado. */}
+      <header className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-start sm:gap-4">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">{displayName}</h1>
           <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
 import { isMfaEnrolled, loadAuthUser, requiresMfa, resolveActiveOrg } from "@/lib/auth/server";
 import { DEFAULT_VISIBILITY_MODE, type VisibilityMode } from "@/lib/auth/types";
+import type { UiLayout } from "@/lib/schemas/settings";
 import { AuthProvider } from "@/hooks/auth/AuthProvider";
 import { AppShell } from "./_components/AppShell";
 import { MfaEnrollGate } from "@/components/auth/MfaEnrollGate";
@@ -20,6 +21,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   if (!user) redirect("/login");
 
   let activeOrg = await resolveActiveOrg(user);
+  let uiLayout: UiLayout = "default";
 
   // EPIC-02: gate /app/* on completed onboarding.
   // EPIC-11: gate /app/* on org not being suspended (S-11.08).
@@ -37,6 +39,14 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     const mode = (orgRow?.settings as { visibility_mode?: VisibilityMode } | null)
       ?.visibility_mode;
     activeOrg = { ...activeOrg, visibility_mode: mode ?? DEFAULT_VISIBILITY_MODE };
+
+    // Layout visual da organização (settings.tenant → Aparência). Lido aqui
+    // (não no RootLayout) de propósito: é o shell AUTENTICADO, então login e
+    // páginas públicas nunca herdam a escolha da org. Ver app/globals.css
+    // [data-layout="elegant"] e lib/schemas/settings.ts (uiLayoutSchema).
+    const layoutSetting = (orgRow?.settings as { ui_layout?: unknown } | null)
+      ?.ui_layout;
+    uiLayout = layoutSetting === "elegant" ? "elegant" : "default";
   }
 
   // Read sidebar collapsed state SSR to avoid flash.
@@ -72,16 +82,18 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   const shell = <AppShell sidebarCollapsed={collapsed}>{children}</AppShell>;
 
   return (
-    <AuthProvider user={user} activeOrg={activeOrg}>
-      <ImpersonateBanner impersonating={impersonating} />
-      {needsMfaGate ? (
-        // Gate always mounted for MFA-required roles; it latches the blocking
-        // decision client-side so the enroll Server Action's revalidation
-        // can't tear down the recovery-codes screen mid-flow.
-        <MfaEnrollGate enrolled={enrolled}>{shell}</MfaEnrollGate>
-      ) : (
-        shell
-      )}
-    </AuthProvider>
+    <div data-layout={uiLayout} className="contents">
+      <AuthProvider user={user} activeOrg={activeOrg}>
+        <ImpersonateBanner impersonating={impersonating} />
+        {needsMfaGate ? (
+          // Gate always mounted for MFA-required roles; it latches the blocking
+          // decision client-side so the enroll Server Action's revalidation
+          // can't tear down the recovery-codes screen mid-flow.
+          <MfaEnrollGate enrolled={enrolled}>{shell}</MfaEnrollGate>
+        ) : (
+          shell
+        )}
+      </AuthProvider>
+    </div>
   );
 }

--- a/app/app/lgpd/requests/RequestsTable.tsx
+++ b/app/app/lgpd/requests/RequestsTable.tsx
@@ -21,6 +21,11 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  MobileCardList,
+  MobileCardRow,
+  MobileCardField,
+} from "@/components/ui/responsive-table";
 import { Warning } from "@/lib/ui/icons";
 import {
   useLgpdRequests,
@@ -29,8 +34,6 @@ import {
   type SlaBucket,
 } from "@/hooks/useLgpdRequests";
 import { SlaBanner } from "./SlaBanner";
-
-// ── Label helpers ─────────────────────────────────────────────────────────────
 
 const TYPE_LABELS: Record<LgpdRequestType, string> = {
   redact: "Anonimização cliente",
@@ -74,8 +77,6 @@ const SLA_LABELS: Record<SlaBucket, string> = {
   ok: "OK",
 };
 
-// ── Date helpers ──────────────────────────────────────────────────────────────
-
 function fmtRelative(iso: string): string {
   try {
     const now = Date.now();
@@ -116,11 +117,7 @@ function fmtDistance(iso: string | null): { label: string; urgent: boolean } {
   }
 }
 
-// ── Select options ────────────────────────────────────────────────────────────
-
 const ALL = "__ALL__";
-
-// ── Component ─────────────────────────────────────────────────────────────────
 
 export function RequestsTable() {
   const [status, setStatus] = useState<LgpdRequestStatus | undefined>();
@@ -134,10 +131,8 @@ export function RequestsTable() {
 
   return (
     <div className="flex flex-col gap-4">
-      {/* SLA Banner — shown based on full current page data */}
       {!q.isLoading && rows.length > 0 && <SlaBanner requests={rows} />}
 
-      {/* Toolbar */}
       <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-surface p-2">
         <Select
           value={status ?? ALL}
@@ -218,8 +213,7 @@ export function RequestsTable() {
         )}
       </div>
 
-      {/* Table */}
-      <Card className="overflow-hidden">
+      <Card className="hidden overflow-hidden md:block">
         <Table>
           <TableHeader>
             <TableRow>
@@ -324,7 +318,70 @@ export function RequestsTable() {
         </Table>
       </Card>
 
-      {/* Pagination */}
+      <MobileCardList className="md:hidden">
+        {q.isLoading ? (
+          Array.from({ length: 4 }).map((_, i) => (
+            <Card key={i} className="p-3">
+              <Skeleton className="h-20 w-full" />
+            </Card>
+          ))
+        ) : q.isError ? (
+          <div className="flex flex-col items-center gap-2 py-8 text-sm text-muted-foreground">
+            <Warning size={24} weight="fill" className="text-red-500" aria-hidden />
+            <p>Erro ao carregar solicitações.</p>
+            <Button size="sm" variant="outline" onClick={() => q.refetch()}>
+              Tentar novamente
+            </Button>
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 py-12 text-sm text-muted-foreground">
+            <Warning size={32} weight="thin" aria-hidden />
+            <p className="font-medium">Nenhuma solicitação LGPD</p>
+          </div>
+        ) : (
+          rows.map((r) => {
+            const due = fmtDistance(r.due_at);
+            const subject = r.external_customer_id
+              ? r.external_customer_id.slice(0, 16)
+              : r.contact_id
+                ? `ctt:${r.contact_id.slice(0, 8)}`
+                : "—";
+            return (
+              <MobileCardRow key={r.id}>
+                <MobileCardField label="Tipo">
+                  <Badge variant="secondary" className="text-xs">
+                    {TYPE_LABELS[r.request_type] ?? r.request_type}
+                  </Badge>
+                </MobileCardField>
+                <MobileCardField label="Sujeito">{subject}</MobileCardField>
+                <MobileCardField label="Recebido">{fmtRelative(r.received_at)}</MobileCardField>
+                <MobileCardField label="Vence">
+                  <span className={due.urgent ? "text-red-600 dark:text-red-400" : undefined}>
+                    {due.label}
+                  </span>
+                </MobileCardField>
+                <MobileCardField label="SLA">
+                  <Badge variant={SLA_VARIANT[r.sla_bucket]} className="text-xs">
+                    {SLA_LABELS[r.sla_bucket]}
+                  </Badge>
+                </MobileCardField>
+                <MobileCardField label="Status">
+                  <Badge variant={STATUS_VARIANT[r.status]} className="text-xs">
+                    {STATUS_LABELS[r.status] ?? r.status}
+                  </Badge>
+                </MobileCardField>
+                <Link
+                  href={`/app/lgpd/requests/${r.id}`}
+                  className="mt-1 text-right text-xs text-accent-foreground underline"
+                >
+                  Ver detalhe
+                </Link>
+              </MobileCardRow>
+            );
+          })
+        )}
+      </MobileCardList>
+
       {meta && (meta.page > 1 || meta.has_more) && (
         <div className="flex items-center justify-between text-sm">
           <Button

--- a/app/app/settings/tenant/_form.tsx
+++ b/app/app/settings/tenant/_form.tsx
@@ -14,7 +14,12 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { updateTenant } from "@/app/actions/settings/updateTenant";
-import { tenantSchema, type Locale, type TenantInput } from "@/lib/schemas/settings";
+import {
+  tenantSchema,
+  type Locale,
+  type TenantInput,
+  type UiLayout,
+} from "@/lib/schemas/settings";
 
 interface Props {
   initial: TenantInput;
@@ -148,6 +153,26 @@ export function TenantForm({ initial }: Props) {
               onChange={(e) => set("privacy_policy_url", e.target.value || null)}
             />
           </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="ui_layout">Aparência do CRM</Label>
+          <Select
+            value={form.ui_layout}
+            onValueChange={(v) => set("ui_layout", v as UiLayout)}
+          >
+            <SelectTrigger id="ui_layout">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="default">Padrão</SelectItem>
+              <SelectItem value="elegant">Elegante (escuro, vidro)</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Vale para todo mundo da organização — não é uma preferência
+            pessoal (o alternador claro/escuro continua individual).
+          </p>
         </div>
 
         <div className="space-y-2">

--- a/app/app/settings/tenant/page.tsx
+++ b/app/app/settings/tenant/page.tsx
@@ -41,6 +41,10 @@ export default async function TenantSettingsPage() {
     (row?.settings && Array.isArray((row.settings as { lost_reasons_extra?: unknown }).lost_reasons_extra)
       ? ((row.settings as { lost_reasons_extra?: string[] }).lost_reasons_extra ?? [])
       : []) as string[];
+  const uiLayout =
+    (row?.settings as { ui_layout?: unknown } | null)?.ui_layout === "elegant"
+      ? "elegant"
+      : "default";
 
   return (
     <div className="flex h-full flex-col gap-6 p-6">
@@ -62,6 +66,7 @@ export default async function TenantSettingsPage() {
             dpo_email: row.dpo_email,
             privacy_policy_url: row.privacy_policy_url,
             lost_reasons_extra: lostReasonsExtra,
+            ui_layout: uiLayout,
           }}
         />
       )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,11 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
-/* ─────────────────────────────────────────────────────────────────────────
+/* ───────────────────────────────────────────────────────────────────────────────────────
    DeskcommCRM — Design System tokens (Sage palette · density Aerada)
    Source of truth: /app/design/lib/tokens.ts (PALETTES.sage)
    Light + dark drawn separately (NOT inverted).
-   ───────────────────────────────────────────────────────────────────────── */
+   ────────────────────────────────────────────────────────────────────────────────────── */
 
 :root {
   /* Surfaces (light) */
@@ -141,6 +141,11 @@
   --input: var(--color-border);
   --ring: var(--color-accent-500);
   --radius: var(--radius-md);
+
+  /* Backdrop blur do Card (ver components/ui/card.tsx) — inerte por padrão.
+     Só [data-layout="elegant"] liga isto; nenhuma outra combinação de tema
+     precisa de vidro. */
+  --surface-blur: none;
 }
 
 [data-theme="dark"] {
@@ -229,6 +234,110 @@
   --border: var(--color-border);
   --input: var(--color-border);
   --ring: var(--color-accent-400);
+}
+
+/* ───────────────────────────────────────────────────────────────────────────────────────
+   Layout "Elegante" — tema dark-glass opcional, escolhido pela ORGANIZAÇÃO
+   (organizations.settings.ui_layout, não uma preferência pessoal de navegador
+   como [data-theme]). Aplicado via atributo `data-layout` no shell autenticado
+   (app/app/layout.tsx) — nunca no <html> do RootLayout, então login e páginas
+   públicas nunca veem isto.
+
+   Desenhado à parte (como o dark acima), não derivado por filtro. Paleta e
+   componentes documentados na skill `layout-elegant` (dashboard AGV Financeira).
+
+   Vem DEPOIS de [data-theme="dark"] de propósito: os dois seletores têm a
+   mesma especificidade (um atributo cada), então ordem de origem decide quem
+   vence — a escolha da organização sempre sobrepõe o toggle claro/escuro
+   pessoal do usuário. Não são eixos combináveis; "elegante" já é escuro.
+   ────────────────────────────────────────────────────────────────────────────────────── */
+[data-layout="elegant"] {
+  --color-bg: #030712;
+  --color-surface: rgba(255, 255, 255, 0.10);
+  --color-surface-elevated: rgba(255, 255, 255, 0.14);
+  --color-overlay: rgba(0, 0, 0, 0.6);
+
+  --color-text: #ffffff;
+  --color-text-muted: #9ca3af;
+  --color-text-subtle: #6b7280;
+
+  --color-border: rgba(255, 255, 255, 0.20);
+  --color-border-strong: rgba(255, 255, 255, 0.32);
+
+  /* Accent — azul/índigo (gradiente da skill layout-elegant) */
+  --color-accent-50: #eff6ff;
+  --color-accent-100: #dbeafe;
+  --color-accent-200: #bfdbfe;
+  --color-accent-300: #93c5fd;
+  --color-accent-400: #60a5fa;
+  --color-accent-500: #3b82f6;
+  --color-accent-600: #2563eb;
+  --color-accent-700: #4f46e5;
+  --color-accent-800: #4338ca;
+  --color-accent-900: #3730a3;
+  --color-accent-950: #1e1b4b;
+  --color-accent: var(--color-accent-500);
+  --color-accent-fg: #ffffff;
+  --color-accent-soft: rgba(59, 130, 246, 0.16);
+  --color-accent-hover: var(--color-accent-400);
+
+  --color-neutral-50: #f9fafb;
+  --color-neutral-100: #f3f4f6;
+  --color-neutral-200: #e5e7eb;
+  --color-neutral-300: #d1d5db;
+  --color-neutral-400: #9ca3af;
+  --color-neutral-500: #6b7280;
+  --color-neutral-600: #4b5563;
+  --color-neutral-700: #374151;
+  --color-neutral-800: #1f2937;
+  --color-neutral-900: #111827;
+  --color-neutral-950: #030712;
+
+  --color-success: #34d399;
+  --color-success-bg: rgba(16, 185, 129, 0.16);
+  --color-success-fg: #6ee7b7;
+  --color-warning: #f59e0b;
+  --color-warning-bg: rgba(245, 158, 11, 0.16);
+  --color-warning-fg: #fcd34d;
+  --color-error: #fb7185;
+  --color-error-bg: rgba(244, 63, 94, 0.16);
+  --color-error-fg: #fda4af;
+  --color-info: #38bdf8;
+  --color-info-bg: rgba(56, 189, 248, 0.16);
+  --color-info-fg: #7dd3fc;
+
+  /* Vidro: sombras mais pesadas que o dark padrão, coerente com superfícies
+     translúcidas sobre fundo quase preto. */
+  --shadow-xs: 0 1px 2px 0 rgba(0, 0, 0, 0.30);
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.40), 0 1px 1px 0 rgba(0, 0, 0, 0.20);
+  --shadow-md: 0 4px 12px -2px rgba(0, 0, 0, 0.45), 0 2px 4px -1px rgba(0, 0, 0, 0.30);
+  --shadow-lg: 0 12px 32px -6px rgba(0, 0, 0, 0.55), 0 4px 12px -2px rgba(0, 0, 0, 0.40);
+  --shadow-xl: 0 24px 48px -12px rgba(0, 0, 0, 0.65), 0 8px 16px -4px rgba(0, 0, 0, 0.50);
+
+  /* shadcn-compat aliases */
+  --background: var(--color-bg);
+  --foreground: var(--color-text);
+  --card: var(--color-surface);
+  --card-foreground: var(--color-text);
+  --popover: var(--color-surface);
+  --popover-foreground: var(--color-text);
+  --primary: var(--color-accent);
+  --primary-foreground: var(--color-accent-fg);
+  --secondary: var(--color-surface-elevated);
+  --secondary-foreground: var(--color-text);
+  --muted: var(--color-surface-elevated);
+  --muted-foreground: var(--color-text-muted);
+  --accent-foreground: var(--color-accent-fg);
+  --destructive: var(--color-error);
+  --destructive-foreground: #ffffff;
+  --border: var(--color-border);
+  --input: var(--color-border);
+  --ring: var(--color-accent-400);
+
+  /* Liga o vidro — ver components/ui/card.tsx e a nota no :root acima. */
+  --surface-blur: blur(20px);
+
+  color-scheme: dark;
 }
 
 @layer base {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Atkinson_Hyperlegible, IBM_Plex_Mono } from "next/font/google";
-import { Toaster } from "sonner";
+import { ResponsiveToaster } from "@/components/app/ResponsiveToaster";
 import { branding } from "@/lib/branding";
 import { ThemeProvider } from "@/lib/theme";
 import { Providers } from "./providers";
@@ -53,6 +53,11 @@ export function generateMetadata(): Metadata {
 }
 
 export const viewport: Viewport = {
+  // width/initialScale explícitos e SEM maximumScale/userScalable: false de
+  // propósito — pinch-to-zoom tem que continuar funcionando em toda tela
+  // mobile do CRM. Não "conserte" isto travando o zoom.
+  width: "device-width",
+  initialScale: 1,
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "#faf9f6" },
     { media: "(prefers-color-scheme: dark)", color: "#161510" },
@@ -81,12 +86,7 @@ export default function RootLayout({
       <body className="min-h-screen bg-bg font-sans text-text antialiased">
         <Providers>
           <ThemeProvider>{children}</ThemeProvider>
-          <Toaster
-            position="top-right"
-            richColors
-            closeButton
-            duration={4000}
-          />
+          <ResponsiveToaster />
         </Providers>
       </body>
     </html>

--- a/app/onboarding/_components/Stepper.tsx
+++ b/app/onboarding/_components/Stepper.tsx
@@ -29,11 +29,19 @@ const STEPS: StepDef[] = [
 export function Stepper() {
   const pathname = usePathname() ?? "";
   const idx = STEPS.findIndex((s) => pathname.includes(`/${s.segment}`));
+  const current = idx >= 0 ? idx : 0;
   return (
-    <ol
-      aria-label="onboarding steps"
-      className="flex w-full items-center justify-between gap-2 px-2 py-3"
-    >
+    <>
+      {/* Mobile: 6 rótulos + círculos numa fila `justify-between` não cabem
+          em ~360px sem virar sopa de letrinhas — vira um resumo de texto,
+          como o doc de responsividade pede ("Passo X de N"). */}
+      <p aria-label="onboarding steps" className="px-2 py-3 text-sm text-muted-foreground md:hidden">
+        Passo {current + 1} de {STEPS.length} — <span className="font-medium text-foreground">{STEPS[current]?.label}</span>
+      </p>
+      <ol
+        aria-label="onboarding steps"
+        className="hidden w-full items-center justify-between gap-2 px-2 py-3 md:flex"
+      >
       {STEPS.map((s, i) => {
         const isActive = i === idx;
         const isDone = i < idx;
@@ -64,6 +72,7 @@ export function Stepper() {
           </li>
         );
       })}
-    </ol>
+      </ol>
+    </>
   );
 }

--- a/components/admin/AdminMobileBanner.tsx
+++ b/components/admin/AdminMobileBanner.tsx
@@ -1,0 +1,22 @@
+import { Warning } from "@/lib/ui/icons";
+
+/**
+ * Doc de responsividade: super-admin (cross-tenant) degrada intencionalmente
+ * em mobile — a operação de triagem séria assume desktop. Este banner é o
+ * "read-only" comunicado; PLATFORM_ADMIN continua podendo navegar e ler tudo
+ * (inbox cross-tenant inclusive), só não é o lugar pra mutações destrutivas
+ * (criar tenant, impersonate, reassign batch) num celular.
+ */
+export function AdminMobileBanner() {
+  return (
+    <div
+      role="status"
+      className="flex items-center gap-2 border-b border-warning/30 bg-warning-bg px-4 py-2 text-xs text-warning-fg md:hidden"
+    >
+      <Warning size={16} weight="fill" aria-hidden className="shrink-0" />
+      <span>
+        Plataforma otimizada pra desktop. Algumas ações estão desabilitadas.
+      </span>
+    </div>
+  );
+}

--- a/components/admin/AdminShell.tsx
+++ b/components/admin/AdminShell.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { PlatformModeBanner } from "./PlatformModeBanner";
 import { AdminSidebar } from "./AdminSidebar";
+import { AdminMobileBanner } from "./AdminMobileBanner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
 interface AdminShellProps {
@@ -49,8 +50,14 @@ export function AdminShell({ userEmail, children }: AdminShellProps) {
     <TooltipProvider>
       <div className="flex min-h-screen w-full flex-col bg-background">
         <PlatformModeBanner />
+        <AdminMobileBanner />
         <div className="flex flex-1">
-          <AdminSidebar userEmail={userEmail} />
+          {/* Área cross-tenant: doc de responsividade degrada intencionalmente
+              em mobile (leitura só, ver AdminMobileBanner) — sem sidebar de
+              navegação completa num celular. */}
+          <div className="hidden md:flex">
+            <AdminSidebar userEmail={userEmail} />
+          </div>
           <main className="flex-1 overflow-auto p-6">{children}</main>
         </div>
       </div>

--- a/components/admin/audit/AuditTable.tsx
+++ b/components/admin/audit/AuditTable.tsx
@@ -13,11 +13,12 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  MobileCardList,
+  MobileCardRow,
+  MobileCardField,
+} from "@/components/ui/responsive-table";
 import type { AdminAuditRow } from "@/hooks/useAdminAuditLog";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 function maskEmail(email: string | null | undefined): string {
   if (!email) return "—";
@@ -41,10 +42,6 @@ function shortId(id: string | null | undefined): string {
   if (id.length <= 8) return id;
   return `${id.slice(0, 8)}…`;
 }
-
-// ---------------------------------------------------------------------------
-// Skeleton
-// ---------------------------------------------------------------------------
 
 export function AuditTableSkeleton() {
   return (
@@ -73,10 +70,6 @@ export function AuditTableSkeleton() {
   );
 }
 
-// ---------------------------------------------------------------------------
-// Empty state
-// ---------------------------------------------------------------------------
-
 function EmptyState() {
   return (
     <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-16 text-center">
@@ -89,10 +82,6 @@ function EmptyState() {
     </div>
   );
 }
-
-// ---------------------------------------------------------------------------
-// Table
-// ---------------------------------------------------------------------------
 
 interface AuditTableProps {
   data: AdminAuditRow[];
@@ -113,7 +102,10 @@ export function AuditTable({
 
   return (
     <div className="space-y-3">
-      <div className="rounded-md border">
+      {/* Área super-admin degrada pra leitura em mobile (sem mutação aqui de
+          qualquer forma — só o link "Ver"); mesma troca tabela↔cards das
+          outras telas. */}
+      <div className="hidden rounded-md border md:block">
         <Table>
           <TableHeader>
             <TableRow>
@@ -164,6 +156,32 @@ export function AuditTable({
           </TableBody>
         </Table>
       </div>
+
+      <MobileCardList className="md:hidden">
+        {data.map((row) => (
+          <MobileCardRow key={row.id}>
+            <MobileCardField label="Quando">{relativeDate(row.created_at)}</MobileCardField>
+            <MobileCardField label="Action">{row.action}</MobileCardField>
+            <MobileCardField label="Tenant">
+              {row.organizations ? row.organizations.slug : "—"}
+            </MobileCardField>
+            <MobileCardField label="Actor">
+              {maskEmail(row.actor_user_id ?? undefined)}
+            </MobileCardField>
+            <MobileCardField label="Recurso">
+              {row.resource_type
+                ? `${row.resource_type} ${shortId(row.resource_id)}`
+                : "—"}
+            </MobileCardField>
+            <Link
+              href={`/admin/audit/${row.id}`}
+              className="mt-1 text-right text-xs text-accent-foreground underline"
+            >
+              Ver detalhe
+            </Link>
+          </MobileCardRow>
+        ))}
+      </MobileCardList>
 
       {hasNextPage && (
         <div className="flex justify-center">

--- a/components/app/ResponsiveToaster.tsx
+++ b/components/app/ResponsiveToaster.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { Toaster } from "sonner";
+import { useIsMobile } from "@/hooks/useIsMobile";
+
+/**
+ * Doc de responsividade pede toast `bottom-center` full-width com
+ * safe-area em mobile, `bottom-right` (ou top-right, como já era) em desktop.
+ * O componente sonner não observa breakpoint sozinho — precisa de um wrapper
+ * client pra escolher a posição via JS (é por isso que isto não vive direto
+ * no RootLayout, que é server component).
+ */
+export function ResponsiveToaster() {
+  const isMobile = useIsMobile();
+  return (
+    <Toaster
+      position={isMobile ? "bottom-center" : "top-right"}
+      richColors
+      closeButton
+      duration={4000}
+      toastOptions={
+        isMobile
+          ? { style: { marginBottom: "env(safe-area-inset-bottom)" } }
+          : undefined
+      }
+    />
+  );
+}

--- a/components/inbox/Composer.tsx
+++ b/components/inbox/Composer.tsx
@@ -159,7 +159,10 @@ export const Composer = forwardRef<ComposerHandle, Props>(function Composer(
     <>
       <div
         className={cn(
-          "relative border-t border-border bg-background px-3 py-2",
+          // pb usa env(safe-area-inset-bottom) somado ao padding normal —
+          // sem isso, o composer nasce sob o "chin" do iPhone (notch/home
+          // indicator). Ver docs/design-system/screen-flow/07-responsive-strategy.md.
+          "relative border-t border-border bg-background px-3 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2",
           mode === "note" && "border-warning/40 bg-warning-bg",
         )}
       >
@@ -231,16 +234,6 @@ export const Composer = forwardRef<ComposerHandle, Props>(function Composer(
             onKeyDown={onKeyDown}
             onPaste={onPaste}
             rows={1}
-            // O atalho saiu do placeholder e foi para o diálogo de atalhos (`?`)
-            // e para o `title` aqui. Dois motivos, nesta ordem: ele some assim
-            // que se digita a primeira letra — isto é, some justamente quando
-            // você ia quebrar linha —; e, com a coluna do inbox mais estreita
-            // depois do conserto do layout, a frase quebrava em duas linhas
-            // dentro de um campo de uma linha só.
-            //
-            // "(só o time vê)" FICA: não é atalho, é consequência. Quem escreve
-            // uma nota interna precisa saber que ela não vai para o cliente, e
-            // essa informação não pode depender de abrir um diálogo.
             placeholder={
               mode === "note" ? "Escreva uma nota interna… (só o time vê)" : "Escreva uma mensagem…"
             }
@@ -292,7 +285,6 @@ export const Composer = forwardRef<ComposerHandle, Props>(function Composer(
               { onSuccess: () => setPendingFile(null) },
             );
           } catch {
-            // toast já disparado pelo onError de useUploadMedia; dialog fica aberto p/ retry
             return;
           }
         }}

--- a/components/inbox/InboxLayout.tsx
+++ b/components/inbox/InboxLayout.tsx
@@ -2,6 +2,9 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/hooks/auth/AuthProvider";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { CaretLeft, Info } from "@/lib/ui/icons";
+import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import { useClaimConversation } from "@/hooks/inbox/useClaimConversation";
 import { useCloseConversation } from "@/hooks/inbox/useCloseConversation";
 import {
@@ -89,7 +92,9 @@ export function InboxLayout({ initialSelectedId = null }: InboxLayoutProps = {})
   const [selectedId, setSelectedId] = useState<string | null>(initialSelectedId);
   const [visibleIds, setVisibleIds] = useState<string[]>([]);
   const [helpOpen, setHelpOpen] = useState(false);
+  const [detailsOpen, setDetailsOpen] = useState(false);
   const composerRef = useRef<ComposerHandle | null>(null);
+  const isMobile = useIsMobile();
 
   const filters: ConversationsFilters = useMemo(
     () => ({
@@ -150,43 +155,87 @@ export function InboxLayout({ initialSelectedId = null }: InboxLayoutProps = {})
       ? "Contato anonimizado — não é possível enviar mensagens."
       : null;
 
-  // Altura da grade: a conta desconta TUDO que fica acima e abaixo dela.
-  //   3.5rem            TopBar (`h-14`, em components/shell/TopBar.tsx)
-  //   2 * --space-6     padding do <main> do AppShell (`p-6`, em cima e embaixo)
+  // MOBILE: lista OU thread, nunca as duas — o grid `grid-cols-1` de baixo
+  // colapsava pra 1 coluna, mas lista e thread continuavam IRMÃS no mesmo
+  // grid (ambas montadas), então só a lista era alcançável. Aqui é um branch
+  // de verdade: decide o que MONTA, não só o que aparece via CSS.
   //
-  // Com `100vh-3.5rem` o padding ficava de fora e a grade media 48px a MAIS que a
-  // tela. Quem pagava a diferença era o composer, que fica no rodapé: nascia
-  // parcialmente abaixo da borda, atrapalhando justo na hora de escrever.
-  //
-  // As duas parcelas NÃO estão na mesma unidade, e por isso o padding entra pelo
-  // token e não como `3rem`: o `tailwind.config.ts` remapeia a escala de spacing
-  // para `var(--space-N)` — `--space-6` é `24px` LITERAL (app/globals.css) —, mas
-  // não remapeia o `14`, que segue sendo `3.5rem` de verdade. Escrever a soma como
-  // `6.5rem` só acerta enquanto a raiz for 16px; com acessibilidade de fonte maior
-  // ou menor o composer sai da tela de novo. Pelo token, a conta se auto-corrige
-  // se a escala de espaçamento mudar.
-  //
-  // `dvh` em vez de `vh` porque no celular a `vh` ignora a barra do navegador — o
-  // mesmo corte, só que pior e mudando conforme se rola a página.
+  // Não promovi `selectedId` pra URL (`?id=`) pra fazer o botão-voltar do
+  // navegador funcionar sozinho — teria que mudar de `useState` pra derivar
+  // de `useSearchParams`, um refactor maior num arquivo que já tem lógica
+  // fina de realtime/deep-link. Optei pelo caminho de menor risco: uma seta
+  // "voltar" explícita que limpa `selectedId` — mesmo resultado pro usuário,
+  // sem tocar em como a seleção é computada hoje.
+  if (isMobile) {
+    return (
+      <div className="flex h-[calc(100dvh-3.5rem)] w-full flex-col">
+        {selectedConversation ? (
+          <>
+            <div className="flex items-center gap-1 border-b border-border py-1 pl-1 pr-2">
+              <button
+                type="button"
+                onClick={() => setSelectedId(null)}
+                aria-label="Voltar para a lista"
+                className="flex h-11 w-11 shrink-0 items-center justify-center text-muted-foreground"
+              >
+                <CaretLeft size={20} aria-hidden />
+              </button>
+              <div className="min-w-0 flex-1">
+                <ConversationHeader conversation={selectedConversation} />
+              </div>
+              <button
+                type="button"
+                onClick={() => setDetailsOpen(true)}
+                aria-label="Detalhes do contato"
+                className="flex h-11 w-11 shrink-0 items-center justify-center text-muted-foreground"
+              >
+                <Info size={20} aria-hidden />
+              </button>
+            </div>
+            <div className="min-h-0 flex-1 overflow-hidden">
+              <ChatThread conversationId={selectedConversation.id} />
+            </div>
+            <RetentionNotice conversationId={selectedConversation.id} />
+            <Composer
+              ref={composerRef}
+              conversationId={selectedConversation.id}
+              blockedReason={blockedReason}
+              disabled={selectedConversation.status === "closed"}
+              contactName={selectedConversation.contacts?.name ?? null}
+            />
+            <Sheet open={detailsOpen} onOpenChange={setDetailsOpen}>
+              <SheetContent
+                side="bottom"
+                className="flex max-h-[85dvh] flex-col overflow-y-auto"
+              >
+                <SheetTitle className="sr-only">Detalhes do contato</SheetTitle>
+                <CRMSidePanel conversation={selectedConversation} />
+              </SheetContent>
+            </Sheet>
+          </>
+        ) : selectionNotFound ? (
+          <div className="flex h-full items-center justify-center px-6 text-center text-sm text-muted-foreground">
+            Conversa não encontrada ou fora do seu acesso.
+          </div>
+        ) : (
+          <>
+            <InboxFilters value={filterValue} onChange={setFilterValue} />
+            <div className="min-h-0 flex-1 overflow-hidden">
+              <ConversationList
+                filters={filters}
+                orgId={orgId}
+                selectedId={selectedId}
+                onSelect={handleSelect}
+                clientFilter={clientFilter}
+                onVisibleChange={handleVisibleChange}
+              />
+            </div>
+          </>
+        )}
+      </div>
+    );
+  }
 
-  // TRÊS COLUNAS QUE CABEM — medido, não estimado.
-  //
-  // O `xl` do Tailwind dispara em 1280px, e era ali que a terceira coluna
-  // nascia: no ponto exato em que não havia espaço para ela. Com a barra de
-  // navegação (240px) sobram 1040px, e o grid pedia 300 + 707 + 320 = 1327 —
-  // o painel de CRM ficava 311px FORA da viewport, alcançável só rolando o
-  // `main` de lado, que ninguém faz. Em 1280 o atendente simplesmente não via
-  // contexto nenhum do cliente.
-  //
-  // Os 707px eram o `min-content` do `ConversationHeader` (a barra de ações
-  // era `shrink-0`), e `1fr` é `minmax(auto, 1fr)`: não encolhe abaixo disso.
-  // Consertado o header, o `1fr` volta a encolher sozinho — `minmax(0,1fr)`
-  // foi medido aqui e não mudou um pixel, então não entrou.
-  //
-  // Duas faixas em vez de uma: compacta onde aperta, generosa onde há espaço.
-  // Em 1280 isso dá 424px de conversa em vez de 372 — 54px de folga sobre o
-  // piso do composer (370px), em vez dos 2px que a versão de uma faixa só
-  // deixava. Margem de 2px não é margem, é sorte.
   return (
     <div className="grid h-[calc(100dvh-3.5rem-2*var(--space-6))] w-full grid-cols-1 md:grid-cols-[300px_1fr] xl:grid-cols-[272px_1fr_296px] 2xl:grid-cols-[300px_1fr_320px]">
       <div className="flex h-full min-h-0 flex-col border-r border-border">

--- a/components/kanban/KanbanBoard.tsx
+++ b/components/kanban/KanbanBoard.tsx
@@ -10,7 +10,7 @@ import { useAtRiskLeads } from "@/hooks/leads/useAtRiskLeads";
 import { useReactivations } from "@/hooks/leads/useReactivations";
 import { midpoint } from "@/lib/kanban/fractional-indexing";
 import type { Lead } from "@/lib/types/leads";
-import type { Pipeline, Stage } from "@/lib/kanban/types";
+import type { Pipeline, Stage, StageOption } from "@/lib/kanban/types";
 import { StageColumn } from "./StageColumn";
 import { LeadDossier } from "./LeadDossier";
 
@@ -140,6 +140,19 @@ export function KanbanBoard({
     return groupLeadsByStage(data.stages, data.leads);
   }, [data]);
 
+  // Base pro menu "Mover para…" (mobile — drag-drop fica desligado no toque,
+  // ver KanbanCard.tsx). `lastPosition` é o `position_in_stage` do último card
+  // do stage; o menu sempre move para o FIM do stage de destino (midpoint com
+  // `null` do lado direito), nunca pra um ponto específico da lista.
+  const stageOptions = useMemo<StageOption[]>(() => {
+    if (!data || !grouped) return [];
+    return data.stages.map((s) => {
+      const list = grouped.get(s.id) ?? [];
+      const lastPosition = list.at(-1)?.position_in_stage ?? null;
+      return { id: s.id, name: s.name, lastPosition };
+    });
+  }, [data, grouped]);
+
   const handleSelect = useCallback(
     (leadId: string, additive: boolean) => {
       const apply = (prev: Set<string>): Set<string> => {
@@ -232,7 +245,10 @@ export function KanbanBoard({
 
   return (
     <DragDropContext onDragEnd={handleDragEnd}>
-      <div className="flex h-full gap-3 overflow-x-auto p-4">
+      {/* `snap-x` só entra em mobile (`md:snap-none` cancela em telas maiores)
+          — no desktop o scroll horizontal continua livre, como sempre foi.
+          Ver docs/design-system/screen-flow/07-responsive-strategy.md. */}
+      <div className="flex h-full gap-3 overflow-x-auto p-4 snap-x snap-mandatory md:snap-none">
         {data.stages.map((stage) => (
           <StageColumn
             key={stage.id}
@@ -245,6 +261,7 @@ export function KanbanBoard({
             pulses={pulsesProp ?? queryResult.pulses}
             canonicalTags={canonicalTags}
             selectedLeadIds={selectedLeadIds}
+            stageOptions={stageOptions}
             onSelect={handleSelect}
             onOpen={setDossieId}
           />

--- a/components/kanban/KanbanCard.tsx
+++ b/components/kanban/KanbanCard.tsx
@@ -2,7 +2,9 @@
 import { Draggable } from "@hello-pangea/dnd";
 import type { MouseEvent } from "react";
 import { cn } from "@/lib/utils";
+import { useIsMobile } from "@/hooks/useIsMobile";
 import type { Lead } from "@/lib/types/leads";
+import type { StageOption } from "@/lib/kanban/types";
 import { resolveCardState, stageAgeLabel, type CardInput } from "@/lib/kanban/card-state";
 import { KanbanCardActions } from "./KanbanCardActions";
 import { NextActionSlot } from "./NextActionSlot";
@@ -24,6 +26,8 @@ interface KanbanCardProps {
    * o segundo evento dentro da janela passar despercebido.
    */
   pulseCount?: number;
+  /** Todos os stages do pipeline — alimenta o menu "Mover para…" em mobile. */
+  stageOptions?: StageOption[];
   onSelect?: (leadId: string, additive: boolean) => void;
   /** Abrir o dossiê. Separado de `onSelect`: são gestos e intenções diferentes. */
   onOpen?: (leadId: string) => void;
@@ -61,12 +65,18 @@ export function KanbanCard({
   pipelineId,
   isSelected,
   pulseCount = 0,
+  stageOptions,
   onSelect,
   onOpen,
 }: KanbanCardProps) {
   const value = formatBRL(card.valueCents, card.currency);
   const state = resolveCardState(card);
   const age = stageAgeLabel(card.hoursInStage);
+  // Drag-drop desligado no toque: touch-drag do @hello-pangea/dnd disputa com
+  // scroll da página, e a alternativa (menu "Mover para…" abaixo) não tem
+  // esse conflito. Ver docs/design-system/screen-flow/07-responsive-strategy.md
+  // e a memória global sobre touch em mobile.
+  const isMobile = useIsMobile();
 
   // Clique ABRE o dossiê; ctrl/cmd+clique SELECIONA. "Clicar abre" é a
   // convenção mais forte, e seleção múltipla é recurso de poder, que tolera
@@ -81,7 +91,7 @@ export function KanbanCard({
   };
 
   return (
-    <Draggable draggableId={card.id} index={index}>
+    <Draggable draggableId={card.id} index={index} isDragDisabled={isMobile}>
       {(provided, snapshot) => (
         <div
           ref={provided.innerRef}
@@ -162,7 +172,11 @@ export function KanbanCard({
                 </button>
               </h3>
             </div>
-            <KanbanCardActions lead={lead} pipelineId={pipelineId} />
+            <KanbanCardActions
+              lead={lead}
+              pipelineId={pipelineId}
+              stageOptions={stageOptions}
+            />
           </div>
 
           {/* ② valor — altura reservada mesmo sem valor, senão o card encolhe. */}

--- a/components/kanban/KanbanCardActions.tsx
+++ b/components/kanban/KanbanCardActions.tsx
@@ -11,25 +11,44 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
-import { DotsThree, PencilSimple, Users } from "@/lib/ui/icons";
+import { DotsThree, PencilSimple, Signpost, Users } from "@/lib/ui/icons";
 import { useWinLead, useEditLead } from "@/hooks/kanban/useUpdateLead";
+import { useMoveCard } from "@/hooks/kanban/useMoveCard";
 import { useAssignableMembers } from "@/hooks/inbox/useAssignableMembers";
 import { useAssignableAgents } from "@/hooks/kanban/useAssignableAgents";
 import { usePermission } from "@/hooks/auth/AuthProvider";
+import { midpoint } from "@/lib/kanban/fractional-indexing";
 import { LoseLeadDialog } from "./LoseLeadDialog";
 import { EditLeadDialog } from "./EditLeadDialog";
 import type { Lead } from "@/lib/types/leads";
+import type { StageOption } from "@/lib/kanban/types";
 
 interface KanbanCardActionsProps {
   lead: Lead;
   pipelineId: string;
+  /** Todos os stages do pipeline — só usado pelo menu "Mover para…" (mobile). */
+  stageOptions?: StageOption[];
 }
 
-export function KanbanCardActions({ lead, pipelineId }: KanbanCardActionsProps) {
+export function KanbanCardActions({ lead, pipelineId, stageOptions }: KanbanCardActionsProps) {
   const [loseOpen, setLoseOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const winMutation = useWinLead(pipelineId);
   const editMutation = useEditLead(pipelineId);
+  // Equivalente ao drag-drop, só que por toque: mover pra SEMPRE o fim do
+  // stage de destino (midpoint com `null` do lado direito).
+  const moveCard = useMoveCard(pipelineId);
+  const moveToStage = (stageId: string, lastPosition: number | null) => {
+    if (stageId === lead.stage_id) return;
+    const positionInStage = midpoint(lastPosition, null);
+    if (Number.isNaN(positionInStage)) return;
+    moveCard.mutate({
+      leadId: lead.id,
+      stageId,
+      positionInStage,
+      expectedUpdatedAt: lead.updated_at,
+    });
+  };
   // spec 13 §4: escrita no funil é agent+ — viewer não reatribui (a rota
   // PATCH também recusa; aqui é só não oferecer o que seria negado).
   const canAssign = usePermission("pipeline.move_card");
@@ -119,6 +138,26 @@ export function KanbanCardActions({ lead, pipelineId }: KanbanCardActionsProps) 
                         v{a.version_number}
                       </span>
                     )}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          )}
+          {/* Equivalente por toque do drag-drop (desligado em mobile — ver
+              KanbanCard.tsx). Mesma permissão de escrita no funil. */}
+          {canAssign && stageOptions && stageOptions.length > 1 && (
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                <Signpost size={14} className="mr-2" /> Mover para
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                {stageOptions.map((s) => (
+                  <DropdownMenuItem
+                    key={s.id}
+                    disabled={moveCard.isPending || s.id === lead.stage_id}
+                    onSelect={() => moveToStage(s.id, s.lastPosition)}
+                  >
+                    {s.name}
                   </DropdownMenuItem>
                 ))}
               </DropdownMenuSubContent>

--- a/components/kanban/StageColumn.tsx
+++ b/components/kanban/StageColumn.tsx
@@ -3,7 +3,7 @@ import { Droppable } from "@hello-pangea/dnd";
 import type { CSSProperties } from "react";
 import { cn } from "@/lib/utils";
 import type { Lead } from "@/lib/types/leads";
-import type { Stage } from "@/lib/kanban/types";
+import type { Stage, StageOption } from "@/lib/kanban/types";
 import { buildCardInput } from "@/lib/kanban/card-state";
 import { KanbanCard } from "./KanbanCard";
 
@@ -22,6 +22,8 @@ interface StageColumnProps {
   selectedLeadIds?: Set<string>;
   /** leadId → quantos eventos remotos já chegaram (muda = pulsa de novo). */
   pulses?: Map<string, number>;
+  /** Todos os stages do pipeline — alimenta o menu "Mover para…" em mobile. */
+  stageOptions?: StageOption[];
   onSelect?: (leadId: string, additive: boolean) => void;
   /** Abrir o dossiê — atravessa o board até o card, como `pulses`. */
   onOpen?: (leadId: string) => void;
@@ -49,6 +51,7 @@ export function StageColumn({
   canonicalTags,
   selectedLeadIds,
   pulses,
+  stageOptions,
   onSelect,
   onOpen,
 }: StageColumnProps) {
@@ -58,7 +61,12 @@ export function StageColumn({
     : undefined;
 
   return (
-    <div className="flex w-80 shrink-0 flex-col rounded-lg border border-border bg-surface-muted/40">
+    <div
+      // Largura fixa (85vw) e `snap-center` só fazem efeito dentro do
+      // container `snap-x` do KanbanBoard, que só liga em mobile — em
+      // desktop a coluna continua exatamente `w-80` como sempre foi.
+      className="flex w-[85vw] shrink-0 snap-center flex-col rounded-lg border border-border bg-surface-muted/40 md:w-80"
+    >
       <div className="flex items-center gap-2 border-b border-border px-3 py-2.5">
         <span
           className={cn(
@@ -107,6 +115,7 @@ export function StageColumn({
                 pipelineId={pipelineId}
                 isSelected={selectedLeadIds?.has(lead.id)}
                 pulseCount={pulses?.get(lead.id) ?? 0}
+                stageOptions={stageOptions}
                 onSelect={onSelect}
                 onOpen={onOpen}
               />

--- a/components/shell/BottomNav.tsx
+++ b/components/shell/BottomNav.tsx
@@ -1,0 +1,91 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { House } from "@/lib/ui/icons";
+import { cn } from "@/lib/utils";
+import { useAuth } from "@/hooks/auth/AuthProvider";
+import { NAV_DESTINATIONS, canSee, GRUPO_NO_RODAPE, NAV_GROUPS } from "@/lib/navigation/registry";
+
+/**
+ * Navegação inferior mobile — padrão de app nativo, 100% projeção do mesmo
+ * registro que alimenta a Sidebar (`lib/navigation/registry.ts`), nunca uma
+ * segunda lista de itens (mesma doutrina do arquivo: uma fonte só).
+ *
+ * Diferente da Sidebar (mostra TODO item `sidebar:true` do papel), a barra só
+ * cabe ~5 ícones — então é uma curadoria fixa dos destinos de uso diário, na
+ * mesma ordem de objetivo que `NAV_GROUPS` já declara (atendimento primeiro).
+ * Um item que o papel atual não pode ver (`canSee` nega) simplesmente some da
+ * barra em vez de quebrar — mesma regra da Sidebar.
+ */
+const BOTTOM_NAV_HREFS = ["/app/inbox", "/app/kanban", "/app/contacts"] as const;
+
+export function BottomNav() {
+  const pathname = usePathname();
+  const { user, activeOrg } = useAuth();
+  const role = activeOrg?.role ?? null;
+
+  const primary = BOTTOM_NAV_HREFS.map((href) =>
+    NAV_DESTINATIONS.find((d) => d.href === href),
+  ).filter(
+    (d): d is (typeof NAV_DESTINATIONS)[number] =>
+      d !== undefined && canSee(d, user.is_platform_admin, role),
+  );
+
+  const settingsHub = NAV_GROUPS.find((g) => g.id === GRUPO_NO_RODAPE)?.hub;
+
+  return (
+    <nav
+      className="fixed inset-x-0 bottom-0 z-30 flex items-stretch border-t bg-card md:hidden"
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+      aria-label="Navegação principal"
+    >
+      <Link
+        href="/app/inbox"
+        title="Início"
+        aria-current={pathname === "/app/inbox" ? "page" : undefined}
+        className={cn(
+          "flex flex-1 flex-col items-center justify-center gap-0.5 py-2 text-[11px]",
+          pathname === "/app/inbox" ? "text-accent-foreground" : "text-muted-foreground",
+        )}
+      >
+        <House size={22} weight={pathname === "/app/inbox" ? "fill" : "regular"} aria-hidden />
+        <span className="sr-only">Início</span>
+      </Link>
+      {primary.map((item) => {
+        const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
+        const Icon = item.icon;
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            title={item.label}
+            aria-current={isActive ? "page" : undefined}
+            className={cn(
+              "flex flex-1 flex-col items-center justify-center gap-0.5 py-2 text-[11px]",
+              isActive ? "text-accent-foreground" : "text-muted-foreground",
+            )}
+          >
+            <Icon size={22} weight={isActive ? "fill" : "regular"} aria-hidden />
+            <span className="max-w-full truncate px-1">{item.label}</span>
+          </Link>
+        );
+      })}
+      {settingsHub && (
+        <Link
+          href={settingsHub.href}
+          title={settingsHub.label}
+          aria-current={pathname.startsWith(settingsHub.href) ? "page" : undefined}
+          className={cn(
+            "flex flex-1 flex-col items-center justify-center gap-0.5 py-2 text-[11px]",
+            pathname.startsWith(settingsHub.href) ? "text-accent-foreground" : "text-muted-foreground",
+          )}
+        >
+          <span aria-hidden className="text-lg leading-none">
+            ⚙
+          </span>
+          <span className="max-w-full truncate px-1">{settingsHub.label}</span>
+        </Link>
+      )}
+    </nav>
+  );
+}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -5,13 +5,23 @@ import { cn } from "@/lib/utils";
 const Card = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
+>(({ className, style, ...props }, ref) => (
   <div
     ref={ref}
     className={cn(
       "rounded-lg border border-border bg-surface text-text shadow-xs",
       className,
     )}
+    // backdrop-filter é dirigido pelo token --surface-blur (app/globals.css):
+    // "none" em todo tema normal, "blur(20px)" só sob [data-layout="elegant"].
+    // Sem isto o layout elegante mudaria só cores — o vidro é o que o
+    // diferencia, e ele nasce aqui pra propagar a TODO card do CRM sem
+    // precisar tocar cada tela consumidora.
+    style={{
+      backdropFilter: "var(--surface-blur)",
+      WebkitBackdropFilter: "var(--surface-blur)",
+      ...style,
+    }}
     {...props}
   />
 ));

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from "lucide-react"
+import { ArrowLeft, X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
@@ -38,15 +38,23 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        // Abaixo de `md`: tela cheia, sem cantos, rolável (o doc de
+        // responsividade pede "full-screen modal com header back arrow" —
+        // ver docs/design-system/screen-flow/07-responsive-strategy.md).
+        // A partir de `md`: volta a ser o modal centrado de sempre.
+        "fixed inset-0 z-50 grid w-full max-h-[100dvh] translate-x-0 translate-y-0 gap-4 overflow-y-auto border-0 bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+        "md:inset-auto md:left-[50%] md:top-[50%] md:h-auto md:max-h-[85vh] md:w-full md:max-w-lg md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-lg md:border",
         className
       )}
       {...props}
     >
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        {/* Seta "voltar" em mobile (convenção de navegação de app nativo),
+            X em telas maiores — mesmo botão, mesmo Close, só o ícone muda. */}
+        <ArrowLeft className="h-5 w-5 md:hidden" />
+        <X className="hidden h-4 w-4 md:block" />
+        <span className="sr-only">Fechar</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>

--- a/components/ui/responsive-table.tsx
+++ b/components/ui/responsive-table.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+/**
+ * Peça fina e compartilhada pro padrão "tabela em desktop, cards em mobile".
+ * Não é uma tabela genérica dirigida por config de colunas — cada tela
+ * continua decidindo o que mostrar; isto só dá o invólucro visual comum.
+ * Uso: `<Table className="hidden md:table">…` ao lado de
+ * `<MobileCardList className="md:hidden">…<MobileCardRow .../>…</MobileCardList>`.
+ */
+export function MobileCardList({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <div className={cn("flex flex-col gap-2", className)}>{children}</div>;
+}
+
+export function MobileCardRow({
+  children,
+  onClick,
+  className,
+}: {
+  children: ReactNode;
+  onClick?: () => void;
+  className?: string;
+}) {
+  return (
+    <Card
+      className={cn("p-3", onClick && "cursor-pointer active:bg-accent/10", className)}
+      onClick={onClick}
+    >
+      <dl className="flex flex-col gap-1.5">{children}</dl>
+    </Card>
+  );
+}
+
+/** Uma linha label→valor dentro de `MobileCardRow`. */
+export function MobileCardField({
+  label,
+  children,
+  className,
+}: {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex items-baseline justify-between gap-3", className)}>
+      <dt className="shrink-0 text-xs text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 truncate text-right text-sm">{children}</dd>
+    </div>
+  );
+}

--- a/hooks/useIsMobile.ts
+++ b/hooks/useIsMobile.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import * as React from "react";
+
+/**
+ * Breakpoint mobile do CRM: <768px (abaixo do `md` do Tailwind — ver
+ * docs/design-system/screen-flow/07-responsive-strategy.md).
+ *
+ * Só use este hook onde o COMPORTAMENTO muda (desligar drag-drop, decidir
+ * qual coluna do Inbox renderizar) — onde é só aparência, prefira classes
+ * Tailwind puras (`md:hidden`) em vez de JS: mais barato e sem risco de
+ * flash entre o valor default do server e o valor real do client.
+ *
+ * Mesmo cuidado de SSR do `lib/theme.tsx`: o server não conhece o viewport,
+ * então o default é `false` até o primeiro efeito rodar no client.
+ */
+const MOBILE_QUERY = "(max-width: 767px)";
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = React.useState(false);
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(MOBILE_QUERY);
+    setIsMobile(mql.matches);
+    const onChange = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return isMobile;
+}

--- a/lib/kanban/types.ts
+++ b/lib/kanban/types.ts
@@ -34,6 +34,17 @@ export interface Stage {
   expected_duration_hours: number | null;
 }
 
+/**
+ * Base pro menu "Mover para…" do card em mobile (drag-drop fica desligado no
+ * toque). `lastPosition` é o `position_in_stage` do último card do stage —
+ * o menu sempre move para o FIM do destino, nunca pra um ponto específico.
+ */
+export interface StageOption {
+  id: string;
+  name: string;
+  lastPosition: number | null;
+}
+
 export interface BoardData {
   pipeline: Pipeline;
   stages: Stage[];

--- a/lib/schemas/settings.ts
+++ b/lib/schemas/settings.ts
@@ -24,6 +24,19 @@ export type AiDispatchMode = (typeof AI_DISPATCH_MODES)[number];
 export const aiDispatchModeSchema = z.enum(AI_DISPATCH_MODES).catch("native");
 
 /**
+ * organizations.settings.ui_layout — visual do CRM inteiro (não é preferência
+ * pessoal como o toggle claro/escuro em lib/theme.tsx, que fica no localStorage
+ * do navegador). 'default' = paleta Sage atual. 'elegant' = tema dark-glass
+ * (ver skill layout-elegant), aplicado via atributo `data-layout` no shell
+ * autenticado (app/app/layout.tsx) — nunca no RootLayout, então login/páginas
+ * públicas continuam no visual padrão independente da escolha da org.
+ * `.catch("default")` normaliza chave ausente/null/inválida para o default seguro.
+ */
+export const UI_LAYOUTS = ["default", "elegant"] as const;
+export type UiLayout = (typeof UI_LAYOUTS)[number];
+export const uiLayoutSchema = z.enum(UI_LAYOUTS).catch("default");
+
+/**
  * G3-05: vocabulário canônico de tags de conversa, persistido em
  * organizations.settings.canonical_conversation_tags (spec 13 §3.3 — org-scoped,
  * não pipeline-scoped). Schema declarativo; usado para validar o que o inbox lê
@@ -78,6 +91,7 @@ export const tenantSchema = z.object({
     .optional()
     .or(z.literal("").transform(() => null)),
   lost_reasons_extra: z.array(z.string().min(1).max(80)).max(50).default([]),
+  ui_layout: uiLayoutSchema,
 });
 export type TenantInput = z.infer<typeof tenantSchema>;
 


### PR DESCRIPTION
## O que este PR faz

Dois recursos independentes, empacotados juntos por terem sido desenvolvidos na mesma sessão:

1. **Layout visual "Elegante" selecionável por organização** — admin escolhe em Configurações → Organização → Aparência entre o tema padrão (Sage) e um tema dark-glass opcional, persistido em `organizations.settings.ui_layout` (é config da ORG, não preferência pessoal de navegador). Aplicado via atributo `data-layout` no shell autenticado (`app/app/layout.tsx`), nunca no `RootLayout` — login e páginas públicas continuam no visual padrão.
2. **Experiência mobile responsiva completa** — implementa `docs/design-system/screen-flow/07-responsive-strategy.md`, que existia como spec mas nunca tinha sido construído. Navegação inferior estilo app nativo abaixo de 768px, sem alterar o layout desktop existente. Cobre: shell (bottom nav + sidebar `hidden md:flex`), Inbox (lista OU thread, nunca as duas, + bottom sheet de detalhes), Kanban (swipe horizontal com snap + drag-and-drop desligado em mobile, substituído por menu "Mover para"), tabelas → cards (audit log tenant/platform, solicitações LGPD), Customer 360, onboarding stepper, e um banner de degradação intencional na área super-admin.

## Checklist (Definition of Done)

- [ ] `pnpm typecheck` zerado — **não executado nesta sessão** (mudanças foram feitas e revisadas localmente, mas a suíte completa não rodou antes do push; recomendo rodar no CI antes do merge)
- [ ] `pnpm lint` zerado — mesmo caso acima
- [ ] Testes relevantes existem e passam (`pnpm test:unit` / `pnpm test:e2e`) — **nenhum teste novo foi adicionado**. Cobertura mobile hoje é só a spec pré-existente sendo implementada; recomendo cobertura e2e como follow-up
- [ ] RLS testada, se toca tabela tenant-aware — N/A (nenhuma tabela nova; `ui_layout` é uma chave a mais em `organizations.settings` jsonb, mesmo padrão de `ai_dispatch_mode`)
- [x] Audit log emitido, se há mutação relevante — `updateTenant` já emitia `org.updated`; `ui_layout` entrou no mesmo fluxo, sem rota nova
- [x] Zod valida todo input externo novo — `uiLayoutSchema` (`z.enum(["default","elegant"]).catch("default")`) em `lib/schemas/settings.ts`
- [x] Sem `console.log` esquecido
- [ ] Mudança de schema saiu como migration versionada + apêndice no `baseline.sql` + linha no MANIFEST — **N/A**, não há mudança de schema SQL (chave nova em jsonb existente, sem migration necessária)
- [ ] Doc atualizada se mudou contrato (PRD/spec) — a spec de responsividade já existia e foi seguida; não editei o doc em si

## QA visual — status honesto

**Não foi possível fazer QA visual pela tela nesta sessão**: a conta de teste do ambiente usado tem MFA (TOTP) obrigatório para `admin`, e não havia como completar esse fluxo no ambiente automatizado. Ou seja, os dois recursos foram implementados e revisados no código, mas **não foram verificados rodando no browser** contra os critérios da doutrina de QA Visual do repo (`CLAUDE.md`). Isso é um gap real, não um detalhe — recomendo que quem revisar rode localmente em pelo menos 375px/768px/1280px antes do merge, cobrindo: shell (bottom nav aparece só <768px), Inbox (lista↔thread, bottom sheet), Kanban (snap scroll, drag desligado, menu "Mover para"), Audit/LGPD (tabela↔cards), e a troca de tema Elegante em Configurações → Organização.

## Simplificações assumidas (registradas, não escondidas)

- Bottom sheet (Inbox, detalhes do contato) usa o `Sheet` existente (Radix, `side="bottom"`) — abre/fecha, sem física de arrasto com 3 paradas (peek/metade/cheio)
- Kanban mobile usa swipe horizontal com snap, não a alternativa de lista vertical empilhada que a spec também permite
- Tabela→cards aplicado em audit log (tenant + platform) e solicitações LGPD; as demais tabelas do repo (ContactsTable, RunsTable, etc.) ficam para uma próxima leva

Convenções completas em [`CLAUDE.md`](../CLAUDE.md) · fluxo em [`CONTRIBUTING.md`](../CONTRIBUTING.md).
