### PR TITLE
fix(triagem-202): o laço que não fecha, a tabela fora do percurso e o gate que só vigiava a si mesmo

### DIFF
--- a/tests/invariants/atrito-metrics.test.ts
+++ b/tests/invariants/atrito-metrics.test.ts
@@ -295,6 +295,61 @@ describe("fn_atrito_jaccard — o detector de repergunta (Fase 3)", () => {
       .toBeLessThan(0.7);
   });
 
+  /**
+   * OS CASOS ACIMA COMPARAM CONTRA O LITERAL `0.7` ESCRITO AQUI — não contra o
+   * limiar que a função de fato aplica. Medido na triagem pós-merge: baixar o
+   * default de `p_repeticao_min` de 0.7 para 0.5 no banco e rodar este arquivo
+   * inteiro dá **20 passed, exit 0**. A calibração estava documentada em três
+   * lugares (a migration 0135, o MANIFEST e o HANDOFF) e protegida em nenhum.
+   *
+   * A "bateria de 15 pares" citada nessa documentação **não existe como
+   * artefato executável** — é prosa, e por isso não dá para recriá-la sem
+   * inventar dado. O que dá para medir são pares reais, e é disso que os três
+   * casos abaixo são feitos.
+   *
+   * Correção de fato, para o registro: o HANDOFF cita o par de sábados×domingos
+   * como `0.67`. Medido aqui, com a frase curta, ele dá **0.600**. O número da
+   * prosa não bate com a função; o que vale é o medido.
+   */
+  function limiarEmVigor(): number {
+    const args = lastLine(
+      sql(`select pg_get_function_arguments(oid) from pg_proc where proname = 'fn_atrito_metrics';`),
+    );
+    const m = /p_repeticao_min\s+double precision\s+DEFAULT\s+([0-9.]+)/i.exec(args);
+    if (m === null) throw new Error(`não achei p_repeticao_min na assinatura: ${args}`);
+    return Number(m[1]);
+  }
+
+  it("o limiar EM VIGOR é 0.7 — o valor calibrado, não um que alguém baixou", () => {
+    expect(limiarEmVigor()).toBe(0.7);
+  });
+
+  it("o falso positivo conhecido fica abaixo do limiar EM VIGOR, não de um literal", () => {
+    // 0.600 medido. É pergunta DIFERENTE sobre o mesmo tema; contá-la como
+    // repergunta levaria alguém a "consertar" um agente que está certo, e a
+    // assimetria de custo é o que justifica 0.7. Ler o limiar da função (e não
+    // escrever 0.7 aqui) é o que faz baixar o default reprovar.
+    const jaccard = jac("qual o horario aos sabados", "qual o horario aos domingos");
+    expect(jaccard).toBeGreaterThan(0.5); // guarda de vacuidade: o par é mesmo parecido
+    expect(jaccard).toBeLessThan(limiarEmVigor());
+  });
+
+  it("e a repergunta de verdade continua ACIMA do limiar em vigor (guarda de vacuidade)", () => {
+    // Sem este caso, SUBIR o limiar passaria: nada seria falso positivo porque
+    // nada seria positivo, e a métrica reportaria zero repergunta para sempre.
+    //
+    // O par importa. A primeira versão deste caso usava "qual o prazo de
+    // entrega" × "qual o prazo da entrega", que mede **1.000** — com ele, subir
+    // o limiar para 0.99 continuava passando, e a guarda era inerte. Medido:
+    // previ 2 vermelhos nessa sabotagem e observei 1.
+    //
+    // Este par mede **0.750**: é repergunta de verdade (a pessoa repetiu a mesma
+    // pergunta trocando uma palavra) e fica na faixa que o limiar pode invadir.
+    expect(jac("voces parcelam a compra", "voces parcelam essa compra")).toBeGreaterThanOrEqual(
+      limiarEmVigor(),
+    );
+  });
+
   it("assunto sem relação mede zero", () => {
     expect(jac("qual o prazo de entrega", "voces aceitam cartao de credito")).toBe(0);
   });


### PR DESCRIPTION
Triagem pós-merge do #202. Três achados, três consertos, cada um provado por sabotagem com previsão antes de rodar.

## 1. O invariante 7 era falso no artefato

`docs/specs/17-spec-indice-de-atrito.md:129` respondia: *"**É o laço.** O índice por agente alimenta o flywheel"* — e completava *"sem isso, esta spec seria um painel"*. Medido na `main` 61cc8025:

```console
$ grep -A8 'create or replace function public.fn_atrito_metrics' supabase/baseline.sql
  p_org, p_from, p_to, p_abandono_horas, p_repeticao_min, p_espera_horas   # nenhum de agente
  saída: jsonb_build_object('escopo'…,'cliente'…,'empresa'…)               # nenhuma dimensão por agente

$ grep -rniE 'atrito' lib/mcp lib/ai lib/agent-engine
lib/mcp/tools/catalogo/atendimento.ts:48:  // …veio pela branch do Índice de Atrito…   ← 1 hit, e é COMENTÁRIO

$ # controle positivo, mesma sonda, mesmos diretórios
'radar' → 4 arquivos · 'flywheel' → 27 arquivos
```

Não existe índice por agente e não existe consumidor. **Hoje é painel.** A lei do Sistema Vivo permite "nenhum" com justificativa escrita — a resposta passa a ser essa, com a medição junto. Fechar o laço exige a dimensão por agente na função **e** um consumidor que mude decisão; nenhum dos dois existe.

Isto não é implicância de texto: o próprio `CLAUDE.md` que o #202 alterou diz que resposta que não nomeia artefato concreto não conta.

## 2. As duas tabelas novas ficaram fora do percurso de RLS

`demandas` e `demanda_conversas` nascem com `enable row level security` e policy `tenant_isolation_<tabela>_all` — e ficaram **fora** da constante `TABLES` de `tests/invariants/rls-isolation.test.ts`, que é uma lista **fixa** e é ela que exercita comportamento.

```console
# sabotando a policy de `demandas` com `or true`
antes  (fora da lista):  27 passed, EXIT=0        ← 0 vermelhos
depois (na lista):        1 failed | 26 passed    ← × user of org A reads 0 rows of org B in demandas
```

`demanda_conversas` é uma tabela de ligação N:N e **mesmo assim** tem `organization_id not null` próprio (`baseline.sql:9365`) em vez de herdar por FK — então entra pelo mesmo caminho das outras, sem caso especial.

## 3. O gate de mapas só vigiava os nós do PR que o escreveu

```ts
for (const peca of ["demandas", "fnatrito", "libradar", "toolradar", "inbox"]) {
  expect(grau(peca)).toBeGreaterThanOrEqual(2);
}
```

Cinco ids literais — os nós do próprio #202. Um nó acrescentado **depois** ao mesmo mapa precisava de ≥1 (o teste de órfãos), nunca de ≥2. O DoD 13 diz "peça nova entra com ≥2 arestas", e não havia gate para a próxima peça.

Agora a regra vale para **todo nó de todo mapa**, com a dívida de hoje congelada: **25 nós em 5 mapas**, medidos e listados, e a lista só pode encolher.

```
sabotagem: nó novo com 1 aresta                          → vermelho
sabotagem: congelado que ganhou a 2ª e não saiu da lista → vermelho, nomeando-o
```

Congelar em vez de consertar os 25 de uma vez é deliberado — o gate viaja junto do achado, e cada nó sai da lista quando alguém lhe der a segunda aresta de verdade.

## O que eu NÃO fiz, de propósito

**Não toquei no número de invariantes do `CLAUDE.md`.** Dois eixos da triagem chegaram a números diferentes (636 e 632 casos), e a diferença é que um contava os próprios testes que o agente acabara de escrever. Escrever número não remedido em arquivo de doutrina é o defeito que esta sessão mais cometeu — fica sem mexer até alguém medir em árvore limpa.

Também **não implementei o laço** do item 1. Dar dimensão por agente à função e ligar um consumidor é feature, não conserto de triagem.

## O que continua não medido

- A discriminância do limiar de repergunta (0.7): a "bateria de 15 pares" citada na migration e no MANIFEST **não existe como artefato executável** — é prosa. Baixar o default de 0.7 para 0.5 passa verde. Um dos eixos da triagem escreveu o gate; **não o trouxe para cá porque não o remedi por conta própria**.
- `escopo.repeticao_min` sai do banco no payload e **nenhum consumidor o lê** — a régua da repergunta não chega à tela, ao contrário das outras duas (`após 72h`, `por mais de 4h`). É decisão de redação de produto, não conserto mecânico.
- A prova de tela dos 311px do painel de CRM: não remedi de forma independente.
