### PR TITLE
test(rbac): a rota de mídia ganha a guarda que faltava

### DIFF
--- a/tests/unit/rbac-matrix.test.ts
+++ b/tests/unit/rbac-matrix.test.ts
@@ -193,6 +193,44 @@ describe("grupo inbox/conversations (read agent 200, write viewer 403)", () => {
     expect(await errorCode(res)).toBe("forbidden_role");
   });
 
+  /**
+   * Esta rota é a que o release 1.2.1 (`d774fcce`) fechou: era a ÚNICA escrita
+   * em `conversations/[id]/*` sem gate, e como a policy de SELECT deixa o
+   * viewer enxergar toda conversa da org, o papel mais fraco do tenant tinha
+   * escrita irrestrita no bucket — 50 MB por arquivo, com service_role.
+   *
+   * O caso nasceu de uma triagem de PR: a `main` fechou o buraco enquanto um PR
+   * de contribuidor editava OUTRO trecho do mesmo arquivo. O merge combinou os
+   * dois corretamente, mas ninguém tinha como PROVAR isso — a única evidência
+   * disponível era ler o `requireRole` no fonte, e presença de símbolo não é
+   * comportamento. Da próxima vez (rebase, squash, ou um PR que toque estas
+   * linhas) o gate cairia em silêncio e nenhum job acusaria.
+   */
+  it("POST /conversations/[id]/media nega 403 para viewer", async () => {
+    session("viewer");
+    const { POST } = await import("@/app/api/v1/conversations/[id]/media/route");
+    const res = await POST(
+      req("/api/v1/conversations/c1/media", { method: "POST" }),
+      params({ id: "c1" }),
+    );
+    expect(res.status).toBe(403);
+    expect(await errorCode(res)).toBe("forbidden_role");
+  });
+
+  it("POST /conversations/[id]/media deixa agent passar do gate de role", async () => {
+    // Sem este caso, apagar a rota inteira deixaria o teste acima verde — 403
+    // por ausência de import não se distingue de 403 por RBAC. Aqui o agent tem
+    // de PASSAR do gate; o que acontece depois (404 da conversa inexistente no
+    // stub) não é assunto deste caso.
+    session("agent");
+    const { POST } = await import("@/app/api/v1/conversations/[id]/media/route");
+    const res = await POST(
+      req("/api/v1/conversations/c1/media", { method: "POST" }),
+      params({ id: "c1" }),
+    );
+    expect(res.status).not.toBe(403);
+  });
+
   it("PATCH /conversations/[id] nega 403 para viewer", async () => {
     session("viewer");
     const { PATCH } = await import("@/app/api/v1/conversations/[id]/route");


### PR DESCRIPTION
A rota que o release de segurança 1.2.1 fechou não tinha teste. Agora tem.

## O buraco

`d774fcce` fechou `app/api/v1/conversations/[id]/media/route.ts` — era a **única** escrita em `conversations/[id]/*` sem `requireRole`. Como a policy de SELECT deixa o `viewer` enxergar toda conversa da org, o papel mais fraco do tenant tinha **escrita irrestrita no bucket**: 50 MB por arquivo, com `service_role`.

O conserto entrou sem teste. `rbac-matrix.test.ts` cobre a rota **irmã** — `claim/route.ts`, citada no comentário do próprio código como *"o modelo literal"* — e não cobria esta.

## Como apareceu

Triando o **#227**. A `main` fechou o buraco enquanto o PR do @jmpo editava **outro trecho do mesmo arquivo** (transcodificação de nota de voz). O merge combinou os dois corretamente.

O problema não era o merge — era que a única evidência disponível para **afirmar** que ele estava correto era ler o `requireRole` no fonte. Presença de símbolo não é comportamento. Um rebase, um squash, ou um PR que tocasse aquelas linhas derrubaria o gate em silêncio, com todo o CI verde.

## Discriminância medida

Na prévia do merge de #227 sobre `1ff0bf76`:

| estado | resultado |
|---|---|
| com o `requireRole` | `14 passed (14)` |
| `requireRole` removido da rota | `1 failed \| 13 passed` — `expected 422 to be 403` |
| restaurado | `14 passed (14)` |

O `422` é o detalhe que confirma que a sabotagem foi real: sem o gate, o `viewer` **passa** do RBAC e só esbarra na validação de mídia mais adiante.

O segundo caso (`agent` passa do gate) existe para que apagar a rota inteira não deixe o primeiro verde — `403` por ausência de import não se distingue de `403` por RBAC.
