### PR TITLE
docs(triagem): a liberação do CI vira comando, e a imagem sai da lista de dívida

### DIFF
--- a/triagem/TRIAGEM.md
+++ b/triagem/TRIAGEM.md
@@ -40,7 +40,22 @@ O SHA curto da `main` entra em **toda** afirmação daí em diante. Número sem 
 
 Nesta ordem:
 
-1. Liberar o CI do fork (`gh pr checks`, e a aprovação de workflow se o PR for de primeira viagem).
+1. Liberar o CI do fork. **`gh pr checks` NÃO mostra workflow parado esperando aprovação** — ele
+   lista só o que já começou, então um PR travado aparece como se não tivesse check nenhum, e a
+   acolhida promete "acabei de liberar" sem ter liberado. A sonda que enxerga é o campo
+   `conclusion`, e o comando é este, sempre, antes de qualquer outra coisa:
+
+   ```bash
+   BR=$(gh pr view <n> --json headRefName --jq .headRefName)
+   for id in $(gh api repos/{owner}/{repo}/actions/runs \
+                 --jq "[.workflow_runs[] | select(.head_branch==\"$BR\" and .conclusion==\"action_required\")] | .[].id"); do
+     gh api -X POST "repos/{owner}/{repo}/actions/runs/$id/approve"
+   done
+   ```
+
+   Medido: o PR #176 ficou **6 dias** aberto e, quando a triagem chegou, os 4 workflows estavam em
+   `action_required` desde o primeiro push. A latência de 5h08min que este arquivo cita não é
+   lentidão de runner — é PR esperando um humano clicar.
 2. Aplicar `triagem:recebido` + as labels `area/*` derivadas do diff.
 3. Postar a acolhida — molde em `references/resposta-ao-contribuidor.md`, seção *Acolhida*.
 

--- a/triagem/references/complemento-do-ci.md
+++ b/triagem/references/complemento-do-ci.md
@@ -159,6 +159,27 @@ isso é bloqueador com explicação.
 
 ---
 
+## 9-bis. ~~A imagem Docker não tinha gate nenhum~~ — VIROU GATE (PR #233, 2026-08-12)
+
+**Saiu desta lista.** `publish-image.yml` roda agora em `pull_request` também: em PR ele CONSTRÓI a
+imagem (que é o gate) e não publica (`push: false`, login no GHCR pulado — fork não tem escrita no
+registry).
+
+Fica registrado como o buraco se manifestou, porque a forma é instrutiva: o workflow rodava só em
+push na `main`, em tag e em release. **Nenhum PR conseguia revelar que quebrava a imagem** — e o
+artefato que o self-hoster instala era o único sem gate. Um bump de `next` (16.2.12 → 16.3.0) passou
+por `verify`, `build-and-size`, `invariants` e `e2e` — os quatro obrigatórios — e derrubou o build do
+Dockerfile na `main`.
+
+A causa era fina: `.dockerignore` deixa `tests/` fora da imagem, e a partir do next 16.3 o
+`next build` typecheca os `*.test.ts` **colocados** (os que moram em `app/`, `components/`, `lib/`).
+Sete deles importam `@/tests/helpers/*`. Dentro da imagem, os módulos não existem.
+
+**Falta um passo do mantenedor:** incluir `build-and-push` na branch protection. Enquanto não
+estiver lá, o check informa mas não barra.
+
+---
+
 ## 10. O que TEM gate — não refaça
 
 Para não gastar passe à toa:
@@ -170,6 +191,9 @@ Para não gastar passe à toa:
 | baseline aplica fresh **e** idempotente | `pnpm test:db` (job `invariants`) |
 | isolamento RLS nas 10 tabelas listadas | `pnpm test:db` |
 | tipos, lint, unit, shell, build | job `verify` + `build-and-size` |
+| a imagem Docker do self-host constrói | job `build-and-push` (PR #233) — **ainda não obrigatório** |
+| link do e-mail de auth tem uma query só | `pnpm test:unit` → `link-de-email-tem-uma-query-so.test.ts` (PR #176) |
+| `viewer` barrado na rota de upload de mídia | `pnpm test:unit` → `rbac-matrix.test.ts` (PR #232) |
 
 ---
 


### PR DESCRIPTION
Duas correções na doutrina de triagem, vindas da rodada de hoje (#176, #211..#234).

## `gh pr checks` é a sonda errada para "o CI está liberado?"

Ele lista só o que já **começou**. Workflow parado em `action_required` não aparece — o PR parece não ter check nenhum, e a acolhida promete "acabei de liberar" sem ter liberado.

Aconteceu no **#176**: 6 dias aberto, os 4 workflows parados desde o primeiro push, e eu só percebi ao estranhar que o CI não subia depois de um sync.

O passe 1 **já mandava** liberar — não era lacuna de doutrina, era eu tendo pulado. O que faltava era o **comando**, porque a sonda óbvia é cega para exatamente este estado. Agora está escrito, e a régua é o campo `conclusion`, não a lista de checks.

Isto também explica a latência de 5h08min que o próprio arquivo cita como motivo de existir: não é lentidão de runner, é PR esperando um humano clicar.

## A imagem Docker sai da lista de dívida (passe 11)

`publish-image.yml` rodava só em push na `main`, tag e release. Nenhum PR conseguia revelar que quebrava a imagem — e o artefato que o self-hoster instala era o único sem gate. Um bump de `next` (16.2.12 → 16.3.0) passou por `verify`, `build-and-size`, `invariants` e `e2e`, os quatro obrigatórios, e derrubou o build do Dockerfile na `main`.

Consertado no #233. Vira item 9-bis do complemento, com o registro de como o buraco se manifestou.

Mais três linhas na tabela do "o que TEM gate": a imagem, o link do e-mail de auth (#176) e o `viewer` barrado na rota de mídia (#232).

**Esse é o passe 11 funcionando** — a lista de dívida do CI encolheu em vez de crescer, e a próxima triagem faz menos coisa à mão.
