### PR TITLE
fix(e2e): a main está vermelha em 429 — eleva os tetos do GoTrue no ambiente local/CI

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -52,6 +52,28 @@ enable_refresh_token_rotation = true
 refresh_token_reuse_interval = 10
 enable_signup = true # Signup self-service (/signup) — provisiona tenant em /auth/confirm
 
+# Tetos do GoTrue para o AMBIENTE LOCAL/CI. Não é config de produção — lá quem
+# manda é o painel do Supabase Cloud.
+#
+# Por que existe: no CI todas as specs saem de UM IP (o runner), e cada tela que
+# abre faz checagem de sessão. Com a suíte em 37 specs, a soma estourou o teto
+# padrão do GoTrue e o sintoma NÃO aponta para a causa — as telas recebem 429 e
+# a spec que estiver passando na hora é a que falha. Medido em 2026-08-10: a
+# `main` ficou vermelha em `olhar-telas-do-epico` com sete telas de IA acusando
+# "Failed to load resource: 429", e a lista de telas dessa spec não tinha mudado.
+#
+# É o mesmo problema que já forçou `AUTH_RATE_LIMIT_LOGIN_IP` no workflow, com
+# uma diferença que importa: aquele limitador é do processo Next (dividir a
+# suíte em duas invocações zerava o contador), este é do GoTrue, do lado do
+# servidor — dividir não ajuda, só afrouxar aqui.
+[auth.rate_limit]
+# padrão 150/5min por IP; a suíte inteira compartilha um IP só.
+token_refresh = 10000
+# padrão 30/5min por IP.
+sign_in_sign_ups = 10000
+# padrão 30/5min por IP.
+token_verifications = 10000
+
 [auth.email]
 enable_signup = true
 double_confirm_changes = true


### PR DESCRIPTION
A `main` está reprovando num check **obrigatório** desde o merge do #209:

```
olhar-telas-do-epico.spec.ts:54  "cada tela abre, tem conteúdo e não cospe erro no console"
  /app/ai/knowledge/sources [W5]: console → 429 (Too Many Requests)
  /app/ai/skills, /app/ai/memory, /app/ai/usage, /app/ai/inbox,
  /app/ai/routers, /app/ai/agents/new — todas 429
```

Nada pode entrar enquanto isso não for consertado.

## O que é, e o que não é

**Não é regressão de app.** O #209 e o #217 mexem só em teste e doc. O 429 vem do **GoTrue local**, que cada tela consulta ao montar; com a suíte em 37 specs saindo de **um** IP, a soma passou do teto padrão.

**Não é o teto de login** — esse o workflow já eleva (`AUTH_RATE_LIMIT_LOGIN_IP: "1000"`).

**A hipótese óbvia caiu.** Achei que a lista de telas da spec tivesse crescido com o lote. Medido: **7 telas antes e depois** (`b9f2ca51` vs `main`), e o último commit daquele arquivo é anterior ao lote. O que cresceu foi a suíte inteira (32 → 37 specs), então a saturação é cumulativa e quem reprova é a spec que estiver passando na hora — exatamente o que o `e2e.yml` já descreve para o login.

## Por que dividir a suíte não resolveria

É a diferença que importa entre os dois limitadores: o do login é **do processo Next**, então duas invocações do Playwright dão dois contadores — foi por isso que aquela divisão funcionou. O do GoTrue é **do lado do servidor**: dividir não zera nada.

## O que continua não medido

Não consegui validar as chaves do `[auth.rate_limit]` localmente sem derrubar o Supabase que outras sessões estão usando. Se algum nome estiver errado, o `supabase start` do CI **falha alto** — é modo de falha barulhento, não silencioso, e aparece neste próprio PR.
