### PR TITLE
fix(imagem): o build de produção para de typechecar teste — e o PR passa a gatear a imagem

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -10,6 +10,14 @@ on:
     branches: ["main"]
   release:
     types: [published]
+  # Em PR a imagem é CONSTRUÍDA e não publicada. Sem isto, nada no PR consegue
+  # revelar que a mudança quebra a imagem — foi assim que um bump de `next`
+  # passou por `verify`, `build-and-size`, `invariants` e `e2e` (os quatro
+  # obrigatórios) e derrubou o build do Dockerfile na `main`: o `next build`
+  # dentro da imagem não enxerga `tests/` (`.dockerignore`), e a partir do
+  # next 16.3 ele typecheca os `*.test.ts` colocados. O artefato que o
+  # self-hoster instala era o único sem gate.
+  pull_request:
   workflow_dispatch: {}
 
 env:
@@ -26,6 +34,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -52,7 +61,10 @@ jobs:
           context: .
           # linux/amd64: o VPS HostGator e a imagem do WAHA são amd64.
           platforms: linux/amd64
-          push: true
+          # PR de fork não tem permissão de escrita no GHCR, e publicar imagem
+          # de código não revisado seria pior que não gatear. Em PR: constrói
+          # (que é o gate) e descarta.
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{ts,tsx,md,json,css}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,md,json,css}\"",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "db:migrate": "echo 'TODO: wire supabase db push or pg-migrate' && exit 0",
     "db:reset": "supabase db reset",
     "test:e2e": "playwright test",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,9 @@
     "node_modules",
     ".next",
     "dist",
-    "scripts/**"
+    "scripts/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "tests/**"
   ]
 }

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,28 @@
+{
+  // O `pnpm typecheck` do repo — cobre TUDO, inclusive os testes.
+  //
+  // Por que existe um segundo tsconfig: desde o next 16.3 o `next build`
+  // typecheca os `*.test.ts` COLOCADOS (os que moram em app/, components/,
+  // lib/ ao lado do código que testam). Isso amarra o build de produção ao
+  // toolchain de teste — e o `.dockerignore` deixa `tests/` fora da imagem,
+  // então a imagem do self-host passou a falhar com TS2307/TS2339 enquanto
+  // `verify`, `build-and-size`, `invariants` e `e2e` seguiam verdes.
+  //
+  // Medido, mesma árvore, sem `tests/`: next 16.2.12 constrói (exit 0);
+  // next 16.3.0 não (exit 1). Excluir teste do tsconfig do BUILD resolve na
+  // raiz — o build de produção não tem por que compilar teste.
+  //
+  // A cobertura de tipos NÃO cai: é este arquivo que o `pnpm typecheck` usa,
+  // e ele reinclui o que o outro exclui.
+  "extends": "./tsconfig.json",
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
+    "tests/**/*.ts",
+    "tests/**/*.tsx"
+  ],
+  "exclude": ["node_modules", ".next", "dist", "scripts/**"]
+}


### PR DESCRIPTION
A imagem Docker do self-host está quebrada na `main` e nenhum check obrigatório viu.

## O defeito

`.dockerignore` deixa `tests/` fora da imagem, de propósito. Mas 7 arquivos `*.test.ts` **colocados** (dentro de `app/`, `components/`, `lib/`) importam `@/tests/helpers/*` e `@/tests/support/*`. A partir do **next 16.3**, o `next build` typecheca esses colocados — e dentro da imagem os módulos não existem.

Causa estabelecida com **uma variável só**, mesma árvore, sem `tests/`:

| `next` | build |
|---|---|
| 16.2.12 | **exit 0** |
| 16.3.0 | **exit 1** — 7× `TS2307: Cannot find module '@/tests/...'` |

## O caminho errado que eu tentei primeiro

Manter `tests/helpers` no contexto do build. Passa do `TS2307` e cai no `TS2339` do jest-dom, cuja augmentação de tipos também mora em `tests/`. Perseguir os módulos um a um é perseguir o sintoma: **o build de produção não tem por que compilar teste.**

## O conserto

- `tsconfig.json` — o que o `next build` usa — exclui `**/*.test.ts(x)` e `tests/**`.
- `tsconfig.typecheck.json` (novo) reinclui tudo; `pnpm typecheck` aponta para ele.

A imagem fica hermética **sem perder um arquivo de cobertura de tipos**.

| experimento | esperado | medido |
|---|---|---|
| build sem `tests/` | verde | `exit 0`, 0 erros TS |
| erro de tipo em `tests/unit/rbac-matrix.test.ts` | vermelho | `exit 2` — `TS2322` |
| erro de tipo em `app/api/v1/system/version/route.test.ts` | vermelho | `exit 2` — `TS2322` |
| ambos restaurados | verde | `exit 0` |

Os dois do meio são o que separa isto de "apagar a guarda": os dois lados da fronteira continuam vigiados — o teste que mora em `tests/` e o colocado.

## A catraca (passe 11)

`publish-image.yml` rodava **só** em push na `main`, tag e release — nunca em `pull_request`. Nenhum PR conseguia revelar que quebrava a imagem, e foi exatamente assim que um bump de dependência passou por `verify`, `build-and-size`, `invariants` e `e2e` — **os quatro obrigatórios** — e derrubou o artefato que o cliente instala.

Agora o PR **constrói** a imagem (que é o gate) e **não publica**: `push: false` em `pull_request` e login no GHCR pulado. Fork não tem escrita no registry, e publicar imagem de código não revisado seria pior que não gatear.

**Falta um passo que é seu:** incluir `build-and-push` na branch protection da `main`. Sem isso o check existe e informa, mas não barra.
