### PR TITLE
fix(e2e): o harness passa a definir NEXT_PUBLIC_APP_URL na porta que ele mesmo serve

### DIFF
--- a/scripts/gerar-env-e2e.sh
+++ b/scripts/gerar-env-e2e.sh
@@ -76,6 +76,19 @@ case "$API_URL" in
     ;;
 esac
 
+# Mesmo default do `playwright.config.ts` (PORT = process.env.E2E_PORT ??
+# "3001"). NEXT_PUBLIC_APP_URL é uma NEXT_PUBLIC_* — o Next a embute no bundle
+# (server E client) em BUILD time, não runtime; por isso ela precisa entrar
+# aqui, no arquivo que `e2e-build.sh` exporta antes do `next build`, e não
+# bastaria setá-la só no `next start`. Sem isto, app/auth/confirm/route.ts
+# monta o redirect contra o default do schema (http://localhost:3000) — porta
+# onde não há NADA escutando durante o teste — e o browser, que SEMPRE segue
+# 3xx (diferente de `curl` sem `-L`), estoura ERR_CONNECTION_REFUSED em vez de
+# chegar em /login/reset ou /onboarding/welcome. Medido: as 3 specs do fluxo de
+# auth por e-mail (password-recovery, reset-password-mfa, signup-journey)
+# reprovam assim mesmo com token_hash válido — o defeito independe de PKCE.
+E2E_PORT="${E2E_PORT:-3001}"
+
 cat > .env.e2e <<EOF
 # ── Ambiente do E2E — LOCAL, nunca a nuvem ──────────────────────────────────
 # GERADO por 'pnpm e2e:env'. Não versionado (.gitignore cobre '.env*').
@@ -84,6 +97,9 @@ NEXT_PUBLIC_SUPABASE_URL=$API_URL
 NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON
 SUPABASE_SERVICE_ROLE_KEY=$SERVICE
 SUPABASE_DB_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+
+# Precisa bater com o baseURL real do Playwright (ver comentário acima).
+NEXT_PUBLIC_APP_URL=http://localhost:$E2E_PORT
 
 # Placeholders: 'next start' roda em NODE_ENV=production, e lib/env.ts exige
 # estas vars em produção. As specs não exercitam os serviços por trás delas.


### PR DESCRIPTION
A régua do e2e estava errada, e ela reprovou um PR de contribuidor por isso.

## O defeito

`scripts/gerar-env-e2e.sh` nunca escrevia `NEXT_PUBLIC_APP_URL` no `.env.e2e`. Como é uma `NEXT_PUBLIC_*`, o Next a **embute no bundle em build time** — então o valor que vale nas specs é o default do schema (`http://localhost:3000`), enquanto o `baseURL` do Playwright é `http://localhost:3001` (`playwright.config.ts`, `E2E_PORT ?? "3001"`).

Hoje isso não aparece porque `app/auth/confirm/route.ts` monta o redirect sobre `url.origin` e **acerta a porta por acidente**. Qualquer código que use a var declarada — que é o comportamento certo atrás de proxy — cai numa porta onde nada escuta.

O modo de falha engana: o browser do Playwright **sempre segue 3xx**, ao contrário de `curl` sem `-L`. Medido isoladamente, o `curl` devolve `307` com `location: http://localhost:3000/...` e parece saudável; o browser tenta conectar e estoura `ERR_CONNECTION_REFUSED`.

## Como apareceu

Triando o **#176** (@marketingcroma), que troca `url.origin` por `env.NEXT_PUBLIC_APP_URL` — conserto legítimo de um bug real (atrás do proxy do kit, `url.origin` resolve para o bind interno e o link de recuperação vai para `0.0.0.0:3000`).

As 3 specs do fluxo de auth por e-mail reprovaram, e a leitura fácil seria "o PR quebrou o login". Estava errada: a régua é que media o ambiente errado.

## Prova

`reset-password-mfa.spec.ts` é a spec limpa para isolar isto — ela gera o token por `admin.auth.admin.generateLink`, sem passar por template de e-mail:

| estado | resultado |
|---|---|
| sem esta linha | `ERR_CONNECTION_REFUSED` |
| com esta linha | `1 passed` |
| revertendo só este script + rebuild | `ERR_CONNECTION_REFUSED` de novo |

Previ 1 reprovação na sabotagem, medi 1.

## O que este PR **não** resolve

As outras duas specs (`password-recovery`, `signup-journey`) passam pelo template de e-mail e têm um **segundo** defeito, independente deste, que só se manifesta junto com o #176. Esse conserto vai na branch dele, porque só está correto lá — detalhado no #176.
