### PR TITLE
docs: a VPS vira o caminho principal do README, e a 1.2.0 ganha changelog para ser cortada

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,24 +8,88 @@ Se você roda o DeskcommCRM numa VPS, **leia a seção da versão para a qual es
 
 ## [Não lançado]
 
-## [1.2.0] — 2026-08-06
+## [1.2.0] — 2026-08-11
 
-Versão grande: 122 correções e 62 novidades desde a 1.1.0. O tema é o agente de IA deixar de
-ser um respondedor e virar parte da operação — com papel próprio, capacidades declaradas e
-lugar na tela —, e o sistema parar de mentir quando algo dá errado.
+A maior versão até aqui: **126 novidades e 205 correções** desde a 1.1.0 (contadas por commit).
+Dois temas.
+
+O primeiro é o **agente de IA deixar de ser um respondedor e virar parte da operação**: ele
+ganha papéis separados, capacidades declaradas, um follow-up que não deixa conversa morrer no
+silêncio, e um painel onde você escolhe qual inteligência atende cada parte do sistema.
+
+O segundo é o **sistema parar de mentir quando algo dá errado**: falha de IA deixa rastro em
+vez de sumir, botão que não controlava nada foi ligado (ou removido), e erro de rede diz onde
+mexer em vez de mandar reiniciar o que nunca caiu.
 
 ### Adicionado
 
-- **O agente publicado ganha papel próprio**, entre atendente e gerente: ele assume o lead,
-  devolve para uma pessoa quando precisa, e a volta aparece na linha do tempo em vez de sumir.
-- **Roteador de intenção por número.** Um WhatsApp só passa a atender vários assuntos: o
-  roteador entende o que o cliente quer e entrega para o agente certo.
+**O agente ganha papéis**
+
+- **Três papéis em vez de um** — Conversador, Operador e Segurança. Quem fala não é quem
+  executa, e o disparo de ação passou a ser imposto pelo sistema, não decidido pelo modelo.
+  Efeito medido: a taxa de resposta em que dado interno vazava para o cliente (URL de sistema,
+  UUID, jargão de CRM) caiu de **3 em 10 turnos para 1 em 10** — mesmos cenários, ferramentas
+  executadas contra dados reais, controle calibrado contra a linha de base.
+- **O agente publicado tem lugar próprio**, entre atendente e gerente: assume o lead, devolve
+  para uma pessoa quando precisa, e a volta aparece na linha do tempo em vez de sumir.
+- **Capacidades declaradas.** Você escolhe o que ele pode fazer, vê quantas vezes usou cada
+  uma, e ele avisa quando falta uma capacidade em vez de falhar calado.
+- **Roteador de intenção por número** — um WhatsApp só passa a atender vários assuntos — agora
+  com escolha do modelo (e do provedor) que identifica a intenção.
+
+**Follow-up: nenhuma conversa morre no silêncio**
+
+- **O follow-up nasce sozinho** quando o negócio entra numa etapa do funil, ou quando o agente
+  abre um caso pedindo ajuda — e morre quando o caso fecha.
+- **Ramos nomeados no canvas:** cada regra é uma bolinha com nome, e publicar exige cobertura
+  por ramo, dizendo qual ramo ficou descoberto.
+- **Pausar, retomar, adiar e pular** um follow-up sem matá-lo.
+- **Tempo adaptativo** — a IA escolhe o intervalo e a tela mostra qual foi, e se bateu no seu
+  limite.
+- **Dossiê do follow-up:** o que já foi tentado, com o que o motor realmente fez.
+- O painel inteiro fala **português** — UUID saiu da tela.
+
+**Escolher a sua IA**
+
+- **Painel de Provedores** (Agente de IA → Provedores): a tela onde se vê e se escolhe qual
+  inteligência atende **cada uma das 23 partes do sistema** que usam IA — conversar, classificar
+  sentimento, indexar conhecimento, ouvir áudio. Antes disso a escolha existia só no `.env`.
+- **OpenRouter completa** — uma chave só, com catálogo que se atualiza sozinho contra a origem
+  (cerca de 400 modelos na sincronização de referência; o número acompanha o que eles publicam).
+- **O instalador pergunta qual IA vai atender** (OpenRouter, Anthropic ou OpenAI) e valida a
+  chave na hora, em vez de assumir uma e falhar semanas depois.
+- **Catálogo de modelos atualizado** nos provedores — quem instala não escolhe mais entre
+  modelos de duas gerações atrás, pagando mais caro por pior.
+
+**Ver o que a IA fez**
+
+- **Tela de Execuções** (Agente de IA → Execuções): o que a IA fez e, quando falhou, o que
+  aconteceu e o que fazer a respeito.
+- **Falha de IA deixa rastro.** Antes, um erro no meio do caminho sumia — o log mentia por
+  omissão e a operação não tinha como saber que algo não rodou.
+
+**A conversa vira CRM sozinha**
+
+- **A conversa vira lead** sem alguém transcrever nada à mão.
+- **A IA propõe o dado que o cliente disse** — telefone, e-mail, nome — e **não grava nada**:
+  o dado espera numa fila até uma pessoa confirmar na tela.
+- **Demandas viram entidade de primeira classe:** nascem no ponto de entrada, aparecem no painel
+  de quem atende, e o Radar mostra as que estão **sem próximo passo** — o que corre risco de
+  morrer sem resposta.
+- **Escopo de funil do agente:** você marca em quais funis ele mexe, e ele só escreve nesses.
+
+**Medir a operação**
+
+- **Índice de Atrito** (Desempenho) — o sistema passa a medir o próprio propósito.
+- **Abandono, repergunta e espera calada** — as perdas de que ninguém reclama, agora contadas.
+
+**Atendimento**
+
 - **Fila de leads por atendente, com rodízio.** A distribuição deixa de ser combinada por fora
   e vira porta na tela.
-- **Capacidades do agente.** Você escolhe o que ele pode fazer, vê quantas vezes usou cada uma,
-  e ele avisa quando falta uma capacidade em vez de falhar calado.
-- **Catálogo de modelos atualizado** nos três provedores — quem instala não escolhe mais entre
-  modelos de duas gerações atrás, pagando mais caro por pior.
+- **Colar imagem no composer com Ctrl+V.**
+- **Declarar desde quando o número é usado** e poder pular o aquecimento — um número antigo
+  não precisa ser tratado como recém-nascido.
 - **Aviso de mensagem presa.** Uma tarefa automática detecta mensagem que ficou "enviando" e
   abre um aviso na Central, em vez de deixar o cliente sem resposta em silêncio.
 
@@ -35,6 +99,18 @@ lugar na tela —, e o sistema parar de mentir quando algo dá errado.
 - **"O WhatsApp está fora do ar" quando o serviço estava de pé.** Toda falha de rede caía na
   mesma frase, mandando reiniciar um container que nunca havia caído. Agora a mensagem
   distingue endereço errado de serviço parado e diz onde mexer.
+- **Escolher OpenRouter ou OpenAI no instalador tornava a instalação impossível** — e, num
+  segundo defeito, a escolha era decorativa: aceita na pergunta e ignorada depois.
+- **O instalador perdia a chave que você tinha configurado à mão** no `.env`, e a segunda
+  execução desfazia a entrevista já respondida.
+- **O papel Operador escrevia no CRM depois de o humano assumir a conversa** — era o único
+  turno sem a guarda.
+- **A telemetria da IA voltou a dizer a verdade** (5 defeitos de uma unificação anterior), e a
+  troca de modelo voltou a ser auditada — o registro era engolido em silêncio.
+- **Duas mutações perdiam a auditoria caladas** por chave natural gravada em coluna `uuid`.
+- **A aba "Minhas" mostrava tudo que o atendente já tinha fechado.**
+- **O filtro por tag da tela não filtrava** — a rota ignorava o parâmetro.
+- **O menu passava da dobra em telas de 900px** depois que as telas novas entraram.
 - **O roteador recusava um número que existia**, com a mensagem "não encontrado nesta
   organização", quando na verdade a consulta é que havia falhado.
 - **A tela de funis misturava organizações** do mesmo usuário.
@@ -43,19 +119,35 @@ lugar na tela —, e o sistema parar de mentir quando algo dá errado.
 - **Erro ao publicar o agente no onboarding criava um agente novo a cada clique.**
 - **O custo de IA sem agente dono sumia da auditoria** — as telas de consumo mostravam zero
   numa instalação com tráfego real e provedor pago.
+- **Mover um lead pelo assistente** deixou de pular o que mover pela mão aciona.
+- **Telefone descoberto depois estourava a restrição de unicidade** e a mensagem do cliente
+  sumia.
+- **O `update.sh` inventava gasto de IA** e podia pausar o agente de quem estava atualizando.
+- **Uma migration anterior apagou três tipos de aviso da Central** — corrigido, e agora há um
+  gate que compara.
 
 ### Segurança
 
 - **8 de 25 funções internas do banco estavam executáveis pela chave pública** que vai para o
   navegador, incluindo uma que escreve recebendo a organização por parâmetro, sem checar se
   você pertence a ela. Todas fechadas, com uma varredura que reprova a próxima.
+- **Desligar uma camada de proteção do agente era escrita de qualquer membro** da organização —
+  agora exige papel de gestão.
+- **Expressão regular vulnerável a ReDoS** na leitura do telefone dentro da conversa.
+- **O limitador de requisições vazava uma chave por janela** em memória.
+- **O Sentry da comunidade recebia sessão além de erro** — agora recebe só o relatório de erro,
+  como o README sempre descreveu.
 
 **⚠️ Requer atenção**
 
-Esta versão traz mudanças de banco (migrations 0100 a 0114). O `update.sh` aplica tudo sozinho
-e faz backup antes — você não precisa rodar nada à mão. Se a sua instalação está há muito tempo
-sem atualizar, é normal a etapa do banco demorar mais e imprimir vários avisos de "já existe":
-eles são esperados e o script só destaca o que não for.
+Esta versão traz **51 mudanças de banco** (migrations 0087 a 0148). O `update.sh` aplica tudo
+sozinho e **faz backup antes** — você não precisa rodar nada à mão. Se a sua instalação está há
+muito tempo sem atualizar, é normal a etapa do banco demorar mais e imprimir vários avisos de
+"já existe": eles são esperados, e o script só destaca o que não for.
+
+Se você instalou entre 30/07 e hoje, seu servidor já roda este código (a instalação acompanha a
+`main`) — esta tag existe para que a atualização pela tela e o `update.sh` voltem a ter um alvo
+publicado para comparar.
 
 ## [1.1.0] — 2026-07-30
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![CI](https://github.com/melgarafael/DeskcommCRM/actions/workflows/ci.yml/badge.svg)](https://github.com/melgarafael/DeskcommCRM/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-[**🧭 Visão**](VISION.md) · [**📘 Setup Guide**](docs/SETUP.md) · [**🏗️ Arquitetura**](ARCHITECTURE.md) · [**🤝 Contribuir**](CONTRIBUTING.md) · [**📋 PRDs**](docs/prd/) · [**🗺️ Roadmap**](#%EF%B8%8F-roadmap)
+[**⚡ Instalar**](#-instalar-na-sua-vps-o-caminho-principal) · [**🔄 Atualizar**](#-atualizar) · [**🧭 Visão**](VISION.md) · [**🏗️ Arquitetura**](ARCHITECTURE.md) · [**🤝 Contribuir**](CONTRIBUTING.md) · [**🗺️ Roadmap**](#%EF%B8%8F-roadmap)
 
 </div>
 
@@ -23,7 +23,7 @@
 > ### ☁️ Rode este CRM em produção com 1 comando
 >
 > O DeskcommCRM foi desenvolvido em **parceria com a HostGator**: o [`hostgator-setup-kit/`](hostgator-setup-kit/)
-> instala o CRM completo (app + WAHA + banco) numa VPS com um único comando, e o
+> instala o CRM completo (app + WhatsApp + banco) numa VPS com um único comando, e o
 > [runbook de produção](docs/runbooks/waha-hostgator.md) já assume esse ambiente.
 >
 > **[👉 Assinar a VPS HostGator com desconto da parceria](https://www.hostgator.com.br/52708-141-3-52.html)** —
@@ -39,22 +39,143 @@
 >
 > *(prefere ler antes de executar? clone o repo e rode `bash hostgator-setup-kit/comecar.sh` —
 > ele não instala nada sem você confirmar.)*
->
-> Já tem a VPS? Entre nela por SSH e rode:
->
-> ```bash
-> git clone https://github.com/melgarafael/DeskcommCRM.git
-> cd DeskcommCRM
-> bash hostgator-setup-kit/install.sh
-> ```
->
-> O instalador pergunta só o que é seu (domínio, chaves do Supabase, chave de IA, senha do
-> admin), valida cada resposta antes de seguir, gera todos os outros segredos sozinho, aplica
-> o schema do banco e sobe a stack inteira com HTTPS. Detalhes em
-> [`hostgator-setup-kit/README.md`](hostgator-setup-kit/README.md).
->
-> ⚠️ O **Quickstart** abaixo é o caminho de *desenvolvimento* (rodar o app na sua máquina).
-> Se você comprou a VPS pra rodar o CRM, use o comando acima, não o Quickstart.
+
+---
+
+## ⚡ Instalar na sua VPS (o caminho principal)
+
+Entre na sua VPS por SSH e rode:
+
+```bash
+git clone https://github.com/melgarafael/DeskcommCRM.git
+cd DeskcommCRM
+bash hostgator-setup-kit/install.sh
+```
+
+É isso. **Você não instala Node, nem pnpm, nem compila nada** — a imagem do app já vem pronta.
+Se faltar Docker, o instalador pergunta e instala sozinho.
+
+### O que você precisa ter em mãos
+
+| Item | Onde conseguir |
+|---|---|
+| **VPS com Docker** | [HostGator](https://www.hostgator.com.br/52708-141-3-52.html) (parceria) — ou qualquer VPS com Docker. 4 GB de RAM recomendados |
+| **Domínio** | Um registro **A** apontando pro IP da VPS (ex.: `crm.suaempresa.com.br`) |
+| **Banco** | Conta grátis no [supabase.com](https://supabase.com) — 3 chaves + connection string do **Session pooler** |
+| **IA** | Uma chave de **OpenRouter**, **Anthropic** ou **OpenAI** — o instalador pergunta qual você quer |
+| **WhatsApp** | Seu número, conectado por QR code no onboarding (ou o canal oficial da Meta) |
+
+> 💡 **O Supabase pode ser criado pelo próprio instalador.** Exporte um
+> `SUPABASE_ACCESS_TOKEN` antes de rodar e ele cria o projeto, espera o banco ficar saudável,
+> busca as 4 credenciais e descobre o host do pooler testando conexão real — sem copiar e colar.
+
+### O que o instalador faz por você
+
+Ele **pergunta só o que é seu** (domínio, chaves, senha do admin), **valida cada resposta antes
+de seguir** — chave errada ele recusa na hora, não três passos depois — e cuida do resto:
+
+1. Gera todos os segredos técnicos sozinho (você não inventa senha nenhuma).
+2. Cria as extensões do Postgres e aplica o schema completo (`supabase/baseline.sql`).
+3. Cria o primeiro admin com o e-mail e a senha que você escolheu.
+4. Sobe a stack inteira com **HTTPS automático** e confere a saúde no fim.
+5. Instala o **cron das automações** (sem ele, as regras QUANDO/SE/ENTÃO ficam paradas na fila)
+   e o **agente de atualização**, que é o que faz o botão "Atualizar agora" existir na tela.
+
+**Rodar de novo não quebra nada** — o `install.sh` é idempotente: não duplica cron, não recria
+usuário, retoma de onde parou.
+
+> **Modo não-interativo:** copie `.env.hostgator.example` para `.env`, preencha e rode
+> `bash hostgator-setup-kit/install.sh --yes`.
+
+### Outra hospedagem? (Hostinger, Coolify, Dokploy, CapRover…)
+
+Funciona. Se a sua VPS já vem com um **proxy reverso próprio** ocupando as portas 80/443, o
+instalador **detecta isso sozinho** e publica o CRM através dele, em vez de tentar subir um
+Caddy que não caberia. Num caso específico — proxy em `--network host`, como faz a Hostinger —
+ele **pergunta em vez de adivinhar**, porque publicar atrás do proxy errado instala "com
+sucesso" um site mudo. Detalhes em [`hostgator-setup-kit/README.md`](hostgator-setup-kit/README.md#vps-que-já-vem-com-proxy-próprio-hostinger-coolify-dokploy).
+
+### Primeiro acesso
+
+Abra `https://<seu-domínio>` (o cadeado leva ~1 min pra aparecer), entre com o admin, e tenha o
+**Google Authenticator** ou **Authy** à mão — o primeiro login de admin exige MFA. No onboarding,
+escaneie o QR code com o WhatsApp do seu número.
+
+### 🤖 Prefere que uma IA instale pra você?
+
+Jogue a pasta `hostgator-setup-kit/` no chat do **Claude Code** rodando dentro da VPS e diga
+*"instala o DeskcommCRM pra mim"*. Ele lê o [`CLAUDE.md`](hostgator-setup-kit/CLAUDE.md) do kit
+— que traz o passo a passo e as armadilhas já mapeadas — e conduz tudo em português.
+
+---
+
+## 🔄 Atualizar
+
+Saiu versão nova? Há dois caminhos, e o primeiro **não exige terminal**.
+
+### Pela tela (recomendado)
+
+Quando existe versão nova, o rodapé do menu lateral acende **"Nova versão"** — só pro dono do
+servidor, porque avisar quem não pode atualizar é ruído. Clique e você cai em
+**Configurações → Atualização**, que mostra o que muda, faz **backup do banco sozinha** e
+acompanha cada fase (backup → código → banco → no ar) até terminar. Nada de SSH.
+
+Se a versão nova subir quebrada, o agente **volta pra imagem anterior sozinho** e grava essa
+volta no `.env` — sem isso, o próximo restart traria o app quebrado de novo, em silêncio.
+
+> Por baixo: o app só registra o pedido; quem executa é o agente que o `install.sh` deixou na
+> sua VPS, num cron que confere **a cada 5 minutos** — então a atualização começa em até 5
+> minutos depois do clique. Se esse agente estiver fora do ar, a tela avisa
+> **"Atualização automática indisponível"** e mostra o comando abaixo — ela não finge que deu certo.
+
+### Pelo terminal
+
+```bash
+cd /caminho/do/DeskcommCRM
+bash hostgator-setup-kit/update.sh
+```
+
+O comando faz, nesta ordem: (1) confere se há mesmo versão nova — se não houver, sai na hora;
+(2) **faz backup do banco antes de tocar em qualquer coisa**; (3) baixa o código novo;
+(4) atualiza o banco re-aplicando o `baseline.sql`, que é idempotente e **auto-curativo**
+(conserta sozinho dados bagunçados por versões antigas); (5) puxa a imagem nova do app;
+(6) confere a saúde no fim.
+
+**O alvo é a última versão publicada** (`v1.2.3`), não o topo da `main` — atualizar leva sempre
+a uma versão marcada e descrita no [`CHANGELOG.md`](CHANGELOG.md), nunca a um commit não testado.
+Ele **recusa** voltar pra uma versão anterior à instalada (isso desligaria coisas que você já tem);
+pra isso existe `--force`, de propósito.
+
+**Coisas normais que você vai ver:** um monte de `already exists` / `multiple primary keys` na
+parte do banco — **é esperado e inofensivo**, são coisas que já existiam. O script filtra esse
+ruído e mostra `✓ banco atualizado`. Se aparecer `⚠ avisos que não são os esperados`, aí sim
+guarde a mensagem.
+
+**Deu ruim?** `bash hostgator-setup-kit/restore.sh` volta pro backup.
+**Quer só diagnosticar?** `bash hostgator-setup-kit/healthcheck.sh`.
+
+> ⚠️ **Numa instalação antiga que ainda não tem o agente da tela**, rode `update.sh` **duas
+> vezes**: a primeira execução ainda é a do script velho (que baixa o novo); a segunda instala
+> o agente e liga o botão.
+
+Passo a passo em linguagem simples: [`docs/ATUALIZANDO.md`](docs/ATUALIZANDO.md).
+
+### Outros comandos do kit
+
+| Script | Função |
+|---|---|
+| `install.sh` | Instala tudo (idempotente — pode rodar de novo) |
+| `update.sh` | Atualiza pra versão nova, com backup automático |
+| `backup.sh` | Backup do banco + sessões de WhatsApp |
+| `restore.sh` | Restaura um backup |
+| `reset-password.sh` | Redefine a senha de um usuário |
+| `reset-mfa.sh` | Remove o MFA de quem perdeu o celular |
+| `healthcheck.sh` | Diagnóstico de todos os serviços de uma vez |
+
+> **Backup importa:** o plano grátis do Supabase **não faz backup sozinho**. Vale agendar
+> `backup.sh` no cron diariamente. O `update.sh` já roda um backup antes de cada atualização.
+
+---
 
 ## ✨ O que é
 
@@ -64,58 +185,38 @@ O projeto nasceu como CRM de e-commerce e a comunidade o levou muito além: hoje
 
 ### Diferenciais
 
-- 🤖 **Agentes de IA que operam o CRM** — RAG por tenant, análise de sentimento, handoff IA→humano auditado, IA como assignee de primeira classe e controle de budget por organização. Não é chatbot decorativo: o agente atende, qualifica e move o funil.
-- 🔁 **Agentes que se auto-aprimoram** — conversas resolvidas viram conhecimento novo na base RAG; handoffs marcam onde o agente ainda não alcança; métricas fecham o loop. Cada mês de operação torna o agente melhor, com gate humano no que importa.
+- 🤖 **Agentes de IA que operam o CRM** — RAG por tenant, skills que o agente executa sozinho durante o atendimento, memória da operação, análise de sentimento, handoff IA→humano auditado, IA como assignee de primeira classe e teto de gasto por organização. Não é chatbot decorativo: o agente atende, qualifica e move o funil.
+- 🔁 **Nada morre no silêncio** — follow-up que retoma a conversa esfriada (com tempo adaptativo e gatilhos por etapa do funil), radar do que está em risco de morrer sem resposta, e central de avisos pro que precisa de decisão humana.
+- 🧠 **Agentes que se auto-aprimoram** — conversas resolvidas viram conhecimento novo; a tela de **Evolução da IA** mostra se o agente está melhorando, onde erra e o que falta ensinar; **Propostas** são melhorias que a IA sugere pra si mesma, aplicáveis como versão nova — sempre com gate humano.
 - 🧩 **Multi-nicho por design** — vocabulário configurável por pipeline: lead vira *Cliente*, *Paciente* ou *Comprador*; won vira *Pago*, *Agendado* ou *Fechado*. O mesmo core serve e-commerce (nosso berço, com integração Nuvemshop), clínica, imobiliária ou infoproduto.
-- 🔌 **MCP-ready** — MCP server interno pros agentes; contrato público pra agentes externos em construção. O CRM como infraestrutura pra qualquer agente de IA.
-- 💬 **WhatsApp-native via WAHA** — multi-número, anti-banimento (throttle + jitter + janela de horário), mídia via Storage, STOP detection.
-- 👥 **Governança de atendimento** — RBAC server-side de verdade, atribuição/transferência auditada, fila com posição, roteamento automático e escopo de visualização por papel.
+- 💬 **WhatsApp de duas formas** — por **QR code** (WAHA, multi-número, com anti-banimento: throttle + jitter + janela de horário) ou pelo **canal oficial da Meta** (Cloud API, com templates aprovados e sincronizados). Mídia via Storage, STOP detection.
+- 🔀 **Escolha sua IA** — OpenRouter, Anthropic ou OpenAI, decidido na instalação e trocável depois pela tela, **por parte do sistema** (o que conversa não precisa ser o que indexa).
+- 👥 **Governança de atendimento** — RBAC server-side de verdade, atribuição/transferência auditada, fila com rodízio, roteamento automático por intenção e escopo de visualização por papel.
 - 🏢 **Multi-tenant + LGPD by-design** — RLS em toda tabela tenant-aware com teste de isolamento como gate de CI; anonimização preferida sobre delete; audit append-only com retenção 5 anos.
-- 🖥️ **Self-hosted de verdade** — seus dados na sua VPS; instalação com 1 comando; sem versão paga, sem feature travada.
+- 🖥️ **Self-hosted de verdade** — seus dados na sua VPS; instalação e atualização com 1 comando (ou 1 clique); sem versão paga, sem feature travada.
 
 ### 🔌 Webhooks & Automações
 
 Todo tenant pode criar **fontes de captação**: um endereço público (`/api/v1/webhooks/in/<token>`) que recebe leads de landing pages, formulários próprios ou ferramentas como Zapier/n8n via POST (JSON ou `application/x-www-form-urlencoded`) e já entra direto no funil/estágio escolhido — sem código, sem integração customizada por tenant. Em cima dessas fontes (e dos outros eventos do CRM — lead mudou de etapa, ganhou tag, chegou mensagem no WhatsApp), o tenant monta **automações**: regras no formato QUANDO/SE/ENTÃO que disparam ações como adicionar tag, mover o lead no funil, atribuir a um atendente, mandar uma mensagem de WhatsApp ou avisar outro sistema via webhook de saída.
 
-Na UI, tudo mora em **Webhooks** na sidebar (visível só pra quem tem papel `manager`/`admin` — `agent`/`viewer` não veem o item nem acessam a rota, redirecionados pro inbox). A tela tem três abas: **Receber dados** (criar fonte, copiar o endereço/formulário pronto, disparar um lead de teste, ver os últimos recebimentos), **Automações** (montar a regra, que sempre nasce pausada até o tenant revisar e ligar) e **Atividade** (timeline de cada execução, com o resultado de cada ação e reenvio manual quando uma chamada de webhook externo falha).
+Na UI, tudo mora em **Webhooks** na sidebar (visível só pra quem tem papel `manager`/`admin`). A tela tem três abas: **Receber dados** (criar fonte, copiar o endereço/formulário pronto, disparar um lead de teste, ver os últimos recebimentos), **Automações** (montar a regra, que sempre nasce pausada até você revisar e ligar) e **Atividade** (timeline de cada execução, com o resultado de cada ação e reenvio manual quando uma chamada externa falha).
 
-Por baixo, cada evento (lead criado, tag adicionada, etc.) vira uma linha em `event_log` — nenhum trigger de banco faz chamada HTTP diretamente. Quem drena essa fila e realmente dispara as automações é a rota `/api/v1/cron/event-log-drain`, chamada a cada minuto. No Vercel isso é um Cron Job gerenciado; **no kit self-host da HostGator** (`hostgator-setup-kit/`), o `install.sh`/`update.sh` já configura sozinho uma linha de `crontab` que roda essa rota todo minuto com o `INTERNAL_SECRET` do `.env` — sem esse cron ativo, fontes e automações continuam sendo criadas normalmente, mas os eventos ficam empilhados em `event_log` e nenhuma automação chega a rodar de verdade.
+Por baixo, cada evento vira uma linha em `event_log` — nenhum trigger de banco faz chamada HTTP diretamente. Quem drena essa fila é a rota `/api/v1/cron/event-log-drain`, chamada a cada minuto. **O `install.sh`/`update.sh` já configuram esse cron sozinhos** — sem ele, as automações são criadas normalmente mas nunca rodam.
 
 ---
 
-## 🚀 Quickstart (5 minutos pra ver rodando)
+## 🖥️ O que você opera (as telas)
 
-```bash
-# 1. Clone
-git clone https://github.com/melgarafael/DeskcommCRM.git
-cd DeskcommCRM
+| Grupo | Telas |
+|---|---|
+| **Atendimento** | **Inbox** (conversas de WhatsApp, você e a IA lado a lado) · **Radar** (quem esfriou e ainda está aberto) · **Respostas rápidas** |
+| **CRM** | **Kanban** (onde cada negócio está no funil) · **Contatos** · **Funis** (etapas, vocabulário do negócio e motivos de perda) |
+| **Agente de IA** | **Agentes** · **Follow-ups** · **Roteadores** · **Provedores** e **Credenciais** · **Conhecimento** (RAG) · **Memória** · **Skills** · **Casos** · **Alertas** · **Propostas** · **Execuções** · **Uso e orçamento** |
+| **Canais** | **Conexões** (QR ou canal oficial da Meta, com saúde, reconexão e templates) · **Nuvemshop** · **Webhooks** |
+| **Análise** | **Desempenho** (funil e performance por atendente) · **Evolução da IA** · **Audit Log** |
+| **Organização** | **Equipe** · **Distribuição de atendimento** · **Organização** · **LGPD** · **API Tokens** · **Segurança** (MFA, códigos de recuperação, sessões) · Perfil, Notificações, Billing |
 
-# 2. Node 22 + pnpm
-nvm use                    # ou instale Node 22+
-npm install -g pnpm
-pnpm install
-
-# 3. Env vars
-cp .env.example .env.local
-# Edite .env.local — guia completo em docs/SETUP.md
-
-# 4. WAHA local (opcional em dev sem WhatsApp)
-docker compose up -d
-
-# 5. Schema do banco — aplique o baseline, NÃO as migrations
-#    As migrations 0001-0009 e 0013 são stubs `SELECT 1;`: a cadeia não sobe do
-#    zero. O schema real vive no baseline.sql, que é o mesmo que o install.sh
-#    aplica na VPS. `supabase db push` "passa" e deixa o banco vazio.
-supabase link --project-ref <seu-ref>
-psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f supabase/baseline.sql
-
-# 6. Sobe o app
-pnpm dev
-```
-
-App: <http://localhost:3000> · Health check: <http://localhost:3000/api/v1/health>
-
-> 🆕 **Primeira vez? Não pula etapa.** [`docs/SETUP.md`](docs/SETUP.md) é o tutorial completo passo a passo de **todas as integrações** (Supabase, WAHA, Anthropic, Upstash, Sentry, Resend, Nuvemshop) — feito pra quem nunca configurou nada disso antes. ~60–90 min do zero ao app rodando.
+Toda tela tem porta na navegação — o CI reprova tela que existe mas em que só se chega digitando a URL.
 
 ---
 
@@ -129,15 +230,47 @@ App: <http://localhost:3000> · Health check: <http://localhost:3000/api/v1/heal
 | **Auth** | Supabase Auth via `@supabase/ssr` | Cookie SameSite=Strict, HttpOnly |
 | **Realtime** | Supabase Realtime | postgres_changes + broadcast |
 | **Storage** | Supabase Storage (URLs assinadas) | Bucket privado `whatsapp-media` |
-| **WhatsApp** | WAHA Plus (engine NOWEB) | Multi-tenant, retry, S3 |
-| **Filas** | `event_log` table + workers (cron) | Sem Inngest/Trigger no MVP |
+| **WhatsApp** | WAHA Plus (engine NOWEB) + Meta Cloud API | QR pra começar rápido; canal oficial pra escala |
+| **Filas** | `event_log` table + workers (cron) | Trigger de banco nunca faz HTTP |
 | **Rate limit** | Upstash Redis (sliding window) | Serverless, free tier suficiente |
-| **AI** | Vercel AI SDK v7 (providers Anthropic/Google/OpenAI v4) via AI Gateway | Fallback automático, ZDR |
+| **AI** | Vercel AI SDK v7 — OpenRouter, Anthropic, OpenAI e Google | Instalador pergunta qual; troca depois pela tela |
 | **Validação** | Zod | Input externo, env, payloads |
 | **Observability** | Sentry (scrub em erro, transação, span e breadcrumb) | Telemetria opt-in no install |
-| **Hospedagem** | Vercel (app) + Hostgator VPS Turing/SP (WAHA) | Edge + dedicado pra WhatsApp; datacenter Brasil |
+| **Hospedagem** | VPS com Docker (HostGator/SP na parceria) | App + WhatsApp + workers na sua máquina |
 
 Detalhes: [`ARCHITECTURE.md`](ARCHITECTURE.md).
+
+---
+
+## 🧑‍💻 Desenvolvimento (só pra contribuir com o código)
+
+> ⚠️ **Se você quer USAR o CRM, não é aqui** — use o [instalador da VPS](#-instalar-na-sua-vps-o-caminho-principal).
+> Esta seção é pra quem vai mexer no código.
+
+```bash
+git clone https://github.com/melgarafael/DeskcommCRM.git
+cd DeskcommCRM
+
+nvm use                     # Node 22
+npm install -g pnpm && pnpm install
+
+cp .env.example .env.local  # guia completo em docs/SETUP.md
+
+docker compose up -d        # WAHA local (opcional em dev sem WhatsApp)
+
+# Schema: aplique o baseline, NÃO as migrations.
+# As migrations 0001-0009 e 0013 são stubs `SELECT 1;` — a cadeia não sobe do zero.
+# O schema real vive no baseline.sql, o mesmo que o install.sh aplica na VPS.
+# `supabase db push` "passa" e deixa o banco vazio.
+supabase link --project-ref <seu-ref>
+psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f supabase/baseline.sql
+
+pnpm dev
+```
+
+App: <http://localhost:3000> · Health check: <http://localhost:3000/api/v1/health>
+
+[`docs/SETUP.md`](docs/SETUP.md) é o tutorial completo de **todas as integrações** (Supabase, WAHA, provedores de IA, Upstash, Sentry, Resend, Nuvemshop) — ~60–90 min do zero ao app rodando.
 
 ---
 
@@ -148,19 +281,19 @@ DeskcommCRM/
 ├── app/                    # Next.js App Router
 │   ├── (admin)/            # Rotas super-admin (impersonate, tenants)
 │   ├── (public)/           # Login, recovery
-│   ├── app/                # Rotas autenticadas: inbox, kanban, contacts,
-│   │                       #   connections, ai (agentes), integrations,
-│   │                       #   metrics, lgpd, audit, team, settings
-│   └── api/v1/             # API REST canônica
+│   ├── app/                # Rotas autenticadas: inbox, radar, kanban, contacts,
+│   │                       #   connections, ai/*, integrations, metrics, lgpd,
+│   │                       #   audit, team, settings
+│   └── api/v1/             # API REST canônica (196 route handlers)
 ├── components/             # React (ui/, inbox/, kanban/, shell/, ...)
-├── lib/                    # supabase/, waha/, ai/, api/, routing/, env.ts
-├── hooks/
+├── lib/                    # supabase/, waha/, channels/, ai/, agent-engine/,
+│                           #   api/, routing/, navigation/, env.ts
+├── workers/                # consumers de event_log (IA, RAG, LGPD, mídia, rotinas)
 ├── supabase/migrations/    # SQL versionado (+ baseline.sql pro self-host)
-├── workers/                # consumers de event_log (IA, RAG, LGPD, rotinas)
-├── tests/{e2e,unit,invariants}/
+├── tests/{e2e,unit,invariants,shell}/
 ├── scripts/                # seeds, qa-waves, manutenção
-├── docs/                   # PRDs, specs, stories, SETUP.md
-└── hostgator-setup-kit/    # instalação self-host com 1 comando
+├── docs/                   # PRDs, specs, runbooks, SETUP.md, ATUALIZANDO.md
+└── hostgator-setup-kit/    # instalação e atualização self-host
 ```
 
 ---
@@ -175,9 +308,18 @@ pnpm test:db       # Postgres efêmero + baseline install/update + invariantes
 pnpm test:e2e      # Playwright (requer dev server)
 ```
 
-O job **`verify`** roda `typecheck`, `lint`, `lint:channels`, `test:unit` e `test:shell` em todo PR. Um segundo job — **`invariants`** — sobe um Postgres limpo, aplica o `supabase/baseline.sql` em modo install (`ON_ERROR_STOP=1`) e depois em modo update (provando idempotência), e roda **364 testes de invariante** distribuídos em 56 arquivos, cobrindo RBAC, atribuição, escopo de visualização, roteamento, follow-up, webhooks e automações.
+**Quatro checks são obrigatórios** pra mergear na `main` — todos verificados na branch protection, não só no papel:
 
-Entre eles está o **teste de isolamento RLS**: cria 2 organizações, simula os claims JWT pelo mesmo caminho `auth.uid()` / `fn_user_org_ids()` que as policies de produção usam, e prova que um usuário da org A enxerga **zero linhas** da org B em `conversations`, `messages`, `contacts` e `crm_leads`. Antes disso, um caso de controle prova que as linhas da org B realmente existem no banco — sem ele, o teste passaria mesmo com a tabela vazia.
+| Check | O que faz |
+|---|---|
+| `verify` | typecheck + lint + `lint:channels` + `test:unit` + `test:shell` |
+| `invariants` | sobe um Postgres limpo, aplica o `baseline.sql` em modo **install** (`ON_ERROR_STOP=1`) e depois em modo **update** (provando idempotência), e roda **618 invariantes em 98 arquivos** — RBAC, atribuição, escopo, roteamento, follow-up, webhooks e automações |
+| `build-and-size` | `pnpm build` em Node 22 |
+| `e2e` | sobe Supabase local, aplica o `baseline.sql` e roda **44 das 45 specs** Playwright pelo frontend |
+
+A única spec fora do `e2e` é `vps-fresh-onboarding` — ela precisa de WAHA + Redis + Resend + Nuvemshop de verdade. Ela é a **P0** da nossa doutrina de QA visual, então `e2e` verde **não** prova a jornada de instalação fresca; essa se prova numa VPS.
+
+Entre os invariantes está o **teste de isolamento RLS**: cria 2 organizações, simula os claims JWT pelo mesmo caminho `auth.uid()` / `fn_user_org_ids()` que as policies de produção usam, e prova que um usuário da org A enxerga **zero linhas** da org B em `conversations`, `messages`, `contacts` e `crm_leads`. Antes disso, um caso de controle prova que as linhas da org B realmente existem — sem ele, o teste passaria com a tabela vazia.
 
 ---
 
@@ -185,18 +327,18 @@ Entre eles está o **teste de isolamento RLS**: cria 2 organizações, simula os
 
 | Doc | O que tem |
 |---|---|
+| [`hostgator-setup-kit/README.md`](hostgator-setup-kit/README.md) | **Instalação self-host** — o kit, os scripts, as hospedagens com proxy próprio |
+| [`docs/ATUALIZANDO.md`](docs/ATUALIZANDO.md) | **Como atualizar** sua instalação, em linguagem simples |
 | [`VISION.md`](VISION.md) | **Visão e posicionamento** — o que o projeto é, no que acredita e pra onde vai |
-| [`docs/SETUP.md`](docs/SETUP.md) | **Setup completo passo a passo** de todas as integrações |
-| [`docs/white-label.md`](docs/white-label.md) | **Instalar para clientes** — trocar a marca, uma instalação por cliente vs compartilhada, operação de revenda |
+| [`CHANGELOG.md`](CHANGELOG.md) | O que mudou em cada versão — **leia a seção da versão antes de atualizar** |
+| [`docs/SETUP.md`](docs/SETUP.md) | Setup de desenvolvimento, passo a passo de todas as integrações |
+| [`docs/white-label.md`](docs/white-label.md) | **Instalar para clientes** — trocar a marca, uma instalação por cliente vs compartilhada, revenda |
+| [`docs/runbooks/waha-hostgator.md`](docs/runbooks/waha-hostgator.md) | Runbook de WAHA em produção (dimensionamento, recuperação) |
+| [`docs/runbooks/deploy.md`](docs/runbooks/deploy.md) | Deploy em produção |
 | [`CLAUDE.md`](CLAUDE.md) | Convenções não-negociáveis (leitura obrigatória pra contribuir) |
 | [`ARCHITECTURE.md`](ARCHITECTURE.md) | Visão de 1 página da arquitetura |
-| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Fluxo PR + epic-executor |
-| [`docs/prd/`](docs/prd/) | PRDs (master, platform, customer 360, WhatsApp, pipeline, IA-RAG, Nuvemshop) |
-| [`docs/specs/`](docs/specs/) | Specs técnicas 01–13 (schema SQL, payloads, MCP, governança) |
-| [`docs/business-rules/`](docs/business-rules/) | Regras de negócio fora do código |
-| [`docs/DEPLOY-CHECKLIST.md`](docs/DEPLOY-CHECKLIST.md) | Preflight pré-go-live |
-| [`docs/runbooks/waha-hostgator.md`](docs/runbooks/waha-hostgator.md) | Runbook completo de WAHA em produção (VPS Hostgator) |
-| [`docs/ATUALIZANDO.md`](docs/ATUALIZANDO.md) | Como atualizar uma instalação self-host |
+| [`docs/index.md`](docs/index.md) | Índice dos 157 documentos, com regra de precedência |
+| [`docs/prd/`](docs/prd/) · [`docs/specs/`](docs/specs/) | PRDs e specs técnicas (schema SQL, payloads, MCP, governança) |
 
 ---
 
@@ -225,13 +367,13 @@ Essa linha é a lista **completa** dos gates obrigatórios, de propósito: rodar
 resto como surpresa vermelha depois de horas de espera é a pior primeira experiência que este
 repositório sabe entregar.
 
-**Definition of Done:** typecheck zero, lint zero, testes relevantes verdes, RLS testada se toca tabela tenant-aware, audit log emitido em mutações, migration versionada se muda schema. Detalhes em [`CLAUDE.md`](CLAUDE.md#definition-of-done).
+**Definition of Done:** typecheck zero, lint zero, testes relevantes verdes, RLS testada se toca tabela tenant-aware, audit log emitido em mutações, migration versionada **+ apêndice no `baseline.sql`** se muda schema (senão a mudança não chega em quem se auto-hospeda). Detalhes em [`CLAUDE.md`](CLAUDE.md#definition-of-done).
 
 ---
 
 ## 🐛 Reportando bugs
 
-Abra uma [issue](https://github.com/melgarafael/DeskcommCRM/issues/new/choose) — o template pede o que precisamos (ambiente, `/api/v1/health`, steps).
+Abra uma [issue](https://github.com/melgarafael/DeskcommCRM/issues/new/choose) — o template pede o que precisamos (ambiente, `/api/v1/health`, steps). Rodar `bash hostgator-setup-kit/healthcheck.sh` e colar a saída ajuda muito.
 
 Pra **vulnerabilidades de segurança**, **NÃO abra issue pública** — use o [relato privado de vulnerabilidades](https://github.com/melgarafael/DeskcommCRM/security/advisories/new). Detalhes em [`SECURITY.md`](SECURITY.md).
 
@@ -242,19 +384,20 @@ Pra **vulnerabilidades de segurança**, **NÃO abra issue pública** — use o [
 ### ✅ Entregue
 
 - **Fundação & plataforma** — auth (MFA pra admin), multi-tenancy com RLS + teste de isolamento, RBAC 4 papéis, audit log append-only, onboarding de tenant.
-- **Atendimento WhatsApp** — inbox 3 painéis em tempo real, conexões WAHA multi-número, mídia via Storage, anti-banimento (throttle + jitter + janela de horário), STOP detection.
-- **CRM & pedidos** — kanban com vocabulário configurável por nicho (fractional indexing), customer 360, contatos, tags, integração Nuvemshop pra e-commerce.
-- **IA nativa** — agentes com RAG por tenant (pgvector), análise de sentimento, handoff IA→humano, controle de budget por org, MCP server interno.
+- **Atendimento WhatsApp** — inbox 3 painéis em tempo real, conexões multi-número por **QR (WAHA)** ou **canal oficial da Meta** (templates aprovados e sincronizados), mídia via Storage, anti-banimento (throttle + jitter + janela de horário), STOP detection.
+- **CRM & pedidos** — kanban com vocabulário configurável por nicho (fractional indexing), gestão de funis pela tela, customer 360, contatos, tags, integração Nuvemshop.
+- **IA nativa** — agentes com RAG por tenant (pgvector), **skills** que o agente executa sozinho, **memória da organização**, roteador de intenção por número, análise de sentimento, handoff IA→humano, teto de gasto por org, MCP server interno.
+- **Escolha de provedor de IA** — OpenRouter, Anthropic ou OpenAI, decidido na instalação e trocável por parte do sistema pela tela.
+- **Follow-up vivo** — retomada de conversa esfriada com tempo adaptativo, gatilhos por etapa do funil e por caso, fila com rodízio, e o Radar do que corre risco de morrer sem resposta.
 - **LGPD** — export e redact via workers, anonimização em cascata, consentimento auditado.
-- **Self-host** — `hostgator-setup-kit` (app + WAHA + banco com 1 comando), `baseline.sql` auto-curativo, runbook de produção.
+- **Self-host** — `hostgator-setup-kit` (app + WhatsApp + banco com 1 comando), `baseline.sql` auto-curativo, **atualização pela tela** com backup automático, runbook de produção.
 - **Webhooks & automação** — fontes de captação + regras QUANDO/SE/ENTÃO + gatilhos pra sistemas externos.
-- **Governança de atendimento** — RBAC server-side em toda a API, atribuição e transferência auditadas (IA como assignee de 1ª classe), visualização por papel (RLS) + métricas por atendente, roteamento automático com fila e painel de gestão, e contrato de governança pra agentes de IA externos ([`docs/specs/14`](docs/specs/14-contrato-governanca-agentes-externos.md)). Épico guiado por 100+ invariantes (G1–G6).
-- **Operação visível** — telas pro operador entender o agente: motivo da retenção anti-ban traduzido na conversa, central de avisos com severidade, controle de proteção de envio (janela/ritmo/teto) e propostas do flywheel aplicáveis como versão nova (com gate humano).
+- **Governança de atendimento** — RBAC server-side em toda a API, atribuição e transferência auditadas (IA como assignee de 1ª classe), visualização por papel (RLS) + métricas por atendente, roteamento automático com fila e painel de gestão, e contrato de governança pra agentes de IA externos ([`docs/specs/14`](docs/specs/14-contrato-governanca-agentes-externos.md)).
+- **Operação visível** — motivo da retenção anti-ban traduzido na conversa, central de avisos com severidade, aviso de mensagem presa, controle de proteção de envio (janela/ritmo/teto), capacidades declaradas do agente e propostas do flywheel aplicáveis como versão nova (com gate humano).
 
 ### 🔮 Próximo
 
 - **MCP público** — capabilities do CRM expostas pro ecossistema de agentes: plugue o agente que quiser e ele opera o Deskcomm.
-- **Flywheel de auto-aprimoramento** — o loop conversa resolvida → conhecimento → agente melhor, medido e com gate humano.
 - **Templates por nicho** — pipelines e vocabulários prontos pra clínica, imobiliária, infoproduto e serviços (e-commerce já entregue).
 - **Integrações** — VTEX e Shopify via adapter pattern (Nuvemshop já entregue).
 - **Identity probabilística** — unificação de contatos entre canais.
@@ -287,9 +430,8 @@ Este é um projeto **self-host**: cada pessoa roda o CRM na **própria infraestr
   [Issues](https://github.com/melgarafael/DeskcommCRM/issues) ou
   [Discussions](https://github.com/melgarafael/DeskcommCRM/discussions). Não há SLA nem
   suporte garantido — é open source mantido por boa vontade.
-- **Você é responsável pela sua instalação.** Atualizações não são automáticas
-  (`bash hostgator-setup-kit/update.sh` quando quiser), e manter/backup do seu servidor
-  é com você.
+- **Você é responsável pela sua instalação.** Atualizações não são automáticas (você clica
+  ou roda `update.sh` quando quiser), e manter/backup do seu servidor é com você.
 - **LGPD — atenção:** quem **hospeda** a instância é o **controlador** dos dados pessoais
   ali tratados (clientes, conversas, pedidos), com as obrigações legais decorrentes. Os
   mantenedores do projeto **não são** controladores nem operadores da sua instância, e não
@@ -312,8 +454,8 @@ Este é um projeto **self-host**: cada pessoa roda o CRM na **própria infraestr
 
 - **WAHA** ([devlikeapro](https://waha.devlikeapro.com/)) — engine WhatsApp.
 - **Supabase** — Postgres + Auth + Storage + Realtime numa stack só.
-- **Vercel** — hosting + AI Gateway.
-- **Anthropic** (Claude) — IA conversacional.
+- **HostGator** — parceria de infraestrutura que tornou o self-host de 1 comando possível.
+- **Anthropic**, **OpenAI** e **OpenRouter** — os provedores de IA que o CRM sabe usar.
 - **shadcn/ui** — base de componentes.
 - A comunidade que nos levou do e-commerce pra clínicas, imobiliárias, infoprodutos e além — vocês definiram o que este projeto é.
 


### PR DESCRIPTION
## Por quê

Duas coisas que apontam para o mesmo público — quem instala numa VPS.

**1. O README abria com um Quickstart de desenvolvimento.** `nvm`, `pnpm install`, `supabase link`, `psql`. Quem comprou servidor para rodar o CRM seguia o caminho errado por ser o primeiro que aparecia — e o README nunca ensinou a **atualizar**.

**2. A 1.2.0 foi anunciada no changelog e nunca publicada.** O commit `a65b5b49` (06/08) escreveu a seção e a tag nunca foi empurrada.

## O congelamento — reproduzido, não deduzido

```
$ git ls-remote --tags origin | grep -E 'v[0-9]'     → só v1.0.0 e v1.1.0
$ curl ghcr.io/v2/melgarafael/deskcommcrm/manifests/1.2.0   → HTTP 404
  (latest, 1.1.0, 1.1, 1.0.0 → HTTP 200)
```

Num clone `--depth 1` da `main` — exatamente o que o `install.sh` faz (linha 700) — a guarda real do kit:

```
TARGET_TAG  = v1.1.0
CURRENT_TAG = ''                        ← segue a main
is_already_in_head(v1.1.0) => 0         ← retrocesso → refuse, exit 3
commits de v1.1.0 até HEAD: 801
```

Resultado para **quem já instalou**: o `update.sh` recusa e não toca em nada; a tela mostra "Você está à frente da versão publicada" sem botão, porque o `agent.sh` aplica o mesmo teste de ancestralidade. **As duas pontas acertam** — não existe alvo publicado para comparar. Quem instala do zero hoje está bem (`main` + `:latest`, republicado a cada merge).

## O que este PR faz

**README** — a instalação na VPS vira seção própria logo abaixo do bloco da HostGator (mantido intacto, com o link de parceria); seção **Atualizar** nova, cobrindo a tela e o `update.sh`; Quickstart de dev demovido para "Desenvolvimento (só pra contribuir)" com aviso explícito. Números remedidos em `8c9f117a`: invariantes 364/56 → **618/98**, e2e **44 das 45** specs e agora obrigatório, 196 route handlers, 157 docs. Acrescenta o que já existia em código e não no README: canal oficial da Meta, escolha de provedor de IA, follow-up vivo, radar, skills, memória, casos, evolução da IA, gestão de funis.

**CHANGELOG** — a `[1.2.0]` passa a cobrir `v1.1.0..main` (redatada para 11/08), porque cortar em `a65b5b49` deixaria os 377 commits seguintes sem versão de novo e a seção `[Não lançado]` está vazia.

## Números conferidos na fonte, não copiados de mensagem de commit

- **30% → 10%** se sustenta (3/10 → 1/10, mesmos cenários, ferramentas executadas contra dados reais, controle calibrado) — mas o *assunto* estava errado na mensagem original: não é "ação indevida", é dado interno vazando na resposta ao cliente. Corrigido no texto.
- **23 pontos de IA** batem com `lib/ai/pontos/registro.ts`.
- **400 modelos da OpenRouter** viraram "na sincronização de referência" — o catálogo se atualiza sozinho e o número anda.
- **Migrations 0087–0148** (51 arquivos). O texto anterior dizia "0100 a 0114", incompleto já para o próprio escopo.
- **Fora de propósito:** o canal Zernio (PR #200) não entrou. Não aparece na UI nem em `selectable.ts` — anunciá-lo seria vender tela que não existe.

## Depois do merge

Cortar a tag na ponta da `main`, o que dispara o `publish-image` (imagens `1.2.0` e `1.2`) e devolve um alvo publicado às instalações existentes. Vale também criar as GitHub Releases da `v1.1.0` e da `v1.2.0` — hoje a `v1.1.0` existe só como tag.

## Gates

`pnpm typecheck` exit 0 · `pnpm lint` exit 0 (242 warnings pré-existentes). Mudança é só de `.md` — nenhum código tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VP81jNMpcqZePhfiCZBsBA
