### PR TITLE
fix(e2e): a main destrava — SENTRY_DSN vazio não desliga, seleciona o Sentry da comunidade

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -128,6 +128,17 @@ jobs:
         run: pnpm e2e:build
         env:
           NEXT_TELEMETRY_DISABLED: "1"
+          # `off`, NÃO vazio. Vazio seleciona o Sentry DA COMUNIDADE — está
+          # escrito em lib/sentry/dsn.ts:8-10, e é o default de propósito num
+          # produto self-host. Só "off" desliga.
+          #
+          # Sem isto, o SDK do browser tuneliza por /monitoring (next.config.ts:71)
+          # para o Sentry real do projeto, que devolve 429 por cota. Os 429 caem
+          # no console, e `olhar-telas-do-epico` — a ÚNICA spec que afirma "não
+          # cospe erro no console" — reprova nas 7 telas de uma vez.
+          # Medido em 2026-08-10 capturando a URL: /monitoring?o=4509908078559232,
+          # que é o org id do DEFAULT_SENTRY_DSN (lib/sentry/dsn.ts:17).
+          SENTRY_DSN: "off"
 
       - name: Instalar o browser
         run: pnpm exec playwright install --with-deps chromium
@@ -232,6 +243,8 @@ jobs:
           # (60/5min) é irreal aqui. O teto por CONTA (5 falhas) NÃO muda — é
           # ele que barra brute force.
           AUTH_RATE_LIMIT_LOGIN_IP: "1000"
+          # ver o comentário do passo de build: vazio NÃO desliga.
+          SENTRY_DSN: "off"
 
       - name: E2E — parte 2 de 2 (processo novo, contador de login zerado)
         run: |
@@ -253,6 +266,8 @@ jobs:
           # (60/5min) é irreal aqui. O teto por CONTA (5 falhas) NÃO muda — é
           # ele que barra brute force.
           AUTH_RATE_LIMIT_LOGIN_IP: "1000"
+          # ver o comentário do passo de build: vazio NÃO desliga.
+          SENTRY_DSN: "off"
 
       - name: Declarar o que este job ainda NÃO cobre
         if: always()

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -28,7 +28,11 @@ jobs:
         run: pnpm build
         env:
           NEXT_TELEMETRY_DISABLED: "1"
-          SENTRY_DSN: ""
+          # "off", não vazio: vazio seleciona o Sentry DA COMUNIDADE
+          # (lib/sentry/dsn.ts:8-10). A intenção aqui sempre foi desligar, e
+          # com aspas vazias ela não era alcançada — o build seguia com o DSN
+          # padrão embutido.
+          SENTRY_DSN: "off"
 
       - name: Report bundle sizes
         run: |


### PR DESCRIPTION
A `main` está vermelha num check **obrigatório** desde o merge do #209. Este PR conserta, e a causa não era nenhuma das duas que eu chutei antes.

## A medição que resolveu

Abri as telas num browser contra o app buildado na `main` e capturei a URL que devolve 429:

```
http://127.0.0.1:3399/monitoring?o=4509908078559232&p=4509908083212288&r=us  → 429
```

`/monitoring` é o `tunnelRoute` do Sentry (`next.config.ts:71`), e `o=4509908078559232` é o org id do `DEFAULT_SENTRY_DSN` (`lib/sentry/dsn.ts:17`). **O CI manda telemetria para o Sentry real do projeto, que devolve 429 por cota.**

Não é API do produto, não é GoTrue, não é regressão de app: é telemetria barrada caindo no console. E `olhar-telas-do-epico` é a **única** spec que afirma "não cospe erro no console" — por isso só ela vê. O 429 provavelmente acontece em toda tela.

## A armadilha, que está documentada e eu atropelei

`lib/sentry/dsn.ts:8-10`:

```
SENTRY_DSN=off        → desliga toda a telemetria (nada é enviado)
SENTRY_DSN=<seu-dsn>  → manda os erros pro SEU Sentry
SENTRY_DSN=  (vazio)  → usa o Sentry da comunidade (padrão)
```

**Vazio não desliga.** É o default certo para um produto self-host — quem instala manda erro para o projeto e isso dá visibilidade —, mas em CI é exatamente o que não se quer.

Por isso o `perf.yml` vai junto: ele setava `SENTRY_DSN: ""` com a intenção de desligar, e **nunca desligou**.

## O chute anterior, e por que ele caiu

Abri o #219 elevando o teto do GoTrue, por analogia com o teto de login que já forçou dividir a suíte. O próprio `e2e` falsificou: `supabase start` subiu (as chaves eram válidas), a suíte rodou, e vieram **as mesmas 7 telas com o mesmo 429**. Fechei o PR e fui medir.

O sinal que eu tinha e li mal: **as 7 telas da lista falham, todas**. Saturação pega umas e não outras; isso era sistemático.

## O que continua não medido

Não confirmei que o 429 aparece em telas fora dessa lista — a hipótese é que sim, e que só esta spec o denuncia. Se for, vale considerar se as outras specs deveriam afirmar o mesmo sobre o console.
