### PR TITLE
TESTE TEMPORÁRIO: sabotagem do build (será fechado)

### DIFF
--- a/Dockerfile.scheduler
+++ b/Dockerfile.scheduler
@@ -26,3 +26,5 @@ HEALTHCHECK --interval=60s --timeout=5s --start-period=10s --retries=3 \
   CMD pgrep crond >/dev/null || exit 1
 
 CMD ["/usr/local/bin/entrypoint.sh"]
+
+RUN este-comando-nao-existe-de-proposito


### PR DESCRIPTION
PR temporário para provar que o check `imagens-ok` reprova um build quebrado. Será fechado assim que a medição sair.