### PR TITLE
fix(auth): getUser() descartava o erro — falha transitória virava redirect silencioso

### DIFF
--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -35,7 +35,29 @@ export async function loadAuthUser(): Promise<AuthUser | null> {
   const supabase = await createClient();
   const {
     data: { user },
+    error,
   } = await supabase.auth.getUser();
+  // ⚠️ O `error` era DESCARTADO — nem chegava a ser desestruturado —, e aqui
+  // `user: null` é tão ambíguo quanto o `data: null` que a query logo abaixo
+  // trata com todo o cuidado: significa "não está logado" (estado normal) E
+  // "não deu para perguntar" (rede, GoTrue fora do ar, token ilegível).
+  //
+  // A ação não muda, e isso é deliberado: sem usuário confirmado, devolver
+  // `null` — e portanto redirecionar para o login — é o desfecho seguro.
+  // Falhar FECHADO na ação continua certo. O que estava errado era falhar
+  // fechado também na INFORMAÇÃO: quem investigasse depois via só uma pessoa
+  // "deslogada", sem nada distinguindo isso de uma falha transitória.
+  //
+  // Custou caro uma vez: um vermelho de e2e em que a barra lateral "perdeu o
+  // logo" foi, por eliminação, uma casca de app que não era a casca do app —
+  // e a hipótese nº 1 é justamente um redirect nascido aqui. Com este log, a
+  // próxima ocorrência se explica sozinha em vez de custar uma investigação.
+  if (error) {
+    logger.error("[auth] getUser falhou — tratando como não autenticado", {
+      codigo: (error as { status?: number }).status ?? null,
+      detalhe: error.message,
+    });
+  }
   if (!user) return null;
 
   // Platform admin? (active = no revoked_at). RLS returns null for non-admins.

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -31,6 +31,33 @@ interface RawMembershipRow {
  * - organizations: id IN fn_user_org_ids()  (orgs_select)
  * - platform_admins: only platform admins read (so non-admins get null — correct)
  */
+/**
+ * "Não havia sessão nenhuma" — o estado NORMAL, não um incidente.
+ *
+ * `getUser()` não devolve `error: null` para quem não está logado. Sem cookie de
+ * sessão, `GoTrueClient._getUser` corta antes de falar com o GoTrue e devolve
+ * `{ data: { user: null }, error: new AuthSessionMissingError() }` (status 400).
+ * Medido em `@supabase/auth-js` 2.112.1, com um cookie store vazio:
+ *
+ *     user  = null
+ *     error = AuthSessionMissingError: Auth session missing! (status=400)
+ *
+ * Isso importa porque **não há `middleware.ts` neste projeto**: o gate de
+ * `/app/*` é o próprio `app/app/layout.tsx`, que chama `loadAuthUser()` e só
+ * então redireciona. Ou seja, todo visitante deslogado — e todo crawler — passa
+ * por aqui sem sessão. Logar esse caso como erro reintroduziria, do lado do log,
+ * exatamente a ambiguidade que o bloco acima existe para desfazer: o estado
+ * normal e a falha transitória voltariam a ser a mesma linha, agora afogadas em
+ * volume de tráfego anônimo.
+ *
+ * Compara por `name` e não por `instanceof`: há DUAS cópias de `@supabase/auth-js`
+ * na árvore (2.111.0 e 2.112.1 em `node_modules/.pnpm`), e `instanceof` só acerta
+ * quando o erro vem da mesma cópia que o teste importou.
+ */
+export function ehSessaoAusente(error: { name?: string } | null | undefined): boolean {
+  return error?.name === "AuthSessionMissingError";
+}
+
 export async function loadAuthUser(): Promise<AuthUser | null> {
   const supabase = await createClient();
   const {
@@ -52,7 +79,12 @@ export async function loadAuthUser(): Promise<AuthUser | null> {
   // logo" foi, por eliminação, uma casca de app que não era a casca do app —
   // e a hipótese nº 1 é justamente um redirect nascido aqui. Com este log, a
   // próxima ocorrência se explica sozinha em vez de custar uma investigação.
-  if (error) {
+  //
+  // ⚠️ MAS NEM TODO `error` AQUI É INCIDENTE — e é por isso que `ehSessaoAusente`
+  // existe. Ver o comentário dela: sem esse filtro, este log dispara em todo
+  // visitante deslogado e refaz, do lado do log, a mesma fusão que este bloco
+  // existe para desfazer.
+  if (error && !ehSessaoAusente(error)) {
     logger.error("[auth] getUser falhou — tratando como não autenticado", {
       codigo: (error as { status?: number }).status ?? null,
       detalhe: error.message,

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -85,9 +85,20 @@ export async function loadAuthUser(): Promise<AuthUser | null> {
   // visitante deslogado e refaz, do lado do log, a mesma fusão que este bloco
   // existe para desfazer.
   if (error && !ehSessaoAusente(error)) {
+    // As chaves são as MESMAS do outro `logger.error` desta função (linha ~134):
+    // `code` e `message`. Dois nomes para o mesmo conceito, dentro da mesma
+    // função, obrigariam quem consulta o agregador a escrever duas buscas — num
+    // conserto cujo objeto é diagnóstico.
+    //
+    // `name` viaja junto porque é o que separa as CLASSES: `AuthRetryableFetchError`
+    // (rede, GoTrue fora do ar) de `AuthApiError` (token ilegível). Ambas podem
+    // chegar com o mesmo `status`, e a mensagem vem em inglês do upstream — sem o
+    // nome, distinguir as duas viraria regex sobre texto que muda entre versões.
     logger.error("[auth] getUser falhou — tratando como não autenticado", {
-      codigo: (error as { status?: number }).status ?? null,
-      detalhe: error.message,
+      name: error.name,
+      code: error.code ?? null,
+      status: error.status ?? null,
+      message: error.message,
     });
   }
   if (!user) return null;

--- a/tests/unit/auth-getuser-erro-mudo.test.ts
+++ b/tests/unit/auth-getuser-erro-mudo.test.ts
@@ -36,7 +36,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 interface RespostaGetUser {
   data: { user: unknown };
-  error: { name?: string; message: string; status?: number } | null;
+  error: { name?: string; message: string; status?: number; code?: string } | null;
 }
 
 const resposta: { atual: RespostaGetUser } = {
@@ -72,18 +72,30 @@ beforeEach(() => {
 });
 
 describe("loadAuthUser — o erro do getUser deixa rastro", () => {
-  it("falha transitória do GoTrue REGISTRA, com código e detalhe", async () => {
+  it("falha transitória do GoTrue REGISTRA, com a classe e o código", async () => {
     resposta.atual = {
       data: { user: null },
-      error: { name: "AuthRetryableFetchError", message: "fetch failed", status: 503 },
+      error: {
+        name: "AuthRetryableFetchError",
+        code: "over_request_rate_limit",
+        message: "fetch failed",
+        status: 503,
+      },
     };
 
     expect(await loadAuthUser()).toBeNull(); // a ação não muda: falha fechado
     expect(erros).toHaveLength(1);
     expect(erros[0]!.msg).toMatch(/getUser falhou/);
-    // Sem o código e o detalhe a linha não diagnostica nada — seria só um
-    // "algo deu errado" que manda investigar do zero, que é o custo original.
-    expect(erros[0]!.ctx).toMatchObject({ codigo: 503, detalhe: "fetch failed" });
+    // Sem estes campos a linha não diagnostica nada — seria um "algo deu errado"
+    // que manda investigar do zero, que é o custo que o conserto veio evitar.
+    // `name` é o que separa rede (AuthRetryableFetchError) de token ilegível
+    // (AuthApiError); as chaves são as mesmas do log irmão da própria função.
+    expect(erros[0]!.ctx).toMatchObject({
+      name: "AuthRetryableFetchError",
+      code: "over_request_rate_limit",
+      status: 503,
+      message: "fetch failed",
+    });
   });
 
   it("visitante SEM SESSÃO não registra nada — é o estado normal, não incidente", async () => {

--- a/tests/unit/auth-getuser-erro-mudo.test.ts
+++ b/tests/unit/auth-getuser-erro-mudo.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * O ERRO DO `getUser()` É REGISTRADO — E O NÃO-ERRO NÃO É.
+ *
+ * ## O defeito original
+ *
+ * `loadAuthUser` desestruturava só `data: { user }` e jogava o `error` fora. Como
+ * `user: null` significa TANTO "não está logado" (estado normal) QUANTO "não deu
+ * para perguntar" (GoTrue fora do ar, rede, token ilegível), uma falha transitória
+ * virava, no log, uma pessoa simplesmente deslogada — indistinguível do normal.
+ *
+ * A ação segue certa e não muda: sem usuário confirmado, `null` → login. Falhar
+ * FECHADO na ação é o desfecho seguro. O que estava errado era falhar fechado
+ * também na INFORMAÇÃO.
+ *
+ * ## O segundo defeito, que o conserto do primeiro quase introduziu
+ *
+ * `if (error) logger.error(...)` parece a correção óbvia e é uma armadilha:
+ * `getUser()` **devolve erro no caminho normal**. Sem cookie de sessão,
+ * `GoTrueClient._getUser` nem chega a falar com o servidor — retorna
+ * `AuthSessionMissingError` (status 400). E como este projeto **não tem
+ * `middleware.ts`** (o gate de `/app/*` é o próprio `app/app/layout.tsx`, que
+ * chama esta função), TODO visitante deslogado passa por aqui sem sessão.
+ *
+ * Sem o filtro, o log de erro se enche de tráfego anônimo e a linha diagnóstica
+ * — a razão de o PR existir — fica indistinguível do ruído. Seria a mesma fusão
+ * de estados de antes, mudada de lado.
+ *
+ * ## Por que os dois casos, e não só um
+ *
+ * Um teste que só exercitasse o incidente passaria com `if (error)` puro, que é
+ * justamente o código defeituoso. O par é o que prende o comportamento: registra
+ * o que é incidente, cala no que é estado normal.
+ */
+
+interface RespostaGetUser {
+  data: { user: unknown };
+  error: { name?: string; message: string; status?: number } | null;
+}
+
+const resposta: { atual: RespostaGetUser } = {
+  atual: { data: { user: null }, error: null },
+};
+
+const erros: { msg: string; ctx: unknown }[] = [];
+
+vi.mock("next/headers", () => ({ cookies: async () => ({ getAll: () => [], set: () => {} }) }));
+vi.mock("next/navigation", () => ({ redirect: () => { throw new Error("redirect"); } }));
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: (msg: string, ctx: unknown) => erros.push({ msg, ctx }),
+    warn: () => {},
+    info: () => {},
+    debug: () => {},
+  },
+}));
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    auth: { getUser: async () => resposta.atual },
+    from: () => {
+      throw new Error("não deveria consultar tabela sem usuário");
+    },
+  }),
+}));
+
+const { loadAuthUser, ehSessaoAusente } = await import("@/lib/auth/server");
+
+beforeEach(() => {
+  erros.length = 0;
+  resposta.atual = { data: { user: null }, error: null };
+});
+
+describe("loadAuthUser — o erro do getUser deixa rastro", () => {
+  it("falha transitória do GoTrue REGISTRA, com código e detalhe", async () => {
+    resposta.atual = {
+      data: { user: null },
+      error: { name: "AuthRetryableFetchError", message: "fetch failed", status: 503 },
+    };
+
+    expect(await loadAuthUser()).toBeNull(); // a ação não muda: falha fechado
+    expect(erros).toHaveLength(1);
+    expect(erros[0]!.msg).toMatch(/getUser falhou/);
+    // Sem o código e o detalhe a linha não diagnostica nada — seria só um
+    // "algo deu errado" que manda investigar do zero, que é o custo original.
+    expect(erros[0]!.ctx).toMatchObject({ codigo: 503, detalhe: "fetch failed" });
+  });
+
+  it("visitante SEM SESSÃO não registra nada — é o estado normal, não incidente", async () => {
+    // O que o @supabase/auth-js 2.112.1 devolve com cookie store vazio, medido:
+    //   user  = null
+    //   error = AuthSessionMissingError: Auth session missing! (status=400)
+    resposta.atual = {
+      data: { user: null },
+      error: { name: "AuthSessionMissingError", message: "Auth session missing!", status: 400 },
+    };
+
+    expect(await loadAuthUser()).toBeNull();
+    expect(
+      erros,
+      "deslogado é o caminho normal de /app/*: logar como erro afoga a linha diagnóstica em tráfego anônimo",
+    ).toEqual([]);
+  });
+
+  it("sem erro nenhum também não registra", async () => {
+    resposta.atual = { data: { user: null }, error: null };
+
+    expect(await loadAuthUser()).toBeNull();
+    expect(erros).toEqual([]);
+  });
+});
+
+describe("ehSessaoAusente — o predicado, isolado", () => {
+  it("reconhece a sessão ausente pelo nome", () => {
+    expect(ehSessaoAusente({ name: "AuthSessionMissingError" })).toBe(true);
+  });
+
+  it("não engole erro de rede nem de token", () => {
+    expect(ehSessaoAusente({ name: "AuthRetryableFetchError" })).toBe(false);
+    expect(ehSessaoAusente({ name: "AuthApiError" })).toBe(false);
+  });
+
+  it("tolera ausência de erro sem lançar", () => {
+    expect(ehSessaoAusente(null)).toBe(false);
+    expect(ehSessaoAusente(undefined)).toBe(false);
+    expect(ehSessaoAusente({})).toBe(false);
+  });
+});


### PR DESCRIPTION
`loadAuthUser` roda em **todo request autenticado** e fazia:

```ts
const { data: { user } } = await supabase.auth.getUser();
if (!user) return null;
```

O `error` não era nem desestruturado. E `user: null` é tão ambíguo quanto o
`data: null` da query que vem **logo abaixo, no mesmo arquivo** — que é tratada
com um comentário exemplar sobre por que separar "não é platform admin" de "a
query falhou". A primeira chamada ficou de fora do cuidado que a segunda recebeu.

## A ação não muda, e isso é deliberado

Sem usuário confirmado, devolver `null` — e portanto mandar para o login — é o
desfecho seguro. **Falhar fechado na ação continua certo.** O que estava errado
era falhar fechado também na **informação**: uma falha transitória contra o
GoTrue virava, no log, uma pessoa simplesmente "deslogada", indistinguível do
estado normal.

## Como isto apareceu

Um vermelho de e2e afirmava que a barra lateral tinha perdido o logo depois de
um upload recusado. A investigação provou, por cadeia de eliminação, que nada
havia sido apagado — os dois `logo_path` seguiam no banco — e que **o DOM medido
não era a casca do app**. Foi redirect ou troca de casca; qual delas, não deu
para saber, porque nenhum dos caminhos possíveis registra nada.

A hipótese nº 1 é um redirect nascido exatamente aqui: `/login` renderiza o logo
num `<div>`, não num `<aside>`, então o seletor do teste devolve vazio e o
sintoma fica idêntico a "a barra perdeu o logo".

Quatro agentes para chegar a uma pergunta que uma linha de log responderia.

**Não é o conserto do vermelho** — é o conserto de por que o vermelho foi mudo.

Gates: `typecheck` 0, `lint` 0 erros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCiffR3ugjQbxsfceQE2GB