### PR TITLE
fix(ci): imagens-ok sem bloco permissions — o gate do #241 pegou meu job

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -141,6 +141,16 @@ jobs:
   imagens-ok:
     if: always()
     runs-on: ubuntu-latest
+    # Nenhuma permissão: este job só lê o resultado de `needs` e sai. Sem o bloco,
+    # o GITHUB_TOKEN herdaria o default do REPOSITÓRIO — configuração que vive fora
+    # do repo, muda num clique e não passa por PR.
+    #
+    # A regra e o gate que a impõe vieram do PR #241 (alertas do CodeQL), de um
+    # contribuidor. O teste dele pegou este job: eu o criei sem o bloco, e o defeito
+    # só apareceu quando a `main` entrou naquela branch. É o próprio caso que a
+    # justificativa do teste antecipa — "um job novo nasce sem bloco e herda o
+    # default de novo".
+    permissions: {}
     needs: [build-and-push]
     steps:
       - name: Falhar se qualquer imagem não construiu


### PR DESCRIPTION
O job `imagens-ok` (criado no #243) nasceu sem `permissions:`. Ele só lê `needs`, então o correto é `permissions: {}`.

**Como apareceu:** o teste que pega isso vem do #241, de um contribuidor. Ao atualizar aquela branch com a main, o teste dele flagrou o job novo que eu tinha acabado de mergear — meu PR passou verde porque a guarda ainda não estava na base.

É o caso que a justificativa do próprio teste antecipa: *"um job novo nasce sem bloco e herda o default de novo"*.

Vai **antes** da tag v1.3.0: não corto release com job sem permissão declarada enquanto um PR de segurança cobra isso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKm2XcTcfgi1vdMcDYSRWa