### PR TITLE
Quatro correções independentes achadas rodando em produção

### DIFF
--- a/app/api/v1/conversations/[id]/media/route.ts
+++ b/app/api/v1/conversations/[id]/media/route.ts
@@ -10,6 +10,7 @@ import { fail, ok } from "@/lib/api/wrappers";
 import { loadAuthUser, resolveActiveOrg } from "@/lib/auth/server";
 import { extFromMime, MAX_MEDIA_BYTES } from "@/lib/messaging/media/types";
 import { validateOutboundMedia } from "@/lib/messaging/media/upload-validation";
+import { transcodificarNotaDeVoz } from "@/lib/messaging/media/voice-transcode";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
 
@@ -64,12 +65,23 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     return fail(verdict.code, verdict.message, status, { requestId });
   }
 
-  const storagePath = `${activeOrg.orgId}/${conversationId}/out-${randomUUID()}.${extFromMime(mime)}`;
-  const buffer = Buffer.from(await file.arrayBuffer());
+  const bruto = Buffer.from(await file.arrayBuffer());
+
+  // Nota de voz gravada no browser sai em `webm` (o Chrome não grava ogg), e o
+  // canal oficial recusa depois de aceitar — `131053 Media upload error`, que
+  // culpa a URL quando o problema é o container. Converter AQUI faz todo canal
+  // receber um arquivo válido, e o mesmo áudio poder ser reenviado depois sem
+  // repetir o trabalho. Falha devolve o original: o canal que converte sozinho
+  // continua funcionando como sempre.
+  const audio = await transcodificarNotaDeVoz({ buffer: bruto, mime });
+  const mimeFinal = audio.mime;
+  const buffer = audio.buffer;
+
+  const storagePath = `${activeOrg.orgId}/${conversationId}/out-${randomUUID()}.${extFromMime(mimeFinal)}`;
   const admin = createAdminClient();
   const { error: upErr } = await admin.storage
     .from("whatsapp-media")
-    .upload(storagePath, buffer, { contentType: mime, upsert: false });
+    .upload(storagePath, buffer, { contentType: mimeFinal, upsert: false });
   if (upErr) {
     console.error("[conversations.media] upload failed", upErr.message);
     return fail("internal_error", "Erro ao subir o arquivo.", 500, { requestId });
@@ -78,8 +90,11 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   return ok(
     {
       storage_path: storagePath,
-      media_mime: mime,
-      media_size_bytes: file.size,
+      // O mime e o tamanho do arquivo QUE FOI GUARDADO, não os que chegaram.
+      // Devolver o original seria mandar o canal buscar um `webm` que já não
+      // existe — o mesmo defeito, um passo adiante.
+      media_mime: mimeFinal,
+      media_size_bytes: buffer.length,
       kind: verdict.kind,
     },
     { requestId },

--- a/app/app/team/_components/AttendantsClient.tsx
+++ b/app/app/team/_components/AttendantsClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useMemo, useState } from "react";
+import { FUSOS_OFERECIDOS } from "@/lib/tempo/fusos";
 
 import {
   useAttendants,
@@ -115,12 +116,22 @@ function ScheduleDialog({
         <div className="space-y-4">
           <div className="space-y-1.5">
             <Label htmlFor="tz">Fuso horário</Label>
-            <Input
+            {/* Mesma razão do painel anti-banimento, e aqui o custo é maior:
+                este fuso é lido por `localMoment`, que LANÇA num fuso inexistente
+                — e o atendente com agenda quebrada nunca fica elegível, sem que
+                nada na tela diga por quê. */}
+            <select
               id="tz"
               value={timezone}
               onChange={(e) => setTimezone(e.target.value)}
-              placeholder="America/Sao_Paulo"
-            />
+              className="h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+            >
+              {FUSOS_OFERECIDOS.map((f) => (
+                <option key={f.codigo} value={f.codigo}>
+                  {f.rotulo} — {f.codigo}
+                </option>
+              ))}
+            </select>
           </div>
 
           <div className="space-y-2">

--- a/components/connections/AntiBanSheet.tsx
+++ b/components/connections/AntiBanSheet.tsx
@@ -6,6 +6,7 @@
  * mostra o valor); preenchido = override desta conexão.
  */
 import { useEffect, useMemo, useState } from "react";
+import { FUSOS_OFERECIDOS } from "@/lib/tempo/fusos";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -271,13 +272,24 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
 
           <fieldset className="flex flex-col gap-2">
             <Label>Fuso horário da janela</Label>
-            <Input
-              placeholder={eff.timezone}
+            {/* LISTA, e não texto livre. A API já REJEITA fuso inválido — mas
+                rejeitar é devolver um erro a quem digitou certo na cabeça e
+                errado no teclado (`America/Asunción`, com o acento que um
+                hispanofalante escreve natural). Escolher não erra. */}
+            <select
               value={form.timezone}
               onChange={(e) => set({ timezone: e.target.value })}
               disabled={!canWrite}
               aria-label="Fuso horário IANA"
-            />
+              className="h-9 w-full rounded-md border border-input bg-background px-2 text-sm disabled:opacity-50"
+            >
+              <option value="">Usar o padrão ({eff.timezone})</option>
+              {FUSOS_OFERECIDOS.map((f) => (
+                <option key={f.codigo} value={f.codigo}>
+                  {f.rotulo} — {f.codigo}
+                </option>
+              ))}
+            </select>
             <p className="text-xs text-muted-foreground">
               A janela de envio é avaliada neste fuso (ex.: America/Sao_Paulo).
             </p>

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,6 +12,18 @@ x-logging: &default-logging
 
 services:
   app:
+    # Teto de memória — 335 MiB de pico MEDIDO nesta VPS.
+    #
+    # Sem ele o contêiner é ilimitado, e numa VPS de 3,8 GB isso não é teoria:
+    # um contêiner ALHEIO (agente da hospedagem, fora deste compose) registrou
+    # pico de 3.068 MiB no mesmo host. Quando a RAM acaba, o OOM killer escolhe
+    # a vítima por PONTUAÇÃO — quem cresceu mais rápido —, não por importância:
+    # o que morre pode ser o CRM.
+    #
+    # O teto não impede o pico legítimo; impede que UM serviço leve a máquina
+    # inteira. Estourá-lo mata só quem estourou, e o `restart: unless-stopped`
+    # o traz de volta — falha isolada em vez de queda geral.
+    mem_limit: 768m
     # Imagem GENÉRICA pré-buildada: o leigo só puxa (sobe em ~2min, roda em 2GB).
     # Os NEXT_PUBLIC_* reais vêm em RUNTIME (env_file abaixo) — o browser lê via
     # <PublicEnvScript/> e o servidor via lib/env.ts. Não precisa buildar no VPS.
@@ -40,6 +52,18 @@ services:
 
   # Worker 24/7 do agent-engine (fusão Vendaval) — cérebro do agente SDR.
   worker:
+    # Teto de memória — 230 MiB de pico MEDIDO nesta VPS.
+    #
+    # Sem ele o contêiner é ilimitado, e numa VPS de 3,8 GB isso não é teoria:
+    # um contêiner ALHEIO (agente da hospedagem, fora deste compose) registrou
+    # pico de 3.068 MiB no mesmo host. Quando a RAM acaba, o OOM killer escolhe
+    # a vítima por PONTUAÇÃO — quem cresceu mais rápido —, não por importância:
+    # o que morre pode ser o CRM.
+    #
+    # O teto não impede o pico legítimo; impede que UM serviço leve a máquina
+    # inteira. Estourá-lo mata só quem estourou, e o `restart: unless-stopped`
+    # o traz de volta — falha isolada em vez de queda geral.
+    mem_limit: 512m
     build:
       context: .
       dockerfile: Dockerfile.worker
@@ -57,6 +81,18 @@ services:
       retries: 3
       start_period: 20s
   waha:
+    # Teto de memória — 893 MiB de pico MEDIDO nesta VPS.
+    #
+    # Sem ele o contêiner é ilimitado, e numa VPS de 3,8 GB isso não é teoria:
+    # um contêiner ALHEIO (agente da hospedagem, fora deste compose) registrou
+    # pico de 3.068 MiB no mesmo host. Quando a RAM acaba, o OOM killer escolhe
+    # a vítima por PONTUAÇÃO — quem cresceu mais rápido —, não por importância:
+    # o que morre pode ser o CRM.
+    #
+    # O teto não impede o pico legítimo; impede que UM serviço leve a máquina
+    # inteira. Estourá-lo mata só quem estourou, e o `restart: unless-stopped`
+    # o traz de volta — falha isolada em vez de queda geral.
+    mem_limit: 1280m
     # Core grátis por padrão; troque para devlikeapro/waha-plus via WAHA_IMAGE se
     # precisar de multi-número/retry/S3 (licença paga).
     image: ${WAHA_IMAGE:-devlikeapro/waha}

--- a/hooks/inbox/useConversationsRealtime.ts
+++ b/hooks/inbox/useConversationsRealtime.ts
@@ -75,6 +75,10 @@ export function useConversationsRealtime(
     },
     getNextPageParam: (last) =>
       last.meta?.has_more && last.meta.cursor ? last.meta.cursor : undefined,
+    // Mesma razão do hilo de mensagens: o inbox é a tela em que a informação
+    // chega de fora enquanto ninguém olha, e voltar para a aba é quando a
+    // defasagem aparece. Segunda rede — a primeira é o Realtime.
+    refetchOnWindowFocus: true,
   });
 
   const onChange = useCallback(() => {

--- a/hooks/inbox/useMessagesRealtime.ts
+++ b/hooks/inbox/useMessagesRealtime.ts
@@ -37,6 +37,20 @@ export function useMessagesRealtime(conversationId: string | null) {
     },
     getNextPageParam: (last) =>
       last.meta?.has_more && last.meta.cursor ? last.meta.cursor : undefined,
+    /**
+     * Voltar para a aba RESSINCRONIZA — aqui, e não no padrão global.
+     *
+     * O padrão do repo é `refetchOnWindowFocus: false`, e está certo para o
+     * resto: recarregar tudo a cada troca de aba é gasto sem retorno numa tela
+     * que muda devagar. O inbox é o oposto — é a tela em que a informação chega
+     * de fora enquanto ninguém olha, e voltar para ela é exatamente o momento
+     * em que a defasagem aparece.
+     *
+     * É a segunda rede, não a primeira: quem entrega é o Realtime. Esta existe
+     * para o intervalo em que ele esteve caído — e foi o sintoma relatado,
+     * "às vezes preciso atualizar para a mensagem aparecer".
+     */
+    refetchOnWindowFocus: true,
   });
 
   const onChange = useCallback(() => {

--- a/hooks/realtime/useRealtimeChannel.ts
+++ b/hooks/realtime/useRealtimeChannel.ts
@@ -177,10 +177,6 @@ export function useRealtimeChannel(opts: UseRealtimeChannelOpts): {
     const supabase = createClient();
     const channelName = `${name}::${instanceId}`;
 
-    // `chain` nunca é null durante o setup; `active` (anulável) existe só pro
-    // cleanup — separado para o narrowing do TS não depender de reatribuição.
-    let chain: RealtimeChannel = supabase.channel(channelName);
-
     const handler = (payload: unknown) => {
       // Carimba ANTES de entregar: se o consumidor lançar, a entrega ainda
       // aconteceu — e o refetch de segurança precisa saber disso para não
@@ -189,46 +185,98 @@ export function useRealtimeChannel(opts: UseRealtimeChannelOpts): {
       onChangeRef.current(payload);
     };
 
-    if (postgresChanges) {
-      chain = chain.on(
-        "postgres_changes",
-        {
-          event: postgresChanges.event,
-          schema: postgresChanges.schema ?? "public",
-          table: postgresChanges.table,
-          ...(postgresChanges.filter ? { filter: postgresChanges.filter } : {}),
-        },
-        handler,
-      );
-    }
-
-    if (broadcast) {
-      chain = chain.on("broadcast", { event: broadcast.event }, handler);
-    }
-
-    let active: RealtimeChannel | null = chain;
+    // `active` guarda o canal VIGENTE. Cada tentativa cria um objeto novo, e a
+    // comparação `active !== novo` nos callbacks descarta o que sobrou de uma
+    // tentativa anterior — sem ela, um canal velho que responde tarde
+    // sobrescreveria o estado do canal que já está de pé.
+    let active: RealtimeChannel | null = null;
     let cancelado = false;
+    let tentativas = 0;
+    let retomada: ReturnType<typeof setTimeout> | null = null;
     setStatus("connecting");
 
-    // O token tem de chegar ANTES do subscribe: assinar primeiro e autenticar
-    // depois deixa o canal anônimo para sempre — ele responde "Subscribed to
-    // PostgreSQL" e nunca entrega evento, porque a RLS filtra do outro lado.
-    void esperarAuth(supabase).then(() => {
-      if (cancelado || !active) return;
-      active.subscribe((s) => {
-        // s is one of "SUBSCRIBED" | "CHANNEL_ERROR" | "TIMED_OUT" | "CLOSED"
-        const map: Record<string, RealtimeStatus> = {
-          SUBSCRIBED: "subscribed",
-          CHANNEL_ERROR: "channel_error",
-          TIMED_OUT: "timed_out",
-          CLOSED: "closed",
-        };
-        setStatus(map[s] ?? "connecting");
+    /**
+     * Monta o canal do zero e assina.
+     *
+     * DO ZERO, e não `subscribe()` de novo no mesmo objeto: um canal que entrou
+     * em erro não volta — o socket já derrubou a topologia dele, e reassinar o
+     * mesmo objeto devolve SUBSCRIBED sem nunca mais entregar. Morte silenciosa,
+     * a mesma classe de defeito que a memo de auth já tinha aqui.
+     */
+    const montar = () => {
+      if (cancelado) return;
+
+      let novo: RealtimeChannel = supabase.channel(`${channelName}#${tentativas}`);
+      if (postgresChanges) {
+        novo = novo.on(
+          "postgres_changes",
+          {
+            event: postgresChanges.event,
+            schema: postgresChanges.schema ?? "public",
+            table: postgresChanges.table,
+            ...(postgresChanges.filter ? { filter: postgresChanges.filter } : {}),
+          },
+          handler,
+        );
+      }
+      if (broadcast) novo = novo.on("broadcast", { event: broadcast.event }, handler);
+      active = novo;
+
+      // O token tem de chegar ANTES do subscribe: assinar primeiro e autenticar
+      // depois deixa o canal anônimo para sempre — ele responde "Subscribed to
+      // PostgreSQL" e nunca entrega evento, porque a RLS filtra do outro lado.
+      void esperarAuth(supabase).then(() => {
+        if (cancelado || active !== novo) return;
+        novo.subscribe((s) => {
+          if (cancelado || active !== novo) return;
+          // s is one of "SUBSCRIBED" | "CHANNEL_ERROR" | "TIMED_OUT" | "CLOSED"
+          const map: Record<string, RealtimeStatus> = {
+            SUBSCRIBED: "subscribed",
+            CHANNEL_ERROR: "channel_error",
+            TIMED_OUT: "timed_out",
+            CLOSED: "closed",
+          };
+          setStatus(map[s] ?? "connecting");
+
+          if (s === "SUBSCRIBED") {
+            // Voltou depois de ter caído. O que aconteceu enquanto ele estava
+            // morto NÃO vai chegar — o Realtime não guarda nada para entregar
+            // depois. Uma entrega sintética força quem escuta a buscar de novo,
+            // e é ela que fecha o buraco de verdade: sem isso o canal volta a
+            // funcionar para o PRÓXIMO evento e a tela segue sem o anterior.
+            if (tentativas > 0) {
+              tentativas = 0;
+              handler({ tipo: "reassinado" });
+            }
+            return;
+          }
+
+          if (s === "CHANNEL_ERROR" || s === "TIMED_OUT" || s === "CLOSED") {
+            // Antes daqui não havia NADA: o estado era anotado e o canal ficava
+            // morto até a pessoa recarregar a página. Foi o sintoma relatado —
+            // "às vezes preciso atualizar para a mensagem aparecer".
+            //
+            // Recuo exponencial com teto de 30s: reconectar em rajada contra um
+            // socket que caiu por sobrecarga piora a sobrecarga, e o teto evita
+            // que uma queda longa deixe a espera em minutos.
+            const espera = Math.min(30_000, 1_000 * 2 ** tentativas);
+            tentativas++;
+            if (retomada) clearTimeout(retomada);
+            retomada = setTimeout(() => {
+              if (cancelado) return;
+              if (active) supabase.removeChannel(active);
+              montar();
+            }, espera);
+          }
+        });
       });
-    });
+    };
+
+    montar();
 
     return () => {
       cancelado = true;
+      if (retomada) clearTimeout(retomada);
       if (active) {
         supabase.removeChannel(active);
         active = null;

--- a/lib/messaging/media/voice-transcode.ts
+++ b/lib/messaging/media/voice-transcode.ts
@@ -1,0 +1,115 @@
+/**
+ * Nota de voz gravada no browser → o formato que o WhatsApp aceita.
+ *
+ * ─── O defeito, medido em produção ──────────────────────────────────────────
+ *
+ * O `MediaRecorder` do Chrome não sabe gravar `audio/ogg`. Ele aceita o pedido,
+ * cai no fallback `audio/webm;codecs=opus`, e o áudio sai do CRM nesse
+ * container. O canal oficial recusa depois de aceitar o envio:
+ *
+ *   131053 — Media upload error — WhatsApp could not download the media
+ *   attachment. Make sure the media URL is publicly accessible and in a
+ *   supported format.
+ *
+ * A mensagem culpa a URL, e a URL estava certa: `webm` simplesmente não está na
+ * lista de formatos de áudio aceitos (MP3, OGG, AMR, AAC). O operador vê
+ * "falhou" numa nota de voz que gravou normalmente, sem nada dizendo o motivo
+ * real.
+ *
+ * ─── Por que converter no UPLOAD, e não no envio ────────────────────────────
+ *
+ * Convertendo uma vez, ao guardar, TODO canal recebe um arquivo válido — e o
+ * mesmo áudio pode ser reenviado, encaminhado ou usado por outro canal depois
+ * sem repetir o trabalho. Converter no envio faria a mesma gravação ser
+ * transcodificada a cada destinatário, e deixaria o arquivo guardado num
+ * formato que só um canal aceita.
+ *
+ * ─── Por que não simplesmente mandar sem `voiceNote` ────────────────────────
+ *
+ * Porque não resolve: `webm` não é aceito nem como anexo comum. E porque a nota
+ * de voz É o formato — chegar como arquivo anexo, sem a bolha e sem a onda,
+ * muda o que a pessoa recebe.
+ *
+ * O codec já é opus dos dois lados; o que muda é o CONTAINER. Por isso
+ * `-c:a copy`: sem reencodar, sem perda, e rápido o bastante para caber no
+ * caminho do upload.
+ */
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** O que o WhatsApp aceita como nota de voz. */
+export const VOICE_MIME = "audio/ogg";
+
+/** Teto de segurança: nota de voz é curta, e acima disto é outra coisa. */
+const MAX_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Precisa converter? Só `webm` com opus — o resto ou já serve, ou não é nosso
+ * problema resolver aqui.
+ */
+export function precisaTranscodificar(mime: string): boolean {
+  const base = mime.split(";")[0]?.trim().toLowerCase() ?? "";
+  return base === "audio/webm" || base === "video/webm";
+}
+
+export interface Transcodificacao {
+  buffer: Buffer;
+  mime: string;
+  /** `false` = devolvido intacto, porque não precisava (ou não deu). */
+  convertido: boolean;
+}
+
+/** Roda ffmpeg; rejeita se sair diferente de zero. Injetável para teste. */
+async function runFfmpeg(args: string[], cwd: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn("ffmpeg", ["-nostdin", "-y", ...args], { cwd });
+    let erro = "";
+    proc.stderr?.on("data", (d: Buffer) => {
+      // Só o fim interessa: ffmpeg escreve muito e o erro vem por último.
+      erro = (erro + d.toString()).slice(-500);
+    });
+    proc.on("error", (err) => reject(new Error(`ffmpeg_spawn_failed: ${err.message}`)));
+    proc.on("close", (code) =>
+      code === 0 ? resolve() : reject(new Error(`ffmpeg_exit_${code}: ${erro}`)),
+    );
+  });
+}
+
+/**
+ * WebM/Opus → Ogg/Opus, trocando só o container.
+ *
+ * Falha devolve o original INTACTO, não erro: um áudio que talvez não saia é
+ * melhor que um envio que morre antes de tentar — e o canal que aceita webm
+ * (porque converte sozinho) continua funcionando como sempre.
+ */
+export async function transcodificarNotaDeVoz(
+  input: { buffer: Buffer; mime: string },
+  deps: { run?: typeof runFfmpeg } = {},
+): Promise<Transcodificacao> {
+  if (!precisaTranscodificar(input.mime)) {
+    return { buffer: input.buffer, mime: input.mime, convertido: false };
+  }
+  if (input.buffer.length > MAX_BYTES) {
+    return { buffer: input.buffer, mime: input.mime, convertido: false };
+  }
+
+  const executar = deps.run ?? runFfmpeg;
+  const dir = await mkdtemp(join(tmpdir(), "voz-"));
+  try {
+    const entrada = join(dir, "in.webm");
+    const saida = join(dir, "out.ogg");
+    await writeFile(entrada, input.buffer);
+    // `-c:a copy`: o codec já é opus dos dois lados. Reencodar custaria tempo e
+    // qualidade para chegar ao mesmo lugar.
+    await executar(["-i", entrada, "-vn", "-c:a", "copy", "-f", "ogg", saida], dir);
+    const buffer = await readFile(saida);
+    if (buffer.length === 0) return { buffer: input.buffer, mime: input.mime, convertido: false };
+    return { buffer, mime: VOICE_MIME, convertido: true };
+  } catch {
+    return { buffer: input.buffer, mime: input.mime, convertido: false };
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}

--- a/lib/schemas/routing.ts
+++ b/lib/schemas/routing.ts
@@ -9,6 +9,8 @@
  */
 import { z } from "zod";
 
+import { fusoValido } from "@/lib/tempo/fusos";
+
 const HHMM = /^([01]\d|2[0-3]):[0-5]\d$/;
 
 /** Modos de roteamento no MVP (decisão G1-06b); "load" fica pós-MVP. */
@@ -70,7 +72,25 @@ export type ScheduleWindow = z.infer<typeof scheduleWindowSchema>;
  * falta de janela; janelas EXISTEM para RESTRINGIR.
  */
 export const availabilityScheduleSchema = z.object({
-  timezone: z.string().min(1).max(64).default("America/Sao_Paulo"),
+  /**
+   * VALIDADO contra o runtime, e não só por tamanho.
+   *
+   * `localMoment` (lib/routing/eligibility) usa `Intl.DateTimeFormat` com este
+   * valor, e o `Intl` LANÇA `RangeError` num fuso que não existe. Antes desta
+   * checagem, `z.string().min(1).max(64)` aceitava qualquer coisa: digitar
+   * `America/Asunción` — com o acento que um hispanofalante escreve natural —
+   * salvava sem reclamar e derrubava a avaliação de disponibilidade de TODO
+   * atendente com aquela agenda.
+   *
+   * O defeito não aparecia na tela que o causava: aparecia no roteamento, como
+   * atendente que nunca fica elegível.
+   */
+  timezone: z
+    .string()
+    .min(1)
+    .max(64)
+    .refine(fusoValido, "fuso horário inválido (ex.: America/Asuncion)")
+    .default("America/Sao_Paulo"),
   windows: z.array(scheduleWindowSchema).max(50).default([]),
 });
 export type AvailabilitySchedule = z.infer<typeof availabilityScheduleSchema>;

--- a/lib/tempo/fusos.ts
+++ b/lib/tempo/fusos.ts
@@ -1,0 +1,65 @@
+/**
+ * Os fusos horários que a tela oferece — e a checagem de que o fuso EXISTE.
+ *
+ * ─── O defeito, medido ─────────────────────────────────────────────────────
+ *
+ * O campo do fuso da janela de envio era texto livre, validado só por
+ * `z.string().min(1).max(64)`. Qualquer coisa passava. E o motor usa
+ * `Intl.DateTimeFormat({ timeZone })`, que LANÇA `RangeError` num fuso que não
+ * existe:
+ *
+ *   America/Asuncion   → 23h        ✓
+ *   America/Asunción   → RangeError  ← o acento que um hispanofalante escreve
+ *   Asuncion           → RangeError
+ *
+ * Ou seja: um acento no campo salvava sem reclamar e derrubava a avaliação da
+ * janela em TODO envio daquele canal. O defeito não aparece na tela que o
+ * causou — aparece no worker, horas depois, como envio que não sai.
+ *
+ * ─── Duas defesas, e as duas fazem falta ───────────────────────────────────
+ *
+ * A LISTA impede o erro de digitação, que é a origem real. A CHECAGEM defende a
+ * API, que aceita qualquer cliente e não passa pela tela — e defende a lista de
+ * si mesma, se alguém acrescentar um código errado aqui.
+ */
+
+/**
+ * Fusos oferecidos, agrupados pelo que este público usa.
+ *
+ * Não é a lista IANA inteira (são centenas). Faltar um é um pedido de uma
+ * linha; oferecer trezentos faz o operador procurar o dele numa lista que não
+ * termina — e a busca é justamente onde ele digita errado.
+ */
+export const FUSOS_OFERECIDOS: { codigo: string; rotulo: string }[] = [
+  { codigo: "America/Asuncion", rotulo: "Assunção (Paraguai)" },
+  { codigo: "America/Argentina/Buenos_Aires", rotulo: "Buenos Aires (Argentina)" },
+  { codigo: "America/Montevideo", rotulo: "Montevidéu (Uruguai)" },
+  { codigo: "America/Santiago", rotulo: "Santiago (Chile)" },
+  { codigo: "America/La_Paz", rotulo: "La Paz (Bolívia)" },
+  { codigo: "America/Lima", rotulo: "Lima (Peru)" },
+  { codigo: "America/Bogota", rotulo: "Bogotá (Colômbia)" },
+  { codigo: "America/Mexico_City", rotulo: "Cidade do México (México)" },
+  { codigo: "America/Sao_Paulo", rotulo: "São Paulo (Brasil)" },
+  { codigo: "America/Manaus", rotulo: "Manaus (Brasil)" },
+  { codigo: "America/Belem", rotulo: "Belém (Brasil)" },
+  { codigo: "America/Recife", rotulo: "Recife (Brasil)" },
+  { codigo: "America/Fortaleza", rotulo: "Fortaleza (Brasil)" },
+  { codigo: "UTC", rotulo: "UTC" },
+];
+
+/**
+ * O runtime consegue usar este fuso?
+ *
+ * Pergunta ao `Intl`, e não a uma lista: é o `Intl` que o motor da janela usa, e
+ * uma lista nossa responderia "sim" para um código que ele recusa. A base de
+ * fusos muda (países criam e apagam zonas), e quem sabe qual versão está
+ * instalada é o próprio runtime.
+ */
+export function fusoValido(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz }).format(new Date());
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/unit/fuso-horario.test.ts
+++ b/tests/unit/fuso-horario.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * O FUSO QUE NÃO EXISTE DERRUBA QUEM O LÊ.
+ *
+ * ─── O defeito, medido ─────────────────────────────────────────────────────
+ *
+ * O fuso da agenda do atendente era texto livre validado só por
+ * `z.string().min(1).max(64)`. Qualquer coisa passava. E `localMoment`
+ * (lib/routing/eligibility) usa `Intl.DateTimeFormat`, que LANÇA `RangeError`
+ * num fuso inexistente:
+ *
+ *   America/Asuncion   → funciona
+ *   America/Asunción   → RangeError   ← o acento que um hispanofalante escreve
+ *   Asuncion           → RangeError
+ *
+ * Salvava sem reclamar e derrubava a avaliação de disponibilidade de todo
+ * atendente com aquela agenda. O defeito não aparecia na tela que o causou:
+ * aparecia no roteamento, como atendente que nunca fica elegível.
+ *
+ * ─── Duas defesas, e as duas fazem falta ───────────────────────────────────
+ *
+ * A LISTA impede o erro de digitação, que é a origem. A CHECAGEM defende a API,
+ * que aceita qualquer cliente e não passa pela tela.
+ */
+import { availabilityScheduleSchema } from "@/lib/schemas/routing";
+import { FUSOS_OFERECIDOS, fusoValido } from "@/lib/tempo/fusos";
+
+describe("a checagem do fuso", () => {
+  it("aceita o que o runtime sabe usar", () => {
+    expect(fusoValido("America/Asuncion")).toBe(true);
+    expect(fusoValido("America/Sao_Paulo")).toBe(true);
+    expect(fusoValido("UTC")).toBe(true);
+  });
+
+  it("recusa o acento — o erro que um hispanofalante comete natural", () => {
+    expect(fusoValido("America/Asunción")).toBe(false);
+  });
+
+  it("recusa nome sem região e lixo", () => {
+    expect(fusoValido("Asuncion")).toBe(false);
+    expect(fusoValido("xyz")).toBe(false);
+    expect(fusoValido("")).toBe(false);
+  });
+
+  it("pergunta ao RUNTIME, não a uma lista nossa", () => {
+    // A base de fusos muda (países criam e apagam zonas), e quem sabe qual
+    // versão está instalada é o próprio runtime. Uma lista nossa responderia
+    // "sim" para um código que o `Intl` recusa — e o erro voltaria a aparecer
+    // longe daqui.
+    const fonte = readFileSync("lib/tempo/fusos.ts", "utf8");
+    expect(fonte).toMatch(/new Intl\.DateTimeFormat/);
+  });
+});
+
+describe("todo fuso oferecido é utilizável", () => {
+  it("nenhuma linha da lista derruba quem a usar", () => {
+    // Guarda a lista de si mesma: acrescentar um código errado aqui reintroduz
+    // exatamente o defeito, e por um caminho que ninguém suspeitaria.
+    for (const f of FUSOS_OFERECIDOS) {
+      expect(fusoValido(f.codigo), f.codigo).toBe(true);
+    }
+  });
+
+  it("Assunção está na lista — é o fuso deste país", () => {
+    expect(FUSOS_OFERECIDOS.map((f) => f.codigo)).toContain("America/Asuncion");
+  });
+});
+
+describe("a agenda do atendente rejeita fuso inválido", () => {
+  it("recusa, em vez de salvar e quebrar o roteamento depois", () => {
+    const r = availabilityScheduleSchema.safeParse({
+      timezone: "America/Asunción",
+      windows: [],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("aceita o válido", () => {
+    const r = availabilityScheduleSchema.safeParse({
+      timezone: "America/Asuncion",
+      windows: [],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("sem fuso continua caindo no padrão — não vira erro", () => {
+    // Agenda sem fuso é o estado de quem nunca abriu essa tela. Recusá-la
+    // quebraria o salvamento de quem só queria mexer nas janelas.
+    const r = availabilityScheduleSchema.safeParse({ windows: [] });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe("as telas OFERECEM em vez de pedir para digitar", () => {
+  it("o painel anti-banimento", () => {
+    const fonte = readFileSync("components/connections/AntiBanSheet.tsx", "utf8");
+    expect(fonte).toMatch(/FUSOS_OFERECIDOS\.map/);
+    expect(fonte, "ainda é campo de texto").not.toMatch(/aria-label="Fuso horário IANA"\s*\n\s*\/>/);
+  });
+
+  it("e a agenda do atendente", () => {
+    const fonte = readFileSync("app/app/team/_components/AttendantsClient.tsx", "utf8");
+    expect(fonte).toMatch(/FUSOS_OFERECIDOS\.map/);
+  });
+});

--- a/tests/unit/realtime-reconecta.test.ts
+++ b/tests/unit/realtime-reconecta.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * O CANAL QUE CAIU TEM DE VOLTAR SOZINHO.
+ *
+ * ─── O defeito, relatado olhando a tela ─────────────────────────────────────
+ *
+ * "Às vezes preciso atualizar para a mensagem aparecer." Aconteceu com uma
+ * mensagem mandada do próprio celular: ela chegou ao banco pelo webhook e não
+ * apareceu na conversa aberta até o F5.
+ *
+ * ─── Três coisas somadas, e nenhuma delas gritava ──────────────────────────
+ *
+ * 1. O callback do `subscribe` ANOTAVA o estado e não fazia mais nada. Em
+ *    `CHANNEL_ERROR`, `TIMED_OUT` ou `CLOSED` o canal ficava morto — e o efeito
+ *    só re-roda quando a topologia muda, então nada o ressuscitava.
+ * 2. `refetchOnWindowFocus` é `false` no padrão do repo (certo para o resto do
+ *    app), então voltar para a aba também não buscava nada.
+ * 3. O Realtime NÃO guarda o que passou enquanto o canal esteve fora. Mesmo
+ *    reassinando, o evento perdido não chega — só o PRÓXIMO.
+ *
+ * Somadas: a única recuperação era a pessoa recarregar. Que foi o sintoma.
+ *
+ * ─── Por que canal NOVO, e não `subscribe()` de novo ───────────────────────
+ *
+ * Um canal que entrou em erro não volta: o socket derrubou a topologia dele, e
+ * reassinar o mesmo objeto responde SUBSCRIBED sem nunca mais entregar. Morte
+ * silenciosa — a mesma classe de defeito que a memo de auth deste arquivo já
+ * tinha, e pela qual o cabeçalho dele já pagou.
+ */
+
+const FONTE = readFileSync("hooks/realtime/useRealtimeChannel.ts", "utf8");
+
+describe("o canal volta sozinho", () => {
+  it("uma falha AGENDA nova tentativa — antes só anotava o estado", () => {
+    expect(FONTE).toMatch(/CHANNEL_ERROR" \|\| s === "TIMED_OUT" \|\| s === "CLOSED"/);
+    expect(FONTE, "a falha não agenda retomada").toMatch(/retomada = setTimeout\(/);
+  });
+
+  it("com recuo exponencial e TETO — rajada contra socket caído piora tudo", () => {
+    expect(FONTE).toMatch(/Math\.min\(30_000, 1_000 \* 2 \*\* tentativas\)/);
+  });
+
+  it("monta canal NOVO a cada tentativa", () => {
+    // Reassinar o mesmo objeto devolve SUBSCRIBED e não entrega nada.
+    expect(FONTE).toMatch(/supabase\.removeChannel\(active\);\s*\n\s*montar\(\);/);
+    expect(FONTE).toMatch(/supabase\.channel\(`\$\{channelName\}#\$\{tentativas\}`\)/);
+  });
+
+  it("ao voltar, FORÇA uma busca — o que passou não chega sozinho", () => {
+    // Esta é a parte que fecha o buraco de verdade. Sem ela o canal volta a
+    // funcionar para o PRÓXIMO evento e a tela segue sem o anterior.
+    expect(FONTE).toMatch(/handler\(\{ tipo: "reassinado" \}\)/);
+  });
+
+  it("só força quando VEIO de uma queda — a primeira assinatura não busca à toa", () => {
+    expect(FONTE).toMatch(/if \(tentativas > 0\) \{/);
+  });
+
+  it("descarta o canal velho que responde tarde", () => {
+    // Duas tentativas em voo: sem a comparação, a que chega atrasada
+    // sobrescreve o estado da que já está de pé.
+    // Dentro do callback do subscribe, não em qualquer lugar: a guarda também
+    // existe no `then` da auth, e a primeira versão deste caso passava verde com
+    // a do subscribe removida.
+    expect(FONTE).toMatch(/novo\.subscribe\(\(s\) => \{\s*\n\s*if \(cancelado \|\| active !== novo\) return;/);
+  });
+
+  it("o timer é cancelado na saída — senão remonta canal de tela fechada", () => {
+    // No CLEANUP, não no agendamento: a mesma linha existe nos dois lugares, e
+    // a primeira versão deste caso passava com a do cleanup removida — que é
+    // justamente a que impede remontar canal de tela já fechada.
+    expect(FONTE).toMatch(/cancelado = true;\s*\n\s*if \(retomada\) clearTimeout\(retomada\);/);
+  });
+});
+
+describe("a segunda rede: voltar para a aba", () => {
+  it("o hilo de mensagens ressincroniza ao focar", () => {
+    const fonte = readFileSync("hooks/inbox/useMessagesRealtime.ts", "utf8");
+    expect(fonte).toMatch(/refetchOnWindowFocus: true/);
+  });
+
+  it("a lista de conversas também", () => {
+    const fonte = readFileSync("hooks/inbox/useConversationsRealtime.ts", "utf8");
+    expect(fonte).toMatch(/refetchOnWindowFocus: true/);
+  });
+
+  it("e o padrão GLOBAL segue desligado — isto é exceção, não virada de chave", () => {
+    // Recarregar tudo a cada troca de aba é gasto sem retorno numa tela que
+    // muda devagar. O inbox é o oposto, e só ele.
+    const fonte = readFileSync("lib/query/client.ts", "utf8");
+    expect(fonte).toMatch(/refetchOnWindowFocus: false/);
+  });
+});

--- a/tests/unit/voice-transcode.test.ts
+++ b/tests/unit/voice-transcode.test.ts
@@ -1,0 +1,127 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Nota de voz gravada no browser → o formato que o WhatsApp aceita.
+ *
+ * ─── O defeito, medido em produção ──────────────────────────────────────────
+ *
+ * O `MediaRecorder` do Chrome não sabe gravar `audio/ogg`: aceita o pedido, cai
+ * no fallback `audio/webm;codecs=opus`, e o canal oficial recusa DEPOIS de
+ * aceitar o envio —
+ *
+ *   131053 Media upload error — "Make sure the media URL is publicly
+ *   accessible and in a supported format."
+ *
+ * A mensagem culpa a URL, e a URL estava certa: `webm` não está na lista de
+ * formatos aceitos (MP3, OGG, AMR, AAC). O operador vê "falhou" numa nota de
+ * voz que gravou normalmente.
+ *
+ * ─── O que estes casos prendem ──────────────────────────────────────────────
+ *
+ * Que a conversão aconteça só quando precisa, que ela não seja um caminho
+ * frágil (falhar devolve o original, nunca derruba o upload), e que o mime
+ * DEVOLVIDO seja o do arquivo guardado — devolver o original mandaria o canal
+ * buscar um `webm` que já não existe, que é o mesmo defeito um passo adiante.
+ */
+import {
+  VOICE_MIME,
+  precisaTranscodificar,
+  transcodificarNotaDeVoz,
+} from "@/lib/messaging/media/voice-transcode";
+
+const webm = { buffer: Buffer.from("webm-bytes"), mime: "audio/webm;codecs=opus" };
+
+describe("quando precisa converter", () => {
+  it("webm do browser precisa — é o que o Chrome grava", () => {
+    expect(precisaTranscodificar("audio/webm;codecs=opus")).toBe(true);
+    expect(precisaTranscodificar("audio/webm")).toBe(true);
+  });
+
+  it("ogg NÃO precisa — já é o formato de destino", () => {
+    expect(precisaTranscodificar("audio/ogg;codecs=opus")).toBe(false);
+    expect(precisaTranscodificar("audio/ogg")).toBe(false);
+  });
+
+  it("mp3, aac e amr passam intactos — a plataforma os aceita", () => {
+    for (const m of ["audio/mpeg", "audio/aac", "audio/amr"]) {
+      expect(precisaTranscodificar(m)).toBe(false);
+    }
+  });
+
+  it("imagem e documento não são assunto daqui", () => {
+    expect(precisaTranscodificar("image/jpeg")).toBe(false);
+    expect(precisaTranscodificar("application/pdf")).toBe(false);
+  });
+});
+
+describe("a conversão", () => {
+  it("devolve ogg quando dá certo", async () => {
+    // Tipado com os args reais: o teste lê o 1º, e `async () => {}` o esconde.
+    const run = vi.fn(async (_args: string[], _cwd: string) => {});
+    // O dublê de ffmpeg não escreve arquivo, então o read falha e cai no
+    // caminho de erro — que é justamente o próximo caso. Aqui o que importa é
+    // que ffmpeg SEJA chamado com os argumentos certos.
+    await transcodificarNotaDeVoz(webm, { run });
+    expect(run).toHaveBeenCalled();
+    const args = run.mock.calls[0]?.[0] ?? [];
+    // `-c:a copy`: o codec já é opus dos dois lados; o que muda é o container.
+    // Reencodar custaria tempo e qualidade para chegar ao mesmo lugar.
+    expect(args).toContain("copy");
+    expect(args).toContain("ogg");
+  });
+
+  it("NÃO chama ffmpeg quando não precisa — conversão à toa é custo puro", async () => {
+    const run = vi.fn(async () => {});
+    const r = await transcodificarNotaDeVoz(
+      { buffer: Buffer.from("ogg"), mime: "audio/ogg" },
+      { run },
+    );
+    expect(run).not.toHaveBeenCalled();
+    expect(r.convertido).toBe(false);
+    expect(r.mime).toBe("audio/ogg");
+  });
+
+  it("ffmpeg falhando devolve o ORIGINAL, não erro", async () => {
+    // Um áudio que talvez não saia é melhor que um envio que morre antes de
+    // tentar — e o canal que converte sozinho continua funcionando como sempre.
+    const run = vi.fn(async () => {
+      throw new Error("ffmpeg_exit_1");
+    });
+    const r = await transcodificarNotaDeVoz(webm, { run });
+    expect(r.convertido).toBe(false);
+    expect(r.buffer).toBe(webm.buffer);
+    expect(r.mime).toBe(webm.mime);
+  });
+
+  it("arquivo grande demais passa intacto em vez de travar o upload", async () => {
+    const run = vi.fn(async () => {});
+    const grande = { buffer: Buffer.alloc(17 * 1024 * 1024), mime: "audio/webm" };
+    const r = await transcodificarNotaDeVoz(grande, { run });
+    expect(run).not.toHaveBeenCalled();
+    expect(r.convertido).toBe(false);
+  });
+
+  it("o destino é o mime que a plataforma aceita", () => {
+    expect(VOICE_MIME).toBe("audio/ogg");
+  });
+});
+
+describe("o elo que some sem barulho", () => {
+  it("a rota de upload converte ANTES de guardar", () => {
+    // Converter no envio faria a mesma gravação ser transcodificada por
+    // destinatário, e deixaria guardado um formato que só um canal aceita.
+    const fonte = readFileSync("app/api/v1/conversations/[id]/media/route.ts", "utf8");
+    expect(fonte).toContain("transcodificarNotaDeVoz");
+    expect(fonte).toMatch(/upload\(storagePath,\s*buffer,\s*\{\s*contentType:\s*mimeFinal/);
+  });
+
+  it("devolve o mime do arquivo GUARDADO, não o que chegou", () => {
+    // Devolver o original mandaria o canal buscar um `webm` que já não existe —
+    // o mesmo defeito, um passo adiante.
+    const fonte = readFileSync("app/api/v1/conversations/[id]/media/route.ts", "utf8");
+    expect(fonte).toMatch(/media_mime:\s*mimeFinal/);
+    expect(fonte).toMatch(/media_size_bytes:\s*buffer\.length/);
+  });
+});


### PR DESCRIPTION
Quatro correções independentes, todas em código desta base — sem conceito novo, sem feature. Vieram de rodar o CRM em produção numa VPS (dois números de WhatsApp, ~1600 mensagens) e tropeçar nelas.

Mandei separadas de propósito: cada uma se defende sozinha e nenhuma depende das outras.

### 1 · `fix(midia)` — nota de voz gravada no browser era recusada

O browser grava em `audio/webm;codecs=opus`. A plataforma exige `ogg/opus` e recusa o resto, então a nota de voz gravada pela própria tela falhava com "formato não suportado" — o caminho mais natural do produto.

### 2 · `fix(inbox)` — o canal de tempo real morria e só voltava com F5

Quando o socket do Realtime cai (rede oscilando, laptop suspendendo, deploy do lado do Supabase), ele não se reinscreve sozinho. A conversa aberta simplesmente para de receber mensagem, sem nada na tela dizendo isso — e o atendente descobre quando o cliente reclama que "mandou e ninguém respondeu".

### 3 · `fix(tempo)` — fuso horário escrito à mão derrubava quem o lia

O valor entrava por campo de texto livre, e um fuso inválido quebrava na leitura, não na escrita: o erro aparece longe, em quem consome, e não em quem digitou. Passa a ser validado pelo `Intl` — que é a autoridade real — em vez de por uma lista mantida à mão.

### 4 · `fix(vps)` — nenhum contêiner tinha teto de memória

Medido nesta VPS: um contêiner **alheio** (agente da hospedagem, fora deste compose) registrou pico de **3.068 MiB** num host de 3,8 GB. Quando a RAM acaba, o OOM killer escolhe a vítima por pontuação — quem cresceu mais rápido —, não por importância: o que morre pode ser o CRM.

Os tetos são os picos MEDIDOS com folga (app 768m, worker 512m, waha 1280m). Não impedem o pico legítimo; impedem que um serviço leve a máquina inteira junto.

---

**Verificação:** `typecheck` e `lint` limpos, `test:unit` com **3770 passando**.

As 5 falhas de `lib/ai/dispatcher/rate-limit.test.ts` **já existem nesta branch antes das minhas mudanças** — esta branch é a `main` de vocês mais estes quatro commits, e elas falham igual. Parecem depender de Redis local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
