### PR TITLE
Doutrina de packaging: o worker que nunca era atualizado

### DIFF
--- a/.env.hostgator.example
+++ b/.env.hostgator.example
@@ -17,23 +17,27 @@
 #   1.2.1    → uma release, para sempre. É o que uma instalação de verdade usa.
 #   stable   → a última release publicada (move a cada release)
 #   latest   → o TOPO DA MAIN. Apesar do nome, NÃO é a última release: é código
-#              ainda não lançado. Use só para avaliar o projeto.
+#              ainda não lançado. Use só para avaliar o projeto — nunca num
+#              servidor que atende cliente.
 #
 # pull_policy acompanha a tag: imutável usa `missing`, móvel usa `always`.
 # Não é preferência — foi medido que, com `always` e o registro sem responder
 # para aquela referência, o `up -d` FALHA e o contêiner não sobe, mesmo com a
 # imagem já no disco. Numa tag imutável isso só amarra a subida do seu CRM à
 # disponibilidade do GHCR.
-APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:latest   # troque pelo seu fork se publicar o seu
+# Os valores abaixo são o PISO seguro para quem preenche à mão (stable = a
+# última release). O install.sh sobrescreve com o NÚMERO da versão, que é o que
+# uma instalação de verdade usa — ver a regra de ouro na doutrina.
+APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:stable   # troque pelo seu fork se publicar o seu
 APP_PULL_POLICY=always
 
 # O worker (agente de IA 24/7) e o scheduler (crons) acompanham a versão do app.
 # Até 2026-08-13 eles não tinham imagem: eram compilados na sua VPS no install e
 # nenhum update.sh jamais os reconstruía — o agente ficava congelado no código
 # do dia da instalação. Deixe-os na mesma versão do APP_IMAGE acima.
-WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:latest
+WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:stable
 WORKER_PULL_POLICY=always
-SCHEDULER_IMAGE=ghcr.io/melgarafael/deskcomm-scheduler:latest
+SCHEDULER_IMAGE=ghcr.io/melgarafael/deskcomm-scheduler:stable
 SCHEDULER_PULL_POLICY=always
 
 # -----------------------------------------------------------------------------

--- a/.env.hostgator.example
+++ b/.env.hostgator.example
@@ -8,10 +8,33 @@
 # =============================================================================
 
 # -----------------------------------------------------------------------------
-# 0) IMAGEM DO APP (imagem genérica pré-buildada — o leigo só puxa, não builda)
+# 0) AS TRÊS IMAGENS (genéricas e pré-buildadas — o leigo só puxa, não builda)
 # -----------------------------------------------------------------------------
+# O install.sh preenche isto com a ÚLTIMA VERSÃO PUBLICADA, não com um canal
+# móvel, e as três sempre na MESMA versão. Regra em docs/doctrine/packaging.md.
+#
+# Sobre as tags:
+#   1.2.1    → uma release, para sempre. É o que uma instalação de verdade usa.
+#   stable   → a última release publicada (move a cada release)
+#   latest   → o TOPO DA MAIN. Apesar do nome, NÃO é a última release: é código
+#              ainda não lançado. Use só para avaliar o projeto.
+#
+# pull_policy acompanha a tag: imutável usa `missing`, móvel usa `always`.
+# Não é preferência — foi medido que, com `always` e o registro sem responder
+# para aquela referência, o `up -d` FALHA e o contêiner não sobe, mesmo com a
+# imagem já no disco. Numa tag imutável isso só amarra a subida do seu CRM à
+# disponibilidade do GHCR.
 APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:latest   # troque pelo seu fork se publicar o seu
 APP_PULL_POLICY=always
+
+# O worker (agente de IA 24/7) e o scheduler (crons) acompanham a versão do app.
+# Até 2026-08-13 eles não tinham imagem: eram compilados na sua VPS no install e
+# nenhum update.sh jamais os reconstruía — o agente ficava congelado no código
+# do dia da instalação. Deixe-os na mesma versão do APP_IMAGE acima.
+WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:latest
+WORKER_PULL_POLICY=always
+SCHEDULER_IMAGE=ghcr.io/melgarafael/deskcomm-scheduler:latest
+SCHEDULER_PULL_POLICY=always
 
 # -----------------------------------------------------------------------------
 # 1) DOMÍNIO / HTTPS (você define; aponte o A-record deste domínio pro IP do VPS)

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -97,10 +97,15 @@ jobs:
             # quem quer "a última versão estável" pedia `latest` e recebia edge.
             # Trocar o significado de `latest` faria downgrade silencioso em quem
             # já o consome, então o canal novo é o que ganha o nome certo.
-            # Restrito a tag `v*`: `ref_type == 'tag'` sozinho deixaria um
-            # workflow_dispatch numa tag qualquer (ou uma tag de teste) mover o
-            # canal que os implementadores usam para decidir o que instalar.
-            type=raw,value=stable,enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
+            # Três condições, e cada uma barra um caminho medido. `ref_type ==
+            # 'tag'` sozinho deixaria um dispatch numa branch mover o canal;
+            # `startsWith(…, 'v')` barra tag de teste (o registry já tem uma
+            # `quebrada-teste`, que nenhum push na main consegue produzir);
+            # e `event_name == 'push'` barra o pior caso — um dispatch numa
+            # release ANTIGA faria `stable` REGREDIR, e todo self-hoster no
+            # default do compose sofreria downgrade silencioso no próximo
+            # `up -d`, com app velho sobre banco já migrado.
+            type=raw,value=stable,enable=${{ github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
           labels: |
             org.opencontainers.image.title=${{ matrix.title }}
 

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,8 +1,15 @@
 name: Publicar imagem Docker (GHCR)
 
-# Builda a imagem GENÉRICA do app e publica no GitHub Container Registry.
-# O leigo puxa essa imagem no VPS (não builda lá). Roda nos runners do GitHub,
-# então o build pesado (~6min) nunca cai no VPS do usuário.
+# Builda as imagens GENÉRICAS que o self-hoster instala e publica no GitHub
+# Container Registry. O leigo puxa no VPS (não builda lá). Roda nos runners do
+# GitHub, então o build pesado nunca cai no VPS do usuário.
+#
+# São TRÊS imagens, e a razão de o worker e o scheduler estarem aqui é um defeito
+# real: o serviço `worker` não tinha `image:` no compose de produção, só `build:`.
+# Serviço build-only é pulado por `docker compose pull` e imune a `up -d` sem
+# `--build` — ele era construído na VPS de cada cliente, no install, e NENHUM
+# update.sh jamais o reconstruiu. O runtime do agente de IA congelava no código
+# do dia da instalação. Doutrina: docs/doctrine/packaging.md, invariante 1.
 
 on:
   push:
@@ -22,7 +29,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
@@ -30,6 +36,24 @@ jobs:
     permissions:
       contents: read
       packages: write
+
+    strategy:
+      # fail-fast desligado: se o worker quebrar, ainda quero saber se o app
+      # também quebrou. Com ele ligado, o primeiro erro esconde os outros dois e
+      # o conserto vira uma rodada por imagem.
+      fail-fast: false
+      matrix:
+        include:
+          - name: deskcommcrm
+            dockerfile: Dockerfile
+            title: DeskcommCRM
+          - name: deskcomm-worker
+            dockerfile: Dockerfile.worker
+            title: DeskcommCRM worker
+          - name: deskcomm-scheduler
+            dockerfile: Dockerfile.scheduler
+            title: DeskcommCRM scheduler
+
     steps:
       - uses: actions/checkout@v7
 
@@ -41,16 +65,36 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # A versão que a imagem vai reportar em /api/v1/health. Numa tag v1.2.3 é
+      # "1.2.3"; fora de tag, o SHA curto — que ainda responde "o que está
+      # rodando aqui?", que é a pergunta que o campo existe para responder.
+      - name: Resolver APP_VERSION
+        id: ver
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Docker metadata (tags/labels)
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.name }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
+            # `stable` = a última RELEASE publicada. Existe porque `latest` aqui
+            # significa topo da `main` (código não lançado), e o nome engana:
+            # quem quer "a última versão estável" pedia `latest` e recebia edge.
+            # Trocar o significado de `latest` faria downgrade silencioso em quem
+            # já o consome, então o canal novo é o que ganha o nome certo.
+            type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.title }}
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v4
@@ -59,6 +103,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          file: ${{ matrix.dockerfile }}
           # linux/amd64: o VPS HostGator e a imagem do WAHA são amd64.
           platforms: linux/amd64
           # PR de fork não tem permissão de escrita no GHCR, e publicar imagem
@@ -67,7 +112,25 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          build-args: |
+            APP_VERSION=${{ steps.ver.outputs.value }}
+          # Cache por imagem: as três têm camadas diferentes e um escopo único
+          # faria uma sobrescrever o cache da outra a cada run.
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
           # Sem build-args de segredo: a imagem é genérica (NEXT_PUBLIC_* viram
           # placeholder; valores reais entram em runtime no VPS do usuário).
+
+  # Job de fachada: dá UM nome estável para a branch protection exigir. Sem ele,
+  # o required check teria que listar as três instâncias da matriz pelo nome
+  # gerado, e acrescentar uma quarta imagem um dia quebraria o gate em silêncio —
+  # o merge voltaria a passar sem que ninguém tivesse decidido isso.
+  imagens-ok:
+    if: always()
+    runs-on: ubuntu-latest
+    needs: [build-and-push]
+    steps:
+      - name: Falhar se qualquer imagem não construiu
+        run: |
+          echo "resultado do build-and-push: ${{ needs.build-and-push.result }}"
+          [ "${{ needs.build-and-push.result }}" = "success" ]

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -86,13 +86,21 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            # `enable={{is_default_branch}}` NÃO basta: o metadata-action o
+            # considera verdadeiro também num push de TAG, então toda release
+            # movia `latest` junto. Isso apagava a distinção que a doutrina
+            # inteira depende — `latest` = topo da main, `stable` = última
+            # release — e fazia `latest` oscilar entre os dois.
+            type=raw,value=latest,enable=${{ github.ref_type == 'branch' && github.ref_name == 'main' }}
             # `stable` = a última RELEASE publicada. Existe porque `latest` aqui
             # significa topo da `main` (código não lançado), e o nome engana:
             # quem quer "a última versão estável" pedia `latest` e recebia edge.
             # Trocar o significado de `latest` faria downgrade silencioso em quem
             # já o consome, então o canal novo é o que ganha o nome certo.
-            type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
+            # Restrito a tag `v*`: `ref_type == 'tag'` sozinho deixaria um
+            # workflow_dispatch numa tag qualquer (ou uma tag de teste) mover o
+            # canal que os implementadores usam para decidir o que instalar.
+            type=raw,value=stable,enable=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
           labels: |
             org.opencontainers.image.title=${{ matrix.title }}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,11 +164,28 @@ o summary do job. Se você mexeu em UI fora desse subconjunto, a prova é sua.
   higieniza — não confie nele como única camada.
 - Não commite screenshot/dump com dado real de cliente.
 
+## Packaging — se você tocou `Dockerfile*`, `docker-compose*.yml` ou `hostgator-setup-kit/`
+
+Lei completa em [`docs/doctrine/packaging.md`](docs/doctrine/packaging.md). O não-negociável:
+
+- **Nenhum serviço de `docker-compose.prod.yml` constrói na máquina do cliente.** Todo serviço
+  declara `image:` de uma imagem publicada; `build:` só existe **ao lado**, como escape.
+  Serviço `build:`-only é pulado por `docker compose pull` e imune a `up -d` sem `--build` —
+  ele não é só caro de instalar, ele **nunca é atualizado**.
+- **Publicação é ato do CI**, nunca da sua máquina: build ARM local não roda na VPS amd64.
+- **Instalação de cliente aponta para número de versão**, nunca para tag móvel. Aqui `latest`
+  significa **topo da `main`**, não última release — quem quer a última release usa `stable`.
+- **Dependência upstream é referenciada com tag fixa, nunca republicada** (WAHA é licenciado).
+- **Bump de versão não pode exigir que o operador da VPS edite arquivo à mão.**
+
+`pnpm test:shell` é o único gate que exercita o kit. Rode-o.
+
 ## Critério de conclusão
 
 Vale a **Definition of Done de 15 itens em [`CLAUDE.md`](CLAUDE.md)**. Não declare pronto
 sem: typecheck/lint zerados, testes relevantes verdes, RLS testada se tocou tabela
-tenant-aware, migration + baseline + MANIFEST se mudou schema, e prova visual se mudou UI.
+tenant-aware, migration + baseline + MANIFEST se mudou schema, prova visual se mudou UI, e a
+regra de packaging acima se mudou o artefato que o self-hoster instala.
 
 ## Regra final — não invente
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ o summary do job. Se você mexeu em UI fora desse subconjunto, a prova é sua.
 
 ## Critério de conclusão
 
-Vale a **Definition of Done de 13 itens em [`CLAUDE.md`](CLAUDE.md)**. Não declare pronto
+Vale a **Definition of Done de 15 itens em [`CLAUDE.md`](CLAUDE.md)**. Não declare pronto
 sem: typecheck/lint zerados, testes relevantes verdes, RLS testada se tocou tabela
 tenant-aware, migration + baseline + MANIFEST se mudou schema, e prova visual se mudou UI.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Se você roda o DeskcommCRM numa VPS, **leia a seção da versão para a qual es
 
 ## [Não lançado]
 
+Esta versão mexe em como o sistema **chega e se atualiza** no seu servidor. Em uso, três
+coisas mudam para melhor: a instalação deixa de ter uma etapa que podia falhar por falta de
+memória no meio (o servidor não compila mais nada — tudo vem pronto), sobra folga de memória
+para o que importa de verdade na operação (WhatsApp, mídia, mais atendimentos na mesma
+máquina), e a instalação fica bem mais rápida. A recomendação de servidor **continua a
+mesma**: o que consome memória é operar o sistema no dia a dia — 7 serviços e cerca de 150 MB
+por número de WhatsApp conectado —, e isso não mudou.
+
 ### Corrigido
 
 - **O agente de IA nunca recebia atualização.** O worker — o processo que faz o agente

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ Se você roda o DeskcommCRM numa VPS, **leia a seção da versão para a qual es
 
 ## [Não lançado]
 
+### Corrigido
+
+- **O agente de IA nunca recebia atualização.** O worker — o processo que faz o agente
+  atender 24 horas por dia — era compilado dentro do seu servidor no dia da instalação, e
+  nenhuma atualização o reconstruía. Na prática: você atualizava o CRM, o site mudava, e o
+  agente continuava rodando exatamente o código do dia em que você instalou, para sempre.
+  Correções e melhorias do agente não chegavam. Agora ele é uma imagem pronta, publicada
+  junto com o resto, e o `update.sh` a traz como traz o app.
+- **Duas instalações "na mesma versão" rodavam código diferente.** Uma instalação nova ficava
+  apontada para o canal `latest`, que — apesar do nome — acompanha o desenvolvimento em
+  andamento, não a última versão lançada. Quem instalou em semanas diferentes tinha software
+  diferente, e não havia como dizer qual. Agora o instalador grava o **número da versão**
+  (ex.: `1.2.1`), e é essa versão que fica no seu servidor até você decidir atualizar.
+- **O CRM podia não subir por causa de um serviço externo fora do ar.** A configuração pedia
+  ao Docker que verificasse o registro de imagens a cada subida; se ele não respondesse, o
+  contêiner não subia — mesmo com a imagem já baixada no seu disco. Como a versão agora é
+  fixa, essa verificação deixou de ser necessária e saiu.
+- **O agendador de tarefas dependia da internet para voltar.** A cada reinício ele baixava
+  dois programas antes de começar. Sem internet no momento do reboot — justo quando a máquina
+  está se recuperando de alguma coisa —, as tarefas automáticas não voltavam. Agora já vêm
+  dentro da imagem.
+- **A versão mostrada em `/api/v1/health` era sempre `0.1.0`**, em qualquer instalação. Agora
+  é a versão de verdade.
+- O WhatsApp (WAHA) e o serviço de limites deixaram de acompanhar automaticamente qualquer
+  versão nova publicada por terceiros. Passam a mudar só quando nós testamos e lançamos.
+
+Nenhuma dessas correções exige ação sua além de rodar o `update.sh` de sempre. Um `.env`
+antigo continua funcionando: as configurações novas têm valor padrão e o próprio `update.sh`
+as acrescenta.
+
 ## [1.2.1] — 2026-08-12
 
 **Versão de segurança. Se você roda o DeskcommCRM numa VPS, atualize.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,10 @@ Se você roda o DeskcommCRM numa VPS, **leia a seção da versão para a qual es
 
 Esta versão mexe em como o sistema **chega e se atualiza** no seu servidor. Em uso, três
 coisas mudam para melhor: a instalação deixa de ter uma etapa que podia falhar por falta de
-memória no meio (o servidor não compila mais nada — tudo vem pronto), sobra folga de memória
-para o que importa de verdade na operação (WhatsApp, mídia, mais atendimentos na mesma
-máquina), e a instalação fica bem mais rápida. A recomendação de servidor **continua a
-mesma**: o que consome memória é operar o sistema no dia a dia — 7 serviços e cerca de 150 MB
-por número de WhatsApp conectado —, e isso não mudou.
+memória no meio (o servidor não compila mais nada — tudo vem pronto), fica bem mais rápida, e
+o agente de IA passa a receber as correções de cada versão. A recomendação de servidor
+**continua exatamente a mesma**: o que consome memória é operar o sistema no dia a dia — 7
+serviços e cerca de 150 MB por número de WhatsApp conectado —, e isso não mudou nem um pouco.
 
 ### Corrigido
 
@@ -31,8 +30,9 @@ por número de WhatsApp conectado —, e isso não mudou.
   (ex.: `1.2.1`), e é essa versão que fica no seu servidor até você decidir atualizar.
 - **O CRM podia não subir por causa de um serviço externo fora do ar.** A configuração pedia
   ao Docker que verificasse o registro de imagens a cada subida; se ele não respondesse, o
-  contêiner não subia — mesmo com a imagem já baixada no seu disco. Como a versão agora é
-  fixa, essa verificação deixou de ser necessária e saiu.
+  contêiner não subia — mesmo com a imagem já baixada no seu disco. Agora que o seu servidor
+  fica numa versão fixa, essa verificação deixa de ser feita **na sua instalação** (quem
+  acompanha um canal móvel continua com ela, que é onde ela serve para alguma coisa).
 - **O agendador de tarefas dependia da internet para voltar.** A cada reinício ele baixava
   dois programas antes de começar. Sem internet no momento do reboot — justo quando a máquina
   está se recuperando de alguma coisa —, as tarefas automáticas não voltavam. Agora já vêm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 **Este arquivo é a doutrina — a autoridade final sobre convenção e anti-pattern.** Complementos, na ordem em que ajudam:
 
 - [`AGENTS.md`](AGENTS.md) — mesmo contrato em forma portável (para Codex/Cursor/Copilot e afins). É derivado deste arquivo, não o substitui. **Ao mudar doutrina aqui, verifique se `AGENTS.md` desatualizou.**
-- [`docs/index.md`](docs/index.md) — índice dos 123 docs, com regra de precedência quando dois docs discordam. Use antes de sair varrendo `docs/`.
+- [`docs/index.md`](docs/index.md) — índice dos 149 docs, com regra de precedência quando dois docs discordam. Use antes de sair varrendo `docs/`.
 - [`docs/current-state.md`](docs/current-state.md) — o que está pronto, incompleto e quebrado. **Leia antes de estimar ou prometer qualquer coisa.**
 - [`docs/harness-audit.md`](docs/harness-audit.md) — onde a verificação tem buraco. Importante: `pnpm gov:verify` **não** cobre `test:db` nem `test:e2e` — verde ali não é prova para mudança de schema ou de UI.
 - [`docs/threat-model.md`](docs/threat-model.md) — superfície de ataque real do self-host.
@@ -178,6 +178,41 @@ O caminho normal **não constrói nada na VPS**: commit → push → PR → merg
 de emergência e é dívida: existe só naquele disco e qualquer `up -d` sem
 `APP_PULL_POLICY=never` a substitui em silêncio.
 
+Essa frase já foi meia-verdade: valia para o `app` e era falsa para o produto,
+porque o serviço `worker` não tinha `image:` — era construído na VPS de todo
+cliente e nunca reconstruído por nenhum `update.sh`. Hoje os três serviços
+nossos (`app`, `worker`, `scheduler`) são imagens publicadas, e um teste
+reprova o retorno do padrão. Ver a doutrina abaixo.
+
+---
+
+## Packaging e distribuição — DOUTRINA (NÃO NEGOCIÁVEL)
+
+Lei completa em [`docs/doctrine/packaging.md`](docs/doctrine/packaging.md);
+decisões estruturais e o que foi recusado em
+[`docs/adr/0001-packaging-e-distribuicao.md`](docs/adr/0001-packaging-e-distribuicao.md).
+O não-negociável, em quatro linhas:
+
+1. **Nenhum serviço de `docker-compose.prod.yml` constrói na máquina do
+   cliente.** Todo serviço declara `image:` de uma imagem publicada; `build:`
+   só existe **ao lado**, como escape. Serviço `build:`-only é invisível para
+   `docker compose pull` e imune a `up -d` sem `--build` — ele não é só caro de
+   instalar, ele **nunca é atualizado**.
+2. **Publicação é ato do CI.** Nunca da sua máquina: build ARM local não roda
+   na VPS amd64 do cliente, e a falha só aparece no `up -d` dele. `build-and-push`
+   é status check obrigatório.
+3. **Instalação de cliente aponta para número de versão, nunca para tag móvel.**
+   `latest` aqui significa **topo da `main`**, não última release — quem quer a
+   última release usa `stable`. `pull_policy` acompanha a mutabilidade da tag:
+   imutável → `missing`, móvel → `always`.
+4. **Dependência upstream é referenciada com tag fixa, nunca republicada.**
+   Vale para WAHA (licenciado — republicar é passivo jurídico), Redis, Caddy e
+   `serverless-redis-http`.
+
+Bump de versão **não pode** exigir que o operador da VPS edite `.env`, compose
+ou qualquer arquivo à mão. Se exigir, não entra: vira issue com plano de
+migração e vai para uma major.
+
 ---
 
 ## Como rodar local
@@ -323,5 +358,6 @@ Antes de declarar uma task pronta:
 12. **Se tocou UI/fluxo de usuário: provado pela tela como um leigo faria**, em ambiente fresco estilo VPS, com evidência visual (ver Doutrina de QA Visual com Recursos Reais) — curl não conta
 13. **Living System Checklist respondido** (lei em `docs/doctrine/sistema-vivo.md`; racional no manual `docs/doctrine/sistema-vivo/`) — a feature não é ilha: tem entrada + saída, emite atividade/log, aparece na tela, tem porta na navegação, tem mecanismo anti-morte, **declara seu laço de retorno** (invariante 7 — o que muda no sistema quando ela erra), e o mapa vivo (`docs/architecture/`) reflete peça nova com ≥2 arestas. Resposta que não **nomeia o artefato concreto** (consumidor real, tela real, log real) não conta
 14. **Tela nova tem porta** — declarada em `lib/navigation/registry.ts` com seu grupo, ou na allowlist de `tests/unit/navegacao-completude.test.ts` **com justificativa escrita**. Ter tela e ser alcançável são coisas diferentes: o CI reprova tela que existe mas em que só se chega digitando a URL
+15. **Se tocou Dockerfile, compose ou setup kit: a mudança chega a quem já instalou** (lei em `docs/doctrine/packaging.md`) — nenhum serviço de produção ficou `build:`-only; variável nova tem default que não quebra `.env` antigo; a atualização não pede edição manual de arquivo; e, se mudou o que a imagem contém, o `update.sh` alcança essa peça. Rode `pnpm test:shell` — é o único gate que exercita o kit
 
 Um staff engineer aprovaria? Se não, itera.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,8 +199,12 @@ O não-negociável, em quatro linhas:
    `docker compose pull` e imune a `up -d` sem `--build` — ele não é só caro de
    instalar, ele **nunca é atualizado**.
 2. **Publicação é ato do CI.** Nunca da sua máquina: build ARM local não roda
-   na VPS amd64 do cliente, e a falha só aparece no `up -d` dele. `build-and-push`
-   é status check obrigatório.
+   na VPS amd64 do cliente, e a falha só aparece no `up -d` dele. O job
+   `imagens-ok` reprova quando qualquer uma das três imagens não constrói —
+   mas **ainda não é status check obrigatório** (a branch protection tem
+   `verify, build-and-size, invariants, e2e`). Ativá-lo é o passo final do
+   merge desta doutrina: um required check ausente na base dos PRs abertos
+   travaria todos eles. Confira na fonte antes de confiar nesta linha.
 3. **Instalação de cliente aponta para número de versão, nunca para tag móvel.**
    `latest` aqui significa **topo da `main`**, não última release — quem quer a
    última release usa `stable`. `pull_policy` acompanha a mutabilidade da tag:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,12 +67,25 @@ Ao finalizar um epic:
    - Mudança de schema saiu como **tripla**: arquivo em `supabase/migrations/`, apêndice idempotente
      no `supabase/baseline.sql` e linha no `MANIFEST.md`. O kit self-host aplica **só o baseline** —
      migration que não chega lá não chega em quem instalou numa VPS. Nenhum job de CI confere isso
+   - **Se você tocou `Dockerfile*`, `docker-compose*.yml` ou `hostgator-setup-kit/`:** a mudança
+     alcança quem **já** instalou. Lei em [`docs/doctrine/packaging.md`](docs/doctrine/packaging.md).
+     O CI reprova o essencial (serviço `build:`-only, imagem quebrada, instalação em tag móvel);
+     o que fica com você é o resto: variável nova com default que não quebre `.env` antigo, e a
+     atualização não pedindo edição manual de arquivo. **Nenhum bump pode exigir que o operador
+     da VPS edite alguma coisa na mão** — se exigir, abra issue com plano de migração em vez de PR
    - Docs atualizadas se mudou contrato (PRD/spec)
    - `pnpm test:e2e` (subset relevante) — **opcional se você contribui de fora**, ver abaixo
 4. Abrir PR contra `main`. Description deve referenciar o epic e listar evidências (logs/screenshots dos testes).
-5. CI deve passar antes de merge. Obrigatórios: `verify`, `invariants` (isolamento RLS) e `build-and-size`.
-   O job `e2e` roda e é **não-bloqueante de propósito** — ele mesmo imprime, no resumo, quais specs
-   não cobriu. Verde nele não é "jornada provada".
+5. CI deve passar antes de merge. Obrigatórios: `verify`, `invariants` (isolamento RLS),
+   `build-and-size`, `e2e` e `build-and-push` (a imagem que o self-hoster instala).
+
+   Verde no `e2e` **não** é "jornada provada": ele mesmo imprime, no resumo, quais specs não
+   cobriu — e a que fica de fora é justamente `vps-fresh-onboarding`, a instalação do zero.
+
+   > Esta lista dizia "três obrigatórios" e chamava o `e2e` de não-bloqueante. Estava
+   > desatualizada nos dois pontos, e quem a usasse como régua mediria contra a régua errada.
+   > Confira na fonte antes de confiar em qualquer lista escrita:
+   > `gh api repos/melgarafael/DeskcommCRM/branches/main/protection --jq '.required_status_checks.contexts'`
 
 ### Pegando uma issue — o protocolo
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Ao finalizar um epic:
      migration que não chega lá não chega em quem instalou numa VPS. Nenhum job de CI confere isso
    - **Se você tocou `Dockerfile*`, `docker-compose*.yml` ou `hostgator-setup-kit/`:** a mudança
      alcança quem **já** instalou. Lei em [`docs/doctrine/packaging.md`](docs/doctrine/packaging.md).
-     O CI reprova o essencial (serviço `build:`-only, imagem quebrada, instalação em tag móvel);
+     O CI reprova serviço `build:`-only e instalação em tag móvel (imagem quebrada ainda não bloqueia merge);
      o que fica com você é o resto: variável nova com default que não quebre `.env` antigo, e a
      atualização não pedindo edição manual de arquivo. **Nenhum bump pode exigir que o operador
      da VPS edite alguma coisa na mão** — se exigir, abra issue com plano de migração em vez de PR
@@ -77,7 +77,10 @@ Ao finalizar um epic:
    - `pnpm test:e2e` (subset relevante) — **opcional se você contribui de fora**, ver abaixo
 4. Abrir PR contra `main`. Description deve referenciar o epic e listar evidências (logs/screenshots dos testes).
 5. CI deve passar antes de merge. Obrigatórios: `verify`, `invariants` (isolamento RLS),
-   `build-and-size`, `e2e` e `build-and-push` (a imagem que o self-hoster instala).
+   `build-and-size` e `e2e`.
+
+   O job `imagens-ok` (constrói as três imagens que o self-hoster instala) roda em PR e
+   **ainda não bloqueia** — a ativação depende de um passo de administração do repositório.
 
    Verde no `e2e` **não** é "jornada provada": ele mesmo imprime, no resumo, quais specs não
    cobriu — e a que fica de fora é justamente `vps-fresh-onboarding`, a instalação do zero.

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,11 @@ ARG NEXT_PUBLIC_SUPABASE_URL=https://placeholder.supabase.co
 ARG NEXT_PUBLIC_SUPABASE_ANON_KEY=placeholder-anon-key
 ARG NEXT_PUBLIC_APP_URL=https://placeholder.invalid
 ARG NEXT_PUBLIC_ADMIN_URL=https://placeholder.invalid
-# O build do Next (webpack + Sentry) é faminto: o heap default do Node (~2GB)
-# estoura. NODE_OPTIONS eleva pra 4GB → requer VPS com >=4GB RAM (ou swap).
-# O install.sh checa RAM/swap antes de buildar.
+# O build do Next é faminto: o heap default do Node (~2GB) estoura. NODE_OPTIONS
+# eleva pra 4GB. Isso é custo de QUEM BUILDA — o CI —, não de quem instala: o
+# caminho normal do self-hoster é `docker compose pull`, e o install.sh não
+# builda o app. Buildar na VPS é o override opcional de docker-compose.build.yml,
+# e é lá que o requisito de RAM de build se aplica (docs/runbooks/deploy.md §4).
 ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL \
     NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY \
     NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL \
@@ -45,10 +47,25 @@ RUN pnpm build
 # ---- runner: imagem slim de produção ----
 FROM node:22-alpine AS runner
 WORKDIR /app
+
+# Procedência (doutrina de packaging, invariante 2). O CI já injeta os labels
+# OCI via docker/metadata-action; estes aqui são defesa em profundidade — valem
+# para qualquer build, inclusive o local de docker-compose.build.yml, que não
+# passa pelo metadata-action e sem isto sairia sem origem nenhuma.
+LABEL org.opencontainers.image.source="https://github.com/melgarafael/DeskcommCRM" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.title="DeskcommCRM"
+
+# A versão que /api/v1/health reporta (invariante 7). Precisa vir por ARG: a
+# alternativa anterior era `process.env.npm_package_version`, que é `undefined`
+# sob `CMD ["node","server.js"]` — só existe quando o processo nasce de um
+# `npm`/`pnpm run`. Toda instalação do mundo reportava o fallback "0.1.0".
+ARG APP_VERSION=dev
 ENV NODE_ENV=production \
     PORT=3000 \
     HOSTNAME=0.0.0.0 \
-    NEXT_TELEMETRY_DISABLED=1
+    NEXT_TELEMETRY_DISABLED=1 \
+    APP_VERSION=$APP_VERSION
 # ffmpeg: a derivação de vídeo (Onda 3.1) roda no processo do app — o cron
 # event-log-drain executa o media_derive handler, que chama `ffmpeg` via spawn
 # pra extrair áudio+frames. Sem o binário, todo vídeo recebido falha a derivação.

--- a/Dockerfile.scheduler
+++ b/Dockerfile.scheduler
@@ -1,0 +1,28 @@
+# Scheduler dos crons — busybox crond batendo nas rotas /api/v1/cron/* pela rede
+# interna do compose. Sem docker.sock: o contêiner não fala com o daemon, só HTTP.
+#
+# Existe como imagem (em vez de `alpine:3.20` + `apk add` no command do compose)
+# porque instalar pacote em todo start amarra a recuperação do cron do cliente à
+# internet da VPS e ao mirror do Alpine — dependência de rede num caminho que
+# deveria ser offline. Doutrina: docs/doctrine/packaging.md, invariante 1.
+FROM alpine:3.20
+
+LABEL org.opencontainers.image.source="https://github.com/melgarafael/DeskcommCRM" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.title="DeskcommCRM scheduler"
+
+ARG APP_VERSION=dev
+ENV APP_VERSION=$APP_VERSION \
+    TZ=UTC
+
+RUN apk add --no-cache curl tzdata
+
+COPY docker/scheduler/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Prova de vida: se o crond morrer, o contêiner cai e o `restart: unless-stopped`
+# o traz de volta. Sem isto, um crond morto fica indistinguível de um cron ocioso.
+HEALTHCHECK --interval=60s --timeout=5s --start-period=10s --retries=3 \
+  CMD pgrep crond >/dev/null || exit 1
+
+CMD ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -4,6 +4,14 @@
 FROM node:22-alpine
 
 WORKDIR /app
+
+# Procedência (doutrina de packaging, invariante 2).
+LABEL org.opencontainers.image.source="https://github.com/melgarafael/DeskcommCRM" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.title="DeskcommCRM worker"
+
+ARG APP_VERSION=dev
+ENV APP_VERSION=$APP_VERSION
 # pnpm fixado na versão do lockfile do repo (pnpm 10 bloquearia build scripts).
 RUN corepack enable && corepack prepare pnpm@9.15.9 --activate
 

--- a/app/api/v1/health/route.ts
+++ b/app/api/v1/health/route.ts
@@ -224,7 +224,16 @@ export async function GET(req: NextRequest) {
     {
       data: {
         status,
-        version: process.env.npm_package_version ?? "0.1.0",
+        // APP_VERSION é injetada no build da imagem (ARG no Dockerfile) e vale
+        // "1.2.3" numa release, ou o SHA curto fora de tag.
+        //
+        // Antes isto era `process.env.npm_package_version ?? "0.1.0"`, e a
+        // variável só existe quando o processo nasce de um `npm`/`pnpm run`. O
+        // CMD da imagem é `node server.js`: TODA instalação do mundo reportava
+        // "0.1.0". Um campo que responde o valor errado com confiança é pior que
+        // um campo ausente — ele desliga a pergunta em vez de deixá-la aberta.
+        // Por isso o fallback agora é "desconhecido", e não um número plausível.
+        version: process.env.APP_VERSION || "desconhecido",
         timestamp: new Date().toISOString(),
         checks,
       },

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -10,7 +10,31 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      # Sem args: a imagem é genérica (NEXT_PUBLIC_* viram placeholder no build
-      # e os valores reais entram em runtime via env_file).
+      # Sem args de segredo: a imagem é genérica (NEXT_PUBLIC_* viram placeholder
+      # no build e os valores reais entram em runtime via env_file). APP_VERSION
+      # não é segredo — é o que /api/v1/health responde, e sem ele a imagem
+      # local diria "desconhecido", que é a resposta certa para uma imagem que
+      # não veio de release nenhuma.
+      args:
+        APP_VERSION: ${APP_VERSION:-local}
     image: ${APP_IMAGE:-deskcomm-app:local}
+    pull_policy: never
+
+  # O worker e o scheduler já têm `build:` no compose de produção (é o escape
+  # que mantém a mudança aditiva). O que este override acrescenta é o
+  # `pull_policy: never`: sem ele, um `up -d` iria ao registry e substituiria a
+  # imagem local em silêncio — o mesmo modo de falha que o runbook descreve
+  # para o app, e que já mordeu uma vez.
+  worker:
+    build:
+      args:
+        APP_VERSION: ${APP_VERSION:-local}
+    image: ${WORKER_IMAGE:-deskcomm-worker:local}
+    pull_policy: never
+
+  scheduler:
+    build:
+      args:
+        APP_VERSION: ${APP_VERSION:-local}
+    image: ${SCHEDULER_IMAGE:-deskcomm-scheduler:local}
     pull_policy: never

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -75,7 +75,17 @@ services:
     # usa a imagem quando ela existe e CONSTRÓI quando não existe (medido). É o
     # que mantém a mudança aditiva — registry fora do ar, ou versão anterior à
     # primeira publicação, caem no comportamento antigo em vez de quebrar.
-    image: ${WORKER_IMAGE:-ghcr.io/melgarafael/deskcomm-worker:latest}
+    #
+    # O default é `:stable` (a última RELEASE), não `:latest`, e a diferença é
+    # concreta para o parque instalado. Numa VPS que atualiza pela primeira vez
+    # depois desta mudança, quem executa é o `update.sh` VELHO — o que está no
+    # disco —, e ele só sabe gravar APP_IMAGE. O `git checkout` da tag já trocou
+    # ESTE arquivo, então worker e scheduler caem no default daqui. Com
+    # `:latest`, esse default seria o TOPO DA MAIN (`enable={{is_default_branch}}`
+    # no publish-image.yml): o app pinado numa release e o runtime do agente de
+    # IA rodando código não lançado, sobre o banco da release. `:stable` é a
+    # última release publicada — pareia com o app em vez de correr na frente.
+    image: ${WORKER_IMAGE:-ghcr.io/melgarafael/deskcomm-worker:stable}
     pull_policy: ${WORKER_PULL_POLICY:-always}
     build:
       context: .
@@ -179,7 +189,7 @@ services:
     # serviço `restart: unless-stopped`, isso significa que o cron do cliente só
     # voltava se a VPS tivesse internet e o mirror do Alpine estivesse de pé,
     # justamente no momento em que a máquina está se recuperando de algo.
-    image: ${SCHEDULER_IMAGE:-ghcr.io/melgarafael/deskcomm-scheduler:latest}
+    image: ${SCHEDULER_IMAGE:-ghcr.io/melgarafael/deskcomm-scheduler:stable}
     pull_policy: ${SCHEDULER_PULL_POLICY:-always}
     build:
       context: .

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -85,8 +85,8 @@ services:
     # depois desta mudança, quem executa é o `update.sh` VELHO — o que está no
     # disco —, e ele só sabe gravar APP_IMAGE. O `git checkout` da tag já trocou
     # ESTE arquivo, então worker e scheduler caem no default daqui. Com
-    # `:latest`, esse default seria o TOPO DA MAIN (`enable={{is_default_branch}}`
-    # no publish-image.yml): o app pinado numa release e o runtime do agente de
+    # `:latest`, esse default seria o TOPO DA MAIN (o canal segue a branch
+    # default): o app pinado numa release e o runtime do agente de
     # IA rodando código não lançado, sobre o banco da release. `:stable` é a
     # última release publicada — pareia com o app em vez de correr na frente.
     image: ${WORKER_IMAGE:-ghcr.io/melgarafael/deskcomm-worker:stable}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -64,6 +64,19 @@ services:
     # inteira. Estourá-lo mata só quem estourou, e o `restart: unless-stopped`
     # o traz de volta — falha isolada em vez de queda geral.
     mem_limit: 512m
+    # Imagem publicada — e não mais `build:` sozinho. O motivo é o modo de falha
+    # que isso escondia: serviço build-only é PULADO por `docker compose pull`
+    # ("Skipped - No image to be pulled") e imune a `up -d` sem `--build`. Ele era
+    # construído na VPS de todo cliente, no install, e NENHUM update.sh jamais o
+    # reconstruía — o runtime do agente de IA congelava no código do dia da
+    # instalação e atravessava todas as atualizações seguintes.
+    #
+    # O `build:` continua abaixo de propósito: com os dois presentes, o Compose
+    # usa a imagem quando ela existe e CONSTRÓI quando não existe (medido). É o
+    # que mantém a mudança aditiva — registry fora do ar, ou versão anterior à
+    # primeira publicação, caem no comportamento antigo em vez de quebrar.
+    image: ${WORKER_IMAGE:-ghcr.io/melgarafael/deskcomm-worker:latest}
+    pull_policy: ${WORKER_PULL_POLICY:-always}
     build:
       context: .
       dockerfile: Dockerfile.worker
@@ -95,7 +108,14 @@ services:
     mem_limit: 1280m
     # Core grátis por padrão; troque para devlikeapro/waha-plus via WAHA_IMAGE se
     # precisar de multi-número/retry/S3 (licença paga).
-    image: ${WAHA_IMAGE:-devlikeapro/waha}
+    #
+    # Tag PINADA: `devlikeapro/waha` sem tag é `:latest`, e o `dc pull` do
+    # update.sh entregava ao cliente qualquer versão que o upstream tivesse
+    # publicado — inclusive uma nunca testada por nós, no meio de uma
+    # atualização. `latest-2026.7.2` é o mesmo digest de `latest` hoje
+    # (65e593e30bb7…), então o pin não muda um bit; muda quem escolhe quando
+    # o WhatsApp do cliente troca de motor. Bumpar faz parte do release.
+    image: ${WAHA_IMAGE:-devlikeapro/waha:latest-2026.7.2}
     restart: unless-stopped
     environment:
       # Prefixo sha512: faz o WAHA HASHEAR o X-Api-Key recebido e comparar com este
@@ -129,8 +149,16 @@ services:
 
   srh:
     # serverless-redis-http: fala o REST do Upstash sobre o redis normal, mantendo
-    # o SDK @upstash/redis sem tocar código. Pinar tag (validar encoding base64 — T6).
-    image: hiett/serverless-redis-http:latest
+    # o SDK @upstash/redis sem tocar código.
+    #
+    # Pinado por DIGEST, não por tag, e o motivo é específico: `latest` e `0.0.10`
+    # NÃO são a mesma imagem (5b0bb923… vs 65128347…), então trocar `:latest` por
+    # `:0.0.10` mudaria o binário que roda no parque — que é exatamente o risco
+    # que a pendência T6 mandava validar antes (encoding base64 do rate limit).
+    # O digest congela o que já está em produção HOJE: zero mudança de conteúdo,
+    # e o `:latest` deixa de poder mudar sozinho debaixo de todo mundo.
+    # Quando a T6 for validada, isto vira `:0.0.10` e o comentário sai.
+    image: hiett/serverless-redis-http@sha256:5b0bb9239fce53abf87b2018a7a0deb9ec7bd900c5360738fe5fbeeb426f9150
     restart: unless-stopped
     environment:
       SRH_MODE: env
@@ -143,9 +171,19 @@ services:
     networks: [internal]
 
   scheduler:
-    # Cron sem docker.sock: alpine + crond interno batendo curl na rede interna.
+    # Cron sem docker.sock: crond interno batendo curl na rede interna.
     # Resolução de 1 min (= paridade com os crons da Vercel).
-    image: alpine:3.20
+    #
+    # A lista de crons mora em docker/scheduler/entrypoint.sh, não mais aqui. O
+    # `command:` inline instalava curl e tzdata (`apk add`) a CADA start — num
+    # serviço `restart: unless-stopped`, isso significa que o cron do cliente só
+    # voltava se a VPS tivesse internet e o mirror do Alpine estivesse de pé,
+    # justamente no momento em que a máquina está se recuperando de algo.
+    image: ${SCHEDULER_IMAGE:-ghcr.io/melgarafael/deskcomm-scheduler:latest}
+    pull_policy: ${SCHEDULER_PULL_POLICY:-always}
+    build:
+      context: .
+      dockerfile: Dockerfile.scheduler
     restart: unless-stopped
     depends_on:
       app:
@@ -153,30 +191,6 @@ services:
     environment:
       TZ: UTC
       INTERNAL_SECRET: ${INTERNAL_SECRET}
-    command:
-      - /bin/sh
-      - -c
-      - |
-        apk add --no-cache curl tzdata >/dev/null 2>&1
-        cat > /etc/crontabs/root <<EOF
-        * * * * * curl -fsS -m25 -H "Authorization: Bearer $$INTERNAL_SECRET" http://app:3000/api/v1/cron/agent-dispatcher >/dev/null 2>&1
-        * * * * * curl -fsS -m25 -H "Authorization: Bearer $$INTERNAL_SECRET" http://app:3000/api/v1/cron/followup-flow-worker >/dev/null 2>&1
-        * * * * * curl -fsS -m45 -H "Authorization: Bearer $$INTERNAL_SECRET" http://app:3000/api/v1/cron/event-log-drain >/dev/null 2>&1
-        * * * * * curl -fsS -m25 -H "Authorization: Bearer $$INTERNAL_SECRET" http://app:3000/api/v1/cron/routing-worker >/dev/null 2>&1
-        * * * * * curl -fsS -m25 -H "Authorization: Bearer $$INTERNAL_SECRET" http://app:3000/api/v1/cron/recover-stuck-messages >/dev/null 2>&1
-        */5 * * * * curl -fsS -m25 -H "Authorization: Bearer $$INTERNAL_SECRET" "http://app:3000/api/v1/cron/storage-redaction?limit=50" >/dev/null 2>&1
-        */5 * * * * curl -fsS -m25 -H "Authorization: Bearer $$INTERNAL_SECRET" http://app:3000/api/v1/cron/snooze-watcher >/dev/null 2>&1
-        */5 * * * * curl -fsS -m25 -H "Authorization: Bearer $$INTERNAL_SECRET" http://app:3000/api/v1/cron/attendant-heartbeat >/dev/null 2>&1
-        */5 * * * * curl -fsS -m45 -H "Authorization: Bearer $$INTERNAL_SECRET" http://app:3000/api/v1/cron/channel-health >/dev/null 2>&1
-        */15 * * * * curl -fsS -m60 -H "Authorization: Bearer $$INTERNAL_SECRET" http://app:3000/api/v1/cron/risk-watcher >/dev/null 2>&1
-        0 12 * * * curl -fsS -m60 -H "Authorization: Bearer $$INTERNAL_SECRET" http://app:3000/api/v1/cron/lgpd-sla-watcher >/dev/null 2>&1
-        30 3 * * * curl -fsS -m120 -H "Authorization: Bearer $$INTERNAL_SECRET" http://app:3000/api/v1/cron/kb-conversations-batch >/dev/null 2>&1
-        */10 * * * * curl -fsS -m60 -H "Authorization: Bearer $$INTERNAL_SECRET" http://app:3000/api/v1/cron/contact-avatars >/dev/null 2>&1
-        */30 * * * * curl -fsS -m60 -H "Authorization: Bearer $$INTERNAL_SECRET" http://app:3000/api/v1/cron/contact-phones >/dev/null 2>&1
-        15 4 * * * curl -fsS -m60 -H "Authorization: Bearer $$INTERNAL_SECRET" http://app:3000/api/v1/cron/sync-model-catalog >/dev/null 2>&1
-        17 * * * * curl -fsS -m60 -H "Authorization: Bearer $$INTERNAL_SECRET" http://app:3000/api/v1/cron/contact-proposals-watcher >/dev/null 2>&1
-        EOF
-        exec crond -f -l 2
     logging: *default-logging
     networks: [internal]
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -28,7 +28,11 @@ services:
     # Os NEXT_PUBLIC_* reais vêm em RUNTIME (env_file abaixo) — o browser lê via
     # <PublicEnvScript/> e o servidor via lib/env.ts. Não precisa buildar no VPS.
     # Build local (avançado): docker compose -f docker-compose.prod.yml -f docker-compose.build.yml build
-    image: ${APP_IMAGE:-ghcr.io/melgarafael/deskcommcrm:latest}
+    # `:stable` (última release), não `:latest` (topo da `main`). Quem cai neste
+    # default é quem NÃO tem APP_IMAGE no .env — avaliação, ou um .env que
+    # perdeu a chave. Nenhum desses casos quer código não lançado; quem quiser o
+    # topo da main pede `APP_IMAGE=…:latest` explicitamente.
+    image: ${APP_IMAGE:-ghcr.io/melgarafael/deskcommcrm:stable}
     pull_policy: ${APP_PULL_POLICY:-always}
     restart: unless-stopped
     env_file: .env

--- a/docker/scheduler/entrypoint.sh
+++ b/docker/scheduler/entrypoint.sh
@@ -5,11 +5,11 @@
 # só existe no .env do cliente, e o busybox crond não expande variáveis dentro da
 # linha do cron. Então a expansão acontece aqui, uma vez, no start.
 #
-# O que MUDOU em relação à versão anterior (o `command:` inline do compose): não
-# há mais `apk add --no-cache curl tzdata` a cada start. curl e tzdata vêm na
-# imagem. O cron do cliente deixa de depender de a VPS ter internet e de o mirror
-# do Alpine estar de pé no momento de um restart — que é justamente o momento em
-# que a máquina está se recuperando de alguma coisa.
+# O que MUDOU em relação ao `command:` inline do compose: não há mais
+# `apk add --no-cache curl tzdata` a cada start. curl e tzdata vêm na imagem. O
+# cron do cliente deixa de depender de a VPS ter internet e de o mirror do Alpine
+# estar de pé no momento de um restart — que é justamente o momento em que a
+# máquina está se recuperando de alguma coisa.
 set -eu
 
 if [ -z "${INTERNAL_SECRET:-}" ]; then
@@ -18,26 +18,59 @@ if [ -z "${INTERNAL_SECRET:-}" ]; then
   exit 1
 fi
 
-APP_ORIGIN="${SCHEDULER_APP_ORIGIN:-http://app:3000}"
+# Constante, não configuração: `app` é o nome do serviço na rede interna do
+# compose, e o scheduler não fala com mais nada. A primeira versão disto lia um
+# `SCHEDULER_APP_ORIGIN` que o compose nunca repassava e nenhum template
+# documentava — controle decorativo, que é pior que controle nenhum: quem o
+# encontrasse no código o definiria no `.env` e não veria efeito.
+APP_ORIGIN="http://app:3000"
+
+# O crond executa cada linha por `/bin/sh -c`, então o segredo é REAVALIADO pelo
+# shell na hora de disparar. Interpolá-lo cru dentro de aspas duplas fazia com
+# que um `$` no valor virasse expansão de variável (o header sairia truncado, e
+# todo cron responderia 401 em silêncio) e uma crase virasse substituição de
+# comando — execução arbitrária a cada minuto. Medido com um segredo hostil: a
+# versão com aspas duplas entregava `segrafaelmelgacoredo/Users/rafaelmelgaco…`,
+# com o `whoami` EXECUTADO. Aqui o valor vai entre aspas SIMPLES, com as aspas
+# simples internas escapadas — dentro delas o sh não interpreta nada.
+SEGREDO_SEGURO="$(printf '%s' "$INTERNAL_SECRET" | sed "s/'/'\\\\''/g")"
+
+# minuto|timeout|caminho — uma linha por cron. O caminho vai COMPLETO de
+# propósito: o literal `api/v1/cron/<rota>` é o contrato que
+# tests/unit/cron-routes-scheduled.test.ts (e mais dois) leem por grep — esse
+# teste compara a lista com o diretório app/api/v1/cron, e rota criada sem
+# agendamento reprova o CI.
+CRONS="
+* * * * *|25|api/v1/cron/agent-dispatcher
+* * * * *|25|api/v1/cron/followup-flow-worker
+* * * * *|45|api/v1/cron/event-log-drain
+* * * * *|25|api/v1/cron/routing-worker
+* * * * *|25|api/v1/cron/recover-stuck-messages
+*/5 * * * *|25|api/v1/cron/storage-redaction?limit=50
+*/5 * * * *|25|api/v1/cron/snooze-watcher
+*/5 * * * *|25|api/v1/cron/attendant-heartbeat
+*/5 * * * *|45|api/v1/cron/channel-health
+*/10 * * * *|60|api/v1/cron/contact-avatars
+*/15 * * * *|60|api/v1/cron/risk-watcher
+*/30 * * * *|60|api/v1/cron/contact-phones
+17 * * * *|60|api/v1/cron/contact-proposals-watcher
+0 12 * * *|60|api/v1/cron/lgpd-sla-watcher
+30 3 * * *|120|api/v1/cron/kb-conversations-batch
+15 4 * * *|60|api/v1/cron/sync-model-catalog
+"
+
+# CRONTAB_PATH é ponto de injeção do teste (tests/shell/scheduler-entrypoint.test.sh).
+# Sem ele este script só seria exercitável dentro de um contêiner — e o único
+# artefato executável novo desta entrega ficaria sem gate nenhum, que foi
+# exatamente o achado da revisão adversarial.
+DESTINO="${CRONTAB_PATH:-/etc/crontabs/root}"
 
 umask 077
-cat > /etc/crontabs/root <<EOF
-* * * * * curl -fsS -m25 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/agent-dispatcher >/dev/null 2>&1
-* * * * * curl -fsS -m25 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/followup-flow-worker >/dev/null 2>&1
-* * * * * curl -fsS -m45 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/event-log-drain >/dev/null 2>&1
-* * * * * curl -fsS -m25 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/routing-worker >/dev/null 2>&1
-* * * * * curl -fsS -m25 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/recover-stuck-messages >/dev/null 2>&1
-*/5 * * * * curl -fsS -m25 -H "Authorization: Bearer $INTERNAL_SECRET" "$APP_ORIGIN/api/v1/cron/storage-redaction?limit=50" >/dev/null 2>&1
-*/5 * * * * curl -fsS -m25 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/snooze-watcher >/dev/null 2>&1
-*/5 * * * * curl -fsS -m25 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/attendant-heartbeat >/dev/null 2>&1
-*/5 * * * * curl -fsS -m45 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/channel-health >/dev/null 2>&1
-*/10 * * * * curl -fsS -m60 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/contact-avatars >/dev/null 2>&1
-*/15 * * * * curl -fsS -m60 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/risk-watcher >/dev/null 2>&1
-*/30 * * * * curl -fsS -m60 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/contact-phones >/dev/null 2>&1
-17 * * * * curl -fsS -m60 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/contact-proposals-watcher >/dev/null 2>&1
-0 12 * * * curl -fsS -m60 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/lgpd-sla-watcher >/dev/null 2>&1
-30 3 * * * curl -fsS -m120 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/kb-conversations-batch >/dev/null 2>&1
-15 4 * * * curl -fsS -m60 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/sync-model-catalog >/dev/null 2>&1
-EOF
+: > "$DESTINO"
+echo "$CRONS" | while IFS='|' read -r quando timeout rota; do
+  [ -n "$rota" ] || continue
+  printf '%s curl -fsS -m%s -H '"'"'Authorization: Bearer %s'"'"' "%s/%s" >/dev/null 2>&1\n' \
+    "$quando" "$timeout" "$SEGREDO_SEGURO" "$APP_ORIGIN" "$rota" >> "$DESTINO"
+done
 
 exec crond -f -l 2

--- a/docker/scheduler/entrypoint.sh
+++ b/docker/scheduler/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Entrypoint do deskcomm-scheduler: escreve o crontab e entrega o PID 1 ao crond.
+#
+# Por que gerar em runtime em vez de assar o arquivo na imagem: o INTERNAL_SECRET
+# só existe no .env do cliente, e o busybox crond não expande variáveis dentro da
+# linha do cron. Então a expansão acontece aqui, uma vez, no start.
+#
+# O que MUDOU em relação à versão anterior (o `command:` inline do compose): não
+# há mais `apk add --no-cache curl tzdata` a cada start. curl e tzdata vêm na
+# imagem. O cron do cliente deixa de depender de a VPS ter internet e de o mirror
+# do Alpine estar de pé no momento de um restart — que é justamente o momento em
+# que a máquina está se recuperando de alguma coisa.
+set -eu
+
+if [ -z "${INTERNAL_SECRET:-}" ]; then
+  echo "scheduler: INTERNAL_SECRET vazio — os crons responderiam 401 em silêncio." >&2
+  echo "scheduler: confira a chave no .env e suba de novo." >&2
+  exit 1
+fi
+
+APP_ORIGIN="${SCHEDULER_APP_ORIGIN:-http://app:3000}"
+
+umask 077
+cat > /etc/crontabs/root <<EOF
+* * * * * curl -fsS -m25 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/agent-dispatcher >/dev/null 2>&1
+* * * * * curl -fsS -m25 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/followup-flow-worker >/dev/null 2>&1
+* * * * * curl -fsS -m45 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/event-log-drain >/dev/null 2>&1
+* * * * * curl -fsS -m25 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/routing-worker >/dev/null 2>&1
+* * * * * curl -fsS -m25 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/recover-stuck-messages >/dev/null 2>&1
+*/5 * * * * curl -fsS -m25 -H "Authorization: Bearer $INTERNAL_SECRET" "$APP_ORIGIN/api/v1/cron/storage-redaction?limit=50" >/dev/null 2>&1
+*/5 * * * * curl -fsS -m25 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/snooze-watcher >/dev/null 2>&1
+*/5 * * * * curl -fsS -m25 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/attendant-heartbeat >/dev/null 2>&1
+*/5 * * * * curl -fsS -m45 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/channel-health >/dev/null 2>&1
+*/10 * * * * curl -fsS -m60 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/contact-avatars >/dev/null 2>&1
+*/15 * * * * curl -fsS -m60 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/risk-watcher >/dev/null 2>&1
+*/30 * * * * curl -fsS -m60 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/contact-phones >/dev/null 2>&1
+17 * * * * curl -fsS -m60 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/contact-proposals-watcher >/dev/null 2>&1
+0 12 * * * curl -fsS -m60 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/lgpd-sla-watcher >/dev/null 2>&1
+30 3 * * * curl -fsS -m120 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/kb-conversations-batch >/dev/null 2>&1
+15 4 * * * curl -fsS -m60 -H "Authorization: Bearer $INTERNAL_SECRET" $APP_ORIGIN/api/v1/cron/sync-model-catalog >/dev/null 2>&1
+EOF
+
+exec crond -f -l 2

--- a/docs/DEPLOY-CHECKLIST.md
+++ b/docs/DEPLOY-CHECKLIST.md
@@ -29,8 +29,13 @@ O procedimento completo está em [`doctrine/packaging.md`](doctrine/packaging.md
       não chegar lá não chega a ninguém
 - [ ] `pnpm test:db` verde localmente (aplica o baseline em install **e** update num Postgres limpo)
 - [ ] `pnpm test:shell` verde (é o único gate que exercita o kit)
-- [ ] O número da versão nunca foi publicado: `git tag --list 'vX.Y.Z'` vazio **e** ausente de
-      `curl -s .../deskcommcrm/tags/list`
+- [ ] O número da versão nunca foi publicado: `git tag --list 'vX.Y.Z'` vazio **e**
+      `ghcr_status deskcommcrm X.Y.Z` → **404**
+
+      Use a função `ghcr_status` de [`doctrine/packaging.md`](doctrine/packaging.md)
+      §Checklist de release. **Não use `curl` cru no GHCR**: ele responde `401`, e um corpo de
+      erro não contém a versão procurada — o que faria este item aprovar qualquer coisa,
+      inclusive uma versão já publicada.
 
 **Publicar**
 

--- a/docs/DEPLOY-CHECKLIST.md
+++ b/docs/DEPLOY-CHECKLIST.md
@@ -1,42 +1,79 @@
-# Deploy Preflight Checklist
+# Checklist de deploy
 
-Run through this list before promoting to production (or before each release tag).
+Este projeto tem **dois destinos de deploy com bancos diferentes**, e confundi-los já custou um
+incidente. Escolha a seção certa antes de marcar qualquer caixa.
 
-## Environment
+| Destino | O que é | Banco |
+|---|---|---|
+| **A. VPS self-host** | **o produto** — o que o cliente compra e o que a doutrina rege | Supabase cloud provisionado pelo `install.sh` |
+| **B. Vercel** | ambiente do mantenedor, deploy a cada push na `main` | outro projeto Supabase |
 
-- [ ] All envs set in Vercel project (mirror `.env.local`)
-- [ ] `SENTRY_DSN` set; `SENTRY_AUTH_TOKEN` configured for source maps upload
-- [ ] `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY` set
-- [ ] `WAHA_*` envs set (URL, plaintext API key client side, SHA512 hash server side)
-- [ ] `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN` set
-- [ ] `INTERNAL_SECRET` set (rotated at least once)
-
-## Infrastructure
-
-- [ ] Supabase migrations applied to target environment (`supabase/migrations/`)
-- [ ] Supabase RLS policies verified on tenant-aware tables (cross-tenant smoke)
-- [ ] WAHA Plus running with auth'd WhatsApp number, webhook URL pointing to deploy
-- [ ] Sentry project configured + DSN in env, test event captured
-- [ ] Resend domain verified (transactional emails)
-- [ ] Nuvemshop app published in Partners portal
-
-## Verification
-
-- [ ] `pnpm typecheck` clean locally on the release commit
-- [ ] `pnpm lint` clean
-- [ ] `pnpm test:unit` green
-- [ ] `pnpm test:e2e` green against preview URL
-- [ ] Manual smoke: login (with MFA), create lead, send/receive WhatsApp message, see audit log entry, view kanban
-- [ ] Sentry test event captured from prod environment
-- [ ] LCP/CLS/INP within budget (Vercel Analytics RUM)
-- [ ] No `console.log` leaks in build output (`pnpm build | grep -i console` should be quiet)
-
-## Rollback plan
-
-- [ ] Previous deploy URL noted
-- [ ] DB migrations reversible OR forward-only with documented hot-fix path
-- [ ] On-call engineer notified
+> Este arquivo esteve congelado de 2026-04-28 a 2026-08-13 — escrito **dois meses antes de o
+> Dockerfile existir**. Ele cobria só a Vercel e mandava aplicar `supabase/migrations/`, que
+> não é o caminho de nenhum self-hoster (o kit aplica **só** `supabase/baseline.sql`). Quem o
+> seguisse para um deploy de VPS não fazia nada do que o produto exige.
 
 ---
 
-Reference: [`docs/stories/epics/EPIC-12-hardening.md`](stories/epics/EPIC-12-hardening.md) §S-12.10.
+## A. VPS self-host — release de versão
+
+O procedimento completo está em [`doctrine/packaging.md`](doctrine/packaging.md)
+§Checklist de release. O resumo verificável:
+
+**Antes de taguear**
+
+- [ ] `CHANGELOG.md` tem a seção da versão, dizendo o que muda **para quem já instalou**
+- [ ] Nenhuma variável nova é obrigatória sem default (`git diff` em `.env.example` e `lib/env.ts`)
+- [ ] Mudança de schema saiu como **tripla**: `supabase/migrations/` + apêndice idempotente no
+      `supabase/baseline.sql` + linha no `MANIFEST.md`. **O kit aplica só o baseline** — o que
+      não chegar lá não chega a ninguém
+- [ ] `pnpm test:db` verde localmente (aplica o baseline em install **e** update num Postgres limpo)
+- [ ] `pnpm test:shell` verde (é o único gate que exercita o kit)
+- [ ] O número da versão nunca foi publicado: `git tag --list 'vX.Y.Z'` vazio **e** ausente de
+      `curl -s .../deskcommcrm/tags/list`
+
+**Publicar**
+
+- [ ] `git tag vX.Y.Z && git push origin vX.Y.Z` a partir de um commit da `main`
+- [ ] `gh run list --workflow=publish-image.yml --limit 3` → verde
+- [ ] As **três** imagens existem na versão: `deskcommcrm`, `deskcomm-worker`, `deskcomm-scheduler`
+- [ ] `stable` aponta para esta versão (mesmo digest de `X.Y.Z`)
+- [ ] `gh release create vX.Y.Z` com as notas do CHANGELOG
+
+**Provar (o item que exige VPS, e não é opcional)**
+
+- [ ] Ensaio de atualização numa instalação **real e não-fresca**: `update.sh` a partir da
+      versão anterior, sem editar arquivo nenhum na mão
+- [ ] `GET /api/v1/health` responde `version: "X.Y.Z"` depois do update
+- [ ] O domínio responde **307** (redireciona para o login), não 404 — 404 com contêiner
+      `healthy` significa labels de roteamento perdidas (ver `runbooks/deploy.md`)
+- [ ] Smoke manual pela tela: login com MFA, criar lead, receber e enviar mensagem no WhatsApp,
+      ver a entrada no audit log, abrir o kanban
+
+**Rollback**
+
+- [ ] A versão anterior está anotada (é uma linha do `.env`: `APP_IMAGE`)
+- [ ] Existe backup do banco anterior à atualização (`backup.sh` roda sozinho no `update.sh`)
+- [ ] Migração é forward-only com caminho de hot-fix documentado
+
+---
+
+## B. Vercel — deploy do mantenedor
+
+- [ ] Envs do projeto na Vercel espelham o `.env.local`
+- [ ] `SENTRY_DSN` definido; `SENTRY_AUTH_TOKEN` configurado para upload de sourcemap
+- [ ] `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
+- [ ] `WAHA_*` (URL, api key em plaintext no cliente, hash SHA512 no servidor)
+- [ ] `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`
+- [ ] `INTERNAL_SECRET` (rotacionado ao menos uma vez)
+- [ ] **Migrations aplicadas no banco da Vercel** — `supabase/migrations/`, e **confira**: o
+      pipeline da Vercel faz deploy a cada push na `main` e **não aplica migration nenhuma**.
+      Em 2026-08-04 a produção rodou código à frente do banco e o inbox devolveu 500 (`42703`)
+- [ ] RLS verificada nas tabelas tenant-aware (smoke cross-tenant)
+- [ ] Evento de teste do Sentry capturado no ambiente de produção
+- [ ] `pnpm typecheck`, `pnpm lint`, `pnpm test:unit` limpos no commit da release
+- [ ] LCP/CLS/INP dentro do orçamento (Vercel Analytics RUM)
+
+---
+
+Referência: [`stories/epics/EPIC-12-hardening.md`](stories/epics/EPIC-12-hardening.md) §S-12.10.

--- a/docs/adr/0001-packaging-e-distribuicao.md
+++ b/docs/adr/0001-packaging-e-distribuicao.md
@@ -37,12 +37,16 @@ instalado**, por `install.sh` e por `update.sh`, como string literal.
 
 Migrar de namespace não é renomear um repositório: é invalidar o `APP_IMAGE` do parque. O
 `update.sh` que já está no disco dessas VPS continuaria montando o namespace antigo
-(`update.sh:158` tem a string hardcoded), e nenhuma delas receberia a mudança que as
-consertaria — o clássico problema de atualizar o atualizador.
+(a string do namespace está no script que já está no disco dela), e nenhuma receberia a
+mudança que as consertaria — o clássico problema de atualizar o atualizador.
 
-**Custo medido de uma migração futura:** 9 arquivos versionados (`docker-compose.prod.yml`,
-`install.sh`, `update.sh`, `.env.hostgator.example`, `tests/shell/update-guard.test.sh`,
-`CHANGELOG.md`, e 3 docs) **mais** o `.env` de cada instalação viva.
+**Custo medido de uma migração futura:** o namespace vive numa constante única
+(`IMG_NS` em `hostgator-setup-kit/_common.sh`), mais o default de cada serviço em
+`docker-compose.prod.yml`, mais `.env.hostgator.example`, os testes que casam a string
+(`tests/shell/update-guard.test.sh`, `hostgator-setup-kit/test-validators.sh`,
+`tests/unit/packaging-artefato-do-cliente.test.ts`) e os docs — **mais** o `.env` de cada
+instalação viva, que é a parte que nenhum commit alcança. Régua para reconferir antes de
+citar este parágrafo: `grep -rln "ghcr.io/melgarafael" --exclude-dir=node_modules .`
 
 **Reconsideraríamos se:** o projeto ganhar mantenedores com necessidade de publicar sem
 credencial pessoal, ou o repositório mudar de dono. Nesse caso a migração é **aditiva**:
@@ -79,9 +83,12 @@ bundle compilado passa a se pagar.
 
 ### D4 — `stable` é criado; `latest` não muda de significado
 
-`latest` neste projeto aponta para o **topo da `main`**, não para a última release — é a regra
-`type=raw,value=latest,enable={{is_default_branch}}` do `metadata-action`. O nome cria uma
-expectativa que a configuração não cumpre, e instalação fresca herdava isso.
+`latest` neste projeto aponta para o **topo da `main`**, não para a última release. O nome cria
+uma expectativa que a configuração não cumpre, e instalação fresca herdava isso.
+
+A regra `enable={{is_default_branch}}` sozinha nem entregava isso: ela é verdadeira também num
+push de tag, então toda release movia `latest` junto e o canal oscilava entre os dois
+significados. O workflow passou a prendê-lo a `ref_type == 'branch'`.
 
 **Alternativa descartada:** redefinir `latest` como a última release. Seria mais correto
 semanticamente e **quebraria em produção**: quem hoje roda o topo da `main` sofreria um
@@ -114,8 +121,11 @@ GHCR. Instalação pinada grava `missing`; canal móvel continua `always`.
 ## Consequências
 
 **Ganhamos:** o parque para de rodar código congelado no worker; a versão de cada instalação
-vira nomeável e observável; a imagem ganha um gate que reprova merge; e a atualização vira
-ato reversível por uma linha do `.env`.
+vira nomeável e observável; e a atualização vira ato reversível por uma linha do `.env`.
+
+**Ainda não ganhamos:** o gate da imagem só reprova merge depois que `imagens-ok` entrar na
+branch protection — o que não pode acontecer antes deste trabalho estar na `main`, sob pena de
+travar todos os PRs abertos. Enquanto isso, o job roda em PR e informa, mas não bloqueia.
 
 **Pagamos:** três imagens para publicar em vez de uma (mesmo run do CI, sem custo de
 processo); e uma regra a mais no DoD.

--- a/docs/adr/0001-packaging-e-distribuicao.md
+++ b/docs/adr/0001-packaging-e-distribuicao.md
@@ -1,0 +1,145 @@
+# ADR-0001 — Packaging e distribuição do DeskcommCRM
+
+- **Status:** aceito
+- **Data:** 2026-08-13
+- **Contexto medido em:** `f9abedd0` (`main`)
+- **Lei decorrente:** [`docs/doctrine/packaging.md`](../doctrine/packaging.md)
+
+> **Nota de numeração.** Este é o primeiro ADR como arquivo próprio no repo. Já existe uma
+> sequência `ADR-01`…`ADR-12` **dentro** de `docs/specs/09-spec-frontend-backend-integration.md`,
+> restrita a decisões de frontend e citada por número em outras specs. Os arquivos de
+> `docs/adr/` usam **quatro dígitos** (`ADR-0001`) justamente para não colidir com aquela
+> numeração. Se um dia as duas sequências se unificarem, esta é a que se renumera.
+
+---
+
+## Contexto
+
+O DeskcommCRM é distribuído como self-host: a monetização é a venda da VPS com o sistema
+instalado, e a experiência de quem instala **é** o produto. Isso torna o artefato distribuído —
+imagem, compose, kit — parte do contrato, não detalhe de infraestrutura.
+
+Uma consultoria externa de packaging diagnosticou que "a arquitetura de packaging ainda não
+existe". A investigação do repositório mostrou o contrário: ela existe desde 2026-07-02, com
+258 execuções do workflow de publicação e 4 releases. O que faltava não era o pipeline — era a
+**regra** que decide o que entra nele, e um gate que a exerça.
+
+O diagnóstico externo também continha erros materiais, listados em §Erros corrigidos, e não
+enxergou o defeito mais caro, que era o motivo real para escrever esta doutrina.
+
+## Decisões
+
+### D1 — O namespace é `ghcr.io/melgarafael/*`. Não migramos para uma org.
+
+**Escolhido porque** é o namespace que o CI já publica (`IMAGE_NAME: ${{ github.repository }}`),
+que o compose já consome, e — decisivo — que está **gravado no `.env` de cada cliente
+instalado**, por `install.sh` e por `update.sh`, como string literal.
+
+Migrar de namespace não é renomear um repositório: é invalidar o `APP_IMAGE` do parque. O
+`update.sh` que já está no disco dessas VPS continuaria montando o namespace antigo
+(`update.sh:158` tem a string hardcoded), e nenhuma delas receberia a mudança que as
+consertaria — o clássico problema de atualizar o atualizador.
+
+**Custo medido de uma migração futura:** 9 arquivos versionados (`docker-compose.prod.yml`,
+`install.sh`, `update.sh`, `.env.hostgator.example`, `tests/shell/update-guard.test.sh`,
+`CHANGELOG.md`, e 3 docs) **mais** o `.env` de cada instalação viva.
+
+**Reconsideraríamos se:** o projeto ganhar mantenedores com necessidade de publicar sem
+credencial pessoal, ou o repositório mudar de dono. Nesse caso a migração é **aditiva**:
+publicar nos dois namespaces por pelo menos uma minor, `update.sh` reescrevendo `APP_IMAGE`
+sozinho, e o namespace antigo mantido até o parque ter migrado — nunca um corte seco.
+
+### D2 — Os packages e a pergunta que cada um responde
+
+| Package | Pergunta | Status |
+|---|---|---|
+| `deskcommcrm` | "o que a pessoa instala?" | existe desde 2026-07-02 |
+| `deskcomm-worker` | "o que roda 24/7 fora do request?" | **criado aqui** |
+| `deskcomm-scheduler` | "o que dispara os crons?" | **criado aqui** |
+
+Os três passam no teste de fronteira: consumidor distinto (contêiner próprio), topologia de
+execução própria (long-running, cron, request/response), e custo de build que hoje cai no
+cliente. O ciclo de release é **acoplado** — os três sobem juntos, com a mesma tag —, porque
+compartilham o mesmo repositório e a mesma migração de banco; versioná-los independentemente
+criaria matriz de compatibilidade sem consumidor para ela.
+
+### D3 — `deskcomm-worker` é publicado, não fundido na imagem do app
+
+O worker roda TypeScript direto via `tsx` (`workers/agent-worker/main.ts`), enquanto a imagem
+do app é um `.next/standalone` — que não contém `tsx` nem o fonte TS.
+
+**Alternativa descartada:** fundir os dois numa imagem só, com `command:` diferente. Exigiria
+compilar o worker (tsup/esbuild) e embutir o bundle no standalone — mudança de código real
+num caminho crítico, para economizar uma imagem. **Publicar o que já existe é a menor mudança
+que resolve**, e o `Dockerfile.worker` continua exatamente como está.
+
+**Reconsideraríamos se:** o tamanho da imagem do worker virar problema operacional real
+(hoje ela carrega devDeps porque `tsx` precisa), ou se aparecer um segundo worker — aí o
+bundle compilado passa a se pagar.
+
+### D4 — `stable` é criado; `latest` não muda de significado
+
+`latest` neste projeto aponta para o **topo da `main`**, não para a última release — é a regra
+`type=raw,value=latest,enable={{is_default_branch}}` do `metadata-action`. O nome cria uma
+expectativa que a configuração não cumpre, e instalação fresca herdava isso.
+
+**Alternativa descartada:** redefinir `latest` como a última release. Seria mais correto
+semanticamente e **quebraria em produção**: quem hoje roda o topo da `main` sofreria um
+downgrade silencioso no próximo `up -d`, com app antigo sobre banco já migrado. Preferimos um
+nome imperfeito a um downgrade automático.
+
+Então `stable` é criado para nomear a última release, e a instalação de cliente não usa
+nenhum dos dois: usa o número da versão (invariante 3).
+
+### D5 — `pull_policy` passa a acompanhar a mutabilidade da tag
+
+Medido: com `always` e o registry sem responder para aquela referência, o `up -d` falha e o
+contêiner **não sobe**, mesmo com a imagem no disco. Com `missing`, sobe.
+
+Como a instalação passa a nascer pinada numa tag imutável, `always` deixa de proteger de
+qualquer coisa e passa a acoplar a disponibilidade do CRM do cliente à disponibilidade do
+GHCR. Instalação pinada grava `missing`; canal móvel continua `always`.
+
+### D6 — O que foi deliberadamente recusado
+
+| Recusado | Por quê | Reconsideraríamos se |
+|---|---|---|
+| **Republicar WAHA / WAHA Plus** | licenciado; redistribuir binário de terceiro numa imagem nossa é passivo jurídico sobre a dependência mais crítica do produto | nunca, enquanto a licença for essa |
+| **Republicar Redis, Caddy, `srh`, `postgres`** | não agregam nada; upstream referenciado com tag fixa é estritamente melhor | se algum deles for abandonado e precisarmos manter um fork |
+| **`deskcomm-base`** | o build pesado do Next não se resolve com imagem base — resolve-se com cache do buildx no CI, que já está ligado (`cache-from: type=gha`). O único candidato a compartilhar seria `ffmpeg`, e não paga a indireção | 3+ imagens nossas passarem a compartilhar as mesmas deps de sistema |
+| **`deskcomm-migrate` one-shot** | a consultoria o propôs para substituir `supabase db push` na máquina do implementador — fluxo que **não existe** neste projeto. `install.sh` e `update.sh` já aplicam `supabase/baseline.sql` via `postgres:17-alpine` efêmero, dentro da VPS, sem CLI e sem participação humana. Seria um package resolvendo um problema que já está resolvido | o baseline deixar de ser aplicável por psql puro |
+| **Migrar de namespace** | ver D1 | ver D1 |
+| **Trocar `latest` de significado** | ver D4 | nunca sem uma major e um caminho de migração |
+
+## Consequências
+
+**Ganhamos:** o parque para de rodar código congelado no worker; a versão de cada instalação
+vira nomeável e observável; a imagem ganha um gate que reprova merge; e a atualização vira
+ato reversível por uma linha do `.env`.
+
+**Pagamos:** três imagens para publicar em vez de uma (mesmo run do CI, sem custo de
+processo); e uma regra a mais no DoD.
+
+**Assumimos:** que a imutabilidade das tags de versão é garantia **de processo**, não de
+configuração — o GHCR não a impõe. Se isso virar problema, o conserto é habilitar a proteção
+no registry, não mudar a doutrina.
+
+## Erros corrigidos no diagnóstico externo
+
+Registrados porque a consultoria foi feita sem acesso a `.github/workflows/` e ao histórico, e
+porque um diagnóstico errado que sobrevive vira premissa de decisões futuras.
+
+| Alegação | O que a medição mostrou |
+|---|---|
+| "o `Packages` do repo está vazio" | 10 tags publicadas e públicas; `tags/list` anônimo responde, manifest de `latest` = 200. Provável causa do erro: `gh api users/…/packages` devolve **403** sem escopo `read:packages` — instrumento cego lido como ausência |
+| "o compose aponta para `ghcr.io/deskcommcrm/deskcommcrm`" | aponta para `ghcr.io/melgarafael/deskcommcrm`. A org `deskcommcrm` não existe (404). A string aparecia num `git clone` de `docs/deploy-selfhost/README.md` — link quebrado, corrigido aqui |
+| "não há workflow de publish" | existe desde 2026-07-02; 258 runs, 252 verdes |
+| "falta `LABEL` OCI, o package fica órfão" | premissa certa, consequência errada: o `metadata-action` injeta os labels no push, e a imagem publicada traz `image.source` correto. O package está vinculado ao repo |
+| "instalação exige 4 GB e 4–34 min de build" | o app não builda: `install.sh` faz `dc pull`. Os 4 GB são de operação. "4–34 min" não existe no repo |
+| "`update` usa `supabase db push` com a CLI do implementador" | zero invocações do CLI Supabase no kit; o schema é aplicado por psql efêmero dentro da VPS |
+| "`latest` + `always` troca versão num restart" | medido: `docker compose restart` preserva contêiner e image ID. O gatilho real é `up -d` — e o repo já documentava esse modo de falha em `_common.sh:294-299` |
+
+**O que a consultoria não viu, e era o defeito mais caro:** o serviço `worker` não tinha
+`image:`, só `build:`. Era construído na VPS de todo cliente e **nunca atualizado** por
+nenhum `update.sh` — congelando o runtime do agente de IA no código do dia da instalação.
+É o invariante 1 da doutrina.

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -118,6 +118,29 @@ funil** (só de etapas). O primeiro é bug de primeira impressão em mobile.
 
 Estes são achados de código/config verificados nesta auditoria, não relatos.
 
+### 4.0 O agente de IA nunca recebia atualização 🔴 — RESOLVIDO em 2026-08-13
+
+Fica no topo por gravidade e porque é o tipo de defeito que este documento existe para
+tornar visível: durou dois meses, atingia **toda** instalação, e nada na tela, no log ou no
+CI dizia isso.
+
+O serviço `worker` do `docker-compose.prod.yml` — o runtime do agente de IA, e o único
+consumidor de `ai_agent.dispatch_requested` — não tinha `image:`, só `build:`. Serviço
+`build:`-only é pulado por `docker compose pull` ("Skipped — No image to be pulled") e imune
+a `up -d` sem `--build`. Consequência: ele era compilado na VPS do cliente no dia da
+instalação e **nenhum `update.sh` jamais o reconstruiu**. Correções do agente não chegavam a
+lugar nenhum. Enquanto isso, `CLAUDE.md` afirmava que "o caminho normal não constrói nada na
+VPS" — verdade para o app, falso para o produto.
+
+Resolvido publicando `deskcomm-worker` e `deskcomm-scheduler` como imagens, com gate em
+`tests/unit/packaging-artefato-do-cliente.test.ts`. Lei em
+[`doctrine/packaging.md`](doctrine/packaging.md); decisões em
+[`adr/0001-packaging-e-distribuicao.md`](adr/0001-packaging-e-distribuicao.md).
+
+**O que continua aberto:** o gate `imagens-ok` ainda não está na branch protection (não pode
+entrar antes do merge, senão trava os PRs abertos), e não existe ensaio automatizado de
+atualização numa VPS real — o caso U6 de [`testing/user-journey-map.md`](testing/user-journey-map.md).
+
 ### 4.1 Os E2E quase não rodam no CI 🟠 — parcialmente resolvido em 2026-07-30
 
 > **Atualização (2026-08-05, issue #63):** `e2e.yml` roda **28 das 32 specs** contra Supabase

--- a/docs/deploy-selfhost/README.md
+++ b/docs/deploy-selfhost/README.md
@@ -23,7 +23,7 @@
 ## 1. Clonar e configurar
 
 ```bash
-git clone https://github.com/deskcommcrm/deskcommcrm.git && cd deskcommcrm
+git clone https://github.com/melgarafael/DeskcommCRM.git && cd DeskcommCRM
 cp .env.hostgator.example .env   # o template de produção (o .env.example é o de dev)
 ```
 
@@ -161,8 +161,13 @@ de `supabase/templates/` (mesmo link `token_hash` acima).
   (`FLYWHEEL_INTERVAL_MS`) e grava PROPOSTAS de melhoria de prompt em
   `flywheel_distiller_proposals`. Nada é aplicado sozinho: revise e cole o
   bullet no prompt do agente na tela, publicando uma versão nova.
-- **Atualizar**: `git pull && docker compose -f docker-compose.prod.yml up -d --build`
-  + re-rodar o `baseline.sql` (idempotente).
+- **Atualizar**: `bash hostgator-setup-kit/update.sh` — ele puxa a tag publicada,
+  re-aplica o `baseline.sql` (idempotente), sobe e faz backup antes. Não use
+  `up -d --build`: isso reconstrói na sua máquina em vez de puxar a imagem
+  testada, e **numa VPS com proxy reverso próprio o `up -d` precisa dos dois
+  arquivos de compose** — omitir `-f docker-compose.traefik.yml` recria o
+  contêiner sem as labels de roteamento e o domínio inteiro passa a responder
+  404, com o contêiner `healthy`.
 
 ## Solução de problemas
 

--- a/docs/doctrine/packaging.md
+++ b/docs/doctrine/packaging.md
@@ -41,9 +41,15 @@ Se a resposta for "o cliente", a peça está errada e vira imagem publicada.
 |---|---|---|
 | Exemplos | `deskcommcrm`, `deskcomm-worker` | WAHA, Redis, Caddy, `serverless-redis-http`, `postgres` |
 | Quem constrói | nosso CI, uma vez por versão | terceiro, fora do nosso controle |
-| O que fazemos | publicamos com procedência e versão | **referenciamos com tag fixa** |
+| O que fazemos | publicamos com procedência e versão | **referenciamos com tag pinada** (ver ressalva) |
 | O que **nunca** fazemos | publicar da máquina de um dev | republicar, embalar ou copiar |
 | Se quebrar | é bug nosso, com forward-fix | é incidente de fornecedor, com pin de escape |
+
+**Ressalva medida:** `redis:7-alpine` e `caddy:2-alpine` flutuam dentro do major — as duas
+se moveram no Docker Hub em 2026. São dependências de infraestrutura sem estado de negócio, e
+o custo de bumpá-las a cada release não se paga hoje; o item 4 do checklist manda revisitá-las.
+`waha` e `srh` — que tocam WhatsApp e rate limit — estão pinadas de verdade (tag exata e
+digest). O gate reprova tag ausente ou `:latest`, não o major flutuante.
 
 **Nenhuma peça upstream vira imagem nossa.** Não por preguiça: WAHA Plus é licenciado, e
 redistribuir o binário de terceiro dentro de uma imagem nossa é passivo jurídico numa
@@ -65,9 +71,10 @@ publicada. `build:` pode existir **ao lado** — como caminho de escape para que
 worker:
   build: { context: ., dockerfile: Dockerfile.worker }
 
-# CERTO — imagem publicada; o build fica como override opcional
+# CERTO — imagem publicada; o build fica ao lado, como escape
 worker:
-  image: ${WORKER_IMAGE:-ghcr.io/melgarafael/deskcomm-worker:latest}
+  image: ${WORKER_IMAGE:-ghcr.io/melgarafael/deskcomm-worker:stable}
+  build: { context: ., dockerfile: Dockerfile.worker }
 ```
 
 - **Por quê:** um serviço `build:`-only é invisível para `docker compose pull` ("Skipped — No
@@ -121,6 +128,18 @@ OCI — no mínimo `source`, `revision`, `version`, `licenses` — e é constru�
 
 `install.sh` e `update.sh` gravam no `.env` do cliente uma **tag de versão** (`1.2.1`), nunca
 `latest`, `main` ou `stable`.
+
+Duas exceções, ambas deliberadas e ambas com aviso na tela — porque falhar fechado aqui
+seria recusar instalar por não conseguir resolver um número:
+
+1. **Sem rede ou sem tag no remoto**, cai em `latest` e avisa. Trocar previsibilidade por
+   disponibilidade é o negócio errado numa instalação que já começou.
+2. **Quem preenche o `.env` à mão** a partir do template recebe `stable` — o piso seguro
+   para quem não vai rodar a entrevista. `--yes` com o template preserva esse valor.
+
+O que **nenhum** caminho faz é pinar numa versão sem antes conferir que as três imagens
+existem lá: a tag do git nasce minutos antes das imagens, e `deskcomm-worker:1.2.1` nunca
+vai existir porque a v1.2.1 é anterior à criação desse pacote.
 
 - **Por quê:** três consequências de uma só causa. **(a)** A versão do cliente para de mudar
   por acidente — um `up -d` rodado à mão semanas depois não troca o app sob o banco. **(b)**
@@ -203,6 +222,12 @@ default que preserva o comportamento anterior**; se ela precisa existir, quem a 
 ### 7. A versão que roda é observável de fora
 
 `GET /api/v1/health` responde a versão real da imagem em execução.
+
+> **Vale a partir da próxima release.** Nenhuma imagem já publicada carrega
+> `APP_VERSION` — medido: `docker run --rm ghcr.io/melgarafael/deskcommcrm:1.2.1 node -e
+> 'console.log(process.env.APP_VERSION)'` → `undefined`. Todo o parque instalado hoje
+> responde `desconhecido`, que é a resposta honesta e o motivo de o fallback não ser mais
+> um número plausível. O item 9 do checklist de release reprova contra a 1.2.1 de propósito.
 
 - **Por quê:** é o fecho do laço dos invariantes 2 e 3. Procedência sem observabilidade só
   serve a quem tem acesso ao registry; o suporte precisa da resposta a partir da instalação.

--- a/docs/doctrine/packaging.md
+++ b/docs/doctrine/packaging.md
@@ -115,7 +115,9 @@ OCI — no mínimo `source`, `revision`, `version`, `licenses` — e é constru�
   >
   > Enquanto isso valer, este invariante é **conselho, não gate**. A ativação é o último passo
   > do merge desta doutrina, e não pode vir antes: um required check que não existe na base
-  > dos PRs já abertos bloqueia todos eles até que cada um rebase. Uma versão anterior deste
+  > dos PRs já abertos bloqueia todos eles até que cada um rebase. O roteiro, com as
+  > verificações de cada passo, está em
+  > [`../runbooks/ativar-packaging.md`](../runbooks/ativar-packaging.md). Uma versão anterior deste
   > parágrafo afirmava, no presente, que o check já era obrigatório — exatamente o defeito que
   > esta doutrina existe para impedir, cometido dentro dela.
 

--- a/docs/doctrine/packaging.md
+++ b/docs/doctrine/packaging.md
@@ -81,7 +81,7 @@ worker:
   `update.sh` jamais o reconstruiu. A feature-título do produto era a única peça que não
   recebia correção. Enquanto isso, `CLAUDE.md` afirmava *"o caminho normal não constrói nada
   na VPS"* — verdade para o app, falso para o produto.
-- **Verificação:** `tests/unit/packaging-compose-sem-build.test.ts` reprova serviço de
+- **Verificação:** `tests/unit/packaging-artefato-do-cliente.test.ts` reprova serviço de
   `docker-compose.prod.yml` com `build:` e sem `image:`.
 
 ### 2. Publicação é ato do CI, e carrega procedência
@@ -93,12 +93,29 @@ OCI — no mínimo `source`, `revision`, `version`, `licenses` — e é constru�
   imagem que não roda na VPS amd64 do cliente, e a falha aparece só no `up -d` dele. **(b)
   Rastreabilidade:** sem `org.opencontainers.image.revision` não existe resposta para "que
   código está rodando neste cliente?", e o suporte vira adivinhação.
-- **Verificação:** o job `build-and-push` é **status check obrigatório** na branch protection
-  da `main` — junto de `verify`, `build-and-size`, `invariants` e `e2e`. O gate existia e não
-  bloqueava: em 2026-08-12 um bump de `next` passou pelos quatro obrigatórios e quebrou o
-  build da imagem na `main`, porque o `next build` dentro do Dockerfile não enxerga `tests/`
-  (`.dockerignore`) e o next 16.3 passou a typechecar os `*.test.ts` colocados. **O artefato
-  que o self-hoster instala era o único sem gate.**
+- **Verificação:** o job **`imagens-ok`** de `publish-image.yml` reprova quando qualquer uma
+  das três imagens não constrói. Ele existe porque a matriz gera um nome de check por imagem,
+  e exigir os três pelo nome faria uma quarta imagem, um dia, escapar do gate em silêncio.
+
+  > **Pendência de ativação — leia antes de citar esta linha como garantia.** `imagens-ok`
+  > **ainda não está** na branch protection. Medido em 2026-08-13:
+  >
+  > ```console
+  > $ gh api repos/melgarafael/DeskcommCRM/branches/main/protection \
+  >     --jq '.required_status_checks.contexts|join(", ")'
+  > verify, build-and-size, invariants, e2e
+  > ```
+  >
+  > Enquanto isso valer, este invariante é **conselho, não gate**. A ativação é o último passo
+  > do merge desta doutrina, e não pode vir antes: um required check que não existe na base
+  > dos PRs já abertos bloqueia todos eles até que cada um rebase. Uma versão anterior deste
+  > parágrafo afirmava, no presente, que o check já era obrigatório — exatamente o defeito que
+  > esta doutrina existe para impedir, cometido dentro dela.
+
+  O gate importa porque já falhou: em 2026-08-12 um bump de `next` passou pelos quatro
+  obrigatórios e quebrou o build da imagem na `main`, porque o `next build` dentro do
+  Dockerfile não enxerga `tests/` (`.dockerignore`) e o next 16.3 passou a typechecar os
+  `*.test.ts` colocados. **O artefato que o self-hoster instala era o único sem gate.**
 
 ### 3. Instalação de cliente nunca aponta para tag móvel
 
@@ -113,12 +130,19 @@ OCI — no mínimo `source`, `revision`, `version`, `licenses` — e é constru�
   #184 chegou descrevendo o ambiente como *"latest do dia 06/08/2026"*, que é a admissão de
   que a versão não era nomeável.
 - **A armadilha específica deste projeto:** `latest` aqui **não** significa "última release" —
-  significa **topo da `main`**, porque a regra do `metadata-action` é
-  `type=raw,value=latest,enable={{is_default_branch}}`. Uma instalação fresca em `:latest`
-  recebe código não-lançado. Isso inverte a expectativa que o nome cria e é a razão de o
-  canal `stable` existir (§Política de canais).
-- **Verificação:** `tests/shell/update-guard.test.sh` prova que a tag escolhida é **gravada**
-  no `.env` (não só exportada) e que uma instalação nova nasce pinada.
+  significa **topo da `main`**. Uma instalação fresca em `:latest` recebe código não-lançado.
+  Isso inverte a expectativa que o nome cria, e é a razão de o canal `stable` existir
+  (§Política de canais).
+
+  A regra `enable={{is_default_branch}}` do `metadata-action`, sozinha, **não** entrega isso:
+  ela é verdadeira também num push de tag, então toda release movia `latest` junto e o canal
+  oscilava entre os dois significados. O workflow prende `latest` a `ref_type == 'branch'`.
+- **Verificação:** duas, porque são dois caminhos distintos e o primeiro passou verde por
+  meses sem nenhum. `hostgator-setup-kit/test-validators.sh` roda o `install.sh` de verdade
+  contra um remoto local com tags conhecidas e cobra o `.env` pinado na maior delas (a ordem
+  alfabética escolheria `v1.9.0` sobre `v1.10.0` — erro que só apareceria na décima release).
+  `tests/shell/update-guard.test.sh` prova que o `update.sh` grava as **três** imagens na
+  mesma versão, no `.env`, sem duplicar chave.
 
 ### 4. Tag de versão é imutável; canal é móvel
 
@@ -187,8 +211,10 @@ default que preserva o comportamento anterior**; se ela precisa existir, quem a 
   é `undefined` — ela só existe quando o processo nasce de um `npm`/`pnpm run`. Toda
   instalação do mundo reportava `0.1.0`. Um campo que responde com confiança o valor errado é
   pior que um campo ausente: ele desliga a pergunta.
-- **Verificação:** `tests/unit/health-versao.test.ts` prova que a versão vem de
-  `APP_VERSION` (injetada no build via `ARG`) e reprova o retorno ao `npm_package_version`.
+- **Verificação:** `tests/unit/packaging-artefato-do-cliente.test.ts` prova que a versão vem
+  de `APP_VERSION` (injetada no build via `ARG`) e reprova o retorno ao `npm_package_version`.
+  Medido no app real: com `APP_VERSION=9.9.9-teste` o endpoint responde `9.9.9-teste`; sem ela,
+  `desconhecido` — nunca um número plausível.
 
 ---
 
@@ -270,10 +296,10 @@ parque instalado** percorre, e é o único que a suíte de CI não exercita.
 
 | Camada | Artefato | Garante |
 |---|---|---|
-| CI (mecânico) | `build-and-push` obrigatório na branch protection | imagem quebrada **reprova o merge** |
-| CI (mecânico) | `tests/unit/packaging-compose-sem-build.test.ts` | serviço `build:`-only em produção reprova |
-| CI (mecânico) | `tests/unit/health-versao.test.ts` | versão que mente reprova |
-| CI (mecânico) | `tests/shell/update-guard.test.sh` | instalação que nasce em tag móvel reprova |
+| CI (mecânico) | `imagens-ok` em `publish-image.yml` | imagem quebrada reprova — **assim que o check entrar na branch protection** (ver invariante 2) |
+| CI (mecânico) | `tests/unit/packaging-artefato-do-cliente.test.ts` | serviço `build:`-only, pin upstream solto, `pull_policy` trocado e versão que mente reprovam |
+| CI (mecânico) | `tests/shell/update-guard.test.sh` | atualização que não pina as três imagens reprova |
+| CI (mecânico) | `hostgator-setup-kit/test-validators.sh` | instalação que nasce em tag móvel reprova |
 | Gate de sessão | item 15 do Definition of Done (`CLAUDE.md`) | nenhuma task de imagem/compose/kit fecha sem responder |
 | Revisão | bloco de packaging em `CONTRIBUTING.md` | contribuidor externo sabe a régua antes do PR |
 | Operação | `docs/runbooks/deploy.md` | o procedimento reflete a lei |

--- a/docs/doctrine/packaging.md
+++ b/docs/doctrine/packaging.md
@@ -1,0 +1,306 @@
+# Doutrina de Packaging e Distribuição
+
+> Lei de arquitetura para tudo que roda no disco de quem instalou o DeskcommCRM: imagens,
+> composes, tags e o kit de instalação. Complementa [`sistema-vivo.md`](./sistema-vivo.md) —
+> não é aspiração, é critério de aceite. Amarrada ao item 15 do Definition of Done
+> (`CLAUDE.md`).
+
+Esta é a **lei**. O procedimento operacional de deploy vive em
+[`../runbooks/deploy.md`](../runbooks/deploy.md); as decisões estruturais e o que foi
+recusado, em [`../adr/0001-packaging-e-distribuicao.md`](../adr/0001-packaging-e-distribuicao.md).
+Ao mudar um invariante aqui, atualize os dois na mesma sessão.
+
+| Se você quer… | Vá para |
+|---|---|
+| saber se sua mudança precisa virar imagem publicada | §Os 7 invariantes, nº 1 |
+| escolher a tag que uma instalação de cliente consome | §Política de canais |
+| lançar uma versão | §Checklist de release |
+| entender por que o namespace é `melgarafael` e não uma org | o ADR |
+
+---
+
+## O princípio-raiz
+
+**O artefato que a pessoa instala é o produto. O repositório é a receita.**
+
+A distinção não é filosófica — ela decide onde o custo cai. Toda peça do sistema ou é
+**construída uma vez, por nós, no CI**, ou é **construída toda vez, por cada cliente, na VPS
+dele**. A segunda opção transfere para o comprador um custo que é nosso: tempo de instalação,
+RAM, risco de OOM no meio do primeiro contato com o produto — e, pior que tudo, a
+possibilidade de que duas instalações "da mesma versão" estejam rodando código diferente.
+
+Disso decorre a pergunta que classifica qualquer peça nova:
+
+> *"Quando isto muda, quem paga o build?"*
+
+Se a resposta for "o cliente", a peça está errada e vira imagem publicada.
+
+### As duas famílias de artefato
+
+| | **Nosso** | **Upstream** |
+|---|---|---|
+| Exemplos | `deskcommcrm`, `deskcomm-worker` | WAHA, Redis, Caddy, `serverless-redis-http`, `postgres` |
+| Quem constrói | nosso CI, uma vez por versão | terceiro, fora do nosso controle |
+| O que fazemos | publicamos com procedência e versão | **referenciamos com tag fixa** |
+| O que **nunca** fazemos | publicar da máquina de um dev | republicar, embalar ou copiar |
+| Se quebrar | é bug nosso, com forward-fix | é incidente de fornecedor, com pin de escape |
+
+**Nenhuma peça upstream vira imagem nossa.** Não por preguiça: WAHA Plus é licenciado, e
+redistribuir o binário de terceiro dentro de uma imagem nossa é passivo jurídico numa
+dependência crítica. Referência, nunca cópia — e a regra vale para todas, não só a licenciada,
+porque a exceção é o que apaga a regra.
+
+---
+
+## Os 7 invariantes (verificáveis)
+
+### 1. Nenhum serviço de produção constrói na máquina do cliente
+
+Todo serviço de `docker-compose.prod.yml` declara `image:` apontando para uma imagem
+publicada. `build:` pode existir **ao lado** — como caminho de escape para quem quer compilar
+—, nunca sozinho.
+
+```yaml
+# ERRADO — o cliente paga o build, e o update nunca o alcança
+worker:
+  build: { context: ., dockerfile: Dockerfile.worker }
+
+# CERTO — imagem publicada; o build fica como override opcional
+worker:
+  image: ${WORKER_IMAGE:-ghcr.io/melgarafael/deskcomm-worker:latest}
+```
+
+- **Por quê:** um serviço `build:`-only é invisível para `docker compose pull` ("Skipped — No
+  image to be pulled") e imune a `up -d` sem `--build`. Ele não é apenas caro de instalar: ele
+  **nunca é atualizado**. Congela no código do dia da instalação e atravessa todas as
+  atualizações seguintes sem que ninguém perceba.
+- **Anti-exemplo real (o defeito que originou esta doutrina):** o serviço `worker` — que é o
+  runtime do agente de IA, e o único consumidor de `ai_agent.dispatch_requested`, já que
+  `app/api/v1/cron/agent-dispatcher` é no-op permanente — não tinha `image:`. Toda instalação
+  rodava `pnpm install --frozen-lockfile` de 82 pacotes na VPS do cliente, e nenhum
+  `update.sh` jamais o reconstruiu. A feature-título do produto era a única peça que não
+  recebia correção. Enquanto isso, `CLAUDE.md` afirmava *"o caminho normal não constrói nada
+  na VPS"* — verdade para o app, falso para o produto.
+- **Verificação:** `tests/unit/packaging-compose-sem-build.test.ts` reprova serviço de
+  `docker-compose.prod.yml` com `build:` e sem `image:`.
+
+### 2. Publicação é ato do CI, e carrega procedência
+
+Imagem nossa só existe se saiu de `.github/workflows/publish-image.yml`. Ela carrega os labels
+OCI — no mínimo `source`, `revision`, `version`, `licenses` — e é construída para `linux/amd64`.
+
+- **Por quê:** duas razões distintas. **(a) Arquitetura:** um `docker build` num Mac ARM produz
+  imagem que não roda na VPS amd64 do cliente, e a falha aparece só no `up -d` dele. **(b)
+  Rastreabilidade:** sem `org.opencontainers.image.revision` não existe resposta para "que
+  código está rodando neste cliente?", e o suporte vira adivinhação.
+- **Verificação:** o job `build-and-push` é **status check obrigatório** na branch protection
+  da `main` — junto de `verify`, `build-and-size`, `invariants` e `e2e`. O gate existia e não
+  bloqueava: em 2026-08-12 um bump de `next` passou pelos quatro obrigatórios e quebrou o
+  build da imagem na `main`, porque o `next build` dentro do Dockerfile não enxerga `tests/`
+  (`.dockerignore`) e o next 16.3 passou a typechecar os `*.test.ts` colocados. **O artefato
+  que o self-hoster instala era o único sem gate.**
+
+### 3. Instalação de cliente nunca aponta para tag móvel
+
+`install.sh` e `update.sh` gravam no `.env` do cliente uma **tag de versão** (`1.2.1`), nunca
+`latest`, `main` ou `stable`.
+
+- **Por quê:** três consequências de uma só causa. **(a)** A versão do cliente para de mudar
+  por acidente — um `up -d` rodado à mão semanas depois não troca o app sob o banco. **(b)**
+  Atualizar vira **ato deliberado e reversível**: voltar é reescrever uma linha do `.env`.
+  **(c)** O suporte passa a ter resposta exata para "qual versão você está rodando?" — hoje,
+  duas instalações "no latest" feitas em meses diferentes rodam código diferente, e a issue
+  #184 chegou descrevendo o ambiente como *"latest do dia 06/08/2026"*, que é a admissão de
+  que a versão não era nomeável.
+- **A armadilha específica deste projeto:** `latest` aqui **não** significa "última release" —
+  significa **topo da `main`**, porque a regra do `metadata-action` é
+  `type=raw,value=latest,enable={{is_default_branch}}`. Uma instalação fresca em `:latest`
+  recebe código não-lançado. Isso inverte a expectativa que o nome cria e é a razão de o
+  canal `stable` existir (§Política de canais).
+- **Verificação:** `tests/shell/update-guard.test.sh` prova que a tag escolhida é **gravada**
+  no `.env` (não só exportada) e que uma instalação nova nasce pinada.
+
+### 4. Tag de versão é imutável; canal é móvel
+
+`vX.Y.Z` (e a imagem `X.Y.Z`) aponta para um digest **para sempre**. Republicar uma versão é
+proibido — corrige-se com `X.Y.Z+1`. Só `latest`, `main`, `stable` e `X.Y` se movem.
+
+- **Por quê:** a imutabilidade da tag é o que torna a pinagem do invariante 3 uma garantia em
+  vez de uma esperança. Se `1.2.1` puder ser reescrita, todo cliente "pinado" continua exposto
+  — só que agora com uma falsa sensação de controle, que é pior que nenhum controle.
+- **Verificação:** o workflow publica `type=semver` apenas a partir de tag `v*`, e tag git não
+  se reaponta. A dívida conhecida: o GHCR não impõe imutabilidade por configuração — a
+  garantia é de processo, e por isso o checklist de release proíbe reuso de número.
+
+### 5. `pull_policy` acompanha a mutabilidade da tag
+
+Tag imutável → `missing`. Tag móvel → `always`.
+
+- **Por quê:** medido, não deduzido. Com `pull_policy: always` e o registry indisponível
+  **para aquela referência**, o `docker compose up -d` **falha e o contêiner não sobe** —
+  mesmo com a imagem já presente no disco:
+
+  ```console
+  $ docker compose up -d      # pull_policy: always, imagem só local
+   t Error failed to resolve reference "…:1.0.0": not found
+  --> container rodando?           (vazio)
+
+  $ docker compose up -d      # pull_policy: missing, mesma imagem
+   Container polmissing-t-1  Started
+  --> container rodando? running
+  ```
+
+  Com tag móvel, `always` é o que faz o canal significar alguma coisa. Com tag imutável, ele
+  não protege de nada — só amarra a disponibilidade do CRM de um cliente pago à
+  disponibilidade do GHCR, em todo `up -d`. O `update.sh` não depende disso: ele puxa
+  explicitamente com `dc pull` antes de subir.
+- **Verificação:** `tests/shell/update-guard.test.sh` prova que instalação pinada grava
+  `APP_PULL_POLICY=missing`.
+
+### 6. Bump de versão não exige edição manual de `.env`
+
+Uma versão nova sobe sobre o `.env` que o cliente já tem. Variável nova nasce **opcional, com
+default que preserva o comportamento anterior**; se ela precisa existir, quem a acrescenta é o
+`update.sh`, não o usuário.
+
+- **Por quê:** o operador da VPS é leigo por premissa do produto. "Edite o `.env` antes de
+  atualizar" é uma instrução que metade do parque não executa e a outra metade executa errado
+  — e o modo de falha é o app não subir depois de uma atualização que já mexeu no banco.
+- **Anti-exemplo estrutural:** o compose de produção tem 7 variáveis sem fallback
+  (`WAHA_API_KEY_SHA512`, `WAHA_WEBHOOK_BASE_URL`, `WAHA_HMAC_SECRET`, `SRH_TOKEN`,
+  `INTERNAL_SECRET`, `DOMAIN`, `ACME_EMAIL`). Medido: o Compose **não** falha quando elas
+  faltam — substitui por string vazia, avisa em `stderr` e sobe. `DOMAIN: ""` e
+  `WAHA_API_KEY: "sha512:"` quebram em runtime, depois do `up -d`, silenciosamente. Falhar
+  tarde e mudo é pior que falhar cedo.
+- **Verificação:** toda variável nova entra em `.env.example` **e** em `lib/env.ts` com
+  default seguro (já cobrado no DoD); mudança que exija chave nova no `.env` de instalação
+  existente só entra com o `update.sh` sabendo acrescentá-la.
+
+### 7. A versão que roda é observável de fora
+
+`GET /api/v1/health` responde a versão real da imagem em execução.
+
+- **Por quê:** é o fecho do laço dos invariantes 2 e 3. Procedência sem observabilidade só
+  serve a quem tem acesso ao registry; o suporte precisa da resposta a partir da instalação.
+- **Anti-exemplo real:** o campo já existia e **mentia**. `app/api/v1/health/route.ts` lia
+  `process.env.npm_package_version ?? "0.1.0"`, e sob `CMD ["node","server.js"]` essa variável
+  é `undefined` — ela só existe quando o processo nasce de um `npm`/`pnpm run`. Toda
+  instalação do mundo reportava `0.1.0`. Um campo que responde com confiança o valor errado é
+  pior que um campo ausente: ele desliga a pergunta.
+- **Verificação:** `tests/unit/health-versao.test.ts` prova que a versão vem de
+  `APP_VERSION` (injetada no build via `ARG`) e reprova o retorno ao `npm_package_version`.
+
+---
+
+## Política de canais
+
+| Tag | Quem consome | Move? | `pull_policy` | O que significa |
+|---|---|---|---|---|
+| `1.2.1` | **toda instalação de cliente** | **não** | `missing` | uma release, para sempre |
+| `1.2` | ninguém instala | sim | — | conveniência de teste de patch |
+| `stable` | implementador validando antes de atualizar clientes | sim | `always` | a **última release** publicada |
+| `latest` | vitrine, avaliação, quem acompanha o projeto | sim | `always` | **topo da `main`** — código não lançado |
+| `main` | mantenedor e CI | sim | `always` | idêntico a `latest`, nome explícito |
+
+**A regra de ouro:** *instalação que alguém pagou aponta para número de versão. Ponto.*
+
+Ela existe porque o modelo de receita é a venda da VPS com o sistema instalado — quem instala
+para um cliente responde pelo que roda lá. Um canal móvel transfere a decisão de "quando
+atualizar" para o acaso: um reboot, um `up -d` de manutenção, uma queda de energia. Nenhum
+desses eventos é um momento em que alguém escolheu correr o risco de uma versão nova, e
+nenhum deles avisa quando dá errado. Quem descobre é o cliente, por telefone.
+
+**`latest` não é o canal estável, apesar do nome.** Essa é a pegadinha desta configuração: ele
+segue a `main`. `stable` existe para dar nome ao que as pessoas *acham* que `latest` é. E
+`latest` **não muda de significado** — mudá-lo faria clientes que hoje o consomem sofrerem um
+downgrade silencioso no próximo `up -d`, com app antigo sobre banco já migrado.
+
+---
+
+## Retrocompatibilidade — o contrato com quem já instalou
+
+Um bump de versão **pode** exigir do operador da VPS:
+
+- rodar `update.sh` (ou clicar "Atualizar agora" na tela);
+- que a VPS alcance o GHCR e o Supabase durante a atualização.
+
+Um bump de versão **não pode** exigir:
+
+- editar `.env`, compose ou qualquer arquivo à mão;
+- reinstalar, recriar volume, ou recomeçar do zero;
+- que o operador saiba o que é uma imagem, uma tag ou um registry;
+- migração de namespace de imagem — o namespace está gravado no `.env` de todo cliente
+  instalado; trocá-lo é breaking change e só cabe numa major, com o `update.sh` migrando
+  sozinho e o namespace antigo publicando em paralelo durante a transição.
+
+**Mudança que não couber nessas regras não entra: vira issue com plano de migração.**
+
+---
+
+## Checklist de release
+
+Verificável, na ordem. Nenhum item é "conferir se está tudo bem".
+
+```
+[ ] 1. CHANGELOG.md tem a seção da versão, com o que muda para quem já instalou
+[ ] 2. Nenhuma variável nova é obrigatória sem default (grep no diff de .env.example)
+[ ] 3. O número da versão NUNCA foi publicado antes:
+       git tag --list 'vX.Y.Z'  → vazio
+       curl .../tags/list       → não contém X.Y.Z
+[ ] 4. `git tag vX.Y.Z && git push origin vX.Y.Z` — a partir de um commit da `main`
+[ ] 5. O run de publicação ficou verde:
+       gh run list --workflow=publish-image.yml --limit 3
+[ ] 6. As imagens existem no registry, todas as que o compose consome:
+       para IMG in deskcommcrm deskcomm-worker deskcomm-scheduler:
+         curl -sI .../$IMG/manifests/X.Y.Z  → 200
+[ ] 7. `stable` aponta para esta versão (mesmo digest de X.Y.Z)
+[ ] 8. A imagem reporta a versão certa:
+       docker run --rm ghcr.io/…/deskcommcrm:X.Y.Z node -e 'console.log(process.env.APP_VERSION)'
+[ ] 9. `gh release create vX.Y.Z` com as notas do CHANGELOG
+[ ] 10. Ensaio de atualização numa instalação real (não fresca): update.sh a partir da
+        versão anterior, e o /api/v1/health responde X.Y.Z
+```
+
+O item 10 é o único que exige VPS. Ele não é opcional: a atualização é o caminho que **todo o
+parque instalado** percorre, e é o único que a suíte de CI não exercita.
+
+---
+
+## Enforcement
+
+| Camada | Artefato | Garante |
+|---|---|---|
+| CI (mecânico) | `build-and-push` obrigatório na branch protection | imagem quebrada **reprova o merge** |
+| CI (mecânico) | `tests/unit/packaging-compose-sem-build.test.ts` | serviço `build:`-only em produção reprova |
+| CI (mecânico) | `tests/unit/health-versao.test.ts` | versão que mente reprova |
+| CI (mecânico) | `tests/shell/update-guard.test.sh` | instalação que nasce em tag móvel reprova |
+| Gate de sessão | item 15 do Definition of Done (`CLAUDE.md`) | nenhuma task de imagem/compose/kit fecha sem responder |
+| Revisão | bloco de packaging em `CONTRIBUTING.md` | contribuidor externo sabe a régua antes do PR |
+| Operação | `docs/runbooks/deploy.md` | o procedimento reflete a lei |
+
+---
+
+## Decisões registradas
+
+**2026-08-13 — o namespace fica em `melgarafael`.** Uma consultoria externa recomendou criar
+uma org `deskcommcrm` e migrar, sob a premissa de que o compose apontava para uma org
+desvinculada do repo. A premissa era falsa: o compose sempre apontou para
+`ghcr.io/melgarafael/deskcommcrm`, que é o que o CI publica e o que está gravado no `.env` de
+todo cliente instalado. A string `deskcommcrm/deskcommcrm` existia num único lugar — uma URL
+de `git clone` em `docs/deploy-selfhost/README.md`, que retornava 404. O conserto proporcional
+ao defeito foi essa linha. Racional completo no ADR.
+
+**2026-08-13 — a régua de RAM é de operação, não de build.** A mesma consultoria argumentou
+que publicar a imagem derrubaria o requisito de 4 GB para 2 GB. Os 4 GB nunca foram custo de
+build do app: a imagem é pré-buildada desde 2026-07-02. Eles saem de medição de **operação** —
+7 contêineres, `mem_limit` somando 2560m só entre app+worker+waha, e ~150 MB por número de
+WhatsApp conectado. Publicar o worker remove um `pnpm install` da VPS; **não muda o consumo de
+quem opera**, e portanto não muda o tier recomendado. O ganho a comunicar é confiabilidade e
+capacidade — a instalação deixa de poder falhar por memória no meio, e o agente de IA passa a
+receber atualização —, nunca economia de plano.
+
+**2026-08-13 — o limiar codificado continua em 3.500.000 KB.** `install.sh` avisa (amarelo,
+não fatal) abaixo desse valor, e não em 4.000.000, porque `MemTotal` é o que sobra depois do
+que o kernel reserva: uma VPS de 4 GiB reporta ~4.012.000 KB e uma de "4 GB" decimais reporta
+~3.735.000 KB. Cortar em 4.000.000 acusaria justamente quem acabou de comprar o plano
+recomendado, na pior hora possível. Coberto por `hostgator-setup-kit/test-validators.sh`.

--- a/docs/doctrine/packaging.md
+++ b/docs/doctrine/packaging.md
@@ -267,27 +267,55 @@ Um bump de versão **não pode** exigir:
 
 Verificável, na ordem. Nenhum item é "conferir se está tudo bem".
 
+A sonda do registry vem primeiro porque os itens 3 e 6 dependem dela — e porque `curl` cru no
+GHCR responde **401**, que não contém a versão procurada e por isso seria lido como aprovação
+pelo item 3. Um gate que aprova por erro de autenticação é pior que gate nenhum:
+
+```bash
+# Cole no shell antes de começar. Funciona anonimamente (o pacote é público).
+ghcr_status() {   # $1=imagem  $2=tag  → 200 existe | 404 não existe | 403 pacote privado
+  local t
+  t=$(curl -s "https://ghcr.io/token?scope=repository:melgarafael/$1:pull&service=ghcr.io" \
+      | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
+  curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $t" \
+    -H 'Accept: application/vnd.oci.image.index.v1+json' \
+    "https://ghcr.io/v2/melgarafael/$1/manifests/$2"
+}
+```
+
+**403 não é "não existe": é pacote PRIVADO.** Todo pacote recém-criado no GHCR nasce privado,
+e repositório público não muda isso. Enquanto não for tornado público na mão (Package settings
+→ visibility), o `docker compose pull` de **toda VPS** é negado — e, como o `pull` de um
+serviço com `image:` falha a operação inteira, a atualização morre depois do `git checkout` e
+do banco. É o passo que mais trava na estreia de uma imagem nova.
+
 ```
 [ ] 1. CHANGELOG.md tem a seção da versão, com o que muda para quem já instalou
 [ ] 2. Nenhuma variável nova é obrigatória sem default (grep no diff de .env.example)
 [ ] 3. O número da versão NUNCA foi publicado antes:
-       git tag --list 'vX.Y.Z'  → vazio
-       curl .../tags/list       → não contém X.Y.Z
-[ ] 4. `git tag vX.Y.Z && git push origin vX.Y.Z` — a partir de um commit da `main`
-[ ] 5. O run de publicação ficou verde:
+       git tag --list 'vX.Y.Z'                     → vazio
+       ghcr_status deskcommcrm X.Y.Z               → 404
+[ ] 4. Os pins upstream foram revisitados: `waha`, `srh`, `redis`, `caddy`, `postgres`.
+       Bumpar ou confirmar que ficam — congelar sem revisar é como o `srh` ficou
+       três versões atrás sem ninguém decidir isso
+[ ] 5. `git tag vX.Y.Z && git push origin vX.Y.Z` — a partir de um commit da `main`
+[ ] 6. O run de publicação ficou verde:
        gh run list --workflow=publish-image.yml --limit 3
-[ ] 6. As imagens existem no registry, todas as que o compose consome:
-       para IMG in deskcommcrm deskcomm-worker deskcomm-scheduler:
-         curl -sI .../$IMG/manifests/X.Y.Z  → 200
-[ ] 7. `stable` aponta para esta versão (mesmo digest de X.Y.Z)
-[ ] 8. A imagem reporta a versão certa:
-       docker run --rm ghcr.io/…/deskcommcrm:X.Y.Z node -e 'console.log(process.env.APP_VERSION)'
-[ ] 9. `gh release create vX.Y.Z` com as notas do CHANGELOG
-[ ] 10. Ensaio de atualização numa instalação real (não fresca): update.sh a partir da
+[ ] 7. As TRÊS imagens existem E são públicas nesta versão:
+       for i in deskcommcrm deskcomm-worker deskcomm-scheduler; do
+         echo "$i: $(ghcr_status $i X.Y.Z)"; done      → 200 nas três
+       403 em alguma? Torne o pacote público ANTES de seguir
+[ ] 8. `stable` aponta para esta versão (mesmo digest de X.Y.Z):
+       ghcr_status deskcommcrm stable              → 200, e o digest bate
+[ ] 9. A imagem reporta a versão certa:
+       docker run --rm ghcr.io/melgarafael/deskcommcrm:X.Y.Z \
+         node -e 'console.log(process.env.APP_VERSION)'   → X.Y.Z
+[ ] 10. `gh release create vX.Y.Z` com as notas do CHANGELOG
+[ ] 11. Ensaio de atualização numa instalação real (não fresca): update.sh a partir da
         versão anterior, e o /api/v1/health responde X.Y.Z
 ```
 
-O item 10 é o único que exige VPS. Ele não é opcional: a atualização é o caminho que **todo o
+O item 11 é o único que exige VPS. Ele não é opcional: a atualização é o caminho que **todo o
 parque instalado** percorre, e é o único que a suíte de CI não exercita.
 
 ---

--- a/docs/doctrine/packaging.md
+++ b/docs/doctrine/packaging.md
@@ -338,11 +338,16 @@ do banco. É o passo que mais trava na estreia de uma imagem nova.
        docker run --rm ghcr.io/melgarafael/deskcommcrm:X.Y.Z \
          node -e 'console.log(process.env.APP_VERSION)'   → X.Y.Z
 [ ] 10. `gh release create vX.Y.Z` com as notas do CHANGELOG
-[ ] 11. Ensaio de atualização numa instalação real (não fresca): update.sh a partir da
+[ ] 11. Apagar tags de branch dos três pacotes — `docs-doutrina-packaging` e
+        qualquer outra que tenha nascido de um `workflow_dispatch` de ensaio.
+        Tag de branch é artefato de trabalho: se ficar, vira canal órfão que
+        alguém pina por engano achando que é release, e ela nunca mais se move.
+        O registry já carrega uma dessas (`quebrada-teste`) como lembrete.
+[ ] 12. Ensaio de atualização numa instalação real (não fresca): update.sh a partir da
         versão anterior, e o /api/v1/health responde X.Y.Z
 ```
 
-O item 11 é o único que exige VPS. Ele não é opcional: a atualização é o caminho que **todo o
+O item 12 é o único que exige VPS. Ele não é opcional: a atualização é o caminho que **todo o
 parque instalado** percorre, e é o único que a suíte de CI não exercita.
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,6 +110,7 @@ acessibilidade).
 | [`DEPLOY-CHECKLIST.md`](DEPLOY-CHECKLIST.md) | Checklist de deploy |
 | [`ATUALIZANDO.md`](ATUALIZANDO.md) | `update.sh`, `restore.sh`, `healthcheck.sh` |
 | [`runbooks/deploy.md`](runbooks/deploy.md) | **Deploy em produção — os dois `-f` do compose, verificação pós-deploy** |
+| [`runbooks/ativar-packaging.md`](runbooks/ativar-packaging.md) | **Ativação da doutrina de packaging** — os 3 passos que não cabem num PR (pacote público, check obrigatório, primeira release) |
 | [`runbooks/waha-hostgator.md`](runbooks/waha-hostgator.md) | Runbook do WAHA em produção |
 | [`runbooks/ai-credentials-rotation.md`](runbooks/ai-credentials-rotation.md) | Rotação de credenciais de IA |
 | [`../SECURITY.md`](../SECURITY.md) | Política de reporte de vulnerabilidade |

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ audited_against: origin/main @ 789dfa6 (v1.0.0, 2026-07-27)
 
 # Índice da documentação — DeskcommCRM
 
-Mapa dos **119** arquivos `.md` de `docs/`, espalhados por **23** subpastas — régua:
+Mapa dos **149** arquivos `.md` de `docs/`, espalhados por **24** subpastas — régua:
 `git ls-files 'docs/**/*.md' | wc -l`. Existe porque a documentação cresceu sem ponto
 de entrada: sem este índice, humano e agente não acham o que já foi decidido e
 reescrevem por cima.
@@ -83,6 +83,8 @@ Detalham schema SQL e payloads exatos. **Consulte antes de modelar qualquer cois
 | [`doctrine/sistema-vivo/`](doctrine/sistema-vivo/README.md) | **Manual do Sistema Vivo** — 8 capítulos plugáveis (princípio universal + aplicação de referência). O *porquê* de cada invariante, e como adotar a doutrina em outro sistema |
 | [`doctrine/restricao-de-canal.md`](doctrine/restricao-de-canal.md) | Auto-restrição × hetero-restrição de canais externos; contrato de parâmetros derivado |
 | [`doctrine/separacao-fala-e-operacao.md`](doctrine/separacao-fala-e-operacao.md) | Vocabulário interno nunca vaza para o cliente |
+| [`doctrine/packaging.md`](doctrine/packaging.md) | **Doutrina de Packaging — a LEI.** 7 invariantes + política de canais + checklist de release (item 15 do DoD) |
+| [`adr/0001-packaging-e-distribuicao.md`](adr/0001-packaging-e-distribuicao.md) | ADR do packaging: namespace, os 3 packages, e o que foi recusado |
 | [`architecture/agent-turn.html`](architecture/agent-turn.html) | Diagrama do turno do agente (inbound → guardrails → outbound) |
 | [`research/architecture-diagrams.md`](research/architecture-diagrams.md) | Diagramas de arquitetura |
 | [`research/reference-synthesis.md`](research/reference-synthesis.md) | Arquitetura herdada da referência WAHA |

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,6 +110,7 @@ acessibilidade).
 | [`DEPLOY-CHECKLIST.md`](DEPLOY-CHECKLIST.md) | Checklist de deploy |
 | [`ATUALIZANDO.md`](ATUALIZANDO.md) | `update.sh`, `restore.sh`, `healthcheck.sh` |
 | [`runbooks/deploy.md`](runbooks/deploy.md) | **Deploy em produção — os dois `-f` do compose, verificação pós-deploy** |
+| [`runbooks/remediar-worker-congelado.md`](runbooks/remediar-worker-congelado.md) | **Incidente: o worker congelado** — diagnóstico (`diagnostico.sh`), impacto medido e as duas rotas de remediação. **Ainda não ensaiado** |
 | [`runbooks/ativar-packaging.md`](runbooks/ativar-packaging.md) | **Ativação da doutrina de packaging** — os 3 passos que não cabem num PR (pacote público, check obrigatório, primeira release) |
 | [`runbooks/waha-hostgator.md`](runbooks/waha-hostgator.md) | Runbook do WAHA em produção |
 | [`runbooks/ai-credentials-rotation.md`](runbooks/ai-credentials-rotation.md) | Rotação de credenciais de IA |

--- a/docs/runbooks/ativar-packaging.md
+++ b/docs/runbooks/ativar-packaging.md
@@ -1,0 +1,159 @@
+# Runbook — ativar a doutrina de packaging (uma vez só)
+
+Este documento existe porque a entrega da [doutrina de packaging](../doctrine/packaging.md)
+tem três passos que **não podem estar dentro do PR**: dois dependem de administração do
+repositório e um depende de as imagens existirem. Enquanto eles não forem dados, parte da
+doutrina é conselho, não gate — e o texto diz isso onde for o caso.
+
+Faça na ordem. Cada passo tem a verificação que prova que ele funcionou.
+
+---
+
+## Antes de começar: a sonda
+
+Cole no shell. `curl` cru no GHCR responde `401`, e um corpo de erro não contém a versão
+procurada — o que faz qualquer checagem ingênua aprovar tudo.
+
+```bash
+ghcr_status() {   # $1=imagem  $2=tag  → 200 existe | 404 não existe | 403 privado
+  local t
+  t=$(curl -s "https://ghcr.io/token?scope=repository:melgarafael/$1:pull&service=ghcr.io" \
+      | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
+  curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $t" \
+    -H 'Accept: application/vnd.oci.image.index.v1+json' \
+    "https://ghcr.io/v2/melgarafael/$1/manifests/$2"
+}
+```
+
+Estado no momento em que este runbook foi escrito (2026-08-13):
+
+```console
+$ ghcr_status deskcommcrm 1.2.1        → 200
+$ ghcr_status deskcommcrm stable       → 404   (o canal ainda não existe)
+$ ghcr_status deskcomm-worker latest   → 403   (o pacote ainda não existe)
+```
+
+---
+
+## 1. Merge do PR na `main`
+
+O push na `main` dispara `publish-image.yml`, que **cria** os dois pacotes novos
+(`deskcomm-worker`, `deskcomm-scheduler`) publicando `main` e `latest` neles.
+
+**Verificação:**
+
+```bash
+gh run list --workflow=publish-image.yml --limit 3    # o run da main ficou verde?
+ghcr_status deskcomm-worker latest                    # esperado agora: 403 (existe, privado)
+```
+
+`403` aqui é **progresso**, não erro: significa que o pacote passou a existir. `404` significa
+que o run não publicou — investigue o run antes de seguir.
+
+## 2. Tornar os dois pacotes novos PÚBLICOS
+
+**É o passo que mais trava na estreia de uma imagem, e ele é manual.** Todo pacote recém-criado
+no GHCR nasce privado, e repositório público não muda isso. Enquanto for privado, o
+`docker compose pull` de **toda VPS** é negado — e como `pull` de um serviço com `image:` falha
+a operação inteira, a atualização de um cliente morre depois do `git checkout` e do banco.
+
+Para cada um de `deskcomm-worker` e `deskcomm-scheduler`:
+
+> github.com/users/melgarafael/packages/container/`<pacote>`/settings → Danger Zone →
+> Change visibility → **Public**
+
+Enquanto estiver aqui, ligue também **Inherit access from repository**, para o pacote seguir a
+permissão do repositório em vez de uma lista própria.
+
+**Verificação:**
+
+```bash
+for i in deskcommcrm deskcomm-worker deskcomm-scheduler; do
+  echo "$i: $(ghcr_status $i latest)"
+done
+# esperado: 200 nos três
+```
+
+## 3. `imagens-ok` vira status check obrigatório
+
+Só agora, e a ordem importa: um required check que não existe na base dos PRs já abertos
+bloqueia **todos** eles até que cada um faça rebase. Depois do merge, `imagens-ok` existe na
+`main` e todo PR novo já nasce com ele.
+
+```bash
+gh api -X PATCH repos/melgarafael/DeskcommCRM/branches/main/protection/required_status_checks \
+  -f 'checks[][context]=verify' \
+  -f 'checks[][context]=build-and-size' \
+  -f 'checks[][context]=invariants' \
+  -f 'checks[][context]=e2e' \
+  -f 'checks[][context]=imagens-ok'
+```
+
+> Use **`imagens-ok`**, não `build-and-push`. O job de build virou matriz de três imagens, e o
+> nome do check passou a ser `build-and-push (deskcommcrm, …)` — exigir cada um pelo nome faria
+> uma quarta imagem, um dia, escapar do gate em silêncio. `imagens-ok` é o job de fachada que
+> existe exatamente para dar um nome estável.
+
+**Verificação:**
+
+```bash
+gh api repos/melgarafael/DeskcommCRM/branches/main/protection \
+  --jq '.required_status_checks.contexts|join(", ")'
+# esperado: verify, build-and-size, invariants, e2e, imagens-ok
+```
+
+Feito isso, **remova a "Pendência de ativação"** do invariante 2 em
+[`../doctrine/packaging.md`](../doctrine/packaging.md) e as ressalvas correspondentes em
+`CLAUDE.md` e `CONTRIBUTING.md`. Deixar a ressalva de pé depois de a pendência ter sido
+resolvida transforma a doutrina em documento que subestima a si mesmo — o defeito espelhado
+do que ela veio consertar.
+
+## 4. Primeira release completa
+
+Só uma tag `v*` publica os números de versão e o canal `stable`. Até ela existir, o default
+`:stable` do compose não resolve, e o caminho de avaliação (clonar e rodar `up -d` sem `.env`)
+não sobe. Siga o §Checklist de release da doutrina.
+
+**Verificação:**
+
+```bash
+for i in deskcommcrm deskcomm-worker deskcomm-scheduler; do
+  echo "$i X.Y.Z: $(ghcr_status $i X.Y.Z)  stable: $(ghcr_status $i stable)"
+done
+# esperado: 200 em todos
+
+docker run --rm ghcr.io/melgarafael/deskcommcrm:X.Y.Z \
+  node -e 'console.log(process.env.APP_VERSION)'
+# esperado: X.Y.Z   (antes desta release, `undefined` — nenhuma imagem publicada a carrega)
+```
+
+## 5. Ensaio numa VPS real
+
+O item 11 do checklist de release, e o único que o CI não exercita. Numa instalação **não
+fresca**, a partir da versão anterior:
+
+```bash
+bash hostgator-setup-kit/update.sh
+curl -s https://<DOMAIN>/api/v1/health | jq -r '.data.version'   # esperado: X.Y.Z
+curl -s -o /dev/null -w '%{http_code}\n' https://<DOMAIN>/       # esperado: 307
+grep -E '^(APP|WORKER|SCHEDULER)_IMAGE=' .env                    # esperado: as três em X.Y.Z
+docker compose -f docker-compose.prod.yml ps                     # esperado: tudo healthy
+```
+
+O que este ensaio prova e nenhum teste do CI prova: que uma VPS **saiu do estado A e chegou ao
+estado B**. O CI prova que os scripts fazem o que dizem — não que a máquina de alguém mudou.
+É o caso U6 de [`../testing/user-journey-map.md`](../testing/user-journey-map.md), declarado
+como não coberto de propósito.
+
+---
+
+## Enquanto os passos 1–4 não acontecem
+
+Nada quebra, e isso é por construção:
+
+| Quem | O que acontece |
+|---|---|
+| Parque instalado | segue igual — o compose novo só chega a uma VPS pelo `git checkout` de uma tag `v*` nova |
+| Instalação nova | o `install.sh` sonda o registry, vê que o trio não está publicado, **avisa** e constrói worker/scheduler localmente (lento, funciona) |
+| Avaliação (`up -d` sem `.env`) | o app não sobe até o `stable` existir — o passo 4 resolve |
+| PR de contribuidor | `imagens-ok` roda e informa; não bloqueia até o passo 3 |

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -74,10 +74,9 @@ commit → push → PR → merge na main → CI publica imagem → VPS puxa
    não um `up -d` na mão: ele puxa a tag publicada, re-aplica o `baseline.sql`,
    faz backup antes e grava as três imagens no `.env`.
 
-> **`latest` não é a última release.** A regra do CI é
-> `enable={{is_default_branch}}`, então `latest` segue o **topo da `main`** —
-> código ainda não lançado. Quem quer a última release usa `stable`; quem opera
-> um cliente usa o número da versão. Ver
+> **`latest` não é a última release.** Ele é publicado a partir da branch default, então
+> segue o **topo da `main`** — código ainda não lançado. Quem quer a última release usa
+> `stable`; quem opera um cliente usa o número da versão. Ver
 > [`../doctrine/packaging.md`](../doctrine/packaging.md).
 
 ---

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -67,10 +67,18 @@ commit → push → PR → merge na main → CI publica imagem → VPS puxa
    VPS não existe: o CI não o vê, some se a VPS for reconstruída, e é invisível
    pra qualquer outra pessoa.
 2. **PR e merge na `main`.** `publish-image.yml` dispara em push na `main` (ou
-   tag `v*`) e publica `ghcr.io/<repo>:latest`. O build pesado (~6min) roda nos
+   tag `v*`) e publica **três** imagens — `deskcommcrm`, `deskcomm-worker` e
+   `deskcomm-scheduler` — sempre na mesma versão. O build pesado roda nos
    runners do GitHub, nunca na VPS do usuário.
-3. **Deploy na VPS** com o comando da seção 1. Como o `.env` tem
-   `APP_PULL_POLICY='always'`, o `up -d` já puxa a imagem nova sozinho.
+3. **Deploy na VPS.** Numa instalação real isto é `bash hostgator-setup-kit/update.sh`,
+   não um `up -d` na mão: ele puxa a tag publicada, re-aplica o `baseline.sql`,
+   faz backup antes e grava as três imagens no `.env`.
+
+> **`latest` não é a última release.** A regra do CI é
+> `enable={{is_default_branch}}`, então `latest` segue o **topo da `main`** —
+> código ainda não lançado. Quem quer a última release usa `stable`; quem opera
+> um cliente usa o número da versão. Ver
+> [`../doctrine/packaging.md`](../doctrine/packaging.md).
 
 ---
 
@@ -87,11 +95,20 @@ APP_IMAGE=deskcomm-app:local APP_PULL_POLICY=never docker compose \
   -f docker-compose.prod.yml -f docker-compose.traefik.yml --env-file .env up -d app
 ```
 
+O `docker-compose.build.yml` também cobre `worker` e `scheduler` — troque
+`app` pelo serviço que você precisa construir. Eles têm `build:` no próprio
+compose de produção (é o escape que faz a instalação sobreviver a um registry
+fora do ar), mas é o override que traz o `pull_policy: never`; sem ele o
+`up -d` volta a buscar a imagem publicada.
+
 **Isto é dívida, não um caminho paralelo.** A imagem existe só no disco daquela
 VPS: não está no registry, não está no git, e qualquer `docker compose up -d`
 sem `APP_PULL_POLICY=never` a substitui pela do GHCR — silenciosamente, sem erro
 nenhum, revertendo o que você acabou de subir.
 
 Requisitos: >= 4 GB de RAM **ou** swap (medido: ~4min num VPS de 3.8 GB com 4 GB
-de swap). Ao terminar, feche o ciclo — merge na `main` e volte a VPS pra imagem
-oficial.
+de swap) — e isto é o requisito **deste caminho de exceção**, não da operação
+normal. A régua de operação (7 contêineres, ~150 MB por número de WhatsApp,
+`mem_limit` somando 2560m entre app+worker+waha) é outra, e não mudou.
+
+Ao terminar, feche o ciclo — merge na `main` e volte a VPS pra imagem oficial.

--- a/docs/runbooks/remediar-worker-congelado.md
+++ b/docs/runbooks/remediar-worker-congelado.md
@@ -1,18 +1,28 @@
 # Runbook — o worker congelado: diagnóstico e remediação
 
-> ## ⚠️ ESTE RUNBOOK NÃO FOI ENSAIADO
+> ## Estado do ensaio: **U6-b EXECUTADO em 2026-08-13, com uma ressalva que muda o procedimento**
 >
-> Nenhum passo abaixo foi executado numa VPS de ponta a ponta. Ele foi escrito a
-> partir de: o código do `update.sh`, o comportamento medido do `docker compose`, e o
-> diagnóstico read-only da instalação de produção. **Isso não é a mesma coisa que ter
-> feito.**
+> O ensaio rodou numa VPS real, com estado legado **reproduzido** (não simulado): clone
+> no commit `ee520110` de 2026-07-31 — o mesmo em que o worker era `build:`-only —,
+> baseline daquela época aplicado, e a stack subida por `docker compose up -d`, que
+> construiu o worker na máquina, como acontece na instalação de um cliente.
 >
-> O ensaio pendente é o **U6-b** (`docs/testing/user-journey-map.md`): reconstruir uma
-> instalação legada numa VPS descartável, confirmar o sintoma, remediar, verificar que
-> nada se perdeu, e rodar o rollback. Enquanto ele não acontecer, cada passo carrega
-> `[NÃO VERIFICADO]` e o espaço da evidência está reservado, vazio, de propósito.
+> **O que passou:** o worker migrou de imagem local (`2174fb4f`) para a publicada
+> (`ghcr.io/…/deskcomm-worker`, `revision=31096584…`); as três imagens ficaram pinadas
+> na mesma versão; o volume do WAHA, a customização do operador no `.env` e o banco
+> sobreviveram (69 → 73 tabelas, a migração esperada).
 >
-> **Não conduza a remediação de um cliente por este documento antes de o U6-b fechar.**
+> **A ressalva, e ela é o motivo de este aviso continuar aqui:** a **primeira** execução
+> do `update.sh` NÃO consertou o worker. Quem executa a transição é o `update.sh` que
+> está no disco do cliente — o antigo —, e ele só sabe gravar `APP_IMAGE`. O worker cai
+> no default do compose novo, e enquanto o canal `stable` não existir no registry esse
+> default não resolve. Só a **segunda** execução, já com o kit novo em disco, pinou as
+> três e trocou a imagem. Ver §5.0.
+>
+> **Ainda não coberto:** o app não subiu contra um Supabase real (o ensaio usou um
+> Postgres em contêiner como `SUPABASE_DB_URL`), então auth, storage e PostgREST não
+> foram exercitados; e a sessão do WhatsApp foi representada por um arquivo marcador no
+> volume, não por um número pareado de verdade.
 
 ---
 
@@ -133,10 +143,45 @@ mais nova. É o que mantém código e schema no mesmo par.
 
 ## 5. Passo a passo — Rota A
 
-Cada passo traz o rollback ao lado. `[NÃO VERIFICADO]` marca o que o ensaio U6-b ainda
-precisa confirmar.
+Cada passo traz o rollback ao lado. `[ENSAIADO]` foi executado no U6-b de 2026-08-13;
+`[NÃO VERIFICADO]` continua sem prova.
 
-### A1. Diagnosticar e registrar o antes `[NÃO VERIFICADO]`
+### 5.0. Leia isto antes: **a primeira execução pode não bastar**
+
+Medido no ensaio, e é o achado que muda o procedimento.
+
+Quem executa a transição é o `update.sh` que está **no disco do cliente** — o antigo. Ele
+faz `git checkout` da tag nova (o que já troca o `docker-compose.prod.yml` pelo novo) e
+só então segue com a própria lógica, que conhece apenas `APP_IMAGE`. O worker cai no
+default do compose novo, `:stable`.
+
+No ensaio, `stable` ainda não existia no registry. Resultado medido, na ordem:
+
+```
+dc pull  → Image ghcr.io/…/deskcommcrm:… Pulled          (o app veio)
+         → Error: ghcr.io/…/deskcomm-worker:stable: not found
+         → Error: ghcr.io/…/deskcomm-scheduler:stable: not found
+up -d    → o worker seguiu no contêiner que já existia
+worker   → antes 2174fb4f · depois 2174fb4f   (NÃO mudou)
+```
+
+A **segunda** execução, já com o kit novo em disco, chamou `gravar_imagens`, pinou as três
+na mesma versão e trocou a imagem do worker pela publicada.
+
+**Consequências práticas:**
+
+1. **A release precisa existir antes de o parque atualizar.** Com `stable` publicado, o
+   default resolve e a primeira execução já traz o worker. A ordem do
+   [runbook de ativação](ativar-packaging.md) — merge → pacotes públicos → check
+   obrigatório → **release** — não é burocracia: é a precondição desta remediação.
+2. **Rode `update.sh` duas vezes** numa instalação legada, e confira com o
+   `diagnostico.sh` entre uma e outra. O README do kit já pedia isso por outro motivo
+   ("a primeira execução ainda é a do script velho"); aqui o motivo é este, e é medido.
+3. **Confirme pelo detector, não pelo fim do script.** A primeira execução termina sem
+   erro fatal — ela puxa o app, aplica o banco e sobe. Nada na tela diz que o worker
+   ficou para trás. Só o `diagnostico.sh` responde isso.
+
+### A1. Diagnosticar e registrar o antes `[ENSAIADO]`
 
 ```bash
 cd /caminho/do/projeto
@@ -161,7 +206,7 @@ docker system df
 Não use `docker system prune --volumes` — ele apaga volumes, e é lá que mora a sessão
 pareada do WhatsApp.
 
-### A3. Rodar o update `[NÃO VERIFICADO]`
+### A3. Rodar o update `[ENSAIADO — ver §5.0: pode exigir duas execuções]`
 
 ```bash
 bash hostgator-setup-kit/update.sh
@@ -184,7 +229,7 @@ docker compose -f docker-compose.prod.yml up -d
 O banco **não** volta com isso. Para voltá-lo, `bash hostgator-setup-kit/restore.sh` com o
 dump que o A3 gerou — e ele pede confirmação digitada, de propósito.
 
-### A4. Verificar que o worker mudou de verdade `[NÃO VERIFICADO]`
+### A4. Verificar que o worker mudou de verdade `[ENSAIADO]`
 
 ```bash
 bash hostgator-setup-kit/diagnostico.sh          # esperado: exit 0, "NÃO está afetada"
@@ -192,7 +237,7 @@ curl -s localhost:3000/api/v1/health | grep -o '"version":"[^"]*"'
 grep -E '^(APP|WORKER|SCHEDULER)_IMAGE=' .env    # as três na MESMA versão
 ```
 
-### A5. Verificar que nada se perdeu `[NÃO VERIFICADO — o item central do U6-b]`
+### A5. Verificar que nada se perdeu `[ENSAIADO em parte — ver a tabela]`
 
 O que precisa estar intacto, e o que responde por cada um:
 
@@ -211,19 +256,70 @@ U6-b precisa confirmar.**
 
 ---
 
-## 6. Evidência do ensaio
+## 6. Evidência do ensaio (U6-b, 2026-08-13)
 
-> **Reservado.** Aqui entram os dois cenários do U6-b quando forem executados numa VPS
-> descartável: comandos, saídas e o que foi observado na tela.
->
-> - **U6-a — instalação nova:** sobe pinada, `/api/v1/health` com a versão certa, nenhum
->   serviço construído localmente.
-> - **U6-b — atualização de legada:** estado legado reconstruído a partir do commit da
->   época, sintoma confirmado antes, `update.sh` novo, worker passa a rodar imagem
->   publicada, nada perdido (§A5), e rollback verificado.
->
-> Enquanto esta seção estiver vazia, o runbook é uma hipótese bem fundamentada — não um
-> procedimento provado.
+**Ambiente.** VPS real, num diretório isolado (`deskcomm-ensaio`, projeto compose próprio,
+sem publicar portas), lado a lado com uma instalação de produção que **não foi tocada** —
+confirmado antes e depois: 7 contêineres, mesmo uptime, Caddy respondendo 308.
+
+**Estado legado reproduzido, não simulado.** Clone no commit `ee520110` (2026-07-31), o
+mesmo em que `docker-compose.prod.yml` tinha o worker `build:`-only; `baseline.sql`
+daquela época aplicado (69 tabelas); `docker compose up -d` construiu o worker na
+máquina — imagem `deskcomm-ensaio-worker` (`2174fb4f`), **sem labels OCI**, diferente da
+imagem da produção, provando que foi construída ali e não reaproveitada.
+
+**Sintoma confirmado antes de consertar:** `diagnostico.sh` → exit 1, "ESTÁ afetada".
+
+| Verificação | Antes | Depois | |
+|---|---|---|---|
+| imagem do worker | `deskcomm-ensaio-worker` (`2174fb4f`, sem labels) | `ghcr.io/…/deskcomm-worker:docs-doutrina-packaging` (`2082c65e`, `revision=31096584…`) | ✅ |
+| `.env` — as três imagens | só `APP_IMAGE` | as três na mesma versão, `pull_policy: missing` | ✅ |
+| marcador no volume `waha-data` | presente | **presente** | ✅ |
+| customização do operador no `.env` | presente | **presente** | ✅ |
+| tabelas no banco | 69 | 73 (a migração esperada) | ✅ |
+| `diagnostico.sh` | exit 1 (afetada) | **exit 0 (não afetada)** | ✅ |
+
+**O que exigiu duas execuções:** ver §5.0. A primeira não trocou o worker.
+
+### O rollback tem um efeito colateral, e ele foi medido
+
+Restaurar o `.env` anterior (sem `WORKER_IMAGE`) e subir **não devolve o estado exato**.
+O compose no disco já é o novo, então o worker volta ao default `:stable`; como `stable`
+não existia, o Compose **construiu localmente e taggeou a imagem como
+`ghcr.io/melgarafael/deskcomm-worker:stable`**.
+
+O resultado é uma imagem local **com nome de registry** — que parece publicada e não é:
+
+```
+revision: []                                          ← vazio: não veio do CI
+source:   [https://github.com/melgarafael/DeskcommCRM] ← veio do LABEL do Dockerfile
+está no registry de verdade? NAO
+```
+
+O `diagnostico.sh` detectou corretamente (exit 1). Vale registrar por quê: esse é
+exatamente o caso que uma sabotagem do detector tinha inventado — imagem local
+retagueada — e que a primeira versão dele, decidindo pelo **nome** da imagem, deixava
+passar. O caso apareceu sozinho, na vida real, produzido pelo próprio rollback.
+
+**Portanto:** depois de um rollback, rode o `diagnostico.sh`. Voltar o `.env` desfaz a
+pinagem, não o estado da imagem.
+
+### O que este ensaio NÃO cobriu
+
+- **Supabase real.** O `SUPABASE_DB_URL` apontou para um Postgres em contêiner
+  (`pgvector/pgvector:pg17`, o mesmo do CI). O `baseline.sql` foi exercitado de verdade;
+  auth, storage e PostgREST não.
+- **Sessão de WhatsApp pareada de verdade.** Foi representada por um arquivo marcador
+  dentro do volume `waha-data`. Prova que o volume sobrevive ao ciclo; não prova que uma
+  sessão pareada continua `WORKING`.
+- **`install.sh` da época de ponta a ponta.** Ele exige um projeto Supabase (bootstrap do
+  owner pela Admin API). O estado legado foi produzido pelo `docker compose up -d` — que
+  é literalmente a linha que o passo 9 do `install.sh` executa, e é a que produz o worker
+  construído localmente.
+- **Uma release de verdade.** O ensaio usou uma tag local (`vdocs-doutrina-packaging`)
+  apontando para as imagens já publicadas da branch. Foi o artifício que permitiu ensaiar
+  o caminho completo antes de haver release — e é por isso que o cenário do `stable`
+  inexistente apareceu.
 
 ## 7. Decisão do operador — sempre
 

--- a/docs/runbooks/remediar-worker-congelado.md
+++ b/docs/runbooks/remediar-worker-congelado.md
@@ -1,0 +1,236 @@
+# Runbook — o worker congelado: diagnóstico e remediação
+
+> ## ⚠️ ESTE RUNBOOK NÃO FOI ENSAIADO
+>
+> Nenhum passo abaixo foi executado numa VPS de ponta a ponta. Ele foi escrito a
+> partir de: o código do `update.sh`, o comportamento medido do `docker compose`, e o
+> diagnóstico read-only da instalação de produção. **Isso não é a mesma coisa que ter
+> feito.**
+>
+> O ensaio pendente é o **U6-b** (`docs/testing/user-journey-map.md`): reconstruir uma
+> instalação legada numa VPS descartável, confirmar o sintoma, remediar, verificar que
+> nada se perdeu, e rodar o rollback. Enquanto ele não acontecer, cada passo carrega
+> `[NÃO VERIFICADO]` e o espaço da evidência está reservado, vazio, de propósito.
+>
+> **Não conduza a remediação de um cliente por este documento antes de o U6-b fechar.**
+
+---
+
+## 1. O que aconteceu
+
+O serviço `worker` — o processo que faz o agente de IA atender 24/7 — não tinha `image:`
+no `docker-compose.prod.yml`, só `build:`. Duas consequências do Docker Compose, ambas
+medidas:
+
+- `docker compose pull` **pula** serviço build-only (`"Skipped - No image to be pulled"`);
+- `docker compose up -d` **sem `--build`** recria o contêiner sobre a imagem que já existe.
+
+Resultado: o worker era compilado na VPS no dia da instalação e **nenhum `update.sh`
+jamais o reconstruiu**. O app, o banco e todo o resto atualizavam normalmente; só o
+agente ficava parado.
+
+**Não é teoria.** Medido na instalação de produção do projeto em 2026-08-13:
+
+| serviço | imagem | criada |
+|---|---|---|
+| app | `ghcr.io/melgarafael/deskcommcrm:1.2.1` (registry) | 2026-08-12 |
+| worker | `deskcommcrm-worker` (local, sem labels OCI) | **2026-07-31** |
+
+O contêiner do worker havia sido **reiniciado naquele mesmo dia** e continuava rodando a
+imagem de 31/07 — restart não reconstrói.
+
+## 2. Impacto — o que o cliente perdeu
+
+Entre a data da imagem do worker e a versão instalada do app, **9 commits e 399 linhas**
+em `workers/` nunca chegaram. Traduzido para o que se sente na operação:
+
+| O que o cliente percebe | O que estava por trás | Corrigido em |
+|---|---|---|
+| **O agente responde duas vezes à mesma mensagem** | dois runtimes consumiam o mesmo evento de despacho | `#129`, 2026-08-06 |
+| **Áudio e imagem que o cliente manda não viram conteúdo** — a IA responde como se nada tivesse chegado | a mídia só era derivada num dos canais | 2026-08-11 |
+| **O agente vaza dado interno na conversa** (URL de sistema, ID, jargão de CRM) | não havia separação entre quem fala e quem executa | `#181`, 2026-08-07 — vazamento medido caiu de 3-em-10 para 1-em-10 turnos |
+| **Sentimento classificado errado, sem erro visível** | a classificação falhava por truncamento e ficava em silêncio | 2026-08-01 |
+| **Resposta atribuída ao canal errado no histórico** | `sent_via` inválido | `#126`, 2026-08-04 |
+
+**O que NÃO aconteceu:** nenhum dado foi perdido ou corrompido. Conversas, contatos,
+leads, mídia no storage e a sessão pareada do WhatsApp são estado do banco e dos volumes
+— o worker congelado deixou de *melhorar*, não de funcionar. Uma instalação afetada
+atendeu o tempo todo; atendeu com o agente de dois meses atrás.
+
+## 3. Diagnóstico — antes de qualquer conserto
+
+Read-only, seguro em produção, não precisa de clone:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/melgarafael/DeskcommCRM/main/hostgator-setup-kit/diagnostico.sh | bash
+```
+
+Ou, se o operador já tem o projeto no disco:
+
+```bash
+cd /caminho/do/projeto && bash hostgator-setup-kit/diagnostico.sh
+```
+
+Códigos de saída: `0` não afetada · `1` afetada · `2` inconclusivo (Docker parado, stack
+no chão, instalação não encontrada).
+
+**Por que não basta olhar o `/api/v1/health`:** até a versão que conserta isto, ele lê
+`npm_package_version`, que é `undefined` sob `CMD ["node","server.js"]`. Toda instalação
+responde `0.1.0` — afetada ou não. Foi medido na produção.
+
+---
+
+## 4. As duas rotas
+
+### Rota A — Completa: `update.sh` (**recomendada**)
+
+Leva a instalação para a versão nova inteira: app, worker e scheduler pinados na mesma
+versão, `.env` com as chaves novas, `baseline.sql` re-aplicado, backup antes.
+
+```bash
+cd /caminho/do/projeto
+bash hostgator-setup-kit/update.sh
+```
+
+### Rota B — Cirúrgica: só o worker passa a puxar imagem publicada
+
+Blast radius mínimo — não toca no banco, não muda o app, não re-aplica o baseline.
+
+```bash
+cd /caminho/do/projeto
+# 1. anote o estado atual, para poder voltar
+docker compose -f docker-compose.prod.yml ps --format '{{.Service}}|{{.Image}}' > /root/estado-antes.txt
+# 2. aponte SÓ o worker para a imagem publicada da versão que o app já roda
+grep '^APP_IMAGE=' .env            # → confirme a versão, ex.: …deskcommcrm:1.2.1
+printf 'WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:<a-mesma-versão>\n' >> .env
+printf 'WORKER_PULL_POLICY=missing\n' >> .env
+# 3. recrie apenas o worker
+docker compose -f docker-compose.prod.yml up -d --no-deps worker
+```
+
+> Numa VPS com proxy reverso próprio, **todo** `docker compose` leva também
+> `-f docker-compose.traefik.yml`. Omitir recria o contêiner sem as labels de roteamento
+> e o domínio inteiro passa a responder 404, com o contêiner `healthy`.
+
+### Qual usar, e por quê
+
+**Recomendo a Rota A.** A B parece mais segura por mexer em menos, e essa aparência é
+justamente o risco: ela deixa o worker numa versão nova e o **banco** na versão antiga.
+O worker é o consumidor de `ai_agent.dispatch_requested` e escreve em tabelas que
+migrations recentes alteraram — parear código novo com schema velho é a combinação que
+nem o CI nem o ensaio cobrem, porque não é um estado que o produto produz sozinho.
+
+A Rota A é mais longa e é o caminho que o `update.sh` já percorre em toda atualização:
+backup do banco antes, `baseline.sql` idempotente, healthcheck no fim, e rollback
+automático do app se ele não voltar.
+
+**A B tem um uso legítimo:** quando o `update.sh` não pode rodar agora — janela de
+manutenção fechada, ou o operador quer separar o conserto do agente da atualização geral.
+Nesse caso, escolha a tag do worker **igual à do app** (`grep APP_IMAGE .env`), nunca a
+mais nova. É o que mantém código e schema no mesmo par.
+
+---
+
+## 5. Passo a passo — Rota A
+
+Cada passo traz o rollback ao lado. `[NÃO VERIFICADO]` marca o que o ensaio U6-b ainda
+precisa confirmar.
+
+### A1. Diagnosticar e registrar o antes `[NÃO VERIFICADO]`
+
+```bash
+cd /caminho/do/projeto
+bash hostgator-setup-kit/diagnostico.sh | tee /root/antes-remediacao.txt
+docker compose -f docker-compose.prod.yml ps --format '{{.Service}}|{{.Image}}' >> /root/antes-remediacao.txt
+cp .env /root/.env.antes-remediacao        # o .env tem segredos: chmod 600
+chmod 600 /root/.env.antes-remediacao
+```
+
+**Rollback:** nada a desfazer — só leitura e cópia.
+
+### A2. Confirmar que há espaço em disco `[NÃO VERIFICADO]`
+
+O update baixa três imagens novas sem apagar as antigas, e faz um dump do banco.
+
+```bash
+df -h / | tail -1
+docker system df
+```
+
+**Se faltar espaço:** `docker image prune -a` remove imagens **sem contêiner usando**.
+Não use `docker system prune --volumes` — ele apaga volumes, e é lá que mora a sessão
+pareada do WhatsApp.
+
+### A3. Rodar o update `[NÃO VERIFICADO]`
+
+```bash
+bash hostgator-setup-kit/update.sh
+```
+
+O que ele faz, na ordem (lido do script, não ensaiado ponta a ponta): instala o cron do
+agente de atualização → **backup do banco** → `git checkout` da tag → re-aplica o
+`baseline.sql` → grava as três imagens no `.env` → `dc pull` → `dc up -d` → espera o app
+ficar saudável.
+
+**Rollback:** se o app não voltar, o script sai com código 1 e **não** reverte sozinho
+quando executado à mão (o rollback automático existe no `agent.sh`, o caminho do botão na
+tela). Manual:
+
+```bash
+cp /root/.env.antes-remediacao .env
+docker compose -f docker-compose.prod.yml up -d
+```
+
+O banco **não** volta com isso. Para voltá-lo, `bash hostgator-setup-kit/restore.sh` com o
+dump que o A3 gerou — e ele pede confirmação digitada, de propósito.
+
+### A4. Verificar que o worker mudou de verdade `[NÃO VERIFICADO]`
+
+```bash
+bash hostgator-setup-kit/diagnostico.sh          # esperado: exit 0, "NÃO está afetada"
+curl -s localhost:3000/api/v1/health | grep -o '"version":"[^"]*"'
+grep -E '^(APP|WORKER|SCHEDULER)_IMAGE=' .env    # as três na MESMA versão
+```
+
+### A5. Verificar que nada se perdeu `[NÃO VERIFICADO — o item central do U6-b]`
+
+O que precisa estar intacto, e o que responde por cada um:
+
+| O quê | Como conferir | Onde mora |
+|---|---|---|
+| Sessão do WhatsApp pareada | a conexão continua `WORKING` na tela de Conexões, **sem pedir QR de novo** | volume `waha-data` |
+| Mídia recebida | uma conversa antiga ainda abre áudio/imagem | Supabase Storage |
+| Conversas, contatos, leads | contagens iguais às de antes | banco (Supabase) |
+| Certificado HTTPS | o domínio responde 307 sem aviso de certificado | volume do Caddy |
+| Customizações do operador no `.env` | `diff /root/.env.antes-remediacao .env` mostra **só** as chaves de imagem | `.env` |
+
+O `update.sh` mexe em exatamente três chaves do `.env` (`APP_IMAGE`, `APP_PULL_POLICY` e
+— desde esta versão — as do worker e do scheduler) e preserva o resto, inclusive o que o
+operador acrescentou à mão. **O `diff` do A5 é o que prova isso, e é uma das coisas que o
+U6-b precisa confirmar.**
+
+---
+
+## 6. Evidência do ensaio
+
+> **Reservado.** Aqui entram os dois cenários do U6-b quando forem executados numa VPS
+> descartável: comandos, saídas e o que foi observado na tela.
+>
+> - **U6-a — instalação nova:** sobe pinada, `/api/v1/health` com a versão certa, nenhum
+>   serviço construído localmente.
+> - **U6-b — atualização de legada:** estado legado reconstruído a partir do commit da
+>   época, sintoma confirmado antes, `update.sh` novo, worker passa a rodar imagem
+>   publicada, nada perdido (§A5), e rollback verificado.
+>
+> Enquanto esta seção estiver vazia, o runbook é uma hipótese bem fundamentada — não um
+> procedimento provado.
+
+## 7. Decisão do operador — sempre
+
+Nada aqui roda sozinho. Não existe atualização automática nem compulsória: o agente de
+atualização da tela só age quando alguém clica em "Atualizar agora", e o `update.sh` só
+roda quando alguém o executa.
+
+Uma instalação afetada **está funcionando** — atende, responde, registra. O que ela não
+tem são as correções dos últimos dois meses no agente. Quem escolhe o momento de fechar
+essa distância é quem opera o servidor.

--- a/docs/testing/user-journey-map.md
+++ b/docs/testing/user-journey-map.md
@@ -260,7 +260,7 @@ Critério: nenhuma tela quebra, nenhum stack trace, nenhum texto de erro cru.
 |----|--------|--------|-----------|
 | M1 | `supabase/config.toml` trava `major_version = 15`, mas `baseline.sql` exige PG17 (`GRANT MAINTAIN`) — contribuidor open-source não sobe ambiente local | reproduzido | Alta (DX) |
 | M2 | Trilha manual do `docs/deploy-selfhost/README.md` não configura o cron do drain → automações mortas em silêncio | explorer webhooks | Alta |
-| M3 | README self-host aponta repo/imagem `deskcommcrm/*`; kit usa `melgarafael/*` | explorer webhooks | Alta |
+| M3 | ~~README self-host aponta repo/imagem `deskcommcrm/*`; kit usa `melgarafael/*`~~ **CORRIGIDO 2026-08-13** — era um `git clone` de uma org que não existe (404) em `docs/deploy-selfhost/README.md:26`. Uma consultoria externa leu essa string e concluiu que o compose apontava para uma org desvinculada; o compose sempre apontou para `melgarafael`. | explorer webhooks | — |
 | M4 | `INVITE_TOKEN_SECRET` ausente → fallback `"dev-fallback"` → convite forjável em VPS mal configurada | explorer CRM/time | Alta (segurança) |
 | M5 | AI Gateway key ausente → bot mudo sem NENHUM feedback na UI | explorer IA | Média |
 | M6 | Knowledge sources: botões de upload/configurar são stubs "Em breve" | explorer IA | Média |
@@ -511,3 +511,36 @@ edição de invariante é congelada por hook; usei a válvula
 `DESKCOMM_GOV_INVARIANTS_EDIT=1` **declarando o uso no commit** (`685d6e7`) em vez
 de contornar em silêncio. CI verde em `2c045c4` (invariants, verify, e2e,
 build-and-size, build-and-push).
+
+---
+
+## A atualização alcança o worker? (2026-08-13)
+
+**Jornada nova, e ela nasceu de um defeito que nenhuma jornada existente cobria.** Todas as
+jornadas do mapa exercitam o produto DEPOIS de instalado; nenhuma perguntava se uma correção
+entregue numa versão nova chega mesmo a cada peça da VPS.
+
+O serviço `worker` — o runtime do agente de IA — não tinha `image:` no `docker-compose.prod.yml`,
+só `build:`. Isso o tornava invisível para `docker compose pull` ("Skipped — No image to be
+pulled") e imune a `up -d` sem `--build`. Ele era construído na VPS no dia da instalação e
+**nenhum `update.sh` jamais o reconstruiu**. Correções do agente não chegavam a instalação
+nenhuma, e nada na tela nem no log dizia isso.
+
+O dossiê desta suíte já tinha registrado o sintoma sem tirar a conclusão: a linha 295 anota,
+do QA de instalação real, *"cache de build do Docker zerado (a VPS realmente compila o
+worker)"*. O fato estava medido; a pergunta é que faltava.
+
+**Casos desta jornada** (`[P0]` = primeira impressão / parque instalado):
+
+| # | Caso | Estado |
+|---|---|---|
+| U1 `[P0]` | Instalação nova nasce pinada numa VERSÃO, não em canal móvel | coberto — `hostgator-setup-kit/test-validators.sh` roda o `install.sh` contra um remoto local com tags e cobra o `.env` |
+| U2 `[P0]` | `update.sh` grava as TRÊS imagens na mesma versão | coberto — `tests/shell/update-guard.test.sh` §4b |
+| U3 `[P0]` | Nenhum serviço de produção fica `build:`-only | coberto — `tests/unit/packaging-artefato-do-cliente.test.ts` |
+| U4 | O crontab do scheduler não perde rota ao mudar de arquivo | coberto — `tests/shell/scheduler-entrypoint.test.sh` + `tests/unit/cron-routes-scheduled.test.ts` |
+| U5 | `/api/v1/health` responde a versão real da imagem | coberto — medido no app real: com `APP_VERSION=9.9.9-teste` responde `9.9.9-teste`; sem ela, `desconhecido` |
+| U6 `[P0]` | **Ensaio de atualização numa VPS real, de uma versão anterior para a nova, e o worker passa a rodar o código novo** | **NÃO coberto** — exige VPS. É o item 11 do checklist de release (`docs/doctrine/packaging.md`) |
+
+U6 é o buraco que sobra, e ele é da mesma família de `vps-fresh-onboarding`: o CI prova que os
+scripts fazem o que dizem, não que a VPS de alguém saiu do estado A para o estado B. A
+diferença é que a jornada de instalação tem uma spec (fora do CI) e esta ainda não tem.

--- a/docs/testing/user-journey-map.md
+++ b/docs/testing/user-journey-map.md
@@ -539,8 +539,14 @@ worker)"*. O fato estava medido; a pergunta é que faltava.
 | U3 `[P0]` | Nenhum serviço de produção fica `build:`-only | coberto — `tests/unit/packaging-artefato-do-cliente.test.ts` |
 | U4 | O crontab do scheduler não perde rota ao mudar de arquivo | coberto — `tests/shell/scheduler-entrypoint.test.sh` + `tests/unit/cron-routes-scheduled.test.ts` |
 | U5 | `/api/v1/health` responde a versão real da imagem | coberto — medido no app real: com `APP_VERSION=9.9.9-teste` responde `9.9.9-teste`; sem ela, `desconhecido` |
-| U6 `[P0]` | **Ensaio de atualização numa VPS real, de uma versão anterior para a nova, e o worker passa a rodar o código novo** | **NÃO coberto** — exige VPS. É o item 11 do checklist de release (`docs/doctrine/packaging.md`) |
+| U6 `[P0]` | **Ensaio de atualização numa VPS real, de uma versão anterior para a nova, e o worker passa a rodar o código novo** | **EXECUTADO 2026-08-13** — estado legado reproduzido do commit `ee520110`, worker migrou para a imagem publicada, nada perdido. **Com ressalva:** a 1ª execução do `update.sh` não conserta enquanto o canal `stable` não existir; a 2ª conserta. Evidência e limites em [`../runbooks/remediar-worker-congelado.md`](../runbooks/remediar-worker-congelado.md) §6 |
 
-U6 é o buraco que sobra, e ele é da mesma família de `vps-fresh-onboarding`: o CI prova que os
-scripts fazem o que dizem, não que a VPS de alguém saiu do estado A para o estado B. A
-diferença é que a jornada de instalação tem uma spec (fora do CI) e esta ainda não tem.
+U6 deixou de ser buraco em 2026-08-13, e o ensaio pagou o próprio custo: revelou que a
+primeira execução do `update.sh` não conserta o worker enquanto o canal `stable` não
+existir — coisa que nenhum teste do CI podia mostrar, porque não é sobre o que os scripts
+fazem, e sim sobre a ORDEM em que o parque encontra as peças.
+
+O que continua fora: o app contra um Supabase real (o ensaio usou Postgres em contêiner),
+uma sessão de WhatsApp pareada de verdade (foi um marcador no volume), e o `install.sh`
+completo da época (exige projeto Supabase). Segue valendo a régua de `vps-fresh-onboarding`:
+o CI prova que os scripts fazem o que dizem, não que a máquina de alguém mudou de estado.

--- a/hostgator-setup-kit/CLAUDE.md
+++ b/hostgator-setup-kit/CLAUDE.md
@@ -132,7 +132,9 @@ Se mesmo assim aparecerem, aqui está o diagnóstico pronto:
    `install.sh` é idempotente: ignora o 422 e encontra o usuário pelo e-mail. Não trava.
 7. **`/api/v1/health` diz "unhealthy" mas o site funciona** — versões antigas checavam
    rotas erradas (`/ping`, `/api/health`). A imagem atual já checa as rotas certas; se ver
-   isso, garanta que a imagem do app está na tag `latest` mais nova (`bash update.sh`).
+   isso, garanta que o servidor está na versão mais nova (`bash update.sh`). Não troque
+   `APP_IMAGE` para `latest` na mão: aqui `latest` é o topo do desenvolvimento, não a
+   última versão lançada, e o `update.sh` já instala a versão certa.
 8. **Criar agente de IA: seletor de modelo vazio em todo provedor** — `baseline.sql` é um
    dump `--schema-only`, não traz o seed de 8 modelos (`ai_models`, migration 0023). O
    `baseline.sql` atual já inclui esse insert (apêndice idempotente no fim do arquivo);
@@ -143,8 +145,8 @@ Se mesmo assim aparecerem, aqui está o diagnóstico pronto:
    cria a identidade canônica (`contacts.wa_identity`), deduplica contatos/conversas
    existentes e trava a re-duplicação. É **auto-curativo** — quem já tinha o CRM bagunçado
    só precisa rodar `bash update.sh` (re-aplica o baseline, que deduplica e conserta) e
-   reiniciar o app. Se persistir após o update, confirme que o app está na imagem `latest`
-   nova (o código dos webhooks em `lib/waha/ingest.ts` precisa acompanhar o schema).
+   reiniciar o app. Se persistir após o update, confirme pelo `/api/v1/health` que a versão
+   subiu (o código dos webhooks em `lib/waha/ingest.ts` precisa acompanhar o schema).
 
 ## Depois de instalado
 

--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -311,9 +311,50 @@ IMG_SCHEDULER="${IMG_NS}/deskcomm-scheduler"
 ultima_versao_publicada() {
   local url="${1:-https://github.com/melgarafael/DeskcommCRM.git}" ref
   command -v git >/dev/null 2>&1 || return 0
-  ref="$(git ls-remote --tags --refs --sort=-v:refname "$url" 'v*' 2>/dev/null | head -1 | awk '{print $2}')" || return 0
+  # `grep -v -- -` descarta PRERELEASE (v1.11.0-rc1, v1.1.1-jmpo.1 — esta última
+  # existe de verdade neste repo). O `--sort=-v:refname` do git põe o prerelease
+  # ACIMA do release final quando `versionsort.suffix` não está configurado, e
+  # uma instalação nova nasceria num release candidate sem ninguém pedir.
+  ref="$(git ls-remote --tags --refs --sort=-v:refname "$url" 'v*' 2>/dev/null \
+        | awk '{print $2}' | grep -v -- '-' | head -1)" || return 0
   [ -n "$ref" ] || return 0
   printf '%s' "${ref#refs/tags/v}"
+}
+
+# Código HTTP do manifest de uma referência nossa no GHCR, anonimamente.
+#   200 = existe e é pública | 404 = não existe | 403 = pacote PRIVADO | 000 = sem rede
+#
+# 403 é o caso que mais engana: pacote recém-criado no GHCR nasce privado, e
+# repositório público não muda isso. Enquanto ninguém trocar a visibilidade na
+# mão, o `docker compose pull` de toda VPS é negado — e como `pull` de serviço
+# com `image:` falha a operação inteira, a instalação morre no passo de subir.
+ghcr_status() {
+  local img="$1" tag="$2" tok
+  tok="$(curl -fsS --max-time 6 \
+          "https://ghcr.io/token?scope=repository:melgarafael/${img}:pull&service=ghcr.io" 2>/dev/null \
+        | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')" || true
+  if [ -z "$tok" ]; then printf '000'; return 0; fi
+  curl -s -o /dev/null --max-time 6 -w '%{http_code}' \
+    -H "Authorization: Bearer $tok" \
+    -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json' \
+    "https://ghcr.io/v2/melgarafael/${img}/manifests/${tag}" 2>/dev/null || printf '000'
+}
+
+# As TRÊS imagens existem e são públicas nesta referência?
+#
+# Perguntar pelas três juntas, e não só pela do app, é o ponto: `deskcomm-worker`
+# e `deskcomm-scheduler` nasceram depois das releases que já existem, então
+# `deskcomm-worker:1.2.1` nunca vai existir — a v1.2.1 é passado. Pinar as três
+# numa versão sem conferir gravaria no .env do cliente duas referências
+# impossíveis, e o kit as construiria na VPS **em silêncio**, do topo da main:
+# app de uma release + worker/scheduler de outro código. Exatamente a mistura de
+# versões que a doutrina existe para proibir, no caminho de primeira impressão.
+trio_publicado() {
+  local tag="$1" i
+  for i in deskcommcrm deskcomm-worker deskcomm-scheduler; do
+    [ "$(ghcr_status "$i" "$tag")" = "200" ] || return 1
+  done
+  return 0
 }
 
 # Escreve no .env as três imagens da MESMA versão + o pull_policy que combina

--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -288,6 +288,60 @@ enter_project() {
 # psql efêmero via container (não exige psql no host).
 psql_run() { docker run --rm -i postgres:17-alpine psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 "$@"; }
 
+# ── As três imagens que NÓS publicamos ───────────────────────────────────────
+# O namespace é constante e literal de propósito: ele está gravado no .env de
+# toda instalação viva, e derivá-lo de variável faria o kit antigo (que já está
+# no disco do cliente) e o novo montarem strings diferentes.
+IMG_NS="ghcr.io/melgarafael"
+IMG_APP="${IMG_NS}/deskcommcrm"
+IMG_WORKER="${IMG_NS}/deskcomm-worker"
+IMG_SCHEDULER="${IMG_NS}/deskcomm-scheduler"
+
+# A última versão publicada (ex.: "1.2.1"), ou vazio se não deu para saber.
+#
+# Consulta o REMOTO, não o clone: o install.sh clona com `--depth 1`, que não
+# traz tag nenhuma, então `git tag -l` local devolveria vazio e a instalação
+# nasceria em `latest` sem ninguém perceber — que é justamente o defeito que
+# esta função existe para consertar.
+#
+# Falha ABERTA de propósito: sem rede, sem git ou sem tag no remoto ela devolve
+# vazio e quem chama cai no canal móvel, como era antes. Travar a instalação de
+# alguém porque não deu para resolver um número de versão seria trocar um
+# problema de previsibilidade por um de disponibilidade.
+ultima_versao_publicada() {
+  local url="${1:-https://github.com/melgarafael/DeskcommCRM.git}" ref
+  command -v git >/dev/null 2>&1 || return 0
+  ref="$(git ls-remote --tags --refs --sort=-v:refname "$url" 'v*' 2>/dev/null | head -1 | awk '{print $2}')" || return 0
+  [ -n "$ref" ] || return 0
+  printf '%s' "${ref#refs/tags/v}"
+}
+
+# Escreve no .env as três imagens da MESMA versão + o pull_policy que combina
+# com a mutabilidade da tag.
+#
+# As três juntas porque elas sobem juntas: app numa versão e worker em `latest`
+# é a matriz de compatibilidade que ninguém testou. E o pull_policy não é
+# detalhe — foi medido que, com `always` e o registry sem responder para aquela
+# referência, o `up -d` FALHA e o contêiner não sobe, mesmo com a imagem já no
+# disco. Numa tag imutável isso não protege de nada e só amarra a subida do CRM
+# do cliente à disponibilidade do GHCR.
+#
+#   gravar_imagens .env 1.2.1   → pinado,  pull_policy=missing
+#   gravar_imagens .env latest  → canal,   pull_policy=always
+gravar_imagens() {
+  local envfile="$1" versao="$2" politica
+  case "$versao" in
+    latest|main|stable) politica="always" ;;
+    *)                  politica="missing" ;;
+  esac
+  set_env_var "$envfile" APP_IMAGE             "${IMG_APP}:${versao}"
+  set_env_var "$envfile" APP_PULL_POLICY       "$politica"
+  set_env_var "$envfile" WORKER_IMAGE          "${IMG_WORKER}:${versao}"
+  set_env_var "$envfile" WORKER_PULL_POLICY    "$politica"
+  set_env_var "$envfile" SCHEDULER_IMAGE       "${IMG_SCHEDULER}:${versao}"
+  set_env_var "$envfile" SCHEDULER_PULL_POLICY "$politica"
+}
+
 # Grava (ou reescreve) uma chave no .env — sem duplicar linha se ela já existe.
 #   set_env_var .env APP_IMAGE ghcr.io/…:1.1.0
 #

--- a/hostgator-setup-kit/agent.sh
+++ b/hostgator-setup-kit/agent.sh
@@ -185,6 +185,13 @@ report() { post "{\"kind\":\"run_progress\",\"run_id\":\"${RUN_ID}\",\"step\":\"
 # sempre; sem o "|| true" isso já derrubava o agente ANTES de sequer chamar o
 # update.sh (achado só rodando de propósito com o comando falhando).
 PREV_IMAGE="$(dc images -q app 2>/dev/null | head -1)" || true
+# O worker e o scheduler passaram a ser imagens publicadas e pinadas na mesma
+# versão do app (antes eram `build:`-only e nenhum update os alcançava). Isso
+# tem um custo aqui: um rollback que voltasse SÓ o app deixaria o parque com
+# app na versão antiga e worker/scheduler na nova — mistura de versões que a
+# doutrina de packaging existe para impedir. Então os três voltam juntos.
+PREV_WORKER_IMAGE="$(dc images -q worker 2>/dev/null | head -1)" || true
+PREV_SCHEDULER_IMAGE="$(dc images -q scheduler 2>/dev/null | head -1)" || true
 if [ -z "$PREV_IMAGE" ]; then
   # Registrado, não ignorado: sem imagem anterior conhecida, se o update.sh
   # falhar mais adiante NÃO HÁ como voltar — o status vai sair "failed", nunca
@@ -229,16 +236,34 @@ if [ $RC -eq "$REFUSED_RC" ]; then
 elif [ $RC -ne 0 ]; then
   STATUS="failed"
   if [ -n "$PREV_IMAGE" ]; then
+    # Os serviços que temos como voltar. Worker e scheduler entram só se o
+    # `images -q` deles respondeu: numa instalação que ainda não tinha as
+    # imagens novas, voltar o app sozinho continua sendo o comportamento certo,
+    # e é melhor que não voltar nada.
+    ROLLBACK_ARGS=(app)
+    [ -n "$PREV_WORKER_IMAGE" ] && ROLLBACK_ARGS+=(worker)
+    [ -n "$PREV_SCHEDULER_IMAGE" ] && ROLLBACK_ARGS+=(scheduler)
+
     if APP_IMAGE="$PREV_IMAGE" APP_PULL_POLICY=missing \
-         dc up -d app >>"$LOG" 2>&1; then
+       WORKER_IMAGE="${PREV_WORKER_IMAGE:-}" WORKER_PULL_POLICY=missing \
+       SCHEDULER_IMAGE="${PREV_SCHEDULER_IMAGE:-}" SCHEDULER_PULL_POLICY=missing \
+         dc up -d "${ROLLBACK_ARGS[@]}" >>"$LOG" 2>&1; then
       STATUS="failed_rolled_back"
-      # Persiste a volta: o update.sh já gravou a imagem NOVA (quebrada) no
+      # Persiste a volta: o update.sh já gravou as imagens NOVAS (quebradas) no
       # .env antes do pull. Sem reescrever aqui, o próximo `up -d` — o do
       # cliente, semanas depois — traria o app quebrado de volta e desfaria o
-      # rollback em silêncio. PREV_IMAGE é um ID local (não uma tag no
+      # rollback em silêncio. Os IDs guardados são LOCAIS (não tags do
       # registro), então a política de pull precisa ir junto.
       set_env_var .env APP_IMAGE "$PREV_IMAGE"
       set_env_var .env APP_PULL_POLICY missing
+      if [ -n "$PREV_WORKER_IMAGE" ]; then
+        set_env_var .env WORKER_IMAGE "$PREV_WORKER_IMAGE"
+        set_env_var .env WORKER_PULL_POLICY missing
+      fi
+      if [ -n "$PREV_SCHEDULER_IMAGE" ]; then
+        set_env_var .env SCHEDULER_IMAGE "$PREV_SCHEDULER_IMAGE"
+        set_env_var .env SCHEDULER_PULL_POLICY missing
+      fi
     fi
   fi
 fi

--- a/hostgator-setup-kit/agent.sh
+++ b/hostgator-setup-kit/agent.sh
@@ -190,8 +190,22 @@ PREV_IMAGE="$(dc images -q app 2>/dev/null | head -1)" || true
 # tem um custo aqui: um rollback que voltasse SÓ o app deixaria o parque com
 # app na versão antiga e worker/scheduler na nova — mistura de versões que a
 # doutrina de packaging existe para impedir. Então os três voltam juntos.
-PREV_WORKER_IMAGE="$(dc images -q worker 2>/dev/null | head -1)" || true
-PREV_SCHEDULER_IMAGE="$(dc images -q scheduler 2>/dev/null | head -1)" || true
+#
+# SÓ numa instalação que já passou pelo update.sh novo — isto é, cujo .env já
+# tem WORKER_IMAGE/SCHEDULER_IMAGE. Numa instalação LEGADA o `images -q` devolve
+# o ID da imagem antiga, e gravá-lo no .env seria pior que não voltar nada: o
+# scheduler legado era `alpine:3.20` com o crontab montado por um `command:`
+# inline que este compose não tem mais. Pinar aquele ID deixaria o contêiner
+# rodando o CMD do alpine puro — ele sai na hora, e `restart: unless-stopped` o
+# recoloca em crashloop. Os 16 crons parariam, em silêncio, gravado no .env.
+if grep -qE '^WORKER_IMAGE=' .env 2>/dev/null; then
+  PREV_WORKER_IMAGE="$(dc images -q worker 2>/dev/null | head -1)" || true
+fi
+if grep -qE '^SCHEDULER_IMAGE=' .env 2>/dev/null; then
+  PREV_SCHEDULER_IMAGE="$(dc images -q scheduler 2>/dev/null | head -1)" || true
+fi
+PREV_WORKER_IMAGE="${PREV_WORKER_IMAGE:-}"
+PREV_SCHEDULER_IMAGE="${PREV_SCHEDULER_IMAGE:-}"
 if [ -z "$PREV_IMAGE" ]; then
   # Registrado, não ignorado: sem imagem anterior conhecida, se o update.sh
   # falhar mais adiante NÃO HÁ como voltar — o status vai sair "failed", nunca

--- a/hostgator-setup-kit/diagnostico.sh
+++ b/hostgator-setup-kit/diagnostico.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# diagnostico.sh — "esta instalação foi afetada pelo worker que nunca era atualizado?"
+#
+# READ-ONLY ABSOLUTO. Não escreve arquivo, não puxa imagem, não sobe nem reinicia
+# nada, não toca no .env. Só lê o estado e explica. É seguro rodar em produção,
+# a qualquer hora, quantas vezes quiser — que é exatamente o que vai acontecer.
+#
+# ── Por que ele NÃO consulta o /api/v1/health ────────────────────────────────
+# Seria o caminho óbvio, e é o errado: até a versão que conserta isto, o health
+# lia `process.env.npm_package_version`, que é `undefined` sob `CMD ["node",
+# "server.js"]`. TODA instalação — afetada ou não — responde `0.1.0`. Um detector
+# que perguntasse a ele daria a mesma resposta para os dois casos, que é o mesmo
+# que não perguntar. Medido em produção: `version: "0.1.0"` numa instalação
+# comprovadamente afetada.
+#
+# ── Por que ele é AUTOCONTIDO (não sourceia o _common.sh) ────────────────────
+# Duas razões, e as duas são o mesmo problema: ele roda em máquinas ANTIGAS. O
+# `_common.sh` do disco de uma instalação legada é o de dois meses atrás, e
+# depender dele seria diagnosticar o passado com a ferramenta do passado. E
+# precisa poder ser baixado avulso, sem clonar nada:
+#
+#   curl -fsSL https://raw.githubusercontent.com/melgarafael/DeskcommCRM/main/hostgator-setup-kit/diagnostico.sh | bash
+#
+# ── O que ele pode assumir que existe ────────────────────────────────────────
+# Medido numa VPS real: bash 5.1, docker, docker compose, curl, sed/awk/grep.
+# NÃO assume `jq` nem `node` (node não existe fora dos contêineres).
+set -uo pipefail   # sem `-e`: um comando que falha é DADO, não motivo de abortar
+
+COMPOSE_FILE="docker-compose.prod.yml"
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  R=$'\033[31m'; G=$'\033[32m'; Y=$'\033[33m'; B=$'\033[1m'; D=$'\033[2m'; Z=$'\033[0m'
+else
+  R=''; G=''; Y=''; B=''; D=''; Z=''
+fi
+
+titulo() { printf '\n%s%s%s\n' "$B" "$*" "$Z"; }
+item()   { printf '  %s\n' "$*"; }
+
+# ── 0. Achar a instalação ────────────────────────────────────────────────────
+# O install.sh clona em ./deskcommcrm por padrão, mas o operador pode ter posto
+# em qualquer lugar. Procuramos no cwd, no caminho padrão, e por último varremos
+# — em profundidade limitada, para não passear pelo disco inteiro.
+achar_projeto() {
+  local c
+  for c in . ./deskcommcrm /root/DeskcommCRM /root/deskcommcrm /opt/deskcommcrm /var/www/crm; do
+    [ -f "$c/$COMPOSE_FILE" ] && { (cd "$c" && pwd); return 0; }
+  done
+  c="$(find /root /opt /home /var/www -maxdepth 4 -name "$COMPOSE_FILE" 2>/dev/null | head -1)"
+  [ -n "$c" ] && { dirname "$c"; return 0; }
+  return 1
+}
+
+PROJETO="$(achar_projeto)" || {
+  printf '%s✖ Não achei uma instalação do DeskcommCRM nesta máquina.%s\n' "$R" "$Z"
+  printf '  Rode este script de dentro da pasta do projeto (a que tem %s).\n' "$COMPOSE_FILE"
+  exit 2
+}
+cd "$PROJETO" || exit 2
+
+printf '%s══ Diagnóstico do DeskcommCRM ══%s\n' "$B" "$Z"
+item "${D}pasta: $PROJETO${Z}"
+item "${D}data:  $(date -u '+%Y-%m-%d %H:%M UTC')${Z}"
+
+if ! docker info >/dev/null 2>&1; then
+  printf '\n%s✖ O Docker não respondeu.%s Sem ele não dá para diagnosticar nada.\n' "$R" "$Z"
+  printf '  Tente: sudo systemctl start docker\n'
+  exit 2
+fi
+
+# ── 1. Coletar os sinais ─────────────────────────────────────────────────────
+# Cada um foi medido numa instalação afetada de verdade antes de virar regra.
+
+# (a) O .env conhece as imagens novas? Instalação legada não tem essas chaves —
+#     elas passaram a existir junto com a correção.
+ENV_TEM_WORKER=nao
+[ -f .env ] && grep -qE '^WORKER_IMAGE=' .env 2>/dev/null && ENV_TEM_WORKER=sim
+
+# (b) Qual imagem cada serviço está usando AGORA.
+#     `compose ps --format` funciona nas versões que o kit instala; se falhar,
+#     caímos no `docker inspect` do contêiner pelo nome do projeto.
+PROJ_NOME="$(basename "$PROJETO" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')"
+PROJ_NOME="${PROJ_NOME#"${PROJ_NOME%%[!_-]*}"}"
+
+imagem_do_servico() {  # imagem_do_servico <serviço>
+  local svc="$1" img
+  img="$(docker compose -f "$COMPOSE_FILE" ps --format '{{.Service}}|{{.Image}}' 2>/dev/null \
+        | awk -F'|' -v s="$svc" '$1==s{print $2; exit}')"
+  [ -z "$img" ] && img="$(docker inspect "${PROJ_NOME}-${svc}-1" --format '{{.Config.Image}}' 2>/dev/null)"
+  printf '%s' "$img"
+}
+
+IMG_WORKER="$(imagem_do_servico worker)"
+IMG_APP="$(imagem_do_servico app)"
+
+# (c) A imagem do worker veio do NOSSO CI, ou foi construída nesta máquina?
+#
+#     O sinal é `org.opencontainers.image.revision`, e a escolha dele não é
+#     arbitrária: ele é o ÚNICO label que só o CI produz. Medido nas duas
+#     imagens lado a lado —
+#
+#       publicada pelo CI : created, description, licenses, revision, source,
+#                           title, url, version
+#       construída aqui   : licenses, source, title
+#
+#     `source`, `licenses` e `title` vêm do `LABEL` do Dockerfile, então uma
+#     imagem local os carrega também; `revision` (e `version`) vêm do
+#     docker/metadata-action, que só roda no CI.
+#
+#     A primeira versão deste detector decidia pelo NOME da imagem ("tem host,
+#     logo veio de registro") e só consultava os labels quando o nome não tinha
+#     host. Uma sabotagem derrubou isso em um comando: construí local, taguei
+#     como `ghcr.io/melgarafael/deskcomm-worker:falsificado`, e o diagnóstico
+#     deu "NÃO afetada" numa instalação afetada. Pior: o comentário ao lado do
+#     código afirmava que os labels pegariam esse caso — a prosa descrevia uma
+#     proteção que o código não implementava.
+LABEL_SOURCE=""
+LABEL_REVISION=""
+CRIADA_WORKER=""
+CRIADA_APP=""
+if [ -n "$IMG_WORKER" ]; then
+  LABEL_SOURCE="$(docker image inspect "$IMG_WORKER" \
+                  --format '{{index .Config.Labels "org.opencontainers.image.source"}}' 2>/dev/null)"
+  [ "$LABEL_SOURCE" = "<no value>" ] && LABEL_SOURCE=""
+  LABEL_REVISION="$(docker image inspect "$IMG_WORKER" \
+                    --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null)"
+  [ "$LABEL_REVISION" = "<no value>" ] && LABEL_REVISION=""
+  # ATENÇÃO ao usar `docker image inspect`, e não `docker inspect <contêiner>`:
+  # o `.Created` do CONTÊINER é a hora em que ele foi recriado, e um `up -d`
+  # recria todos juntos — na produção os dois batiam no mesmo segundo enquanto
+  # as IMAGENS estavam a 13 dias de distância. Perguntar ao contêiner daria
+  # falso negativo justamente no caso real.
+  CRIADA_WORKER="$(docker image inspect "$IMG_WORKER" --format '{{.Created}}' 2>/dev/null | cut -c1-10)"
+fi
+[ -n "$IMG_APP" ] && CRIADA_APP="$(docker image inspect "$IMG_APP" --format '{{.Created}}' 2>/dev/null | cut -c1-10)"
+
+# A decisão é do `revision`, sozinho. O nome da imagem entra depois, só na
+# explicação — ele é sugestivo e falsificável, o label não.
+WORKER_DO_CI=nao
+[ -n "$LABEL_REVISION" ] && WORKER_DO_CI=sim
+
+# Dois sabores de "construída aqui", com consequências diferentes para o texto:
+#   legado      → sem label nenhum: Dockerfile.worker antigo, anterior à correção
+#   build local → tem `source` mas não `revision`: Dockerfile atual, compilado
+#                 nesta máquina (docker-compose.build.yml). Pode ser deliberado.
+SABOR_LOCAL=legado
+[ -n "$LABEL_SOURCE" ] && SABOR_LOCAL=build_local
+
+# ── 2. O veredito ────────────────────────────────────────────────────────────
+# Afetado = o worker NÃO veio de um registro. Os outros sinais entram como
+# corroboração e como explicação, não como critério — um deles sozinho pode
+# variar por instalação, a origem da imagem não.
+AFETADO=nao
+[ "$WORKER_DO_CI" = "nao" ] && AFETADO=sim
+
+titulo "O que está rodando"
+item "app     : ${IMG_APP:-(não encontrado)}${CRIADA_APP:+   ${D}imagem de $CRIADA_APP${Z}}"
+item "worker  : ${IMG_WORKER:-(não encontrado)}${CRIADA_WORKER:+   ${D}imagem de $CRIADA_WORKER${Z}}"
+
+if [ -z "$IMG_WORKER" ]; then
+  printf '\n%s⚠ Não achei o contêiner do worker.%s\n' "$Y" "$Z"
+  printf '  Ou a stack está parada, ou esta instalação não tem o agente de IA.\n'
+  printf '  Suba com: docker compose -f %s up -d   e rode este diagnóstico de novo.\n' "$COMPOSE_FILE"
+  exit 2
+fi
+
+if [ "$AFETADO" = "nao" ]; then
+  titulo "${G}✓ Esta instalação NÃO está afetada.${Z}"
+  item "O worker roda uma imagem publicada (${IMG_WORKER})."
+  item "Ele recebe as correções de cada versão, como o resto do sistema."
+  [ "$ENV_TEM_WORKER" = "nao" ] && \
+    item "${D}(o .env ainda não fixa WORKER_IMAGE; o próximo update.sh acerta isso)${Z}"
+  exit 0
+fi
+
+titulo "${R}✗ Esta instalação ESTÁ afetada.${Z}"
+item "O worker — o processo que faz o agente de IA atender — está rodando uma"
+item "imagem ${B}construída dentro deste servidor${Z}, não a publicada pelo projeto."
+printf '\n'
+item "${B}Como sabemos:${Z}"
+item "  • a imagem '${IMG_WORKER}' não tem a marca de revisão que o nosso CI"
+item "    carimba em toda imagem publicada (org.opencontainers.image.revision)"
+if [ "$SABOR_LOCAL" = "build_local" ]; then
+  item "  • ela tem as demais etiquetas do projeto, então foi construída a partir"
+  item "    do código atual — pode ter sido uma escolha sua (build local)"
+fi
+[ "$ENV_TEM_WORKER" = "nao" ] && item "  • o .env desta instalação não fixa a versão do worker"
+
+if [ -n "$CRIADA_WORKER" ] && [ -n "$CRIADA_APP" ] && [ "$CRIADA_WORKER" != "$CRIADA_APP" ]; then
+  printf '\n'
+  item "${B}O quanto ele ficou para trás:${Z}"
+  item "  o app é de ${CRIADA_APP} e o worker é de ${CRIADA_WORKER}."
+  # `date -d` é GNU; numa VPS Ubuntu existe. Se não existir, o texto acima já
+  # entregou as duas datas — a conta é conforto, não o dado.
+  if command -v date >/dev/null 2>&1 && date -d "$CRIADA_APP" +%s >/dev/null 2>&1; then
+    DIAS=$(( ( $(date -d "$CRIADA_APP" +%s) - $(date -d "$CRIADA_WORKER" +%s) ) / 86400 ))
+    [ "$DIAS" -gt 0 ] && item "  são ${B}${DIAS} dias${Z} de correções que o agente não recebeu."
+  fi
+fi
+
+cat <<TEXTO
+
+  ${B}O que isso significa na prática${Z}
+  O resto do sistema foi atualizando normalmente. Só o agente de IA ficou parado
+  no código do dia em que você instalou — inclusive correções de coisas que o seu
+  cliente sente: resposta saindo duplicada, áudio e imagem que o cliente manda não
+  virando conteúdo para a IA, e classificação de sentimento falhando em silêncio.
+
+  Nada foi perdido: conversas, contatos e a conexão do WhatsApp estão intactos.
+  O que faltou foi o agente receber as melhorias.
+
+  ${B}O que fazer${Z}
+  O conserto é uma atualização normal, e ${B}quem decide quando é você${Z}:
+
+      cd $PROJETO
+      bash hostgator-setup-kit/update.sh
+
+  Ele faz backup do banco antes, e o passo a passo — com como voltar atrás — está
+  em docs/runbooks/remediar-worker-congelado.md.
+
+  ${D}Este diagnóstico não mudou nada na sua instalação. Só olhou.${Z}
+TEXTO
+exit 1

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -983,7 +983,7 @@ fi
 
 # ── A versão que esta instalação vai rodar ───────────────────────────────────
 # Uma instalação nova nascia em `:latest`, e aqui `latest` NÃO quer dizer "a
-# última release": a regra do CI é `enable={{is_default_branch}}`, então ela
+# última release": ele segue a branch default, então ela
 # segue o topo da `main` — código ainda não lançado. Quem instalava no dia 6
 # e quem instalava no dia 20 rodavam software diferente, ambos dizendo "estou
 # no latest", e o suporte não tinha como saber o quê. A issue #184 chegou
@@ -992,18 +992,41 @@ fi
 #
 # Resolvido no REMOTO porque o clone é `--depth 1` e não traz tag nenhuma.
 VERSAO_ALVO="$(ultima_versao_publicada "$REPO_URL")"
-if [ -n "$VERSAO_ALVO" ]; then
-  IMAGEM_APP_DEFAULT="${IMG_APP}:${VERSAO_ALVO}"
+
+# A tag do git é condição NECESSÁRIA, não suficiente: ela nasce minutos antes
+# das imagens, e `deskcomm-worker`/`deskcomm-scheduler` só passaram a existir
+# depois das releases que já estão publicadas — `deskcomm-worker:1.2.1` nunca
+# vai existir, porque a v1.2.1 é passado. Sem esta conferência, o .env do
+# cliente receberia duas referências impossíveis e o kit as construiria aqui em
+# silêncio, do topo da main: app de uma release + worker de outro código.
+#
+# Cascata, do mais específico ao mais disponível. Cada nível pergunta pelas TRÊS
+# imagens juntas, porque instalar com elas desalinhadas é o defeito, não a
+# solução.
+if [ -n "$VERSAO_ALVO" ] && trio_publicado "$VERSAO_ALVO"; then
+  : # o caminho normal: as três publicadas na última versão
+elif trio_publicado "stable"; then
+  c_ylw "⚠ A versão ${VERSAO_ALVO:-mais recente} ainda não tem as três imagens publicadas."
+  c_ylw "  Instalando pelo canal 'stable' (a última versão completa)."
+  VERSAO_ALVO="stable"
+elif [ -n "$VERSAO_ALVO" ]; then
+  # Nem a versão nem o `stable` têm o trio. Segue assim mesmo — o compose tem
+  # `build:` ao lado do `image:` do worker e do scheduler, então eles são
+  # construídos aqui. É lento, mas instala. O que NÃO pode é isso acontecer
+  # calado: o dono precisa saber que duas peças dele saíram do fonte local.
+  c_ylw "⚠ As imagens do worker e do agendador ainda não estão publicadas."
+  c_ylw "  Elas serão construídas neste servidor — leva alguns minutos a mais."
+  c_ylw "  Rode 'bash hostgator-setup-kit/update.sh' quando a próxima versão sair."
 else
   # Falha ABERTA: sem rede ou sem tag no remoto, segue como antes. Travar a
   # instalação por não resolver um número seria trocar previsibilidade por
   # disponibilidade — mas o aviso sai, porque o dono precisa saber que ficou
   # num canal móvel em vez de numa versão.
   VERSAO_ALVO="latest"
-  IMAGEM_APP_DEFAULT="${IMG_APP}:latest"
   c_ylw "⚠ Não consegui descobrir a última versão publicada (rede?)."
   c_ylw "  Instalando pelo canal 'latest'. Depois rode: bash hostgator-setup-kit/update.sh"
 fi
+IMAGEM_APP_DEFAULT="${IMG_APP}:${VERSAO_ALVO}"
 
 FIELDS=(
   "DOMAIN|Domínio do CRM (ex: crm.suaempresa.com.br)||v_domain||"

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -981,10 +981,34 @@ else
   CAMPO_OPENAI_EXTRA="OPENAI_API_KEY|Chave da OpenAI — só para ouvir áudios e usar a base de conhecimento (Enter pula)||v_openai|secret|opcional"
 fi
 
+# ── A versão que esta instalação vai rodar ───────────────────────────────────
+# Uma instalação nova nascia em `:latest`, e aqui `latest` NÃO quer dizer "a
+# última release": a regra do CI é `enable={{is_default_branch}}`, então ela
+# segue o topo da `main` — código ainda não lançado. Quem instalava no dia 6
+# e quem instalava no dia 20 rodavam software diferente, ambos dizendo "estou
+# no latest", e o suporte não tinha como saber o quê. A issue #184 chegou
+# descrevendo o ambiente como "latest do dia 06/08/2026", que é a admissão de
+# que a versão não era nomeável.
+#
+# Resolvido no REMOTO porque o clone é `--depth 1` e não traz tag nenhuma.
+VERSAO_ALVO="$(ultima_versao_publicada "$REPO_URL")"
+if [ -n "$VERSAO_ALVO" ]; then
+  IMAGEM_APP_DEFAULT="${IMG_APP}:${VERSAO_ALVO}"
+else
+  # Falha ABERTA: sem rede ou sem tag no remoto, segue como antes. Travar a
+  # instalação por não resolver um número seria trocar previsibilidade por
+  # disponibilidade — mas o aviso sai, porque o dono precisa saber que ficou
+  # num canal móvel em vez de numa versão.
+  VERSAO_ALVO="latest"
+  IMAGEM_APP_DEFAULT="${IMG_APP}:latest"
+  c_ylw "⚠ Não consegui descobrir a última versão publicada (rede?)."
+  c_ylw "  Instalando pelo canal 'latest'. Depois rode: bash hostgator-setup-kit/update.sh"
+fi
+
 FIELDS=(
   "DOMAIN|Domínio do CRM (ex: crm.suaempresa.com.br)||v_domain||"
   "ACME_EMAIL|Seu e-mail (avisos de SSL)||v_email||"
-  "APP_IMAGE|Imagem Docker do app|ghcr.io/melgarafael/deskcommcrm:latest|||"
+  "APP_IMAGE|Imagem Docker do app|${IMAGEM_APP_DEFAULT}|||"
   "NEXT_PUBLIC_SUPABASE_URL|Supabase Project URL (Settings > API)||v_supabase_url||"
   "NEXT_PUBLIC_SUPABASE_ANON_KEY|Supabase anon key (Settings > API)||v_anon||"
   "SUPABASE_SERVICE_ROLE_KEY|Supabase service_role key (Settings > API)||v_service|secret|"
@@ -1211,10 +1235,37 @@ if [ -f .env ]; then
   fi
 fi
 
+# A tag que o dono escolheu (o campo APP_IMAGE é editável na entrevista) decide
+# o pull_policy das três imagens. A regra é medida, não estética: com `always` e
+# o registry sem responder para aquela referência, o `up -d` FALHA e o contêiner
+# não sobe, mesmo com a imagem já no disco. Numa tag imutável isso não protege
+# de nada — só amarra a subida do CRM à disponibilidade do GHCR. Numa tag móvel
+# é o contrário: sem `always`, a versão nova nunca chega.
+# Olha só o último segmento do caminho: `registry.local:5000/x/y` tem ':' e NÃO
+# tem tag, e um `${APP_IMAGE##*:}` ingênuo devolveria "5000/x/y" como se fosse
+# uma. Um `@sha256:...` cai aqui como tag imutável, que é o correto.
+_ref_final="${APP_IMAGE##*/}"
+case "$_ref_final" in
+  *:*) TAG_ALVO="${_ref_final##*:}" ;;
+  *)   TAG_ALVO="latest" ;;   # imagem sem ':' é :latest por definição do Docker
+esac
+case "$TAG_ALVO" in
+  latest|main|stable) PULL_POLICY_ALVO="always" ;;
+  *)                  PULL_POLICY_ALVO="missing" ;;
+esac
+
 {
   printf '# Gerado por install.sh — NÃO comitar. Contém segredos.\n'
   envq APP_IMAGE "$APP_IMAGE"
-  envq APP_PULL_POLICY "always"
+  envq APP_PULL_POLICY "$PULL_POLICY_ALVO"
+  # Worker e scheduler acompanham a MESMA versão do app: um em 1.2.1 e outro em
+  # `latest` é uma matriz de compatibilidade que ninguém testou. Estas duas
+  # imagens existem desde que o worker deixou de ser `build:`-only — antes disso
+  # ele era compilado aqui na VPS e nenhum update jamais o alcançava.
+  envq WORKER_IMAGE "${IMG_WORKER}:${TAG_ALVO}"
+  envq WORKER_PULL_POLICY "$PULL_POLICY_ALVO"
+  envq SCHEDULER_IMAGE "${IMG_SCHEDULER}:${TAG_ALVO}"
+  envq SCHEDULER_PULL_POLICY "$PULL_POLICY_ALVO"
   envq DOMAIN "$DOMAIN"
   envq ACME_EMAIL "$ACME_EMAIL"
   printf '# Proxy reverso: "caddy" (o kit sobe o dele nas portas 80/443) ou "traefik"\n'

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -1335,7 +1335,12 @@ esac
   printf '# então ligar isto sem um WAHA Plus (ou proxy que assine) para a ingestão\n'
   printf '# de mensagens. A rota global já não é publicada na internet (ver Caddyfile).\n'
   envq WAHA_WEBHOOK_REQUIRE_SIGNATURE "${WAHA_WEBHOOK_REQUIRE_SIGNATURE:-false}"
-  envq WAHA_IMAGE "${WAHA_IMAGE:-devlikeapro/waha}"
+  # PINADA. Sem a tag, `devlikeapro/waha` é `:latest`, e esta linha gravava isso
+  # no .env de todo cliente — por cima do default pinado do compose, que então
+  # nunca chegava a ninguém. O `dc pull` de cada update entregava qualquer versão
+  # que o upstream tivesse publicado, sem ninguém ter testado.
+  # `latest-2026.7.2` é o mesmo digest de `latest` hoje (65e593e30bb7…).
+  envq WAHA_IMAGE "${WAHA_IMAGE:-devlikeapro/waha:latest-2026.7.2}"
   envq WAHA_DEFAULT_ENGINE "${WAHA_DEFAULT_ENGINE:-NOWEB}"
   envq UPSTASH_REDIS_REST_URL "http://srh:80"
   envq UPSTASH_REDIS_REST_TOKEN "$UPSTASH_REDIS_REST_TOKEN"
@@ -1521,7 +1526,21 @@ SQL
 # ── 9. Sobe a stack ─────────────────────────────────────────────────────────
 fase 4 "Colocando o CRM no ar"
 step "Puxando a imagem e subindo os serviços"
-dc pull
+# A guarda existe porque dar `image:` a um serviço que era build-only mudou o
+# comportamento do `pull`: antes ele PULAVA o worker ("Skipped - No image to be
+# pulled"), agora FALHA a operação inteira se a referência não resolver. E há
+# três motivos reais para não resolver logo depois de um release: pacote novo no
+# GHCR nasce PRIVADO até alguém trocar a visibilidade na mão; a tag git existe
+# minutos antes das imagens; e o GHCR pode estar fora do ar.
+#
+# Sem esta guarda, uma instalação NOVA morria no passo 9 — com o banco já
+# provisionado e o .env já escrito. O `up -d` seguinte não precisa do pull: o
+# worker e o scheduler têm `build:` ao lado do `image:`, e o Compose os constrói
+# quando a imagem não existe (medido).
+if ! dc pull; then
+  c_ylw "⚠ Não consegui puxar todas as imagens do registro."
+  c_ylw "  Sigo assim mesmo: o que faltar é construído aqui (mais lento, mesmo resultado)."
+fi
 dc up -d
 c_grn "✓ containers no ar"
 

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -1246,6 +1246,18 @@ fi
 # uma. Um `@sha256:...` cai aqui como tag imutável, que é o correto.
 _ref_final="${APP_IMAGE##*/}"
 case "$_ref_final" in
+  *@sha256:*)
+    # O operador pinou o app por DIGEST. Derivar a tag daí produziria
+    # `deskcomm-worker:<hash-do-app>` — uma referência que não existe em lugar
+    # nenhum, e o `pull` falharia com "manifest unknown" sem ninguém entender
+    # por quê. Worker e scheduler vão para o canal estável, e o aviso sai porque
+    # quem pinou por digest tinha um motivo e precisa saber que ele não se
+    # propagou às outras duas.
+    TAG_ALVO="stable"
+    c_ylw "⚠ APP_IMAGE está pinado por digest."
+    c_ylw "  O worker e o scheduler ficam em 'stable' — ajuste WORKER_IMAGE/SCHEDULER_IMAGE"
+    c_ylw "  no .env se você precisa deles num digest específico também."
+    ;;
   *:*) TAG_ALVO="${_ref_final##*:}" ;;
   *)   TAG_ALVO="latest" ;;   # imagem sem ':' é :latest por definição do Docker
 esac

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -1004,8 +1004,138 @@ STUB
       "$(grep -oE '^[A-Z_]+=' "$VPS_PROJ/.env" | tail -3 | tr '\n' ' ')"; exit 1
   fi
   printf '  ✓ portas livres → Caddy, e o .env sai inteiro mesmo sem proxy externo\n'
+
+  # ── A regra de ouro da doutrina de packaging, no ponto onde ela vale ───────
+  # Uma instalação nova gravava `APP_IMAGE=…:latest`, e `latest` aqui significa
+  # TOPO DA MAIN (a regra do CI é `enable={{is_default_branch}}`), não a última
+  # release. Duas instalações feitas em semanas diferentes rodavam código
+  # diferente, ambas dizendo "estou no latest" — e a issue #184 chegou com o
+  # ambiente descrito como "latest do dia 06/08/2026".
+  #
+  # Esta prova existe porque a anterior não pegava: sabotei o install.sh para
+  # voltar a gravar `:latest` fixo e a suíte inteira passou verde. A regra mais
+  # importante da doutrina não tinha gate nenhum.
+  #
+  # Nota: nesta fixture o remoto é um dublê sem tags, então `ultima_versao_publicada`
+  # devolve vazio e o install cai — de propósito — no canal móvel. Por isso a
+  # asserção não é "a tag é 1.2.3": é que as TRÊS imagens saem na MESMA
+  # referência e com o pull_policy que combina com ela. É o invariante que
+  # sobrevive aos dois caminhos, com rede e sem.
+  img_app="$(grep -oE "^APP_IMAGE='?[^']*" "$VPS_PROJ/.env" | sed "s/^APP_IMAGE='\?//")"
+  tag_app="${img_app##*:}"
+  for par in "WORKER_IMAGE:deskcomm-worker" "SCHEDULER_IMAGE:deskcomm-scheduler"; do
+    chave="${par%%:*}"; repo="${par##*:}"
+    if ! grep -qE "^${chave}='?ghcr\.io/melgarafael/${repo}:${tag_app}'?$" "$VPS_PROJ/.env"; then
+      printf '  ✗ %s não acompanha a versão do app (%s): %s\n' "$chave" "$tag_app" \
+        "$(grep -E "^${chave}=" "$VPS_PROJ/.env" || echo '(ausente)')"
+      printf '     app numa versão e worker em outra é a matriz que ninguém testou.\n'; exit 1
+    fi
+  done
+  case "$tag_app" in
+    latest|main|stable) esperado="always" ;;
+    *)                  esperado="missing" ;;
+  esac
+  for chave in APP_PULL_POLICY WORKER_PULL_POLICY SCHEDULER_PULL_POLICY; do
+    if ! grep -qE "^${chave}='?${esperado}'?$" "$VPS_PROJ/.env"; then
+      printf '  ✗ %s devia ser %s para a tag %s: %s\n' "$chave" "$esperado" "$tag_app" \
+        "$(grep -E "^${chave}=" "$VPS_PROJ/.env" || echo '(ausente)')"; exit 1
+    fi
+  done
+  printf '  ✓ as três imagens saem na MESMA referência (%s), com pull_policy=%s\n' "$tag_app" "$esperado"
 ) || fail=1
 rm -rf "$TMP3B"
+
+echo "packaging: a instalação resolve a última versão publicada"
+# O outro lado da regra de ouro: com um remoto que TEM tags, o install precisa
+# escolher a maior — e não a primeira que aparecer. `git ls-remote` devolve por
+# ordem alfabética de ref, onde "v1.10.0" vem ANTES de "v1.9.0"; sem o
+# `--sort=-v:refname` a instalação nasceria numa versão velha achando que é a
+# nova. É o tipo de erro que só aparece na décima release.
+(
+  # `ultima_versao_publicada` já está no escopo: o preâmbulo desta suíte faz
+  # `. ./_common.sh`. Sourcear de novo dentro de um subshell que muda de
+  # diretório é como a primeira versão disto quebrou.
+  repo_falso="$(mktemp -d)"
+  git init --quiet --bare "$repo_falso/origem.git"
+  trabalho="$(mktemp -d)"
+  git clone --quiet "$repo_falso/origem.git" "$trabalho/w" 2>/dev/null
+  (
+    cd "$trabalho/w" || exit 1
+    git config user.email t@t; git config user.name t
+    echo x > a; git add -A; git commit --quiet -m init
+    for t in v1.0.0 v1.9.0 v1.10.0 v1.2.0; do git tag "$t"; done
+    git push --quiet origin HEAD --tags 2>/dev/null
+  )
+
+  achou="$(ultima_versao_publicada "$repo_falso/origem.git")"
+  if [ "$achou" != "1.10.0" ]; then
+    printf '  ✗ escolheu a versão errada: esperado 1.10.0, veio "%s"\n' "$achou"
+    printf '     (ordem alfabética põe v1.9.0 depois de v1.10.0 — precisa de --sort=-v:refname)\n'
+    rm -rf "$repo_falso" "$trabalho"; exit 1
+  fi
+  printf '  ✓ entre v1.0.0/v1.2.0/v1.9.0/v1.10.0, escolhe 1.10.0 (ordem de VERSÃO, não alfabética)\n'
+
+  vazio="$(mktemp -d)"; git init --quiet --bare "$vazio/sem-tags.git"
+  semtag="$(ultima_versao_publicada "$vazio/sem-tags.git")"
+  if [ -n "$semtag" ]; then
+    printf '  ✗ remoto sem tag devia devolver vazio, veio "%s"\n' "$semtag"
+    rm -rf "$repo_falso" "$trabalho" "$vazio"; exit 1
+  fi
+  printf '  ✓ remoto sem tag nenhuma devolve vazio (o install cai no canal móvel e avisa)\n'
+  rm -rf "$repo_falso" "$trabalho" "$vazio"
+) || fail=1
+
+echo "packaging: a instalação GRAVA a versão resolvida (não só sabe qual é)"
+# A prova acima mostra que a função escolhe certo; esta mostra que o install.sh
+# a USA. São coisas diferentes, e a diferença não é acadêmica: sabotei o install
+# para voltar a gravar `:latest` fixo e TODA a suíte passou verde, porque nada
+# ligava a função ao arquivo que o cliente recebe.
+#
+# Offline de propósito: REPO_URL aponta para um repositório local com tags
+# conhecidas, então a asserção é exata (1.10.0) e não depende de o CI alcançar o
+# GitHub. Um teste que precisa de rede para provar pinagem falha por motivo
+# errado no dia em que a rede oscila.
+TMP_PIN="$(mktemp -d)"
+(
+  origem="$TMP_PIN/origem.git"
+  git init --quiet --bare "$origem"
+  (
+    cd "$TMP_PIN" || exit 1
+    git clone --quiet "$origem" w 2>/dev/null
+    cd w || exit 1
+    git config user.email t@t; git config user.name t
+    echo x > a; git add -A; git commit --quiet -m init
+    for t in v1.0.0 v1.9.0 v1.10.0; do git tag "$t"; done
+    git push --quiet origin HEAD --tags 2>/dev/null
+  )
+
+  montar_vps "$TMP_PIN/vps" "crmpin" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$DOCKER_LOG"
+case "$1" in
+  compose) case "$*" in *" exec "*) printf 'healthy\n{"data":{"status":"healthy"}}\n' ;; esac; exit 0 ;;
+esac
+exit 0
+STUB
+  export REPO_URL="$origem"
+  rodar install.sh --yes >/dev/null
+  unset REPO_URL
+
+  for par in "APP_IMAGE:deskcommcrm" "WORKER_IMAGE:deskcomm-worker" "SCHEDULER_IMAGE:deskcomm-scheduler"; do
+    chave="${par%%:*}"; repo="${par##*:}"
+    if ! grep -qE "^${chave}='?ghcr\.io/melgarafael/${repo}:1\.10\.0'?$" "$VPS_PROJ/.env"; then
+      printf '  ✗ %s não foi pinado na versão resolvida (1.10.0): %s\n' "$chave" \
+        "$(grep -E "^${chave}=" "$VPS_PROJ/.env" || echo '(ausente)')"
+      printf '     instalação de cliente NUNCA nasce em tag móvel — docs/doctrine/packaging.md, invariante 3.\n'
+      exit 1
+    fi
+  done
+  if grep -qE "^APP_PULL_POLICY='?always'?$" "$VPS_PROJ/.env"; then
+    printf '  ✗ tag imutável com pull_policy=always: o CRM só sobe se o GHCR estiver de pé\n'; exit 1
+  fi
+  printf '  ✓ com v1.0.0/v1.9.0/v1.10.0 no remoto, o .env nasce pinado em 1.10.0 (as três imagens)\n'
+) || fail=1
+rm -rf "$TMP_PIN"
 
 echo "integração: os TRÊS provedores de IA que o instalador oferece"
 # A pergunta "qual IA vai atender" tem três respostas, e até aqui só uma delas

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -1042,6 +1042,24 @@ STUB
     fi
   done
   printf '  ✓ as três imagens saem na MESMA referência (%s), com pull_policy=%s\n' "$tag_app" "$esperado"
+
+  # O .env VENCE o compose — e é por isso que este bloco existe. O compose já
+  # pinava o WAHA, e o install gravava `WAHA_IMAGE=devlikeapro/waha` (sem tag,
+  # isto é `:latest`) por cima: o pin existia e não alcançava ninguém. Um gate
+  # que olha só o compose dá verde para essa classe inteira de defeito, e foi
+  # uma sabotagem que revelou o ponto cego.
+  img_waha="$(grep -E '^WAHA_IMAGE=' "$VPS_PROJ/.env" | head -1 | cut -d= -f2- | tr -d "'\"")"
+  ref_waha="${img_waha##*/}"
+  case "$ref_waha" in
+    *:*) tag_waha="${ref_waha##*:}" ;;
+    *)   tag_waha="latest" ;;   # imagem sem ':' é :latest por definição do Docker
+  esac
+  if [ -z "$img_waha" ] || [ "$tag_waha" = "latest" ]; then
+    printf '  ✗ WAHA gravado sem pin no .env: %s (tag resolvida: %s)\n' "${img_waha:-(ausente)}" "$tag_waha"
+    printf '     sem tag = :latest, e o `dc pull` de cada update entrega ao cliente qualquer\n'
+    printf '     versão que o upstream publicar — sem ninguém ter testado.\n'; exit 1
+  fi
+  printf '  ✓ o WAHA sai pinado no .env (%s), não em :latest\n' "$img_waha"
 ) || fail=1
 rm -rf "$TMP3B"
 

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -883,7 +883,24 @@ montar_vps() {
   : > "$VPS_PROJ/docker-compose.prod.yml"
   cat > "$raiz/bin/docker"
   # Só o v_supabase_url exige resposta online (000 reprova); os outros toleram.
-  printf '#!/usr/bin/env bash\nprintf 200\n' > "$raiz/bin/curl"
+  #
+  # O dublê fala DOIS protocolos porque o install.sh passou a sondar o GHCR
+  # antes de pinar as imagens (`ghcr_status`/`trio_publicado` no _common.sh): o
+  # endpoint de token devolve JSON, o de manifest devolve o código HTTP. Um
+  # dublê que respondesse `200` para tudo faria o `sed` do token sair vazio, a
+  # sonda devolver `000`, e a suíte passaria a exercitar o ramo de fallback
+  # achando que exercita o normal — verde medindo outra coisa.
+  #
+  # `DUBLE_GHCR` permite ao teste escolher o cenário: vazio/`200` = as três
+  # imagens publicadas; `403` = pacote privado; `404` = não existe.
+  cat > "$raiz/bin/curl" <<'STUBCURL'
+#!/usr/bin/env bash
+case "$*" in
+  *ghcr.io/token*) printf '{"token":"dublê"}' ;;
+  *ghcr.io/v2/*)   printf '%s' "${DUBLE_GHCR:-200}" ;;
+  *)               printf 200 ;;
+esac
+STUBCURL
   # O install.sh e o update.sh vão até o fim, e no fim eles AGENDAM CRON. Sem
   # dublê a suíte escreveria no crontab de quem a roda — apontando para um
   # diretório temporário que ela mesma apaga em seguida. Teste que suja a máquina
@@ -1007,7 +1024,7 @@ STUB
 
   # ── A regra de ouro da doutrina de packaging, no ponto onde ela vale ───────
   # Uma instalação nova gravava `APP_IMAGE=…:latest`, e `latest` aqui significa
-  # TOPO DA MAIN (a regra do CI é `enable={{is_default_branch}}`), não a última
+  # TOPO DA MAIN (o canal segue a branch default), não a última
   # release. Duas instalações feitas em semanas diferentes rodavam código
   # diferente, ambas dizendo "estou no latest" — e a issue #184 chegou com o
   # ambiente descrito como "latest do dia 06/08/2026".
@@ -1154,6 +1171,44 @@ STUB
   printf '  ✓ com v1.0.0/v1.9.0/v1.10.0 no remoto, o .env nasce pinado em 1.10.0 (as três imagens)\n'
 ) || fail=1
 rm -rf "$TMP_PIN"
+
+echo "packaging: a tag do git não basta — as imagens têm de existir"
+# A tag nasce minutos antes das imagens, e as do worker/scheduler só passaram a
+# existir depois das releases que já estão publicadas: `deskcomm-worker:1.2.1`
+# nunca vai existir, porque a v1.2.1 é passado. Sem sondar o registry, o .env do
+# cliente receberia referências impossíveis e o kit as construiria aqui EM
+# SILÊNCIO, do topo da main — app de uma release, worker de outro código.
+#
+# 403 é o caso que trava na estreia de uma imagem nova: pacote recém-criado no
+# GHCR nasce privado, e repositório público não muda isso.
+TMP_PRIV="$(mktemp -d)"
+(
+  montar_vps "$TMP_PRIV/vps" "crmpriv" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$DOCKER_LOG"
+case "$1" in
+  compose) case "$*" in *" exec "*) printf 'healthy\n{"data":{"status":"healthy"}}\n' ;; esac; exit 0 ;;
+esac
+exit 0
+STUB
+  export DUBLE_GHCR=403          # pacote existe mas está PRIVADO
+  saida="$(rodar install.sh --yes)"
+  unset DUBLE_GHCR
+
+  if ! printf '%s' "$saida" | grep -q "construídas neste servidor"; then
+    printf '  ✗ com as imagens inalcançáveis, o instalador não avisou que ia construir aqui\n'
+    printf '     silêncio aqui é o defeito: o dono não descobre que duas peças saíram do fonte local.\n'
+    exit 1
+  fi
+  printf '  ✓ imagens inalcançáveis (403): avisa que vai construir no servidor, em vez de calar\n'
+
+  # E ainda assim a instalação COMPLETA — construir é lento, não é impedimento.
+  if ! grep -qE "^APP_IMAGE=" "$VPS_PROJ/.env"; then
+    printf '  ✗ a instalação não chegou a escrever o .env\n'; exit 1
+  fi
+  printf '  ✓ e mesmo assim conclui a instalação (constrói é lento, não é impedimento)\n'
+) || fail=1
+rm -rf "$TMP_PRIV"
 
 echo "integração: os TRÊS provedores de IA que o instalador oferece"
 # A pergunta "qual IA vai atender" tem três respostas, e até aqui só uma delas

--- a/hostgator-setup-kit/update.sh
+++ b/hostgator-setup-kit/update.sh
@@ -180,8 +180,19 @@ gravar_imagens .env "$VERSAO_ALVO"
 # ainda tem `build:` ao lado do `image:` do worker e do scheduler, então o
 # `up -d` os constrói localmente: pior que puxar, melhor que não atualizar.
 if ! dc pull; then
-  c_ylw "⚠ Não consegui puxar todas as imagens da versão ${VERSAO_ALVO}."
-  c_ylw "  Sigo assim mesmo: o compose constrói o que faltar (mais lento, mesmo resultado)."
+  # A mensagem distingue os dois casos porque a consequência é oposta, e uma
+  # frase tranquilizadora sobre o caso errado é o pior desfecho possível: o
+  # `worker` e o `scheduler` têm `build:` ao lado do `image:` e o `up -d` os
+  # constrói; o `app` NÃO tem, então se for a imagem dele que falta, o `up -d`
+  # morre logo abaixo — e dizer "sigo assim mesmo" teria sido mentira.
+  if dc pull app >/dev/null 2>&1; then
+    c_ylw "⚠ Não consegui puxar todas as imagens da versão ${VERSAO_ALVO}."
+    c_ylw "  A do app veio; o que faltar é construído aqui (mais lento, mesmo resultado)."
+  else
+    c_ylw "⚠ Não consegui puxar a imagem do APP na versão ${VERSAO_ALVO}."
+    c_ylw "  Causas comuns: a versão ainda está publicando, ou o pacote está privado no GHCR."
+    c_ylw "  Vou tentar subir mesmo assim — se falhar, rode de novo em alguns minutos."
+  fi
 fi
 # A rede do proxy externo é declarada como EXTERNA no compose: se ela sumiu
 # (um `docker network prune`, ou o `down -v` que o próprio kit ensina como

--- a/hostgator-setup-kit/update.sh
+++ b/hostgator-setup-kit/update.sh
@@ -155,15 +155,34 @@ step "Baixando a versão nova do app e reiniciando"
 # acima) e a imagem do container sejam sempre da mesma versão. Gravada no .env,
 # não só exportada: o compose lê a imagem de lá, e um `up -d` rodado à mão
 # depois voltaria pro ":latest" do install — desfazendo a atualização.
-export APP_IMAGE="ghcr.io/melgarafael/deskcommcrm:${TARGET_TAG#v}"
-set_env_var .env APP_IMAGE "$APP_IMAGE"
-# Devolve a política padrão: um rollback anterior deixou "missing" no .env
-# (porque a imagem de volta é um ID local, que não se puxa do registro), e
-# ninguém desfazia isso — o `up -d` manual do dono parava de puxar imagem para
-# sempre. Aqui o alvo é uma tag do registro de novo, então "always" volta a ser
-# o certo.
-set_env_var .env APP_PULL_POLICY always
-dc pull
+#
+# As TRÊS imagens são gravadas juntas, na mesma versão. O worker e o scheduler
+# passaram a ter imagem publicada porque, antes, eram `build:`-only no compose:
+# `dc pull` os PULAVA ("Skipped - No image to be pulled") e o `dc up -d` abaixo
+# recriava o contêiner sobre a imagem velha, sem `--build`. Resultado: o worker
+# — que é o runtime do agente de IA — ficava congelado no código do dia da
+# instalação e atravessava todas as atualizações. Esta é a linha que conserta
+# isso para o parque já instalado, sem que ninguém precise editar arquivo.
+#
+# `gravar_imagens` também resolve o pull_policy pela mutabilidade da tag: como
+# aqui o alvo é sempre uma tag de versão (imutável), sai `missing`. Isso além de
+# tudo desfaz o "missing" que um rollback anterior deixava para trás — antes ele
+# ficava no .env para sempre, e o `up -d` manual do dono nunca mais puxava nada.
+VERSAO_ALVO="${TARGET_TAG#v}"
+export APP_IMAGE="${IMG_APP}:${VERSAO_ALVO}"
+export WORKER_IMAGE="${IMG_WORKER}:${VERSAO_ALVO}"
+export SCHEDULER_IMAGE="${IMG_SCHEDULER}:${VERSAO_ALVO}"
+gravar_imagens .env "$VERSAO_ALVO"
+
+# `dc pull` falha se alguma das três imagens ainda não existir no registro — o
+# que acontece numa instalação atualizando para a primeira versão publicada
+# depois desta mudança, ou se um run de publicação quebrou. Nesse caso o compose
+# ainda tem `build:` ao lado do `image:` do worker e do scheduler, então o
+# `up -d` os constrói localmente: pior que puxar, melhor que não atualizar.
+if ! dc pull; then
+  c_ylw "⚠ Não consegui puxar todas as imagens da versão ${VERSAO_ALVO}."
+  c_ylw "  Sigo assim mesmo: o compose constrói o que faltar (mais lento, mesmo resultado)."
+fi
 # A rede do proxy externo é declarada como EXTERNA no compose: se ela sumiu
 # (um `docker network prune`, ou o `down -v` que o próprio kit ensina como
 # caminho de recomeço), o `up -d` abaixo morre em "network X declared as

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:journeys": "playwright test -c tests/journeys/playwright.config.ts",
     "test:unit": "vitest run",
     "test:db": "bash scripts/test-db.sh",
-    "test:shell": "bash tests/shell/update-guard.test.sh && bash hostgator-setup-kit/test-validators.sh",
+    "test:shell": "bash tests/shell/update-guard.test.sh && bash tests/shell/scheduler-entrypoint.test.sh && bash hostgator-setup-kit/test-validators.sh",
     "test:invariants": "bash scripts/test-db.sh",
     "lint:channels": "tsx scripts/lint-channels.ts",
     "gov:verify": "pnpm typecheck && pnpm lint && pnpm lint:channels && pnpm test:unit",

--- a/tests/shell/scheduler-entrypoint.test.sh
+++ b/tests/shell/scheduler-entrypoint.test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Gate do docker/scheduler/entrypoint.sh — o único artefato executável novo da
+# doutrina de packaging, e o que ficou sem cobertura na primeira versão dela.
+#
+# O que ele guarda, e por que cada coisa:
+#
+# 1. O SEGREDO SOBREVIVE INTEIRO E LITERAL. O crond executa cada linha do crontab
+#    por `/bin/sh -c`, então o valor é REAVALIADO na hora de disparar. A versão
+#    anterior interpolava o INTERNAL_SECRET dentro de aspas duplas: um `$` no
+#    valor virava expansão de variável (header truncado → todo cron respondendo
+#    401 em silêncio) e uma crase virava substituição de comando — execução
+#    arbitrária a cada minuto. Aqui o teste monta o header com um `sh` DE VERDADE,
+#    como o crond faria, e compara byte a byte.
+#
+# 2. NENHUMA ROTA SE PERDE. O crontab saiu do `command:` inline do compose e veio
+#    para cá; a contagem tem de bater com app/api/v1/cron. (A cerca principal é
+#    tests/unit/cron-routes-scheduled.test.ts; esta aqui pega o caso em que o
+#    arquivo GERADO diverge da lista escrita, que aquele teste não vê.)
+#
+# 3. FALHA FECHADA SEM SEGREDO. Sem INTERNAL_SECRET os crons responderiam 401 e
+#    nada aconteceria — sem erro, sem log, sem sintoma. O script recusa subir.
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+
+ENTRYPOINT="docker/scheduler/entrypoint.sh"
+fail=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+check() {
+  local nome="$1"; shift
+  if "$@" >/dev/null 2>&1; then printf '  ✓ %s\n' "$nome"
+  else printf '  ✗ %s\n' "$nome"; fail=1; fi
+}
+
+# `crond` dublado: o entrypoint termina em `exec crond`, que não existe no macOS
+# nem no runner. Sem o dublê o script morreria DEPOIS de escrever o crontab — o
+# arquivo estaria certo e o teste falharia por motivo errado.
+mkdir -p "$TMP/bin"
+printf '#!/bin/sh\nexit 0\n' > "$TMP/bin/crond"
+chmod +x "$TMP/bin/crond"
+
+rodar() { # $1 = valor de INTERNAL_SECRET ("" = ausente)
+  local out="$TMP/crontab"
+  : > "$out"
+  if [ -z "$1" ]; then
+    env -u INTERNAL_SECRET PATH="$TMP/bin:$PATH" CRONTAB_PATH="$out" \
+      sh "$ENTRYPOINT" >"$TMP/saida" 2>&1
+  else
+    env INTERNAL_SECRET="$1" PATH="$TMP/bin:$PATH" CRONTAB_PATH="$out" \
+      sh "$ENTRYPOINT" >"$TMP/saida" 2>&1
+  fi
+  echo $?
+}
+
+echo "scheduler: o crontab é gerado com todas as rotas"
+RC="$(rodar 'segredo-simples')"
+check "o entrypoint termina com sucesso" test "$RC" -eq 0
+ROTAS_CODIGO="$(find app/api/v1/cron -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+ROTAS_CRONTAB="$(grep -oE 'api/v1/cron/[a-z0-9-]+' "$TMP/crontab" | sort -u | wc -l | tr -d ' ')"
+check "as $ROTAS_CODIGO rotas do código estão no crontab (achei $ROTAS_CRONTAB)" \
+  test "$ROTAS_CODIGO" -eq "$ROTAS_CRONTAB"
+check "uma linha por cron, nenhuma vazia" \
+  test "$(grep -c . "$TMP/crontab")" -eq "$(wc -l < "$TMP/crontab" | tr -d ' ')"
+
+echo "scheduler: o segredo atravessa o sh do crond intacto"
+# Os três caracteres que quebram interpolação ingênua, de uma vez só.
+HOSTIL='seg`whoami`redo$HOME-com'\''aspa-e-"aspas"'
+RC="$(rodar "$HOSTIL")"
+check "gerou o crontab mesmo com segredo cheio de metacaractere" test "$RC" -eq 0
+
+# A medição que importa: pegar a PRIMEIRA linha, tirar o prefixo de agendamento,
+# e mandar um `sh` de verdade avaliá-la — exatamente o que o crond faz. O `curl`
+# é dublado por um script que imprime o header que recebeu.
+printf '#!/bin/sh\nwhile [ $# -gt 0 ]; do [ "$1" = "-H" ] && { printf "%%s" "$2"; exit 0; }; shift; done\nexit 1\n' > "$TMP/bin/curl"
+chmod +x "$TMP/bin/curl"
+LINHA="$(head -1 "$TMP/crontab")"
+COMANDO="${LINHA#* * * * * }"                 # tira o agendamento de 5 campos
+COMANDO="${COMANDO%% >/dev/null*}"            # tira a redireção
+RECEBIDO="$(PATH="$TMP/bin:$PATH" sh -c "$COMANDO")"
+ESPERADO="Authorization: Bearer ${HOSTIL}"
+if [ "$RECEBIDO" = "$ESPERADO" ]; then
+  printf '  ✓ o header chega ao curl byte a byte igual ao segredo do .env\n'
+else
+  printf '  ✗ o segredo foi corrompido pelo sh do crond\n'
+  printf '     esperado: %s\n' "$ESPERADO"
+  printf '     recebido: %s\n' "$RECEBIDO"
+  fail=1
+fi
+# Controle negativo do próprio instrumento: se a crase tivesse sido executada, o
+# crontab conteria a saída de `whoami` no lugar dela, não o texto literal.
+check "a crase NÃO foi executada (está literal no arquivo)" \
+  grep -q 'whoami' "$TMP/crontab"
+
+echo "scheduler: sem INTERNAL_SECRET, recusa em vez de subir mudo"
+RC="$(rodar '')"
+check "sai com código 1" test "$RC" -eq 1
+check "explica o motivo na saída" grep -q "INTERNAL_SECRET" "$TMP/saida"
+check "não deixou crontab pela metade" test ! -s "$TMP/crontab"
+
+if [ "$fail" -eq 0 ]; then
+  echo "OK — todas as provas passaram."
+else
+  echo "FALHOU."
+fi
+exit "$fail"

--- a/tests/shell/update-guard.test.sh
+++ b/tests/shell/update-guard.test.sh
@@ -185,10 +185,40 @@ check "a chave APP_IMAGE não duplicou" test "$(grep -c '^APP_IMAGE=' .env)" -eq
 run_update --to v1.1.0 --force
 check "segunda execução também não duplica" test "$(grep -c '^APP_IMAGE=' .env)" -eq 1
 check "as outras chaves do .env sobreviveram" grep -q '^INTERNAL_SECRET=segredo$' .env
-check "a política de pull volta a 'always' (senão o up -d do dono nunca mais puxa imagem)" \
-  grep -q '^APP_PULL_POLICY=always$' .env
+check "a política de pull vira 'missing' — a tag é imutável, e 'always' derrubaria o CRM se o GHCR caísse" \
+  grep -q '^APP_PULL_POLICY=missing$' .env
 check "e sem duplicar a chave" test "$(grep -c '^APP_PULL_POLICY=' .env)" -eq 1
 check ".env continua 600 (só o dono lê)" test -n "$(find .env -perm 600)"
+
+# Esta prova exigia 'always' até 2026-08-13, e o motivo escrito era real: um
+# rollback deixava 'missing' no .env com um ID de imagem LOCAL, e ninguém
+# desfazia — o `up -d` manual do dono parava de puxar imagem para sempre.
+#
+# O que mudou não foi a preocupação, foi a régua. Medido: com 'always' e o
+# registro sem responder para aquela referência, o `up -d` FALHA e o contêiner
+# NÃO SOBE, mesmo com a imagem já no disco. Como a instalação agora nasce e
+# permanece pinada numa tag imutável, 'always' deixou de proteger de qualquer
+# coisa e passou a amarrar a subida do CRM de um cliente pago à disponibilidade
+# do GHCR. O medo original continua coberto por outro caminho: o update.sh faz
+# `dc pull` EXPLÍCITO, que independe do pull_policy, e regrava a tag por cima do
+# ID local do rollback — que é o que a prova logo acima verifica.
+# Ver docs/doctrine/packaging.md, invariante 5.
+
+echo "── 4b. As três imagens sobem juntas, na mesma versão"
+# O worker e o scheduler eram `build:`-only no compose: `dc pull` os pulava e o
+# `up -d` sem --build recriava o contêiner sobre a imagem velha. O worker — o
+# runtime do agente de IA — ficava congelado no código do dia da instalação.
+# Se estas três linhas voltarem a divergir, o defeito voltou.
+check "o worker é pinado na MESMA versão do app" \
+  grep -q '^WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:1.1.0$' .env
+check "o scheduler é pinado na MESMA versão do app" \
+  grep -q '^SCHEDULER_IMAGE=ghcr.io/melgarafael/deskcomm-scheduler:1.1.0$' .env
+check "o worker herda a política da tag imutável" \
+  grep -q '^WORKER_PULL_POLICY=missing$' .env
+check "o scheduler herda a política da tag imutável" \
+  grep -q '^SCHEDULER_PULL_POLICY=missing$' .env
+check "nenhuma das chaves novas duplicou" \
+  test "$(grep -cE '^(WORKER|SCHEDULER)_(IMAGE|PULL_POLICY)=' .env)" -eq 4
 
 # ── Clone RASO: a topologia que o install.sh realmente entrega ───────────────
 # `install.sh` instala com `git clone --depth 1`. Num repositório raso o

--- a/tests/unit/channel-health-aviso.test.ts
+++ b/tests/unit/channel-health-aviso.test.ts
@@ -228,7 +228,9 @@ describe("os elos que somem sem barulho", () => {
   });
 
   it("o vigia está AGENDADO — rota sem cron nunca roda", () => {
-    const compose = readFileSync("docker-compose.prod.yml", "utf8");
+    // O crontab mora no entrypoint da imagem do scheduler desde que ele deixou
+    // de rodar `apk add` a cada start (docs/doctrine/packaging.md, invariante 1).
+    const compose = readFileSync("docker/scheduler/entrypoint.sh", "utf8");
     // Com o fim ancorado: `channel-healthXX` CONTÉM `channel-health`, e a
     // primeira versão deste caso passou verde com a rota apontando para o nada.
     expect(compose, "o cron não foi agendado no scheduler").toMatch(

--- a/tests/unit/cron-contact-phones.test.ts
+++ b/tests/unit/cron-contact-phones.test.ts
@@ -216,7 +216,9 @@ describe("o encanamento", () => {
   });
 
   it("está agendado — cron que ninguém chama é código morto", () => {
-    const compose = readFileSync("docker-compose.prod.yml", "utf8");
+    // O crontab mora no entrypoint da imagem do scheduler desde que ele deixou
+    // de rodar `apk add` a cada start (docs/doctrine/packaging.md, invariante 1).
+    const compose = readFileSync("docker/scheduler/entrypoint.sh", "utf8");
     expect(compose).toMatch(/cron\/contact-phones/);
   });
 

--- a/tests/unit/cron-routes-scheduled.test.ts
+++ b/tests/unit/cron-routes-scheduled.test.ts
@@ -25,7 +25,11 @@ import { describe, expect, it } from "vitest";
 
 const RAIZ = join(__dirname, "..", "..");
 const DIR_CRON = join(RAIZ, "app", "api", "v1", "cron");
-const COMPOSE = join(RAIZ, "docker-compose.prod.yml");
+// O crontab saiu do `command:` inline do compose e virou o entrypoint da imagem
+// `deskcomm-scheduler` — o `apk add curl tzdata` a cada start amarrava a volta
+// do cron à internet da VPS. A cerca continua a mesma; só a fonte da verdade do
+// "o que roda" mudou de arquivo.
+const CRONTAB = join(RAIZ, "docker", "scheduler", "entrypoint.sh");
 
 /** As rotas que existem, lidas do disco — não de uma lista mantida à mão. */
 function rotasNoCodigo(): string[] {
@@ -37,8 +41,8 @@ function rotasNoCodigo(): string[] {
 
 /** As rotas que o `scheduler` chama, extraídas do crontab embutido no compose. */
 function rotasAgendadas(): string[] {
-  const yml = readFileSync(COMPOSE, "utf8");
-  const achadas = yml.matchAll(/api\/v1\/cron\/([a-z0-9-]+)/g);
+  const sh = readFileSync(CRONTAB, "utf8");
+  const achadas = sh.matchAll(/api\/v1\/cron\/([a-z0-9-]+)/g);
   return [...new Set([...achadas].map((m) => m[1]!))].sort();
 }
 
@@ -55,7 +59,7 @@ describe("rotas de cron × agendamento no self-host", () => {
     const naoAgendadas = rotasNoCodigo().filter((r) => !rotasAgendadas().includes(r));
     expect(
       naoAgendadas,
-      `Rota(s) de cron sem linha no crontab do serviço 'scheduler' em docker-compose.prod.yml: ` +
+      `Rota(s) de cron sem linha no crontab de docker/scheduler/entrypoint.sh: ` +
         `${naoAgendadas.join(", ")}. Num self-host elas NUNCA rodam, e a feature não dá erro — ` +
         `só não acontece. Adicione a linha (ou apague a rota, se ela morreu).`,
     ).toEqual([]);

--- a/tests/unit/packaging-artefato-do-cliente.test.ts
+++ b/tests/unit/packaging-artefato-do-cliente.test.ts
@@ -65,7 +65,7 @@ function lerServicos(yaml: string): Map<string, string> {
     const cabecalho = linha.match(/^ {2}([a-z0-9_-]+):\s*$/i);
     if (cabecalho) {
       fechar();
-      atual = cabecalho[1];
+      atual = cabecalho[1] ?? null;
       continue;
     }
     if (atual) buffer.push(linha);
@@ -124,7 +124,7 @@ describe("packaging — o artefato que o cliente instala", () => {
 
       // Tira a interpolação ${VAR:-default} e fica com o default, que é o que
       // vale para quem não configurou nada — ou seja, para todo mundo.
-      const ref = m[1].replace(/^\$\{[A-Z_]+:-(.+)\}$/, "$1");
+      const ref = (m[1] ?? "").replace(/^\$\{[A-Z_]+:-(.+)\}$/, "$1");
 
       if (ref.includes("@sha256:")) continue; // pin por digest: o mais forte que existe
 
@@ -161,7 +161,7 @@ describe("packaging — o artefato que o cliente instala", () => {
       expect(politica, `'${nome}' não declara pull_policy`).toBeDefined();
 
       const defaultDaPolitica = politica!.replace(/^\$\{[A-Z_]+:-(.+)\}$/, "$1");
-      const imagem = bloco.match(/^\s{4}image:\s*(\S+)/m)![1];
+      const imagem = bloco.match(/^\s{4}image:\s*(\S+)/m)?.[1] ?? "";
       const tagDaImagem = imagem.replace(/^\$\{[A-Z_]+:-(.+)\}$/, "$1").split(":").pop();
       const tagEhMovel = ["latest", "main", "stable"].includes(tagDaImagem ?? "");
       avaliados += 1;

--- a/tests/unit/packaging-artefato-do-cliente.test.ts
+++ b/tests/unit/packaging-artefato-do-cliente.test.ts
@@ -1,0 +1,225 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * O gate mecânico da doutrina de packaging (docs/doctrine/packaging.md).
+ *
+ * Existe porque a regra estava escrita e era falsa há dois meses: `CLAUDE.md`
+ * afirmava que "o caminho normal não constrói nada na VPS", enquanto o serviço
+ * `worker` do compose de produção não tinha `image:` — só `build:`. Ele era
+ * construído na VPS de cada cliente pelo `up -d` do install, e NENHUM update.sh
+ * jamais o reconstruía: `docker compose pull` pula serviço build-only ("Skipped
+ * - No image to be pulled") e `up -d` sem `--build` recria o contêiner sobre a
+ * imagem velha. O runtime do agente de IA — a feature-título do produto —
+ * congelava no código do dia da instalação.
+ *
+ * Duas varreduras manuais e uma consultoria externa de packaging não pegaram
+ * isso. Por isso a regra virou teste: prosa que nenhum gate lê é prosa que
+ * diverge.
+ *
+ * ESCOPO: `docker-compose.prod.yml` — o compose que o self-hoster roda. O
+ * `docker-compose.yml` (dev) e o `docker-compose.build.yml` (override de build
+ * opcional) estão de fora de propósito: construir localmente é justamente o que
+ * eles existem para fazer.
+ */
+
+const RAIZ = process.cwd();
+const COMPOSE_PROD = path.join(RAIZ, "docker-compose.prod.yml");
+
+const compose = fs.readFileSync(COMPOSE_PROD, "utf8");
+
+/**
+ * Parser deliberadamente pequeno: lê os blocos de serviço de 4 espaços de
+ * indentação sob `services:`. Não é um parser de YAML — é o suficiente para
+ * responder "este serviço declara image?" sem trazer uma dependência nova só
+ * para um gate. Se o compose mudar de forma a ponto de isto errar, os testes
+ * abaixo falham alto (nome de serviço faltando), não em silêncio.
+ */
+function lerServicos(yaml: string): Map<string, string> {
+  const linhas = yaml.split("\n");
+  const servicos = new Map<string, string>();
+  let dentroDeServices = false;
+  let atual: string | null = null;
+  let buffer: string[] = [];
+
+  const fechar = () => {
+    if (atual) servicos.set(atual, buffer.join("\n"));
+    atual = null;
+    buffer = [];
+  };
+
+  for (const linha of linhas) {
+    if (/^services:\s*$/.test(linha)) {
+      dentroDeServices = true;
+      continue;
+    }
+    if (!dentroDeServices) continue;
+    // Qualquer chave de topo (coluna 0) encerra a seção de serviços.
+    if (/^\S/.test(linha) && linha.trim() !== "") {
+      fechar();
+      dentroDeServices = false;
+      continue;
+    }
+    const cabecalho = linha.match(/^ {2}([a-z0-9_-]+):\s*$/i);
+    if (cabecalho) {
+      fechar();
+      atual = cabecalho[1];
+      continue;
+    }
+    if (atual) buffer.push(linha);
+  }
+  fechar();
+  return servicos;
+}
+
+const servicos = lerServicos(compose);
+
+/** Só as imagens que NÓS publicamos. Upstream tem regra própria, mais abaixo. */
+const NOSSOS = ["app", "worker", "scheduler"] as const;
+
+describe("packaging — o artefato que o cliente instala", () => {
+  it("o parser enxerga os 7 serviços de produção", () => {
+    // Guarda do próprio instrumento: se o parser parar de enxergar os serviços,
+    // todos os testes abaixo passariam vazios — verde por não ter medido nada.
+    expect([...servicos.keys()].sort()).toEqual(
+      ["app", "caddy", "redis", "scheduler", "srh", "waha", "worker"].sort(),
+    );
+  });
+
+  it.each(NOSSOS)("o serviço '%s' declara image: — nunca só build:", (nome) => {
+    const bloco = servicos.get(nome);
+    expect(bloco, `serviço '${nome}' sumiu do compose de produção`).toBeDefined();
+
+    const temImage = /^\s{4}image:\s*\S/m.test(bloco!);
+    expect(
+      temImage,
+      `'${nome}' não declara image:. Serviço build-only é pulado por 'docker compose pull' ` +
+        `e imune a 'up -d' sem --build: ele é construído na VPS do cliente e NUNCA é ` +
+        `atualizado. Publique a imagem e declare image: (o build: pode ficar ao lado, ` +
+        `como escape). Ver docs/doctrine/packaging.md, invariante 1.`,
+    ).toBe(true);
+  });
+
+  it("nenhum serviço de produção é build-only", () => {
+    const buildOnly = [...servicos.entries()]
+      .filter(([, bloco]) => /^\s{4}build:/m.test(bloco) && !/^\s{4}image:\s*\S/m.test(bloco))
+      .map(([nome]) => nome);
+
+    expect(
+      buildOnly,
+      `serviço(s) build-only em produção: ${buildOnly.join(", ")}. ` +
+        `É o defeito do 'worker' voltando: build na VPS do cliente que nenhum update alcança.`,
+    ).toEqual([]);
+  });
+
+  it("toda imagem upstream está pinada — nunca :latest nem tag implícita", () => {
+    const soltas: string[] = [];
+
+    for (const [nome, bloco] of servicos) {
+      if ((NOSSOS as readonly string[]).includes(nome)) continue;
+      const m = bloco.match(/^\s{4}image:\s*(\S+)/m);
+      if (!m) continue;
+
+      // Tira a interpolação ${VAR:-default} e fica com o default, que é o que
+      // vale para quem não configurou nada — ou seja, para todo mundo.
+      const ref = m[1].replace(/^\$\{[A-Z_]+:-(.+)\}$/, "$1");
+
+      if (ref.includes("@sha256:")) continue; // pin por digest: o mais forte que existe
+
+      const depoisDoHost = ref.split("/").pop() ?? "";
+      const temTag = depoisDoHost.includes(":");
+      const tag = temTag ? depoisDoHost.split(":").pop() : null;
+
+      if (!temTag || tag === "latest") {
+        soltas.push(`${nome} -> ${ref}`);
+      }
+    }
+
+    expect(
+      soltas,
+      `imagem upstream sem pin: ${soltas.join(", ")}. Sem tag = ':latest', e o 'dc pull' do ` +
+        `update.sh entrega ao cliente qualquer versão que o upstream tenha publicado, ` +
+        `inclusive uma nunca testada por nós — no meio de uma atualização. ` +
+        `Ver docs/doctrine/packaging.md, invariante 4.`,
+    ).toEqual([]);
+  });
+
+  it("o pull_policy acompanha a mutabilidade da tag, nos dois sentidos", () => {
+    // Medido, e é a razão de a regra existir: com pull_policy 'always' e o
+    // registry sem responder para aquela referência, o `up -d` FALHA e o
+    // contêiner não sobe — mesmo com a imagem já no disco. Com tag imutável isso
+    // não protege de nada e só amarra a disponibilidade do CRM do cliente à do
+    // GHCR. No sentido oposto, tag móvel com 'missing' puxa uma vez e congela:
+    // é o defeito do worker voltando por outra porta.
+    let avaliados = 0;
+
+    for (const nome of NOSSOS) {
+      const bloco = servicos.get(nome)!;
+      const politica = bloco.match(/^\s{4}pull_policy:\s*(\S+)/m)?.[1];
+      expect(politica, `'${nome}' não declara pull_policy`).toBeDefined();
+
+      const defaultDaPolitica = politica!.replace(/^\$\{[A-Z_]+:-(.+)\}$/, "$1");
+      const imagem = bloco.match(/^\s{4}image:\s*(\S+)/m)![1];
+      const tagDaImagem = imagem.replace(/^\$\{[A-Z_]+:-(.+)\}$/, "$1").split(":").pop();
+      const tagEhMovel = ["latest", "main", "stable"].includes(tagDaImagem ?? "");
+      avaliados += 1;
+
+      const esperado = tagEhMovel ? "always" : "missing";
+      expect(
+        defaultDaPolitica,
+        `'${nome}' aponta para a tag ${tagEhMovel ? "MÓVEL" : "IMUTÁVEL"} '${tagDaImagem}' ` +
+          `com pull_policy '${defaultDaPolitica}'. Tag móvel usa 'always' (senão a versão ` +
+          `nunca chega); tag imutável usa 'missing' (senão o CRM só sobe se o GHCR estiver ` +
+          `de pé). Ver docs/doctrine/packaging.md, invariante 5.`,
+      ).toBe(esperado);
+    }
+
+    // Guarda do instrumento: a primeira versão deste teste só cobrava o caso da
+    // tag imutável e, como os três serviços apontam para tag móvel, ele passava
+    // sem avaliar um único serviço — verde por não ter medido nada.
+    expect(avaliados, "o teste de pull_policy não avaliou nenhum serviço").toBe(NOSSOS.length);
+  });
+
+  it("cada Dockerfile publicado declara procedência OCI e ARG APP_VERSION", () => {
+    // O CI injeta os labels via docker/metadata-action, mas o build local do
+    // docker-compose.build.yml não passa por ele. Sem LABEL no arquivo, essa
+    // imagem sai sem origem nenhuma — e é justamente a que vira dívida numa VPS.
+    for (const arquivo of ["Dockerfile", "Dockerfile.worker", "Dockerfile.scheduler"]) {
+      const conteudo = fs.readFileSync(path.join(RAIZ, arquivo), "utf8");
+      expect(conteudo, `${arquivo} sem org.opencontainers.image.source`).toContain(
+        "org.opencontainers.image.source",
+      );
+      expect(conteudo, `${arquivo} sem ARG APP_VERSION`).toMatch(/^ARG APP_VERSION/m);
+    }
+  });
+
+  it("o workflow publica as três imagens e injeta APP_VERSION", () => {
+    const wf = fs.readFileSync(path.join(RAIZ, ".github/workflows/publish-image.yml"), "utf8");
+    for (const imagem of ["deskcommcrm", "deskcomm-worker", "deskcomm-scheduler"]) {
+      expect(wf, `publish-image.yml não publica '${imagem}'`).toContain(`name: ${imagem}`);
+    }
+    expect(wf, "publish-image.yml não passa APP_VERSION como build-arg").toContain(
+      "APP_VERSION=",
+    );
+    expect(wf, "publish-image.yml não cria o canal 'stable'").toContain("value=stable");
+  });
+});
+
+describe("packaging — a versão que roda é observável de fora", () => {
+  it("o /api/v1/health lê APP_VERSION, e não npm_package_version", () => {
+    // npm_package_version é `undefined` sob `CMD ["node","server.js"]` — só
+    // existe quando o processo nasce de um `npm`/`pnpm run`. Com o fallback
+    // "0.1.0" que havia antes, TODA instalação do mundo reportava a mesma
+    // versão inventada, e o campo desligava a pergunta em vez de respondê-la.
+    const rota = fs.readFileSync(path.join(RAIZ, "app/api/v1/health/route.ts"), "utf8");
+
+    expect(rota, "o health voltou a ler npm_package_version").not.toMatch(
+      /version:\s*process\.env\.npm_package_version/,
+    );
+    expect(rota, "o health não lê process.env.APP_VERSION").toMatch(
+      /version:\s*process\.env\.APP_VERSION/,
+    );
+  });
+});

--- a/tests/unit/packaging-artefato-do-cliente.test.ts
+++ b/tests/unit/packaging-artefato-do-cliente.test.ts
@@ -182,6 +182,32 @@ describe("packaging — o artefato que o cliente instala", () => {
     expect(avaliados, "o teste de pull_policy não avaliou nenhum serviço").toBe(NOSSOS.length);
   });
 
+  it("nenhum serviço nosso cai em `latest` quando o .env não tem a chave", () => {
+    // Ponto cego que este teste tinha e uma sabotagem revelou: ele cobrava
+    // "tag móvel usa always", e `latest` e `stable` são AMBOS móveis — trocar um
+    // pelo outro passava verde. A distinção importa porque quem cai no default é
+    // quem NÃO tem a chave no .env, e o caso real disso é uma instalação legada
+    // atualizando: o update.sh antigo (o que está no disco dela) só grava
+    // APP_IMAGE, então worker e scheduler pegam o default DESTE arquivo. Com
+    // `latest` — que aqui é o topo da `main` — o parque rodaria o runtime do
+    // agente de IA em código não lançado, pareado com um app de release.
+    const proibidos: string[] = [];
+
+    for (const nome of NOSSOS) {
+      const bloco = servicos.get(nome)!;
+      const imagem = bloco.match(/^\s{4}image:\s*(\S+)/m)?.[1] ?? "";
+      const padrao = imagem.replace(/^\$\{[A-Z_]+:-(.+)\}$/, "$1");
+      const tag = padrao.split(":").pop();
+      if (tag === "latest" || tag === "main") proibidos.push(`${nome} -> ${padrao}`);
+    }
+
+    expect(
+      proibidos,
+      `default para canal de desenvolvimento: ${proibidos.join(", ")}. Em produção o mínimo é ` +
+        `\`:stable\` (a última release). Ver docs/doctrine/packaging.md, invariante 3.`,
+    ).toEqual([]);
+  });
+
   it("cada Dockerfile publicado declara procedência OCI e ARG APP_VERSION", () => {
     // O CI injeta os labels via docker/metadata-action, mas o build local do
     // docker-compose.build.yml não passa por ele. Sem LABEL no arquivo, essa


### PR DESCRIPTION
> **Draft de propósito.** Este PR existe para rodar o CI — os gatilhos deste repo não
> disparam em push de feature branch. Ele **não** deve ser mergeado antes do ensaio U6-b
> numa VPS descartável (ver §Pendências).

## O defeito que originou isto

O serviço `worker` do `docker-compose.prod.yml` não tinha `image:`, só `build:`.

1. `docker compose pull` **pula** serviço build-only (`"Skipped - No image to be pulled"`);
2. `up -d` sem `--build` recria o contêiner sobre a imagem velha;
3. logo o worker era compilado na VPS no dia da instalação e **nenhum `update.sh` jamais o
   reconstruiu**.

E ele não é acessório: `app/api/v1/cron/agent-dispatcher` é no-op permanente, então o
agent-worker é o **único** consumidor de `ai_agent.dispatch_requested`. O runtime do agente de
IA — a feature-título — era a única peça que não recebia correção.

### Isto não é projeção. Está em produção agora

Sondagem read-only na VPS de produção (2026-08-13):

| serviço | imagem | criada |
|---|---|---|
| app | `ghcr.io/melgarafael/deskcommcrm:1.2.1` (registry) | 2026-08-12 |
| **worker** | `deskcommcrm-worker:latest` (local, **sem labels OCI**) | **2026-07-31** |

O `.env` não tem `WORKER_IMAGE`. O `/api/v1/health` responde `version: "0.1.0"`. E o contêiner
do worker foi **reiniciado em 13/08 às 12:12 e continua rodando a imagem de 31/07** — restart
não reconstrói.

**O que ficou para trás:** 9 commits, 399 linhas em `workers/`, incluindo
`fix(ia): dois runtimes respondiam a mesma mensagem (#129)`,
`feat(agente): os três papéis (vazamento 30% → 10%) (#181)` e
`fix(canais): a mídia que o cliente manda só virava bytes num canal`.

## O que este PR faz

**Doutrina** — `docs/doctrine/packaging.md` (7 invariantes com *Por quê* + *Verificação*,
política de canais, checklist de release, Enforcement) e `docs/adr/0001-packaging-e-distribuicao.md`.
Enraizada em `CLAUDE.md` (§Packaging + DoD item 15), `CONTRIBUTING.md`, `AGENTS.md`,
`docs/DEPLOY-CHECKLIST.md`, `docs/index.md`, runbooks e mapa de jornadas.

**Implementação**

- `deskcomm-worker` e `deskcomm-scheduler` viram imagens publicadas. **Aditivo por
  construção:** `build:` continua ao lado de `image:`, e foi medido que o Compose constrói
  localmente quando a imagem não existe — registry fora do ar cai no comportamento de hoje.
- `install.sh` **sonda o registry** antes de pinar (`ghcr_status`/`trio_publicado`). A tag do
  git nasce minutos antes das imagens, e `deskcomm-worker:1.2.1` nunca existirá — a v1.2.1 é
  anterior à criação do pacote. Sem a sonda, o `.env` receberia referências impossíveis e o kit
  construiria na VPS **em silêncio**.
- `latest` = topo da `main`; `stable` = última release. Antes do conserto, **toda tag também
  movia `latest`**, e o canal oscilava entre os dois significados.
- `pull_policy` acompanha a mutabilidade da tag. Medido: com `always` e o registry sem
  responder para aquela referência, o `up -d` **falha e o contêiner não sobe**, mesmo com a
  imagem no disco.
- `scheduler` deixa de rodar `apk add` a cada start; WAHA pinado (mesmo digest de hoje — zero
  mudança de conteúdo); `srh` pinado por **digest**, porque `latest` e `0.0.10` são imagens
  diferentes e trocar a tag mudaria o binário do parque.
- `/api/v1/health` para de mentir: lia `npm_package_version`, `undefined` sob
  `CMD ["node","server.js"]` — toda instalação do mundo reportava `0.1.0`.

**Gates novos** — `tests/unit/packaging-artefato-do-cliente.test.ts` (serviço `build:`-only,
pin upstream solto, `pull_policy` trocado, default em canal de desenvolvimento, versão que
mente), `tests/shell/scheduler-entrypoint.test.sh` e provas novas no `test-validators.sh` e no
`update-guard.test.sh`.

## Evidência

Duas revisões adversariais (56 agentes). A primeira achou 27 defeitos reais, 11 altos. A
segunda, sobre os consertos, achou que eu havia plantado **três afirmações falsas** nos
arquivos irmãos — incluindo escrever no `DEPLOY-CHECKLIST` a mesma sonda que a doutrina, no
mesmo commit, declarava proibida por aprovar com `401`. Todos corrigidos.

Cada regra foi **sabotada** para provar que o gate reprova. Duas sabotagens passaram verde e
revelaram pontos cegos nos próprios testes — corrigidos e re-sabotados.

Gates locais (exit code real): `typecheck`, `lint`, `lint:channels`, `test:unit`, `test:shell`,
`build`, `test:db` (718 testes) — todos 0.

Publicação já exercitada por `workflow_dispatch` nesta branch: **4/4 jobs verdes**, e o canal
`latest` permaneceu no digest `8e0ce6ab…` (registrado antes e conferido depois). As três
imagens puxam **anonimamente**, com `revision` e `APP_VERSION` corretos.

## Pendências — não mergear antes disto

- [ ] **U6-b: ensaio de atualização numa VPS descartável.** É o item 11 do checklist de release
      e o caso U6 do mapa de jornadas, declarado **não coberto**. O CI prova que os scripts
      fazem o que dizem; não prova que uma VPS saiu do estado A para o B.
- [ ] Tornar `imagens-ok` status check obrigatório — **depois** do merge, senão trava todos os
      PRs abertos.
- [ ] Cortar a release, para o canal `stable` passar a existir.
- [ ] Remover a tag `docs-doutrina-packaging` dos três pacotes junto do corte.

Roteiro com verificação de cada passo: `docs/runbooks/ativar-packaging.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKm2XcTcfgi1vdMcDYSRWa
