### PR TITLE
docs(readme): EN e ES alcançam o pt-br, e os três ensinam a entrar na VPS por SSH

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -14,7 +14,7 @@
 [![CI](https://github.com/melgarafael/DeskcommCRM/actions/workflows/ci.yml/badge.svg)](https://github.com/melgarafael/DeskcommCRM/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-[**🧭 Vision**](VISION.md) · [**📘 Setup Guide**](docs/SETUP.md) · [**🏗️ Architecture**](ARCHITECTURE.md) · [**🤝 Contributing**](CONTRIBUTING.md) · [**📋 PRDs**](docs/prd/) · [**🗺️ Roadmap**](#%EF%B8%8F-roadmap)
+[**⚡ Install**](#-install-on-your-vps-the-main-path) · [**🔄 Update**](#-updating) · [**🧭 Vision**](VISION.md) · [**🏗️ Architecture**](ARCHITECTURE.md) · [**🤝 Contributing**](CONTRIBUTING.md) · [**🗺️ Roadmap**](#%EF%B8%8F-roadmap)
 
 </div>
 
@@ -23,27 +23,180 @@
 > ### ☁️ Run this CRM in production with one command
 >
 > DeskcommCRM is developed in **partnership with HostGator**: the [`hostgator-setup-kit/`](hostgator-setup-kit/)
-> installs the full CRM (app + WAHA + database) on a VPS with a single command, and the
+> installs the full CRM (app + WhatsApp + database) on a VPS with a single command, and the
 > [production runbook](docs/runbooks/waha-hostgator.md) assumes that environment.
 >
 > **[👉 Get the HostGator VPS with the partnership discount](https://www.hostgator.com.br/52708-141-3-52.html)** —
 > São Paulo datacenter, ideal for WhatsApp running 24/7. *(partner link — subscribing through it supports the project and costs you less)*
 >
-> Already have the VPS? SSH into it and run:
+> **No server yet?** Run this **on your own computer** (macOS, Linux or WSL). It tells you which
+> plan to buy — with the runbook's real numbers, not a "it depends" — and hands you the exact
+> command for your case:
 >
 > ```bash
-> git clone https://github.com/melgarafael/DeskcommCRM.git
-> cd DeskcommCRM
-> bash hostgator-setup-kit/install.sh
+> curl -fsSL https://raw.githubusercontent.com/melgarafael/DeskcommCRM/main/hostgator-setup-kit/comecar.sh | bash
 > ```
 >
-> The installer asks for what only you have (domain, Supabase keys, AI key, admin password),
-> validates each one before moving on, generates every other secret, applies the database
-> schema and brings the whole stack up with HTTPS. Details in
-> [`hostgator-setup-kit/README.md`](hostgator-setup-kit/README.md).
->
-> ⚠️ The **Quickstart** below is the *development* path (running the app on your machine).
-> If you bought a VPS to run the CRM, use the command above, not the Quickstart.
+> *(prefer to read before executing? clone the repo and run `bash hostgator-setup-kit/comecar.sh` —
+> it installs nothing without your confirmation.)*
+
+---
+
+## ⚡ Install on your VPS (the main path)
+
+### 1. Connect to your VPS
+
+Open a **Terminal** on your computer (**PowerShell** on Windows; **Terminal** on macOS or Linux)
+and connect using the IP and port your host emailed you:
+
+```bash
+ssh -p PORT root@YOUR_IP
+```
+
+Replace `PORT` and `YOUR_IP` with yours. If your host never mentioned a port, it's the default
+(22) and you can omit it: `ssh root@YOUR_IP`.
+
+It will ask for your password. **As you type, nothing appears on screen — not even asterisks.**
+That is not a freeze: the terminal is hiding your password. Type (or paste) it and press Enter.
+
+> On the first connection it asks `Are you sure you want to continue connecting?` — answer
+> `yes`. That's the server introducing itself for the first time.
+
+### 2. Run the installer
+
+Once inside the VPS:
+
+```bash
+git clone https://github.com/melgarafael/DeskcommCRM.git
+cd DeskcommCRM
+bash hostgator-setup-kit/install.sh
+```
+
+That's it. **You don't install Node, or pnpm, or compile anything** — the app image is
+prebuilt. If Docker is missing, the installer asks and installs it for you.
+
+### What you need on hand
+
+| Item | Where to get it |
+|---|---|
+| **VPS with Docker** | [HostGator](https://www.hostgator.com.br/52708-141-3-52.html) (partnership) — or any VPS with Docker. 4 GB RAM recommended |
+| **Domain** | An **A** record pointing to your VPS IP (e.g. `crm.yourcompany.com`) |
+| **Database** | Free account at [supabase.com](https://supabase.com) — 3 keys + the **Session pooler** connection string |
+| **AI** | An **OpenRouter**, **Anthropic** or **OpenAI** key — the installer asks which one you want |
+| **WhatsApp** | Your number, connected via QR code during onboarding (or Meta's official channel) |
+
+> 💡 **Supabase can be created by the installer itself.** Export a `SUPABASE_ACCESS_TOKEN`
+> before running and it creates the project, waits for the database to become healthy, fetches
+> all 4 credentials and discovers the pooler host by testing a real connection — no copy-paste.
+
+### What the installer does for you
+
+It **only asks for what's yours** (domain, keys, admin password), **validates every answer
+before moving on** — a wrong key is rejected right there, not three steps later — and handles
+the rest:
+
+1. Generates every technical secret itself (you invent no passwords).
+2. Creates the Postgres extensions and applies the full schema (`supabase/baseline.sql`).
+3. Creates the first admin with the email and password you chose.
+4. Brings the whole stack up with **automatic HTTPS** and checks its health at the end.
+5. Installs the **automations cron** (without it, WHEN/IF/THEN rules pile up in the queue) and
+   the **update agent**, which is what makes the "Update now" button exist on screen.
+
+**Running it again breaks nothing** — `install.sh` is idempotent: it doesn't duplicate the cron,
+doesn't recreate the user, and resumes where it stopped.
+
+> **Non-interactive mode:** copy `.env.hostgator.example` to `.env`, fill it in and run
+> `bash hostgator-setup-kit/install.sh --yes`.
+
+### Another host? (Hostinger, Coolify, Dokploy, CapRover…)
+
+It works. If your VPS already ships with its **own reverse proxy** occupying ports 80/443, the
+installer **detects that on its own** and publishes the CRM through it, instead of trying to
+start a Caddy that wouldn't fit. In one specific case — a proxy on `--network host`, as
+Hostinger does — it **asks instead of guessing**, because publishing behind the wrong proxy
+"successfully" installs a mute website. Details in
+[`hostgator-setup-kit/README.md`](hostgator-setup-kit/README.md).
+
+### First access
+
+Open `https://<your-domain>` (the padlock takes ~1 min to appear), sign in as the admin, and
+have **Google Authenticator** or **Authy** at hand — the first admin login requires MFA. During
+onboarding, scan the QR code with your WhatsApp number.
+
+### 🤖 Rather have an AI install it for you?
+
+Drop the `hostgator-setup-kit/` folder into **Claude Code** running inside the VPS and say
+*"install DeskcommCRM for me"*. It reads the kit's [`CLAUDE.md`](hostgator-setup-kit/CLAUDE.md)
+— which carries the step-by-step and the already-mapped pitfalls — and walks you through it.
+
+---
+
+## 🔄 Updating
+
+New version out? There are two paths, and the first one needs no terminal.
+
+### From the screen (recommended)
+
+When a new version exists, the sidebar footer lights up **"Nova versão"** — only for the server
+owner, because alerting someone who can't update is noise. Click it and you land on
+**Settings → Update**, which shows what changed, **takes a database backup by itself** and
+follows every phase (backup → code → database → live) to the end. No SSH.
+
+If the new version comes up broken, the agent **rolls back to the previous image on its own**
+and records that rollback in `.env` — without it, the next restart would silently bring the
+broken app back.
+
+> Under the hood: the app only records the request; the executor is the agent `install.sh` left
+> on your VPS, on a cron that checks **every 5 minutes** — so the update starts within 5 minutes
+> of the click. If that agent is down, the screen says **"Atualização automática indisponível"**
+> and shows the command below — it never pretends it worked.
+
+### From the terminal
+
+```bash
+cd /path/to/DeskcommCRM
+bash hostgator-setup-kit/update.sh
+```
+
+In order, the command: (1) checks whether there really is a new version — if not, it exits
+immediately; (2) **backs up the database before touching anything**; (3) pulls the new code;
+(4) updates the database by re-applying `baseline.sql`, which is idempotent and **self-healing**
+(it repairs data left inconsistent by older versions); (5) pulls the new app image; (6) checks
+health at the end.
+
+**The target is the latest published release** (`v1.2.3`), not the tip of `main` — updating
+always lands on a tagged version described in [`CHANGELOG.md`](CHANGELOG.md), never on an
+untested commit. It **refuses** to go back to a version older than the installed one (that would
+turn off things you already have); `--force` exists for that, deliberately.
+
+**Normal things you will see:** a pile of `already exists` / `multiple primary keys` during the
+database step — **expected and harmless**, those are things that already existed. The script
+filters that noise and prints `✓ banco atualizado`. If you see `⚠ avisos que não são os
+esperados`, that one is worth keeping.
+
+**Something went wrong?** `bash hostgator-setup-kit/restore.sh` returns to the backup.
+**Just want a diagnosis?** `bash hostgator-setup-kit/healthcheck.sh`.
+
+> ⚠️ **On an older install that doesn't have the screen agent yet**, run `update.sh` **twice**:
+> the first run is still the old script (which downloads the new one); the second installs the
+> agent and turns the button on.
+
+### Other kit commands
+
+| Script | What it does |
+|---|---|
+| `install.sh` | Installs everything (idempotent — safe to re-run) |
+| `update.sh` | Updates to a new version, with automatic backup |
+| `backup.sh` | Backs up the database + WhatsApp sessions |
+| `restore.sh` | Restores a backup |
+| `reset-password.sh` | Resets a user's password |
+| `reset-mfa.sh` | Removes MFA for someone who lost their phone |
+| `healthcheck.sh` | Diagnoses every service at once |
+
+> **Backups matter:** Supabase's free plan **does not back up on its own**. Schedule `backup.sh`
+> daily via cron. `update.sh` already takes one before every update.
+
+---
 
 ## ✨ What is it
 
@@ -53,14 +206,15 @@ The project was born as an e-commerce CRM — and the open-source community took
 
 ### Why it's different
 
-- 🤖 **AI agents that operate the CRM** — per-tenant RAG, sentiment analysis, audited AI→human handoff, AI as a first-class assignee and per-org budget control. Not a decorative chatbot: the agent answers, qualifies and moves the funnel.
-- 🔁 **Self-improving agents** — resolved conversations become new RAG knowledge; handoffs mark where the agent falls short; metrics close the loop. Every month of operation makes the agent better, with a human gate where it matters.
+- 🤖 **AI agents that operate the CRM** — per-tenant RAG, skills the agent executes on its own mid-conversation, operational memory, sentiment analysis, audited AI→human handoff, AI as a first-class assignee and per-org spending caps. Not a decorative chatbot: the agent answers, qualifies and moves the funnel.
+- 🔁 **Nothing dies in silence** — follow-up that revives a cold conversation (with adaptive timing and per-stage triggers), a radar of what's at risk of dying unanswered, and a notice center for what needs a human decision.
+- 🧠 **Self-improving agents** — resolved conversations become new knowledge; the **AI Evolution** screen shows whether the agent is improving, where it fails and what's left to teach; **Proposals** are improvements the AI suggests for itself, applicable as a new version — always human-gated.
 - 🧩 **Multi-niche by design** — configurable vocabulary per pipeline: a lead becomes a *Customer*, *Patient* or *Buyer*; "won" becomes *Paid*, *Booked* or *Closed*. The same core serves e-commerce (our birthplace, with native Nuvemshop integration), clinics, real estate or info-products.
-- 🔌 **MCP-ready** — internal MCP server for the built-in agents; a public contract for external agents is in the works. The CRM as infrastructure for any AI agent.
-- 💬 **WhatsApp-native via WAHA** — multi-number, anti-ban (throttle + jitter + time windows), media via Storage, STOP detection.
-- 👥 **Support governance** — real server-side RBAC, audited assignment/transfer, queue with position, automatic routing and per-role visibility scopes.
+- 💬 **WhatsApp two ways** — via **QR code** (WAHA, multi-number, with anti-ban: throttle + jitter + time windows) or through **Meta's official channel** (Cloud API, with approved templates kept in sync). Media via Storage, STOP detection.
+- 🔀 **Choose your AI** — OpenRouter, Anthropic or OpenAI, decided at install time and switchable later from the screen, **per part of the system** (whatever talks doesn't have to be whatever indexes).
+- 👥 **Support governance** — real server-side RBAC, audited assignment/transfer, round-robin queue, automatic intent routing and per-role visibility scopes.
 - 🏢 **Multi-tenant + privacy by design (LGPD)** — RLS on every tenant-aware table with an isolation test as a CI gate; anonymization preferred over deletion; append-only audit log with 5-year retention.
-- 🖥️ **Truly self-hosted** — your data on your VPS; one-command install; no paid tier, no gated features.
+- 🖥️ **Truly self-hosted** — your data on your VPS; install and update with one command (or one click); no paid tier, no gated features.
 
 ### 🔌 Webhooks & Automations
 
@@ -68,40 +222,22 @@ Every tenant can create **capture sources**: a public endpoint (`/api/v1/webhook
 
 In the UI everything lives under **Webhooks** in the sidebar (visible only to `manager`/`admin` roles). Three tabs: **Receive data** (create a source, copy the ready-made endpoint/form, fire a test lead, see recent deliveries), **Automations** (build rules, which are always born paused until reviewed and enabled) and **Activity** (a timeline of each run, with per-action results and manual retry when an external webhook call fails).
 
-Under the hood, every event becomes a row in `event_log` — no database trigger ever makes an HTTP call. The `/api/v1/cron/event-log-drain` route drains the queue every minute. On Vercel that's a managed Cron Job; **on the HostGator self-host kit** (`hostgator-setup-kit/`), `install.sh`/`update.sh` automatically configures a `crontab` line that hits the route every minute with the `INTERNAL_SECRET` from `.env`.
+Under the hood, every event becomes a row in `event_log` — no database trigger ever makes an HTTP call. The `/api/v1/cron/event-log-drain` route drains the queue every minute. **`install.sh`/`update.sh` configure that cron automatically** — without it, automations get created normally but never run.
 
 ---
 
-## 🚀 Quickstart (see it running in 5 minutes)
+## 🖥️ What you operate (the screens)
 
-```bash
-# 1. Clone
-git clone https://github.com/melgarafael/DeskcommCRM.git
-cd DeskcommCRM
+| Group | Screens |
+|---|---|
+| **Support** | **Inbox** (WhatsApp conversations, you and the AI side by side) · **Radar** (who went cold and is still open) · **Quick replies** |
+| **CRM** | **Kanban** (where each deal sits in the funnel) · **Contacts** · **Pipelines** (stages, business vocabulary and loss reasons) |
+| **AI Agent** | **Agents** · **Follow-ups** · **Routers** · **Providers** and **Credentials** · **Knowledge** (RAG) · **Memory** · **Skills** · **Cases** · **Alerts** · **Proposals** · **Runs** · **Usage & budget** |
+| **Channels** | **Connections** (QR or Meta's official channel, with health, reconnect and templates) · **Nuvemshop** · **Webhooks** |
+| **Analytics** | **Performance** (funnel and per-agent metrics) · **AI Evolution** · **Audit Log** |
+| **Organization** | **Team** · **Support distribution** · **Organization** · **LGPD** · **API Tokens** · **Security** (MFA, recovery codes, sessions) · Profile, Notifications, Billing |
 
-# 2. Node 22 + pnpm
-nvm use                    # or install Node 22+
-npm install -g pnpm
-pnpm install
-
-# 3. Env vars
-cp .env.example .env.local
-# Edit .env.local — full guide in docs/SETUP.md
-
-# 4. Local WAHA (optional in dev without WhatsApp)
-docker compose up -d
-
-# 5. Supabase migrations
-supabase link --project-ref <your-ref>
-supabase db push
-
-# 6. Run the app
-pnpm dev
-```
-
-App: <http://localhost:3000> · Health check: <http://localhost:3000/api/v1/health>
-
-> 🆕 **First time? Don't skip steps.** [`docs/SETUP.md`](docs/SETUP.md) is the complete step-by-step tutorial for **every integration** (Supabase, WAHA, Anthropic, Upstash, Sentry, Resend, Nuvemshop) — written for people who have never configured any of this. ~60–90 min from zero to a running app. *(Docs are in Brazilian Portuguese; translations welcome!)*
+Every screen has a door in the navigation — CI fails a screen that exists but can only be reached by typing its URL.
 
 ---
 
@@ -115,15 +251,47 @@ App: <http://localhost:3000> · Health check: <http://localhost:3000/api/v1/heal
 | **Auth** | Supabase Auth via `@supabase/ssr` | SameSite=Strict, HttpOnly cookies |
 | **Realtime** | Supabase Realtime | postgres_changes + broadcast |
 | **Storage** | Supabase Storage (signed URLs) | Private `whatsapp-media` bucket |
-| **WhatsApp** | WAHA Plus (NOWEB engine) | Multi-tenant, retry, S3 |
-| **Queues** | `event_log` table + workers (cron) | No Inngest/Trigger in the MVP |
+| **WhatsApp** | WAHA Plus (NOWEB engine) + Meta Cloud API | QR to start fast; official channel to scale |
+| **Queues** | `event_log` table + workers (cron) | A database trigger never makes HTTP calls |
 | **Rate limit** | Upstash Redis (sliding window) | Serverless, free tier is enough |
-| **AI** | Vercel AI SDK v7 (Anthropic/Google/OpenAI providers v4) via AI Gateway | Automatic fallback, ZDR |
+| **AI** | Vercel AI SDK v7 — OpenRouter, Anthropic, OpenAI and Google | The installer asks which; switch later from the screen |
 | **Validation** | Zod | External input, env, payloads |
-| **Observability** | Sentry (sanitized `beforeSend`) | No PII in breadcrumbs |
-| **Hosting** | Vercel (app) + HostGator VPS Turing/SP (WAHA) | Edge + dedicated box for WhatsApp; Brazil datacenter |
+| **Observability** | Sentry (scrubbed in errors, transactions, spans and breadcrumbs) | Opt-in telemetry at install time |
+| **Hosting** | Any VPS with Docker (HostGator/SP in the partnership) | App + WhatsApp + workers on your own box |
 
 Details: [`ARCHITECTURE.md`](ARCHITECTURE.md).
+
+---
+
+## 🧑‍💻 Development (only to contribute to the code)
+
+> ⚠️ **If you want to USE the CRM, this is not it** — use the [VPS installer](#-install-on-your-vps-the-main-path).
+> This section is for people who will change the code.
+
+```bash
+git clone https://github.com/melgarafael/DeskcommCRM.git
+cd DeskcommCRM
+
+nvm use                     # Node 22
+npm install -g pnpm && pnpm install
+
+cp .env.example .env.local  # full guide in docs/SETUP.md
+
+docker compose up -d        # local WAHA (optional in dev without WhatsApp)
+
+# Schema: apply the baseline, NOT the migrations.
+# Migrations 0001-0009 and 0013 are `SELECT 1;` stubs — the chain does not build from zero.
+# The real schema lives in baseline.sql, the same one install.sh applies on the VPS.
+# `supabase db push` "succeeds" and leaves you with an empty database.
+supabase link --project-ref <your-ref>
+psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f supabase/baseline.sql
+
+pnpm dev
+```
+
+App: <http://localhost:3000> · Health check: <http://localhost:3000/api/v1/health>
+
+[`docs/SETUP.md`](docs/SETUP.md) is the complete tutorial for **every integration** (Supabase, WAHA, AI providers, Upstash, Sentry, Resend, Nuvemshop) — ~60–90 min from zero to a running app. *(Docs are in Brazilian Portuguese; translations welcome!)*
 
 ---
 
@@ -137,9 +305,18 @@ pnpm test:db       # ephemeral Postgres + baseline install/update + invariants
 pnpm test:e2e      # Playwright (requires dev server)
 ```
 
-CI runs `typecheck`, `lint` and `test:unit` on every PR. A second job — **`invariants`** — boots a clean Postgres, applies `supabase/baseline.sql` in install mode (`ON_ERROR_STOP=1`) and then in update mode (proving idempotency), and runs **364 invariant tests** across 56 files covering RBAC, assignment, visibility scoping, routing, follow-up, webhooks and automations.
+**Four checks are required** to merge into `main` — all verified in branch protection, not just on paper:
 
-Among them is the **RLS isolation test**: it creates 2 organizations, simulates JWT claims through the same `auth.uid()` / `fn_user_org_ids()` path production policies use, and proves a user of org A sees **zero rows** of org B in `conversations`, `messages`, `contacts` and `crm_leads`. A control case first proves org B's rows actually exist in the database — without it, the test would pass against an empty table.
+| Check | What it does |
+|---|---|
+| `verify` | typecheck + lint + `lint:channels` + `test:unit` + `test:shell` |
+| `invariants` | boots a clean Postgres, applies `baseline.sql` in **install** mode (`ON_ERROR_STOP=1`) and then in **update** mode (proving idempotency), and runs **618 invariants across 98 files** — RBAC, assignment, scoping, routing, follow-up, webhooks and automations |
+| `build-and-size` | `pnpm build` on Node 22 |
+| `e2e` | boots a local Supabase, applies `baseline.sql` and runs **44 of the 45** Playwright specs through the frontend |
+
+The only spec outside `e2e` is `vps-fresh-onboarding` — it needs a real WAHA + Redis + Resend + Nuvemshop. It is the **P0** of our visual-QA doctrine, so a green `e2e` does **not** prove the fresh-install journey; that one is proven on a VPS.
+
+Among the invariants is the **RLS isolation test**: it creates 2 organizations, simulates JWT claims through the same `auth.uid()` / `fn_user_org_ids()` path production policies use, and proves a user of org A sees **zero rows** of org B in `conversations`, `messages`, `contacts` and `crm_leads`. A control case first proves org B's rows actually exist — without it, the test would pass against an empty table.
 
 ---
 
@@ -147,15 +324,17 @@ Among them is the **RLS isolation test**: it creates 2 organizations, simulates 
 
 | Doc | What's in it |
 |---|---|
+| [`hostgator-setup-kit/README.md`](hostgator-setup-kit/README.md) | **Self-host installation** — the kit, the scripts, hosts with their own proxy |
+| [`docs/ATUALIZANDO.md`](docs/ATUALIZANDO.md) | **How to update** your installation, in plain language |
 | [`VISION.md`](VISION.md) | **Vision & positioning** — what the project is, what it believes, where it's going |
-| [`docs/SETUP.md`](docs/SETUP.md) | **Complete step-by-step setup** for every integration |
+| [`CHANGELOG.md`](CHANGELOG.md) | What changed in each version — **read your target version's section before updating** |
+| [`docs/SETUP.md`](docs/SETUP.md) | Development setup, step by step, for every integration |
 | [`docs/white-label.md`](docs/white-label.md) | **Installing for clients** — rebranding, one-install-per-client vs shared, reseller operations |
+| [`docs/runbooks/waha-hostgator.md`](docs/runbooks/waha-hostgator.md) | Production runbook for WAHA (sizing, recovery) |
 | [`CLAUDE.md`](CLAUDE.md) | Non-negotiable conventions (required reading to contribute) |
 | [`ARCHITECTURE.md`](ARCHITECTURE.md) | One-page architecture overview |
-| [`CONTRIBUTING.md`](CONTRIBUTING.md) | PR flow |
-| [`docs/prd/`](docs/prd/) | PRDs (master, platform, customer 360, WhatsApp, pipeline, AI-RAG, Nuvemshop) |
-| [`docs/specs/`](docs/specs/) | Technical specs 01–13 (SQL schema, payloads, MCP, governance) |
-| [`docs/runbooks/waha-hostgator.md`](docs/runbooks/waha-hostgator.md) | Full production runbook for WAHA (HostGator VPS) |
+| [`docs/index.md`](docs/index.md) | Index of all 157 documents, with a precedence rule |
+| [`docs/prd/`](docs/prd/) · [`docs/specs/`](docs/specs/) | PRDs and technical specs (SQL schema, payloads, MCP, governance) |
 
 > Most docs are written in Brazilian Portuguese — our primary community. Translation contributions are very welcome.
 
@@ -169,13 +348,25 @@ This project is open source for the community. Every contribution is welcome —
 2. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) — branch flow, commits.
 3. Follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 
-**Definition of Done:** zero typecheck errors, zero lint errors, relevant tests green, RLS tested if a tenant-aware table is touched, audit log emitted on mutations, versioned migration if the schema changes.
+**Short flow:**
+
+```bash
+git checkout -b feat/short-slug
+# implement + tests
+pnpm typecheck && pnpm lint && pnpm lint:channels && pnpm test:unit && pnpm test:shell && pnpm build
+pnpm test:db   # needs Docker — this is the `invariants` job, required to merge
+git commit -m "feat(scope): description"
+```
+
+That line is the **complete** list of required gates on purpose: running half of them and discovering the rest as a red surprise after hours of waiting is the worst first experience this repository knows how to deliver.
+
+**Definition of Done:** zero typecheck errors, zero lint errors, relevant tests green, RLS tested if a tenant-aware table is touched, audit log emitted on mutations, versioned migration **+ an idempotent appendix in `baseline.sql`** if the schema changes (otherwise the change never reaches self-hosters).
 
 ---
 
 ## 🐛 Reporting bugs
 
-Open an [issue](https://github.com/melgarafael/DeskcommCRM/issues/new/choose) — the template asks for what we need (environment, `/api/v1/health`, steps).
+Open an [issue](https://github.com/melgarafael/DeskcommCRM/issues/new/choose) — the template asks for what we need (environment, `/api/v1/health`, steps). Running `bash hostgator-setup-kit/healthcheck.sh` and pasting the output helps a lot.
 
 For **security vulnerabilities**, **do NOT open a public issue** — use [private vulnerability reporting](https://github.com/melgarafael/DeskcommCRM/security/advisories/new). Details in [`SECURITY.md`](SECURITY.md).
 
@@ -186,19 +377,20 @@ For **security vulnerabilities**, **do NOT open a public issue** — use [privat
 ### ✅ Shipped
 
 - **Foundation & platform** — auth (MFA for admins), multi-tenancy with RLS + isolation test, 4-role RBAC, append-only audit log, tenant onboarding.
-- **WhatsApp support** — real-time 3-pane inbox, multi-number WAHA connections, media via Storage, anti-ban (throttle + jitter + time windows), STOP detection.
-- **CRM & orders** — kanban with per-niche configurable vocabulary (fractional indexing), customer 360, contacts, tags, Nuvemshop integration for e-commerce.
-- **Native AI** — agents with per-tenant RAG (pgvector), sentiment analysis, AI→human handoff, per-org budget control, internal MCP server.
+- **WhatsApp support** — real-time 3-pane inbox, multi-number connections via **QR (WAHA)** or **Meta's official channel** (approved templates kept in sync), media via Storage, anti-ban (throttle + jitter + time windows), STOP detection.
+- **CRM & orders** — kanban with per-niche configurable vocabulary (fractional indexing), pipeline management from the screen, customer 360, contacts, tags, Nuvemshop integration.
+- **Native AI** — agents with per-tenant RAG (pgvector), **skills** the agent runs by itself, **organization memory**, per-number intent router, sentiment analysis, AI→human handoff, per-org spending caps, internal MCP server.
+- **AI provider choice** — OpenRouter, Anthropic or OpenAI, decided at install time and switchable per part of the system from the screen.
+- **Living follow-up** — reviving cold conversations with adaptive timing, per-stage and per-case triggers, round-robin queue, and the Radar of what risks dying unanswered.
 - **Privacy (LGPD)** — export and redact via workers, cascading anonymization, audited consent.
-- **Self-host** — `hostgator-setup-kit` (app + WAHA + database with one command), self-healing `baseline.sql`, production runbook.
+- **Self-host** — `hostgator-setup-kit` (app + WhatsApp + database with one command), self-healing `baseline.sql`, **updating from the screen** with automatic backup, production runbook.
 - **Webhooks & automation** — capture sources + WHEN/IF/THEN rules + triggers for external systems.
-- **Support governance** — server-side RBAC across the API, audited assignment/transfer (AI as a first-class assignee), per-role visibility (RLS) + per-agent metrics, automatic routing with queue and management panel, and a governance contract for external AI agents ([`docs/specs/14`](docs/specs/14-contrato-governanca-agentes-externos.md)). Epic driven by 100+ invariants (G1–G6).
-- **Visible operation** — screens that let operators understand the agent: anti-ban hold reasons translated in the conversation, a notice center with severities, send-protection controls (window/pace/cap) and flywheel proposals applicable as a new version (human-gated).
+- **Support governance** — server-side RBAC across the API, audited assignment/transfer (AI as a first-class assignee), per-role visibility (RLS) + per-agent metrics, automatic routing with queue and management panel, and a governance contract for external AI agents ([`docs/specs/14`](docs/specs/14-contrato-governanca-agentes-externos.md)).
+- **Visible operation** — anti-ban hold reasons translated in the conversation, a notice center with severities, stuck-message alerts, send-protection controls (window/pace/cap), declared agent capabilities and flywheel proposals applicable as a new version (human-gated).
 
 ### 🔮 Next
 
 - **Public MCP** — CRM capabilities exposed to the agent ecosystem: plug in any agent and it operates Deskcomm.
-- **Self-improvement flywheel** — the resolved-conversation → knowledge → better-agent loop, measured and human-gated.
 - **Niche templates** — ready-made pipelines and vocabularies for clinics, real estate, info-products and services (e-commerce already shipped).
 - **Integrations** — VTEX and Shopify via the adapter pattern (Nuvemshop already shipped).
 - **Probabilistic identity** — contact unification across channels.
@@ -225,16 +417,19 @@ Distributed under the **MIT** license — see [`LICENSE`](LICENSE). You may use,
 This is a **self-hosted** project: each person runs the CRM on their **own infrastructure** (own VPS, Supabase database and AI key). That means:
 
 - **Support is community-based and "as-is".** No SLA — it's open source maintained by goodwill.
-- **You are responsible for your installation**, including updates (`bash hostgator-setup-kit/update.sh`) and backups.
-- **Data protection:** whoever **hosts** the instance is the **controller** of the personal data processed there. The project maintainers **have no access** to your data.
-- **Telemetry (Sentry):** by default, **anonymized** errors (no PII) are sent to the community Sentry. Set `SENTRY_DSN=off` to disable, or `SENTRY_DSN=<your-dsn>` to use your own.
+- **You are responsible for your installation.** Updates are not automatic (you click, or run `update.sh`, when you want), and keeping/backing up your server is on you.
+- **Data protection:** whoever **hosts** the instance is the **controller** of the personal data processed there (customers, conversations, orders), with the legal obligations that follow. The project maintainers are **neither** controllers nor processors of your instance, and have no access to your database, your WhatsApp or your storage.
+- **Telemetry (Sentry):** `install.sh` **asks** during installation and respects your answer; in non-interactive mode, with no `SENTRY_DSN` set, telemetry is **off**. If you accept the community Sentry, what gets sent are **error reports** (stack traces) with national IDs, phone numbers and emails replaced, sensitive headers stripped, and webhook/invite tokens redacted from URLs — **no** performance tracing and **no** session replay, both pinned to 0 on that path. To turn it off at any time: `SENTRY_DSN=off` in `.env`. To send to **your** Sentry (there, with performance and replay): `SENTRY_DSN=<your-dsn>`. What is redacted, and why, lives in [`lib/sentry/scrub.ts`](lib/sentry/scrub.ts); DSN resolution in [`lib/sentry/dsn.ts`](lib/sentry/dsn.ts).
 
 ---
 
 ## 🙏 Acknowledgements
 
 - **WAHA** ([devlikeapro](https://waha.devlikeapro.com/)) — WhatsApp engine.
-- **Supabase**, **Vercel**, **Anthropic** (Claude), **shadcn/ui**.
+- **Supabase** — Postgres + Auth + Storage + Realtime in one stack.
+- **HostGator** — the infrastructure partnership that made one-command self-hosting possible.
+- **Anthropic**, **OpenAI** and **OpenRouter** — the AI providers the CRM knows how to use.
+- **shadcn/ui** — component base.
 - The community that took Deskcomm from e-commerce to clinics, real estate, info-products and beyond — you defined what this project is.
 
 ---

--- a/README.es.md
+++ b/README.es.md
@@ -2,105 +2,243 @@
 
 [🇧🇷 Português](README.md) · [🇺🇸 English](README.en.md) · 🇪🇸 Español
 
-# 🛠️ DeskcommCRM — El Sistema Operativo de Ventas con Agentes de IA
+# 🛠️ DeskcommCRM — el Sistema Operativo de Ventas con IA, open source, para WhatsApp
 
-**Agentes de IA que atienden, califican y venden por WhatsApp — dentro de un CRM open source corriendo en tu propio servidor.**
-**Sin mensualidad, sin funciones bloqueadas, tus datos contigo. La alternativa abierta a Kommo, Octadesk e Intercom.**
+**Agentes de IA que atienden, califican y venden en WhatsApp — dentro de un CRM open source que corre en tu propio servidor.**
+**Sin mensualidad, sin funciones bloqueadas, tus datos siguen siendo tuyos. La alternativa abierta a Kommo, Octadesk e Intercom.**
 
 [![Next.js 16](https://img.shields.io/badge/Next.js-16-black?logo=next.js)](https://nextjs.org)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6?logo=typescript)](https://www.typescriptlang.org)
 [![Supabase](https://img.shields.io/badge/Supabase-Postgres%2BAuth%2BStorage-3ecf8e?logo=supabase)](https://supabase.com)
 [![Self-hosted](https://img.shields.io/badge/self--hosted-1%20comando-orange)](hostgator-setup-kit/)
+[![CI](https://github.com/melgarafael/DeskcommCRM/actions/workflows/ci.yml/badge.svg)](https://github.com/melgarafael/DeskcommCRM/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-[**🧭 Visión**](VISION.md) · [**📘 Guía de instalación**](docs/SETUP.md) · [**🏗️ Arquitectura**](ARCHITECTURE.md) · [**🤝 Contribuir**](CONTRIBUTING.md) · [**📋 PRDs**](docs/prd/) · [**🗺️ Roadmap**](#%EF%B8%8F-roadmap)
+[**⚡ Instalar**](#-instalar-en-tu-vps-el-camino-principal) · [**🔄 Actualizar**](#-actualizar) · [**🧭 Visión**](VISION.md) · [**🏗️ Arquitectura**](ARCHITECTURE.md) · [**🤝 Contribuir**](CONTRIBUTING.md) · [**🗺️ Roadmap**](#%EF%B8%8F-roadmap)
 
 </div>
 
 ---
 
-> ### ☁️ Pon este CRM en producción con un solo comando
+> ### ☁️ Corre este CRM en producción con 1 comando
 >
 > DeskcommCRM se desarrolla en **alianza con HostGator**: el [`hostgator-setup-kit/`](hostgator-setup-kit/)
-> instala el CRM completo (app + WAHA + base de datos) en un VPS con un único comando, y el
+> instala el CRM completo (app + WhatsApp + base de datos) en un VPS con un único comando, y el
 > [runbook de producción](docs/runbooks/waha-hostgator.md) ya asume ese entorno.
 >
 > **[👉 Contratar el VPS de HostGator con el descuento de la alianza](https://www.hostgator.com.br/52708-141-3-52.html)** —
 > datacenter en São Paulo, ideal para WhatsApp funcionando 24/7. *(enlace de partner — contratar por él apoya el proyecto y te sale más barato)*
 >
-> ¿Ya tienes el VPS? Entra por SSH y ejecuta:
+> **¿Todavía no tienes servidor?** Ejecuta esto **en tu propia computadora** (macOS, Linux o WSL).
+> Te dice qué plan contratar — con los números reales del runbook, no un "depende" — y te
+> devuelve el comando exacto para tu caso:
 >
 > ```bash
-> git clone https://github.com/melgarafael/DeskcommCRM.git
-> cd DeskcommCRM
-> bash hostgator-setup-kit/install.sh
+> curl -fsSL https://raw.githubusercontent.com/melgarafael/DeskcommCRM/main/hostgator-setup-kit/comecar.sh | bash
 > ```
 >
-> El instalador pregunta solo lo que es tuyo (dominio, claves de Supabase, clave de IA,
-> contraseña del admin), valida cada respuesta antes de seguir, genera todos los demás
-> secretos, aplica el schema de la base de datos y levanta toda la stack con HTTPS. Detalles
-> en [`hostgator-setup-kit/README.md`](hostgator-setup-kit/README.md).
->
-> ⚠️ El **Quickstart** de abajo es el camino de *desarrollo* (correr la app en tu máquina).
-> Si compraste un VPS para correr el CRM, usa el comando de arriba, no el Quickstart.
+> *(¿prefieres leer antes de ejecutar? clona el repo y corre `bash hostgator-setup-kit/comecar.sh` —
+> no instala nada sin que confirmes.)*
+
+---
+
+## ⚡ Instalar en tu VPS (el camino principal)
+
+### 1. Entra a tu VPS
+
+Abre la **Terminal** en tu computadora (en Windows, **PowerShell**; en Mac o Linux, la
+**Terminal**) y conéctate con la IP y el puerto que tu hosting te envió por correo:
+
+```bash
+ssh -p PUERTO root@TU_IP
+```
+
+Reemplaza `PUERTO` y `TU_IP` por los tuyos. Si tu hosting no mencionó ningún puerto, es el que
+viene por defecto (22) y puedes omitirlo: `ssh root@TU_IP`.
+
+Te va a pedir la contraseña. **Mientras escribes, no aparece nada en pantalla — ni asteriscos.**
+Eso no es que se haya trabado: la terminal está ocultando tu contraseña. Escríbela (o pégala) y
+presiona Enter.
+
+> En la primera conexión pregunta `Are you sure you want to continue connecting?` — responde
+> `yes`. Es el servidor presentándose por primera vez.
+
+### 2. Ejecuta el instalador
+
+Ya dentro del VPS:
+
+```bash
+git clone https://github.com/melgarafael/DeskcommCRM.git
+cd DeskcommCRM
+bash hostgator-setup-kit/install.sh
+```
+
+Eso es todo. **No instalas Node, ni pnpm, ni compilas nada** — la imagen de la app ya viene
+lista. Si falta Docker, el instalador pregunta y lo instala solo.
+
+### Lo que necesitas tener a mano
+
+| Ítem | Dónde conseguirlo |
+|---|---|
+| **VPS con Docker** | [HostGator](https://www.hostgator.com.br/52708-141-3-52.html) (alianza) — o cualquier VPS con Docker. 4 GB de RAM recomendados |
+| **Dominio** | Un registro **A** apuntando a la IP del VPS (ej.: `crm.tuempresa.com`) |
+| **Base de datos** | Cuenta gratis en [supabase.com](https://supabase.com) — 3 claves + la cadena de conexión del **Session pooler** |
+| **IA** | Una clave de **OpenRouter**, **Anthropic** u **OpenAI** — el instalador pregunta cuál quieres |
+| **WhatsApp** | Tu número, conectado por código QR en el onboarding (o el canal oficial de Meta) |
+
+> 💡 **Supabase puede crearlo el propio instalador.** Exporta un `SUPABASE_ACCESS_TOKEN` antes
+> de ejecutarlo y él crea el proyecto, espera a que la base quede saludable, busca las 4
+> credenciales y descubre el host del pooler probando una conexión real — sin copiar y pegar.
+
+### Lo que el instalador hace por ti
+
+**Pregunta solo lo que es tuyo** (dominio, claves, contraseña del admin), **valida cada
+respuesta antes de seguir** — una clave equivocada la rechaza en el momento, no tres pasos
+después — y se encarga del resto:
+
+1. Genera todos los secretos técnicos solo (tú no inventas ninguna contraseña).
+2. Crea las extensiones de Postgres y aplica el schema completo (`supabase/baseline.sql`).
+3. Crea el primer admin con el correo y la contraseña que elegiste.
+4. Levanta toda la stack con **HTTPS automático** y verifica la salud al final.
+5. Instala el **cron de las automatizaciones** (sin él, las reglas CUANDO/SI/ENTONCES se
+   acumulan en la cola) y el **agente de actualización**, que es lo que hace existir el botón
+   "Actualizar ahora" en pantalla.
+
+**Volver a ejecutarlo no rompe nada** — `install.sh` es idempotente: no duplica el cron, no
+recrea el usuario y retoma donde se quedó.
+
+> **Modo no interactivo:** copia `.env.hostgator.example` a `.env`, complétalo y ejecuta
+> `bash hostgator-setup-kit/install.sh --yes`.
+
+### ¿Otro hosting? (Hostinger, Coolify, Dokploy, CapRover…)
+
+Funciona. Si tu VPS ya viene con un **proxy inverso propio** ocupando los puertos 80/443, el
+instalador **lo detecta solo** y publica el CRM a través de él, en vez de intentar levantar un
+Caddy que no cabría. En un caso específico — proxy en `--network host`, como hace Hostinger —
+**pregunta en vez de adivinar**, porque publicar detrás del proxy equivocado instala "con éxito"
+un sitio mudo. Detalles en [`hostgator-setup-kit/README.md`](hostgator-setup-kit/README.md).
+
+### Primer acceso
+
+Abre `https://<tu-dominio>` (el candado tarda ~1 min en aparecer), entra con el admin y ten a
+mano **Google Authenticator** o **Authy** — el primer inicio de sesión de admin exige MFA. En el
+onboarding, escanea el código QR con el WhatsApp de tu número.
+
+### 🤖 ¿Prefieres que una IA lo instale por ti?
+
+Suelta la carpeta `hostgator-setup-kit/` en el chat de **Claude Code** corriendo dentro del VPS
+y dile *"instálame el DeskcommCRM"*. Lee el [`CLAUDE.md`](hostgator-setup-kit/CLAUDE.md) del kit
+— que trae el paso a paso y las trampas ya mapeadas — y conduce todo.
+
+---
+
+## 🔄 Actualizar
+
+¿Salió versión nueva? Hay dos caminos, y el primero **no exige terminal**.
+
+### Desde la pantalla (recomendado)
+
+Cuando existe versión nueva, el pie del menú lateral enciende **"Nova versão"** — solo para el
+dueño del servidor, porque avisarle a quien no puede actualizar es ruido. Haz clic y llegas a
+**Configuración → Actualización**, que muestra qué cambia, **hace backup de la base sola** y
+acompaña cada fase (backup → código → base → en línea) hasta terminar. Nada de SSH.
+
+Si la versión nueva levanta rota, el agente **vuelve a la imagen anterior solo** y graba esa
+vuelta en el `.env` — sin eso, el siguiente reinicio traería la app rota de nuevo, en silencio.
+
+> Por debajo: la app solo registra el pedido; quien ejecuta es el agente que `install.sh` dejó
+> en tu VPS, en un cron que revisa **cada 5 minutos** — así que la actualización empieza dentro
+> de los 5 minutos del clic. Si ese agente está caído, la pantalla avisa **"Atualização
+> automática indisponível"** y muestra el comando de abajo — nunca finge que funcionó.
+
+### Desde la terminal
+
+```bash
+cd /ruta/al/DeskcommCRM
+bash hostgator-setup-kit/update.sh
+```
+
+El comando hace, en este orden: (1) verifica si de verdad hay versión nueva — si no, sale de
+inmediato; (2) **hace backup de la base antes de tocar nada**; (3) baja el código nuevo;
+(4) actualiza la base re-aplicando `baseline.sql`, que es idempotente y **auto-curativo**
+(repara datos que versiones viejas dejaron inconsistentes); (5) baja la imagen nueva de la app;
+(6) verifica la salud al final.
+
+**El objetivo es la última versión publicada** (`v1.2.3`), no la punta de `main` — actualizar
+siempre lleva a una versión etiquetada y descrita en [`CHANGELOG.md`](CHANGELOG.md), nunca a un
+commit sin probar. **Se niega** a volver a una versión anterior a la instalada (eso apagaría
+cosas que ya tienes); para eso existe `--force`, a propósito.
+
+**Cosas normales que vas a ver:** un montón de `already exists` / `multiple primary keys` en la
+parte de la base — **es esperado e inofensivo**, son cosas que ya existían. El script filtra ese
+ruido y muestra `✓ banco atualizado`. Si aparece `⚠ avisos que não são os esperados`, ahí sí
+guarda el mensaje.
+
+**¿Salió mal?** `bash hostgator-setup-kit/restore.sh` vuelve al backup.
+**¿Solo quieres diagnosticar?** `bash hostgator-setup-kit/healthcheck.sh`.
+
+> ⚠️ **En una instalación vieja que todavía no tiene el agente de la pantalla**, ejecuta
+> `update.sh` **dos veces**: la primera es todavía el script viejo (que baja el nuevo); la
+> segunda instala el agente y enciende el botón.
+
+### Otros comandos del kit
+
+| Script | Función |
+|---|---|
+| `install.sh` | Instala todo (idempotente — puedes volver a ejecutarlo) |
+| `update.sh` | Actualiza a la versión nueva, con backup automático |
+| `backup.sh` | Backup de la base + sesiones de WhatsApp |
+| `restore.sh` | Restaura un backup |
+| `reset-password.sh` | Redefine la contraseña de un usuario |
+| `reset-mfa.sh` | Quita el MFA de quien perdió el celular |
+| `healthcheck.sh` | Diagnóstico de todos los servicios de una vez |
+
+> **El backup importa:** el plan gratis de Supabase **no hace backup solo**. Vale la pena
+> agendar `backup.sh` diariamente en el cron. `update.sh` ya hace uno antes de cada
+> actualización.
+
+---
 
 ## ✨ Qué es
 
 **Deskcomm** viene de **Desk** (escritorio) + **comm** (comercio): toda la operación de ventas de tu negocio en un solo escritorio, operada por personas y agentes de IA trabajando juntos.
 
-El proyecto nació como un CRM de e-commerce — y la comunidad open source lo llevó mucho más allá: hoy funciona en **clínicas, inmobiliarias, negocios de infoproductos, agencias, tiendas y empresas de servicios** — cualquier negocio que vende por WhatsApp. El producto acompañó ese giro y se convirtió en un **sistema operativo de ventas**: agentes de IA con RAG por tenant atienden clientes, califican leads, los mueven por el embudo, disparan automatizaciones y saben cuándo pasar la conversación a un humano — con el CRM completo expuesto vía **MCP** para que los agentes lo operen de verdad. La historia completa está en [`VISION.md`](VISION.md).
+El proyecto nació como CRM de e-commerce y la comunidad lo llevó mucho más lejos: hoy corre en **clínicas, inmobiliarias, infoproductos, agencias, tiendas y prestadores de servicios** — cualquier negocio que venda por WhatsApp. El producto acompañó ese giro y se convirtió en un **sistema operativo de ventas**: agentes de IA con RAG por tenant atienden, califican, mueven leads en el embudo, disparan automatizaciones y saben cuándo pasarle la conversación a una persona — con todo el CRM expuesto vía **MCP** para que los agentes lo operen de verdad. La historia completa está en [`VISION.md`](VISION.md).
 
-### Por qué es diferente
+### Diferenciales
 
-- 🤖 **Agentes de IA que operan el CRM** — RAG por tenant, análisis de sentimiento, handoff IA→humano auditado, la IA como asignado de primera clase y control de presupuesto por organización. No es un chatbot decorativo: el agente atiende, califica y mueve el embudo.
-- 🔁 **Agentes que se auto-mejoran** — las conversaciones resueltas se convierten en conocimiento nuevo para el RAG; los handoffs marcan dónde el agente todavía no llega; las métricas cierran el ciclo. Cada mes de operación hace al agente mejor, con compuerta humana donde importa.
-- 🧩 **Multi-nicho por diseño** — vocabulario configurable por pipeline: un lead se vuelve *Cliente*, *Paciente* o *Comprador*; "ganado" se vuelve *Pagado*, *Agendado* o *Cerrado*. El mismo núcleo sirve para e-commerce (nuestra cuna, con integración nativa con Nuvemshop/Tiendanube), clínicas, inmobiliarias o infoproductos.
-- 🔌 **MCP-ready** — servidor MCP interno para los agentes integrados; contrato público para agentes externos en construcción. El CRM como infraestructura para cualquier agente de IA.
-- 💬 **WhatsApp-nativo vía WAHA** — multi-número, anti-baneo (throttle + jitter + ventanas de horario), medios vía Storage, detección de STOP.
-- 👥 **Gobernanza de atención** — RBAC server-side de verdad, asignación/transferencia auditadas, cola con posición, enrutamiento automático y alcance de visualización por rol.
-- 🏢 **Multi-tenant + privacidad por diseño (LGPD)** — RLS en toda tabla tenant-aware con test de aislamiento como gate de CI; anonimización preferida sobre borrado; log de auditoría append-only con retención de 5 años.
-- 🖥️ **Self-hosted de verdad** — tus datos en tu VPS; instalación con 1 comando; sin versión paga, sin funciones bloqueadas.
+- 🤖 **Agentes de IA que operan el CRM** — RAG por tenant, skills que el agente ejecuta solo durante la atención, memoria de la operación, análisis de sentimiento, handoff IA→humano auditado, IA como responsable de primera clase y tope de gasto por organización. No es un chatbot decorativo: el agente atiende, califica y mueve el embudo.
+- 🔁 **Nada muere en silencio** — follow-up que retoma la conversación enfriada (con tiempo adaptativo y disparadores por etapa), radar de lo que corre riesgo de morir sin respuesta, y central de avisos para lo que necesita una decisión humana.
+- 🧠 **Agentes que se automejoran** — las conversaciones resueltas se vuelven conocimiento nuevo; la pantalla de **Evolución de la IA** muestra si el agente está mejorando, dónde falla y qué falta enseñarle; **Propuestas** son mejoras que la IA sugiere para sí misma, aplicables como versión nueva — siempre con gate humano.
+- 🧩 **Multinicho por diseño** — vocabulario configurable por embudo: lead se vuelve *Cliente*, *Paciente* o *Comprador*; "ganado" se vuelve *Pagado*, *Agendado* o *Cerrado*. El mismo core sirve a e-commerce (nuestra cuna, con integración Nuvemshop), clínicas, inmobiliarias o infoproductos.
+- 💬 **WhatsApp de dos formas** — por **código QR** (WAHA, multinúmero, con anti-baneo: throttle + jitter + ventana horaria) o por el **canal oficial de Meta** (Cloud API, con plantillas aprobadas y sincronizadas). Medios vía Storage, detección de STOP.
+- 🔀 **Elige tu IA** — OpenRouter, Anthropic u OpenAI, decidido en la instalación y cambiable después desde la pantalla, **por parte del sistema** (lo que conversa no tiene que ser lo que indexa).
+- 👥 **Gobernanza de atención** — RBAC server-side de verdad, asignación/transferencia auditada, cola con rotación, enrutamiento automático por intención y alcance de visualización por rol.
+- 🏢 **Multi-tenant + privacidad por diseño (LGPD)** — RLS en toda tabla tenant-aware con test de aislamiento como gate de CI; anonimización preferida sobre borrado; audit log append-only con retención de 5 años.
+- 🖥️ **Self-hosted de verdad** — tus datos en tu VPS; instalación y actualización con 1 comando (o 1 clic); sin versión paga, sin funciones bloqueadas.
 
-### 🔌 Webhooks & Automatizaciones
+### 🔌 Webhooks y Automatizaciones
 
-Cada tenant puede crear **fuentes de captación**: una dirección pública (`/api/v1/webhooks/in/<token>`) que recibe leads de landing pages, formularios propios o herramientas como Zapier/n8n vía POST (JSON o `application/x-www-form-urlencoded`) y los deja directo en el embudo/etapa elegidos — sin código, sin integración a medida por tenant. Sobre esas fuentes (y los demás eventos del CRM — lead cambió de etapa, recibió una etiqueta, llegó un mensaje de WhatsApp), el tenant arma **automatizaciones**: reglas CUANDO/SI/ENTONCES que agregan etiquetas, mueven leads, asignan agentes, envían mensajes de WhatsApp o avisan a sistemas externos vía webhooks de salida.
+Cada tenant puede crear **fuentes de captación**: una dirección pública (`/api/v1/webhooks/in/<token>`) que recibe leads de landing pages, formularios propios o herramientas como Zapier/n8n vía POST (JSON o `application/x-www-form-urlencoded`) y entra directo al embudo/etapa elegida — sin código, sin integración a medida por tenant. Sobre esas fuentes (y los demás eventos del CRM — el lead cambió de etapa, ganó una etiqueta, llegó un mensaje de WhatsApp), el tenant arma **automatizaciones**: reglas CUANDO/SI/ENTONCES que agregan etiquetas, mueven el lead, lo asignan a alguien, mandan un mensaje de WhatsApp o avisan a otro sistema vía webhook de salida.
 
-En la UI todo vive en **Webhooks** en la barra lateral (visible solo para roles `manager`/`admin`). Tres pestañas: **Recibir datos** (crear una fuente, copiar la dirección/formulario listo, disparar un lead de prueba, ver las últimas entregas), **Automatizaciones** (armar la regla, que siempre nace pausada hasta que el tenant la revise y active) y **Actividad** (línea de tiempo de cada ejecución, con el resultado de cada acción y reenvío manual cuando una llamada a un webhook externo falla).
+En la UI todo vive en **Webhooks** en la barra lateral (visible solo para roles `manager`/`admin`). Tres pestañas: **Recibir datos** (crear fuente, copiar la dirección/formulario listo, disparar un lead de prueba, ver las últimas recepciones), **Automatizaciones** (armar la regla, que siempre nace pausada hasta que la revises y la enciendas) y **Actividad** (línea de tiempo de cada ejecución, con el resultado de cada acción y reenvío manual cuando una llamada externa falla).
 
-Por debajo, cada evento se convierte en una fila en `event_log` — ningún trigger de base de datos hace llamadas HTTP. La ruta `/api/v1/cron/event-log-drain` drena la cola cada minuto. En Vercel eso es un Cron Job gestionado; **en el kit self-host de HostGator** (`hostgator-setup-kit/`), `install.sh`/`update.sh` configura solo una línea de `crontab` que ejecuta esa ruta cada minuto con el `INTERNAL_SECRET` del `.env`.
+Por debajo, cada evento se vuelve una fila en `event_log` — ningún trigger de base de datos hace llamadas HTTP. Quien drena esa cola es la ruta `/api/v1/cron/event-log-drain`, llamada cada minuto. **`install.sh`/`update.sh` ya configuran ese cron solos** — sin él, las automatizaciones se crean normalmente pero nunca corren.
 
 ---
 
-## 🚀 Quickstart (velo funcionando en 5 minutos)
+## 🖥️ Lo que operas (las pantallas)
 
-```bash
-# 1. Clona
-git clone https://github.com/melgarafael/DeskcommCRM.git
-cd DeskcommCRM
+| Grupo | Pantallas |
+|---|---|
+| **Atención** | **Inbox** (conversaciones de WhatsApp, tú y la IA lado a lado) · **Radar** (quién se enfrió y sigue abierto) · **Respuestas rápidas** |
+| **CRM** | **Kanban** (dónde está cada negocio en el embudo) · **Contactos** · **Embudos** (etapas, vocabulario del negocio y motivos de pérdida) |
+| **Agente de IA** | **Agentes** · **Follow-ups** · **Enrutadores** · **Proveedores** y **Credenciales** · **Conocimiento** (RAG) · **Memoria** · **Skills** · **Casos** · **Alertas** · **Propuestas** · **Ejecuciones** · **Uso y presupuesto** |
+| **Canales** | **Conexiones** (QR o canal oficial de Meta, con salud, reconexión y plantillas) · **Nuvemshop** · **Webhooks** |
+| **Análisis** | **Desempeño** (embudo y rendimiento por agente) · **Evolución de la IA** · **Audit Log** |
+| **Organización** | **Equipo** · **Distribución de atención** · **Organización** · **LGPD** · **API Tokens** · **Seguridad** (MFA, códigos de recuperación, sesiones) · Perfil, Notificaciones, Billing |
 
-# 2. Node 22 + pnpm
-nvm use                    # o instala Node 22+
-npm install -g pnpm
-pnpm install
-
-# 3. Variables de entorno
-cp .env.example .env.local
-# Edita .env.local — guía completa en docs/SETUP.md
-
-# 4. WAHA local (opcional en dev sin WhatsApp)
-docker compose up -d
-
-# 5. Migraciones de Supabase
-supabase link --project-ref <tu-ref>
-supabase db push
-
-# 6. Levanta la app
-pnpm dev
-```
-
-App: <http://localhost:3000> · Health check: <http://localhost:3000/api/v1/health>
-
-> 🆕 **¿Primera vez? No te saltes pasos.** [`docs/SETUP.md`](docs/SETUP.md) es el tutorial completo paso a paso de **todas las integraciones** (Supabase, WAHA, Anthropic, Upstash, Sentry, Resend, Nuvemshop) — hecho para quien nunca configuró nada de esto. ~60–90 min de cero a la app funcionando. *(La documentación está en portugués de Brasil; ¡las traducciones son bienvenidas!)*
+Toda pantalla tiene puerta en la navegación — el CI reprueba una pantalla que existe pero a la que solo se llega escribiendo la URL.
 
 ---
 
@@ -109,20 +247,52 @@ App: <http://localhost:3000> · Health check: <http://localhost:3000/api/v1/heal
 | Capa | Elección | Por qué |
 |---|---|---|
 | **Frontend** | Next.js 16 App Router (Turbopack) + React 19 + TypeScript 6 estricto | Server Components + Route Handlers en el mismo repo |
-| **Estilos** | Tailwind + shadcn/ui (`new-york`, neutral) | Personalizable sin lock-in |
+| **Estilo** | Tailwind + shadcn/ui (`new-york`, neutral) | Personalizable sin lock-in |
 | **DB** | Supabase (Postgres + RLS + `vector`) | Multi-tenant nativo, embeddings para RAG |
-| **Auth** | Supabase Auth vía `@supabase/ssr` | Cookies SameSite=Strict, HttpOnly |
+| **Auth** | Supabase Auth vía `@supabase/ssr` | Cookie SameSite=Strict, HttpOnly |
 | **Realtime** | Supabase Realtime | postgres_changes + broadcast |
 | **Storage** | Supabase Storage (URLs firmadas) | Bucket privado `whatsapp-media` |
-| **WhatsApp** | WAHA Plus (engine NOWEB) | Multi-tenant, retry, S3 |
-| **Colas** | Tabla `event_log` + workers (cron) | Sin Inngest/Trigger en el MVP |
+| **WhatsApp** | WAHA Plus (motor NOWEB) + Meta Cloud API | QR para empezar rápido; canal oficial para escalar |
+| **Colas** | Tabla `event_log` + workers (cron) | Un trigger de base nunca hace HTTP |
 | **Rate limit** | Upstash Redis (sliding window) | Serverless, el free tier alcanza |
-| **AI** | Vercel AI SDK v7 (providers Anthropic/Google/OpenAI v4) vía AI Gateway | Fallback automático, ZDR |
+| **IA** | Vercel AI SDK v7 — OpenRouter, Anthropic, OpenAI y Google | El instalador pregunta cuál; se cambia después desde la pantalla |
 | **Validación** | Zod | Input externo, env, payloads |
-| **Observabilidad** | Sentry (con `beforeSend` sanitizado) | Sin PII en los breadcrumbs |
-| **Hosting** | Vercel (app) + HostGator VPS Turing/SP (WAHA) | Edge + servidor dedicado para WhatsApp; datacenter en Brasil |
+| **Observabilidad** | Sentry (scrub en error, transacción, span y breadcrumb) | Telemetría opt-in en la instalación |
+| **Hosting** | Cualquier VPS con Docker (HostGator/SP en la alianza) | App + WhatsApp + workers en tu propia máquina |
 
 Detalles: [`ARCHITECTURE.md`](ARCHITECTURE.md).
+
+---
+
+## 🧑‍💻 Desarrollo (solo para contribuir al código)
+
+> ⚠️ **Si quieres USAR el CRM, no es acá** — usa el [instalador del VPS](#-instalar-en-tu-vps-el-camino-principal).
+> Esta sección es para quien va a tocar el código.
+
+```bash
+git clone https://github.com/melgarafael/DeskcommCRM.git
+cd DeskcommCRM
+
+nvm use                     # Node 22
+npm install -g pnpm && pnpm install
+
+cp .env.example .env.local  # guía completa en docs/SETUP.md
+
+docker compose up -d        # WAHA local (opcional en dev sin WhatsApp)
+
+# Schema: aplica el baseline, NO las migrations.
+# Las migrations 0001-0009 y 0013 son stubs `SELECT 1;` — la cadena no sube desde cero.
+# El schema real vive en baseline.sql, el mismo que install.sh aplica en el VPS.
+# `supabase db push` "pasa" y te deja la base vacía.
+supabase link --project-ref <tu-ref>
+psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f supabase/baseline.sql
+
+pnpm dev
+```
+
+App: <http://localhost:3000> · Health check: <http://localhost:3000/api/v1/health>
+
+[`docs/SETUP.md`](docs/SETUP.md) es el tutorial completo de **todas las integraciones** (Supabase, WAHA, proveedores de IA, Upstash, Sentry, Resend, Nuvemshop) — ~60–90 min de cero a la app corriendo. *(La documentación está en portugués de Brasil; ¡las traducciones son bienvenidas!)*
 
 ---
 
@@ -136,45 +306,68 @@ pnpm test:db       # Postgres efímero + baseline install/update + invariantes
 pnpm test:e2e      # Playwright (requiere dev server)
 ```
 
-El CI ejecuta `typecheck`, `lint` y `test:unit` en cada PR. Un segundo job — **`invariants`** — levanta un Postgres limpio, aplica `supabase/baseline.sql` en modo install (`ON_ERROR_STOP=1`) y luego en modo update (probando idempotencia), y ejecuta **364 tests de invariante** repartidos en 56 archivos, cubriendo RBAC, asignación, alcance de visualización, enrutamiento, follow-up, webhooks y automatizaciones.
+**Cuatro checks son obligatorios** para mergear en `main` — todos verificados en la branch protection, no solo en el papel:
 
-Entre ellos está el **test de aislamiento RLS**: crea 2 organizaciones, simula los claims JWT por el mismo camino `auth.uid()` / `fn_user_org_ids()` que usan las policies de producción, y prueba que un usuario de la org A ve **cero filas** de la org B en `conversations`, `messages`, `contacts` y `crm_leads`. Antes, un caso de control prueba que las filas de la org B realmente existen en la base — sin él, el test pasaría contra una tabla vacía.
+| Check | Qué hace |
+|---|---|
+| `verify` | typecheck + lint + `lint:channels` + `test:unit` + `test:shell` |
+| `invariants` | levanta un Postgres limpio, aplica `baseline.sql` en modo **install** (`ON_ERROR_STOP=1`) y después en modo **update** (probando idempotencia), y corre **618 invariantes en 98 archivos** — RBAC, asignación, alcance, enrutamiento, follow-up, webhooks y automatizaciones |
+| `build-and-size` | `pnpm build` en Node 22 |
+| `e2e` | levanta un Supabase local, aplica `baseline.sql` y corre **44 de las 45** specs de Playwright por el frontend |
+
+La única spec fuera del `e2e` es `vps-fresh-onboarding` — necesita WAHA + Redis + Resend + Nuvemshop de verdad. Es la **P0** de nuestra doctrina de QA visual, así que un `e2e` verde **no** prueba el recorrido de instalación fresca; ese se prueba en un VPS.
+
+Entre los invariantes está el **test de aislamiento RLS**: crea 2 organizaciones, simula los claims JWT por el mismo camino `auth.uid()` / `fn_user_org_ids()` que usan las policies de producción, y prueba que un usuario de la org A ve **cero filas** de la org B en `conversations`, `messages`, `contacts` y `crm_leads`. Antes, un caso de control prueba que las filas de la org B realmente existen — sin él, el test pasaría con la tabla vacía.
 
 ---
 
 ## 📚 Documentación
 
-| Doc | Qué contiene |
+| Doc | Qué tiene |
 |---|---|
-| [`VISION.md`](VISION.md) | **Visión y posicionamiento** — qué es el proyecto, en qué cree, hacia dónde va |
-| [`docs/SETUP.md`](docs/SETUP.md) | **Instalación completa paso a paso** de todas las integraciones |
-| [`docs/white-label.md`](docs/white-label.md) | **Instalar para clientes** — cambiar la marca, una instalación por cliente vs compartida, operación de reventa |
+| [`hostgator-setup-kit/README.md`](hostgator-setup-kit/README.md) | **Instalación self-host** — el kit, los scripts, los hostings con proxy propio |
+| [`docs/ATUALIZANDO.md`](docs/ATUALIZANDO.md) | **Cómo actualizar** tu instalación, en lenguaje simple |
+| [`VISION.md`](VISION.md) | **Visión y posicionamiento** — qué es el proyecto, en qué cree y hacia dónde va |
+| [`CHANGELOG.md`](CHANGELOG.md) | Qué cambió en cada versión — **lee la sección de tu versión antes de actualizar** |
+| [`docs/SETUP.md`](docs/SETUP.md) | Setup de desarrollo, paso a paso, de todas las integraciones |
+| [`docs/white-label.md`](docs/white-label.md) | **Instalar para clientes** — cambiar la marca, una instalación por cliente vs compartida, reventa |
+| [`docs/runbooks/waha-hostgator.md`](docs/runbooks/waha-hostgator.md) | Runbook de WAHA en producción (dimensionamiento, recuperación) |
 | [`CLAUDE.md`](CLAUDE.md) | Convenciones no negociables (lectura obligatoria para contribuir) |
 | [`ARCHITECTURE.md`](ARCHITECTURE.md) | Visión de 1 página de la arquitectura |
-| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Flujo de PRs |
-| [`docs/prd/`](docs/prd/) | PRDs (master, plataforma, customer 360, WhatsApp, pipeline, IA-RAG, Nuvemshop) |
-| [`docs/specs/`](docs/specs/) | Specs técnicas 01–13 (schema SQL, payloads, MCP, gobernanza) |
-| [`docs/runbooks/waha-hostgator.md`](docs/runbooks/waha-hostgator.md) | Runbook completo de WAHA en producción (VPS HostGator) |
+| [`docs/index.md`](docs/index.md) | Índice de los 157 documentos, con regla de precedencia |
+| [`docs/prd/`](docs/prd/) · [`docs/specs/`](docs/specs/) | PRDs y specs técnicas (schema SQL, payloads, MCP, gobernanza) |
 
-> La mayor parte de la documentación está en portugués de Brasil — nuestra comunidad primaria. Las contribuciones de traducción son muy bienvenidas.
+> La mayor parte de la documentación está en portugués de Brasil — nuestra comunidad principal. Las contribuciones de traducción son muy bienvenidas.
 
 ---
 
 ## 🤝 Contribuir
 
-Este proyecto es open source para la comunidad. Toda contribución es bienvenida — desde corregir un typo en la documentación hasta una feature nueva.
+Este proyecto es open source para la comunidad. Toda contribución es bienvenida — desde arreglar un typo en la documentación hasta una función nueva.
 
-1. Lee [`CLAUDE.md`](CLAUDE.md) (~5 min) — convenciones no negociables (multi-tenancy, RLS, auditoría, privacidad).
-2. Lee [`CONTRIBUTING.md`](CONTRIBUTING.md) — flujo de branches y commits.
+1. Lee [`CLAUDE.md`](CLAUDE.md) (~5 min) — convenciones no negociables (multi-tenancy, RLS, audit, privacidad).
+2. Lee [`CONTRIBUTING.md`](CONTRIBUTING.md) — flujo de branches, commits.
 3. Sigue el [Código de Conducta](CODE_OF_CONDUCT.md).
 
-**Definition of Done:** typecheck en cero, lint en cero, tests relevantes en verde, RLS testeada si se toca una tabla tenant-aware, log de auditoría emitido en mutaciones, migración versionada si cambia el schema.
+**Flujo corto:**
+
+```bash
+git checkout -b feat/short-slug
+# implementa + tests
+pnpm typecheck && pnpm lint && pnpm lint:channels && pnpm test:unit && pnpm test:shell && pnpm build
+pnpm test:db   # necesita Docker — es el job `invariants`, obligatorio para mergear
+git commit -m "feat(alcance): descripción"
+```
+
+Esa línea es la lista **completa** de los gates obligatorios, a propósito: correr solo la mitad y descubrir el resto como sorpresa roja después de horas de espera es la peor primera experiencia que este repositorio sabe entregar.
+
+**Definition of Done:** typecheck en cero, lint en cero, tests relevantes verdes, RLS testeada si toca una tabla tenant-aware, audit log emitido en mutaciones, migration versionada **+ apéndice idempotente en `baseline.sql`** si cambia el schema (si no, el cambio nunca llega a quien se auto-hospeda).
 
 ---
 
 ## 🐛 Reportar bugs
 
-Abre un [issue](https://github.com/melgarafael/DeskcommCRM/issues/new/choose) — la plantilla pide lo que necesitamos (entorno, `/api/v1/health`, pasos).
+Abre un [issue](https://github.com/melgarafael/DeskcommCRM/issues/new/choose) — la plantilla pide lo que necesitamos (entorno, `/api/v1/health`, pasos). Correr `bash hostgator-setup-kit/healthcheck.sh` y pegar la salida ayuda mucho.
 
 Para **vulnerabilidades de seguridad**, **NO abras un issue público** — usa el [reporte privado de vulnerabilidades](https://github.com/melgarafael/DeskcommCRM/security/advisories/new). Detalles en [`SECURITY.md`](SECURITY.md).
 
@@ -184,22 +377,23 @@ Para **vulnerabilidades de seguridad**, **NO abras un issue público** — usa e
 
 ### ✅ Entregado
 
-- **Fundación & plataforma** — auth (MFA para admins), multi-tenancy con RLS + test de aislamiento, RBAC de 4 roles, log de auditoría append-only, onboarding de tenants.
-- **Atención por WhatsApp** — inbox de 3 paneles en tiempo real, conexiones WAHA multi-número, medios vía Storage, anti-baneo (throttle + jitter + ventana de horario), detección de STOP.
-- **CRM & pedidos** — kanban con vocabulario configurable por nicho (fractional indexing), customer 360, contactos, etiquetas, integración con Nuvemshop/Tiendanube para e-commerce.
-- **IA nativa** — agentes con RAG por tenant (pgvector), análisis de sentimiento, handoff IA→humano, control de presupuesto por org, servidor MCP interno.
-- **Privacidad (LGPD)** — export y redact vía workers, anonimización en cascada, consentimiento auditado.
-- **Self-host** — `hostgator-setup-kit` (app + WAHA + base de datos con 1 comando), `baseline.sql` auto-curativo, runbook de producción.
-- **Webhooks & automatización** — fuentes de captación + reglas CUANDO/SI/ENTONCES + triggers para sistemas externos.
-- **Gobernanza de atención** — RBAC server-side en toda la API, asignación y transferencia auditadas (la IA como asignado de 1ª clase), visualización por rol (RLS) + métricas por agente, enrutamiento automático con cola y panel de gestión, y contrato de gobernanza para agentes de IA externos ([`docs/specs/14`](docs/specs/14-contrato-governanca-agentes-externos.md)). Épica guiada por 100+ invariantes (G1–G6).
-- **Operación visible** — pantallas para que el operador entienda al agente: motivo de la retención anti-baneo traducido en la conversación, central de avisos con severidades, control de protección de envío (ventana/ritmo/tope) y propuestas del flywheel aplicables como versión nueva (con compuerta humana).
+- **Fundación y plataforma** — auth (MFA para admin), multi-tenancy con RLS + test de aislamiento, RBAC de 4 roles, audit log append-only, onboarding de tenant.
+- **Atención WhatsApp** — inbox de 3 paneles en tiempo real, conexiones multinúmero por **QR (WAHA)** o **canal oficial de Meta** (plantillas aprobadas y sincronizadas), medios vía Storage, anti-baneo (throttle + jitter + ventana horaria), detección de STOP.
+- **CRM y pedidos** — kanban con vocabulario configurable por nicho (fractional indexing), gestión de embudos desde la pantalla, customer 360, contactos, etiquetas, integración Nuvemshop.
+- **IA nativa** — agentes con RAG por tenant (pgvector), **skills** que el agente ejecuta solo, **memoria de la organización**, enrutador de intención por número, análisis de sentimiento, handoff IA→humano, tope de gasto por org, servidor MCP interno.
+- **Elección de proveedor de IA** — OpenRouter, Anthropic u OpenAI, decidido en la instalación y cambiable por parte del sistema desde la pantalla.
+- **Follow-up vivo** — retomar conversaciones enfriadas con tiempo adaptativo, disparadores por etapa y por caso, cola con rotación, y el Radar de lo que corre riesgo de morir sin respuesta.
+- **LGPD** — export y redact vía workers, anonimización en cascada, consentimiento auditado.
+- **Self-host** — `hostgator-setup-kit` (app + WhatsApp + base con 1 comando), `baseline.sql` auto-curativo, **actualización desde la pantalla** con backup automático, runbook de producción.
+- **Webhooks y automatización** — fuentes de captación + reglas CUANDO/SI/ENTONCES + disparadores para sistemas externos.
+- **Gobernanza de atención** — RBAC server-side en toda la API, asignación y transferencia auditadas (IA como responsable de 1ª clase), visualización por rol (RLS) + métricas por agente, enrutamiento automático con cola y panel de gestión, y contrato de gobernanza para agentes de IA externos ([`docs/specs/14`](docs/specs/14-contrato-governanca-agentes-externos.md)).
+- **Operación visible** — motivo de la retención anti-baneo traducido en la conversación, central de avisos con severidad, aviso de mensaje trabada, control de protección de envío (ventana/ritmo/tope), capacidades declaradas del agente y propuestas del flywheel aplicables como versión nueva (con gate humano).
 
 ### 🔮 Próximo
 
-- **MCP público** — capacidades del CRM expuestas al ecosistema de agentes: conecta el agente que quieras y opera Deskcomm.
-- **Flywheel de auto-mejora** — el ciclo conversación resuelta → conocimiento → agente mejor, medido y con compuerta humana.
-- **Plantillas por nicho** — pipelines y vocabularios listos para clínicas, inmobiliarias, infoproductos y servicios (e-commerce ya entregado).
-- **Integraciones** — VTEX y Shopify vía adapter pattern (Nuvemshop ya entregada).
+- **MCP público** — capacidades del CRM expuestas al ecosistema de agentes: enchufa el agente que quieras y opera el Deskcomm.
+- **Plantillas por nicho** — embudos y vocabularios listos para clínicas, inmobiliarias, infoproductos y servicios (e-commerce ya entregado).
+- **Integraciones** — VTEX y Shopify vía adapter pattern (Nuvemshop ya entregado).
 - **Identidad probabilística** — unificación de contactos entre canales.
 
 ---
@@ -215,26 +409,29 @@ Para **vulnerabilidades de seguridad**, **NO abras un issue público** — usa e
 
 ## 📜 Licencia
 
-Distribuido bajo la licencia **MIT** — mira [`LICENSE`](LICENSE). Puedes usar, modificar y distribuir libremente, incluso con fines comerciales. El software se entrega **"tal cual", sin garantías**.
+Distribuido bajo la licencia **MIT** — ver [`LICENSE`](LICENSE). Puedes usar, modificar y distribuir libremente, incluso comercialmente. El software se entrega **"tal cual", sin garantías**.
 
 ---
 
-## 🛟 Soporte & responsabilidades (self-host)
+## 🛟 Soporte y responsabilidades (self-host)
 
-Este es un proyecto **self-hosted**: cada persona ejecuta el CRM en su **propia infraestructura** (VPS, base de datos Supabase y clave de IA propias). Eso implica:
+Este es un proyecto **self-host**: cada persona corre el CRM en su **propia infraestructura** (VPS, base Supabase y clave de IA propios). Eso implica:
 
-- **El soporte es comunitario y "as-is".** Sin SLA — es open source mantenido por buena voluntad.
-- **Eres responsable de tu instalación**, incluyendo actualizaciones (`bash hostgator-setup-kit/update.sh`) y backups.
-- **Protección de datos:** quien **hospeda** la instancia es el **responsable** de los datos personales que se procesan ahí. Los mantenedores del proyecto **no tienen acceso** a tus datos.
-- **Telemetría (Sentry):** por defecto se envían errores **anonimizados** (sin PII) al Sentry de la comunidad. Usa `SENTRY_DSN=off` para desactivarlo, o `SENTRY_DSN=<tu-dsn>` para usar el tuyo.
+- **El soporte es comunitario y "as-is".** No hay SLA — es open source mantenido por buena voluntad.
+- **Eres responsable de tu instalación.** Las actualizaciones no son automáticas (haces clic, o corres `update.sh`, cuando quieras), y mantener/respaldar tu servidor es cosa tuya.
+- **Protección de datos:** quien **hospeda** la instancia es el **controlador** de los datos personales tratados ahí (clientes, conversaciones, pedidos), con las obligaciones legales que eso implica. Los mantenedores del proyecto **no son** controladores ni operadores de tu instancia, y no tienen acceso a tu base, a tu WhatsApp ni a tu storage.
+- **Telemetría (Sentry):** `install.sh` **pregunta** durante la instalación y respeta tu respuesta; en modo no interactivo, sin `SENTRY_DSN` definido, la telemetría queda **apagada**. Si aceptas el Sentry de la comunidad, lo que se envía son **reportes de error** (stack trace) con documento, teléfono y correo sustituidos, cabeceras sensibles removidas, y token de webhook/invitación redactado de la URL — **sin** rastreo de performance y **sin** replay de sesión, que quedan en 0 en ese camino. Para apagarlo en cualquier momento: `SENTRY_DSN=off` en el `.env`. Para mandarlo a **tu** Sentry (ahí sí con performance y replay): `SENTRY_DSN=<tu-dsn>`. Qué se redacta, y por qué, está en [`lib/sentry/scrub.ts`](lib/sentry/scrub.ts); la resolución del DSN en [`lib/sentry/dsn.ts`](lib/sentry/dsn.ts).
 
 ---
 
 ## 🙏 Agradecimientos
 
-- **WAHA** ([devlikeapro](https://waha.devlikeapro.com/)) — engine de WhatsApp.
-- **Supabase**, **Vercel**, **Anthropic** (Claude), **shadcn/ui**.
-- La comunidad que llevó Deskcomm del e-commerce a clínicas, inmobiliarias, infoproductos y más allá — ustedes definieron lo que este proyecto es.
+- **WAHA** ([devlikeapro](https://waha.devlikeapro.com/)) — motor de WhatsApp.
+- **Supabase** — Postgres + Auth + Storage + Realtime en una sola stack.
+- **HostGator** — la alianza de infraestructura que hizo posible el self-host de 1 comando.
+- **Anthropic**, **OpenAI** y **OpenRouter** — los proveedores de IA que el CRM sabe usar.
+- **shadcn/ui** — base de componentes.
+- La comunidad que nos llevó del e-commerce a clínicas, inmobiliarias, infoproductos y más allá — ustedes definieron lo que es este proyecto.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,27 @@
 
 ## ⚡ Instalar na sua VPS (o caminho principal)
 
-Entre na sua VPS por SSH e rode:
+### 1. Entre na sua VPS
+
+Abra o **Terminal** no seu computador (no Windows, o **PowerShell**; no Mac ou Linux, o
+**Terminal**) e conecte com o IP e a porta que a hospedagem te mandou por e-mail:
+
+```bash
+ssh -p PORTA root@SEU_IP
+```
+
+Troque `PORTA` e `SEU_IP` pelos seus. Se a hospedagem não mencionou porta nenhuma, é a padrão
+(22) e você pode omitir: `ssh root@SEU_IP`.
+
+Ele pede a senha. **Ao digitar, não aparece nada na tela — nem asteriscos.** Isso não é
+travamento: é o terminal escondendo a senha. Digite (ou cole) e dê Enter.
+
+> Na primeira conexão ele pergunta `Are you sure you want to continue connecting?` — responda
+> `yes`. É o servidor se apresentando pela primeira vez.
+
+### 2. Rode o instalador
+
+Já dentro da VPS:
 
 ```bash
 git clone https://github.com/melgarafael/DeskcommCRM.git


### PR DESCRIPTION
Sequência do #226, que reescreveu só o README pt-br.

## O que estava quebrado

**EN e ES ficaram para trás:** abriam com o Quickstart de desenvolvimento (o público-alvo instala numa VPS), não tinham seção de atualizar, e citavam "364 invariantes em 56 arquivos".

**E o EN estava errado onde mais dói.** O passo 5 mandava:

```bash
supabase db push
```

A cadeia de migrations não sobe do zero — `0001-0009` e `0013` são stubs `SELECT 1;`. O comando **"passa" e deixa o banco vazio**, sem erro para procurar. O pt-br já avisava disso desde antes; a tradução mandava o contribuidor estrangeiro direto para o buraco.

## O que este PR faz

**Espelha a estrutura nova nos dois idiomas** — VPS como caminho principal, seção **Atualizar** (tela + `update.sh` + rollback automático), Quickstart demovido para "Development / Desarrollo (só pra contribuir)" com aviso, tabela das telas, e o que faltava no inventário: canal oficial da Meta, escolha de provedor de IA, follow-up vivo, radar, skills, memória, casos, evolução da IA.

**Números remedidos** nos três: 618 invariantes em 98 arquivos, 44 das 45 specs e2e, os 4 checks obrigatórios.

**A orientação de SSH, nos três idiomas** — faltava o passo anterior a todos os comandos:

```bash
ssh -p PORTA root@SEU_IP
```

Com as duas coisas que travam quem nunca usou SSH e não estão em lugar nenhum da documentação:

- **a senha não aparece na tela enquanto se digita** — nem asteriscos. Quem não sabe disso acha que o terminal travou;
- **a pergunta de fingerprint na primeira conexão** (`Are you sure you want to continue connecting?`), que precisa de um `yes` digitado por extenso.

## Verificação

Todos os links relativos dos três arquivos resolvem (checados um a um). Âncoras internas conferidas contra os títulos: `#-install-on-your-vps-the-main-path`, `#-updating`, `#-instalar-en-tu-vps-el-camino-principal`, `#-actualizar`.

Mudança é só de `.md` — nenhum código tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VP81jNMpcqZePhfiCZBsBA
