### PR TITLE
fix(gate): o teste do elo zernio media adjacência, não pertencimento

### DIFF
--- a/tests/unit/canal-zernio-vocabulario.test.ts
+++ b/tests/unit/canal-zernio-vocabulario.test.ts
@@ -106,8 +106,16 @@ describe("o envelope carrega a thread do provider", () => {
     const fonte = readFileSync("app/api/v1/messages/_handler.ts", "utf8");
     // Ler sem passar, ou passar sem ler, deixa o envio livre quebrado só neste
     // canal — e só quando alguém tentar responder dentro da janela.
-    expect(fonte, "falta a coluna no select da conversa").toMatch(
-      /group_chat_id,\s*provider_conversation_id/,
+    // A régua é PERTENCER ao select, não ficar ao lado de uma coluna vizinha.
+    // A versão anterior casava /group_chat_id,\s*provider_conversation_id/ — e
+    // adjacência é acidente de formatação, não a propriedade guardada: o PR #225
+    // inseriu `bot_silenced_until` entre as duas e reprovou um handler que lia e
+    // passava a coluna exatamente como antes. Gate que reprova o inocente ensina
+    // a contornar gate.
+    const convSelect = /const convSelect =[\s\S]*?`([^`]+)`/.exec(fonte)?.[1];
+    expect(convSelect, "não achei o convSelect do handler — o teste ficou cego").toBeTruthy();
+    expect(convSelect, "falta a coluna no select da conversa").toContain(
+      "provider_conversation_id",
     );
     const passagens = [...fonte.matchAll(/providerConversationId:\s*c\.provider_conversation_id/g)];
     expect(passagens.length, "os DOIS call sites (texto e mídia) precisam passar").toBe(2);


### PR DESCRIPTION
Destrava o #225 e conserta a régua, não o PR do contribuidor.

## O que estava errado

`tests/unit/canal-zernio-vocabulario.test.ts` diz guardar *"o handler LÊ a coluna e a PASSA ao adapter — o elo que some sem barulho"*. A régua era:

```js
expect(fonte).toMatch(/group_chat_id,\s*provider_conversation_id/);
```

Isso exige que as duas colunas fiquem **lado a lado** no `convSelect`. Adjacência é acidente de formatação. A propriedade é **pertencimento**.

## Como apareceu

O #225 (@Gervanno) insere `bot_silenced_until` entre as duas — precisa da coluna para a janela de silêncio da IA. `verify` reprovou um handler que lê e passa a coluna exatamente como antes: `provider_conversation_id` segue no select (`_handler.ts:265`), no tipo `Joined` (`:287`) e nos dois call sites (`:459` e `:472`) — que é o que a *segunda* asserção do próprio teste exige e que nunca chegou a rodar, porque a primeira já havia lançado.

Um gate que reprova o inocente não protege nada: ensina a contornar gate.

## Discriminância medida

Contra `main` `1ff0bf76`, na prévia do merge do #225:

| sabotagem | esperado | medido |
|---|---|---|
| `provider_conversation_id` fora do select | vermelho | ✅ `falta a coluna no select da conversa` |
| colunas reordenadas, coluna presente | verde | ✅ `16 passed` |
| `convSelect` renomeado | vermelho (vacuidade) | ✅ `o teste ficou cego` |
| handler da `main` (adjacente) | verde | ✅ `16 passed` |
| handler do #225 | verde | ✅ `16 passed` |

A guarda de vacuidade é o que impede a versão nova de virar instrumento morto: sem ela, um `convSelect` renomeado devolveria `undefined` e o `toContain` passaria por ausência de dado.

## Ordem

Este entra primeiro; o #225 fica verde sozinho no merge, sem o @Gervanno mexer em nada.
