### PR TITLE
fix(fila): o worker ocioso perguntava 4×/s se havia trabalho, abrindo transação

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -176,6 +176,25 @@ NEXT_PUBLIC_ADMIN_URL=http://localhost:3000
 # dedicada com login (ex.: agent_worker) — nunca a service_role key aqui.
 SUPABASE_DB_URL=
 
+# --- Ritmo da fila do worker (custo de banco) --------------------------------
+# Os dois governam quanto o worker conversa com o Postgres quando NÃO há trabalho
+# — a conta que estourou a cota de egress do plano free do Supabase na issue #258.
+# Ambos são opcionais: sem eles valem os defaults abaixo, que são o comportamento
+# recomendado. Como ver o que está em vigor: a linha `agent-engine pronto` no log
+# do worker imprime os dois. Quando mexer e o que medir:
+# docs/runbooks/custo-e-cota-do-supabase.md
+#
+# TETO de espera do laço da fila. Com a fila vazia, é quanto o worker dorme entre
+# uma consulta e a próxima; com job agendado, ele acorda no vencimento e este
+# valor só limita a soneca. Não passe de 10000: acima disso a conexão ociosa
+# expira entre as rodadas e cada consulta volta a pagar TCP+TLS — gasta MAIS.
+#QUEUE_POLL_INTERVAL_MS=2000
+# Ritmo do "havia trabalho e eu não peguei" (todas as vagas de
+# QUEUE_MAX_CONCURRENCY ocupadas, ou outro turno rodando para o mesmo contato).
+# Aqui há job vencido esperando vaga, então este valor é curto de propósito:
+# aumentá-lo não economiza nada no ocioso e custa throughput no pico.
+#QUEUE_CLAIM_RETRY_INTERVAL_MS=250
+
 # Chave LLM de plataforma (fallback quando a org não tem credencial BYOK
 # cadastrada em /app/ai/credentials). Opcional com BYOK.
 ANTHROPIC_API_KEY=

--- a/docs/deploy-selfhost/README.md
+++ b/docs/deploy-selfhost/README.md
@@ -11,7 +11,7 @@
 |---|---|
 | VPS Linux (2 vCPU / 4 GB+) com Docker | qualquer provedor |
 | Um domínio apontando para a VPS (registro A) | seu DNS |
-| Projeto **Supabase** (o plano free serve) | supabase.com — é o Postgres+Auth+Storage do CRM |
+| Projeto **Supabase** (o plano free serve; acompanhe a cota em Settings → Usage — ver [runbook de custo](../runbooks/custo-e-cota-do-supabase.md)) | supabase.com — é o Postgres+Auth+Storage do CRM |
 | Chave **Anthropic** (ou cadastre BYOK depois na tela) | console.anthropic.com |
 | Um número de WhatsApp para o agente | qualquer chip/celular |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -119,6 +119,7 @@ acessibilidade).
 | [`runbooks/deploy.md`](runbooks/deploy.md) | **Deploy em produção — os dois `-f` do compose, verificação pós-deploy** |
 | [`runbooks/remediar-worker-congelado.md`](runbooks/remediar-worker-congelado.md) | **Incidente: o worker congelado** — diagnóstico (`diagnostico.sh`), impacto medido e as duas rotas de remediação. **Ainda não ensaiado** |
 | [`runbooks/ativar-packaging.md`](runbooks/ativar-packaging.md) | **Ativação da doutrina de packaging** — os 3 passos que não cabem num PR (pacote público, check obrigatório, primeira release) |
+| [`runbooks/custo-e-cota-do-supabase.md`](runbooks/custo-e-cota-do-supabase.md) | **“Meu Supabase estourou a cota”** — como medir a origem do consumo, os dois intervalos da fila e as duas tabelas que só crescem |
 | [`runbooks/waha-hostgator.md`](runbooks/waha-hostgator.md) | Runbook do WAHA em produção |
 | [`runbooks/ai-credentials-rotation.md`](runbooks/ai-credentials-rotation.md) | Rotação de credenciais de IA |
 | [`../SECURITY.md`](../SECURITY.md) | Política de reporte de vulnerabilidade |

--- a/docs/runbooks/custo-e-cota-do-supabase.md
+++ b/docs/runbooks/custo-e-cota-do-supabase.md
@@ -1,0 +1,94 @@
+# Runbook — “meu Supabase estourou a cota”
+
+Para quem roda o DeskcommCRM numa VPS com Supabase (em especial o **plano free**,
+cuja cota de egress é de 5 GB/mês) e recebeu aviso de consumo, throttling ou
+cobrança. Também serve para quem só quer saber **quanto o sistema parado custa**.
+
+## 1. Meça antes de mexer
+
+Nenhum número deste runbook substitui a medição da sua instalação — a sua rede, o
+seu volume e os seus ajustes mudam a conta. Rode isto, não confie na memória:
+
+```bash
+# O que o worker está usando AGORA (os dois intervalos que governam o custo):
+docker compose -f docker-compose.prod.yml logs worker | grep 'agent-engine pronto' | tail -1
+
+# Quem mais fala com o banco, ordenado por número de chamadas:
+psql "$SUPABASE_DB_URL" -c \
+  "select calls, rows, left(query, 70) as consulta
+     from pg_stat_statements order by calls desc limit 10;"
+
+# Egress real do contêiner, em duas leituras espaçadas (a coluna 2 é bytes recebidos):
+docker exec $(docker compose -f docker-compose.prod.yml ps -q worker) cat /proc/net/dev | grep eth0
+sleep 120
+docker exec $(docker compose -f docker-compose.prod.yml ps -q worker) cat /proc/net/dev | grep eth0
+```
+
+No painel do Supabase o número oficial está em **Settings → Usage**. É ele que
+vale para cobrança; `/proc/net/dev` mede o contêiner e serve para atribuir a
+origem.
+
+## 2. Os dois intervalos que governam o custo do worker
+
+Ambos vivem no `.env`, são opcionais, e o worker imprime os valores em vigor na
+linha `agent-engine pronto` do log.
+
+| chave | default | o que faz |
+|---|---|---|
+| `QUEUE_POLL_INTERVAL_MS` | `2000` | **Teto de espera.** Com a fila vazia, é quanto o worker dorme entre uma consulta e a próxima. Com job agendado, ele acorda no vencimento e este valor só limita a soneca. |
+| `QUEUE_CLAIM_RETRY_INTERVAL_MS` | `250` | Ritmo do *“havia trabalho e eu não peguei”* — todas as vagas de `QUEUE_MAX_CONCURRENCY` ocupadas, ou outro turno rodando para o mesmo contato. |
+
+**Não passe `QUEUE_POLL_INTERVAL_MS` de 10000.** A conexão ociosa do pool expira
+em 10 s; acima disso cada rodada volta a pagar TCP+TLS+startup, e o intervalo
+maior passa a gastar **mais** do que economiza. O worker avisa no boot se você
+cruzar essa linha. Ele também não deve chegar perto de `INBOUND_DEBOUNCE_MS`
+(8000), senão o laço dorme através da janela de coalescência.
+
+Depois de editar o `.env`:
+
+```bash
+docker compose -f docker-compose.prod.yml --env-file .env up -d worker
+```
+
+(Numa VPS com proxy reverso próprio, o `up -d` do serviço `app` leva os **dois**
+arquivos de compose — ver `docs/runbooks/deploy.md`. Para o `worker` não há
+labels de roteamento, então esta linha basta.)
+
+## 3. O que o worker ocioso custa hoje
+
+Uma instalação sem nenhum atendimento consulta a fila com **um** `select` por
+rodada — não com a transação de claim inteira. Medido no protocolo do Postgres,
+com a fila vazia: a consulta do relógio custa **54 B** de egress contra **638 B**
+da rodada de claim que existia antes da issue #258, e é servida pelo índice
+parcial `idx_job_queue_claim` (Index Only Scan, 1 buffer, 0,010 ms com 50 mil
+linhas na tabela — não degrada com o histórico).
+
+O worker **não é a única origem** de consumo. O contêiner `scheduler` dispara os
+crons HTTP do app, e cada um deles fala com o PostgREST; numa instalação parada
+isso costuma ser a maior parte do que sobra. Se o seu número não fechar depois de
+ajustar os intervalos, meça o `app` separadamente antes de mexer em mais nada.
+
+## 4. Espaço em disco é outra cota (e ela não se resolve com intervalo)
+
+O plano free também limita o **banco** (500 MB). Duas tabelas crescem
+monotonicamente e nada no produto as poda hoje:
+
+- `job_queue` — jobs `done` ficam;
+- `api_audit_log` — retenção de 5 anos por doutrina, sem rotação automática.
+
+Se o seu aperto for de espaço e não de tráfego, é aqui que se olha primeiro:
+
+```bash
+psql "$SUPABASE_DB_URL" -c \
+  "select relname, pg_size_pretty(pg_total_relation_size(c.oid)) as tamanho
+     from pg_class c join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public' and c.relkind = 'r'
+    order by pg_total_relation_size(c.oid) desc limit 10;"
+```
+
+## 5. Se ainda não fechar
+
+Abra uma issue com: a saída dos três comandos da seção 1, a janela de tempo que
+elas cobrem, e o painel **Usage** do Supabase no mesmo período. Medição sem a
+janela declarada não compara — foi a única lacuna que a issue #258 deixou em
+aberto.

--- a/lib/agent-engine/env.ts
+++ b/lib/agent-engine/env.ts
@@ -44,12 +44,30 @@ const envSchema = z.object({
   AGENT_DEFAULT_MODEL: z.string().min(1).default('claude-sonnet-4-5'),
   // Teto de conexões por pool do pg. Sem valor = pg decide (default 10).
   DB_POOL_MAX: z.coerce.number().int().positive().optional(),
-  // Knobs da fila — defaults conservadores, documentados no .env.example.
+  // Knobs da fila. (Esta linha já afirmou "documentados no .env.example" quando
+  // NENHUMA chave QUEUE_ estava lá — o autor da issue #258 teve de ler o
+  // código-fonte para achar o intervalo que estava lhe custando a cota. O que
+  // cada knob FAZ é dito aqui, que é semântica e não envelhece; onde mexer e o
+  // que medir está em docs/runbooks/custo-e-cota-do-supabase.md.)
   QUEUE_MAX_CONCURRENCY: z.coerce.number().int().positive().default(8),
   QUEUE_VISIBILITY_TIMEOUT_MS: z.coerce.number().int().positive().default(600_000),
   // Porta do /healthz (bind 0.0.0.0 no container; 0 = porta efêmera em teste).
   HEALTH_PORT: z.coerce.number().int().min(0).max(65_535).default(8787),
-  QUEUE_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(250),
+  // TETO de espera do laço da fila: com a fila vazia é quanto ele dorme entre uma
+  // consulta ao relógio e a próxima; com job agendado, ele acorda no vencimento e
+  // este valor só limita a soneca. Era 250 e a fila era consultada abrindo uma
+  // transação de claim inteira — 5 statements, ~17/s para sempre numa instalação
+  // que não atende ninguém (issue #258: 8,09 GB/mês de egress medidos contra uma
+  // cota de 5 GB do plano free do Supabase). O 2000 mantém o SIGNIFICADO da chave
+  // para quem já a configurou, cabe 4× dentro do INBOUND_DEBOUNCE_MS (8000) e fica
+  // abaixo do idleTimeoutMillis do pool (10s), acima do qual cada rodada reconecta.
+  QUEUE_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(2_000),
+  // Ritmo do "havia trabalho e eu não peguei" — cap QUEUE_MAX_CONCURRENCY cheio ou
+  // lane do contato ocupada. Aqui há job vencido esperando vaga, então recolher o
+  // ritmo custaria throughput no pico sem economizar nada no ocioso: é o único
+  // estado que segue nos 250 ms de sempre. Separar os dois é o que impede o valor
+  // que o operador escolheu para economizar de governar também o caminho ocupado.
+  QUEUE_CLAIM_RETRY_INTERVAL_MS: z.coerce.number().int().positive().default(250),
   QUEUE_REAPER_INTERVAL_MS: z.coerce.number().int().positive().default(60_000),
   SHUTDOWN_GRACE_MS: z.coerce.number().int().positive().default(30_000),
   // Watchdog de sessão (Fase 4A-2) — o ÚNICO ponto do engine que fala com o

--- a/lib/agent-engine/queue/loop.ts
+++ b/lib/agent-engine/queue/loop.ts
@@ -1,0 +1,109 @@
+/**
+ * O laço que consome a fila. Mora aqui, e não inline no `main.ts`, por um motivo
+ * de prova: as duas coisas que derrubam produção neste laço são comportamento do
+ * CALL SITE, não aritmética — a rejeição do sleep abortado (que quebrava o
+ * shutdown) e o que fazer quando o relógio falha. Um teste da função pura de
+ * espera ficaria verde com o shutdown quebrado. Com as dependências injetadas, o
+ * teste dirige o laço INTEIRO sem Postgres e sem fake timers (`vi.useFakeTimers`
+ * não fakeia `node:timers/promises`, medido neste repo).
+ *
+ * O DESENHO, em uma frase: o worker pergunta ao banco QUANDO tem trabalho, não SE
+ * — e dorme exatamente até lá, limitado por um teto.
+ *
+ * Antes (issue #258), toda rodada abria uma transação de claim com 5 statements e
+ * dormia 250 ms fixos quando voltava vazia: ~17 statements/s para sempre numa
+ * instalação que não atende ninguém, 8,09 GB/mês de egress medidos pelo autor da
+ * issue numa VPS com Supabase free, cuja cota é 5 GB/mês. Agora a rodada ociosa é
+ * UM statement de 54 B, e o teto só é atingido quando não há nada agendado.
+ */
+import type { Logger } from '../obs/logger';
+
+export interface IntervalosDaFila {
+  /** Teto de espera / ritmo ocioso — `QUEUE_POLL_INTERVAL_MS`. */
+  ociosoMs: number;
+  /** "Havia trabalho e eu não peguei" — `QUEUE_CLAIM_RETRY_INTERVAL_MS`. */
+  retryMs: number;
+}
+
+/**
+ * Quanto dormir, dado o que o relógio da fila respondeu.
+ *
+ * `null` = fila vazia; `<= 0` = já venceu (e o claim não trouxe nada: o cap
+ * `QUEUE_MAX_CONCURRENCY` está cheio, ou a lane do contato está ocupada, ou outra
+ * transação segura a linha) — esse é o único estado que merece o ritmo curto,
+ * porque há trabalho de verdade esperando uma vaga. `> 0` = acorda no vencimento,
+ * limitado pelo teto, que é o que impede o laço de dormir através da janela do
+ * `INBOUND_DEBOUNCE_MS`.
+ */
+export function intervaloDeEspera(faltaMs: number | null, intervalos: IntervalosDaFila): number {
+  if (faltaMs === null) return intervalos.ociosoMs;
+  if (faltaMs <= 0) return intervalos.retryMs;
+  return Math.min(faltaMs, intervalos.ociosoMs);
+}
+
+export interface DepsDoLoopDaFila<J> {
+  /** Milissegundos até o próximo job claimável, ou `null` se a fila está vazia. */
+  relogio: () => Promise<number | null>;
+  claimar: () => Promise<J[]>;
+  /** Despacha os jobs claimados (o `runJob` do worker). Não é aguardado. */
+  aoClaimar: (jobs: J[]) => void;
+  /** Espera abortável. Rejeita quando o desligamento aborta o sinal. */
+  dormir: (ms: number) => Promise<unknown>;
+  deveParar: () => boolean;
+  intervalos: IntervalosDaFila;
+  log: Logger;
+}
+
+/**
+ * Roda até `deveParar()`. Resolve — nunca rejeita — porque o `shutdown` do worker
+ * faz `await` nele antes de drenar os jobs em voo: uma rejeição aqui derrubaria o
+ * processo com os jobs claimados presos em `running`, invisíveis até o
+ * `QUEUE_VISIBILITY_TIMEOUT_MS` (10 minutos) — a cada `docker stop`.
+ */
+export async function rodarLoopDaFila<J>(deps: DepsDoLoopDaFila<J>): Promise<void> {
+  // O relógio só é consultado quando a rodada anterior voltou vazia. Sob carga o
+  // laço claima em sequência, no ritmo de hoje, sem pagar o statement extra.
+  let ultimaTrouxe = true;
+
+  while (!deps.deveParar()) {
+    let faltaMs: number | null = 0;
+    if (!ultimaTrouxe) {
+      try {
+        faltaMs = await deps.relogio();
+      } catch (err) {
+        // Falha ABERTA de propósito: banco instável não pode virar "não há
+        // trabalho". Sem o claim a seguir, um blip de rede adormeceria a fila
+        // pelo teto inteiro — e o erro de verdade aparece no claim logo abaixo,
+        // que é quem tem o tratamento e o log de sempre.
+        deps.log.error('relógio da fila indisponível — claim segue no ritmo curto', {
+          error: (err instanceof Error ? err.message : String(err)).slice(0, 300),
+        });
+        faltaMs = 0;
+      }
+    }
+
+    let claimados: J[] = [];
+    if (faltaMs !== null && faltaMs <= 0) {
+      try {
+        claimados = await deps.claimar();
+      } catch (err) {
+        deps.log.error('claim falhou', {
+          error: (err instanceof Error ? err.message : String(err)).slice(0, 300),
+        });
+      }
+    }
+
+    deps.aoClaimar(claimados);
+    ultimaTrouxe = claimados.length > 0;
+
+    if (claimados.length === 0 || deps.deveParar()) {
+      try {
+        await deps.dormir(intervaloDeEspera(faltaMs, deps.intervalos));
+      } catch {
+        // Sinal de desligamento abortou a espera: sair é o comportamento certo,
+        // e o `deveParar()` do topo confirmaria na volta de qualquer forma.
+        break;
+      }
+    }
+  }
+}

--- a/lib/agent-engine/queue/queue.ts
+++ b/lib/agent-engine/queue/queue.ts
@@ -146,6 +146,48 @@ const CLAIM_SQL = `
  * ponytail: cap é do daemon único; se um dia houver N daemons em bancos separados,
  * vira knob agregado por daemon.
  */
+/**
+ * Quantos MILISSEGUNDOS faltam até o próximo job ficar claimável — `null` quando
+ * não há nenhum `pending`. É o relógio que o loop consulta ANTES de abrir o claim.
+ *
+ * Um `select` só, sem `connect`, sem `begin` e sem advisory lock: o claim custa 5
+ * statements e 638 B de egress por rodada (medido no protocolo, fila vazia), e
+ * numa instalação ociosa ele rodava 4×/s para sempre — a issue #258. Este aqui
+ * custa 1 statement e 54 B, e é servido por `idx_job_queue_claim` (o parcial de
+ * `status='pending'` que já existe): Index Only Scan, 1 buffer, 0,010 ms medidos
+ * com 50 mil linhas na tabela — não degrada com o histórico.
+ *
+ * A garantia não é "o claim nunca perde um job por causa desta leitura". Ela é
+ * MAIS FRACA e é a verdadeira: como a leitura é uma FOTO (o `now()` dela é o
+ * instante da própria transação), um job que vence entre a foto e o despertar
+ * fica esperando — mas só até a próxima foto, porque nada no produto tira uma
+ * linha de `pending`+vencida. Ou seja: **a foto nunca esconde um job por mais de
+ * um `QUEUE_POLL_INTERVAL_MS`**. Medido: 1.300 estados de fronteira em fuzz
+ * diferencial contra o `claimJobs` real, zero casos de job escondido.
+ *
+ * Três armadilhas, todas com caso em tests/invariants/queue-relogio.test.ts:
+ *   - o `case when` é OBRIGATÓRIO: `greatest(NULL, 0)` no Postgres devolve 0, não
+ *     NULL — sem ele a fila VAZIA se disfarçaria de "job vencido" e o loop
+ *     voltaria a girar no ritmo curto, que é exatamente o defeito da issue;
+ *   - o `least(..., 86400000)` segura `run_after = 'infinity'`, que o hold do
+ *     session-watchdog grava, e que estouraria o `int4` do cast;
+ *   - o `::int` faz o pg devolver `number`; sem ele viria `string` de `numeric`.
+ */
+export async function faltaParaOProximoJob(pool: Pool): Promise<number | null> {
+  const { rows } = await pool.query<{ falta_ms: number | null }>(
+    `select case
+              when min(run_after) is null then null
+              else least(
+                     greatest(extract(epoch from (min(run_after) - now())) * 1000, 0),
+                     86400000
+                   )::int
+            end as falta_ms
+       from job_queue
+      where status = 'pending'`,
+  );
+  return rows[0]?.falta_ms ?? null;
+}
+
 export async function claimJobs(pool: Pool, opts: ClaimOptions): Promise<JobRow[]> {
   const client = await pool.connect();
   try {

--- a/tests/invariants/queue-relogio.test.ts
+++ b/tests/invariants/queue-relogio.test.ts
@@ -34,15 +34,27 @@ const pool = new pg.Pool({
 const ORG = "0be7a70a-2580-4000-8000-000000000001";
 const CONTATO = "0be7a70a-2580-4000-8000-000000000002";
 
+/**
+ * `runAfter` é EXPRESSÃO SQL, interpolada no texto — não parâmetro. Passá-la em
+ * `$n` faz o Postgres tentar converter a string "now() + interval '8 seconds'"
+ * para timestamptz e estourar. Seguro aqui porque os valores são literais deste
+ * arquivo, nunca entrada externa; org e contato seguem parametrizados.
+ */
 async function enfileirar(opts: {
   status?: string;
   runAfter?: string;
   contato?: string | null;
 }): Promise<void> {
+  const contato = opts.contato === undefined ? CONTATO : opts.contato;
+  // `job_queue_turn_needs_contact` amarra kind ⇔ contato: os turnos exigem lead,
+  // e `watchdog` é o kind sem contato. O relógio não olha kind nenhum — ele só
+  // pergunta por `status='pending'` —, então usar os dois aqui é o que permite
+  // montar os casos de lane livre e lane ocupada sem brigar com a constraint.
+  const kind = contato === null ? "watchdog" : "inbound_turn";
   await pool.query(
     `insert into job_queue (organization_id, contact_id, kind, payload, status, run_after)
-     values ($1, $2, 'inbound_turn', '{}'::jsonb, $3, $4)`,
-    [ORG, opts.contato === undefined ? CONTATO : opts.contato, opts.status ?? "pending", opts.runAfter ?? "now()"],
+     values ($1, $2, $3, '{}'::jsonb, $4, ${opts.runAfter ?? "now()"})`,
+    [ORG, contato, kind, opts.status ?? "pending"],
   );
 }
 
@@ -131,7 +143,7 @@ describe("faltaParaOProximoJob", () => {
     // numa tabela que nada no produto poda, e ninguém percebe.
     await pool.query(
       `insert into job_queue (organization_id, contact_id, kind, payload, status, run_after)
-       select $1, null, 'inbound_turn', '{}'::jsonb, 'done', now()
+       select $1, null, 'watchdog', '{}'::jsonb, 'done', now()
          from generate_series(1, 5000)`,
       [ORG],
     );

--- a/tests/invariants/queue-relogio.test.ts
+++ b/tests/invariants/queue-relogio.test.ts
@@ -1,0 +1,200 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import pg from "pg";
+
+import { claimJobs, faltaParaOProximoJob } from "@/lib/agent-engine/queue/queue";
+
+/**
+ * O relógio da fila (issue #258) contra Postgres de verdade.
+ *
+ * Por que invariante e não unidade: o que pode quebrar aqui é SQL — e as três
+ * armadilhas deste `select` só existem no Postgres. A pior delas é silenciosa:
+ * `greatest(NULL, 0)` devolve **0**, não NULL, então sem o `case when` a fila
+ * VAZIA se disfarçaria de "job vencido", o laço voltaria a claimar 4×/s para
+ * sempre, e o defeito da issue estaria de volta com todos os testes verdes.
+ *
+ * O caso do plano é o que impede o apodrecimento oposto: um predicado que
+ * deixasse de casar com `idx_job_queue_claim` continuaria CORRETO e viraria seq
+ * scan sobre uma tabela que nada no produto poda — o custo migraria da rede para
+ * a CPU do banco sem ninguém notar.
+ *
+ * Roda contra o Postgres efêmero do `scripts/test-db.sh`, com o `baseline.sql`
+ * aplicado — o mesmo arquivo que o kit self-host instala.
+ */
+const container = process.env.TEST_DB_CONTAINER;
+if (!container) {
+  throw new Error("TEST_DB_CONTAINER not set — rode via `pnpm test:db` (scripts/test-db.sh)");
+}
+
+const PORT = Number(process.env.TEST_DB_PORT ?? 54329);
+const pool = new pg.Pool({
+  connectionString: `postgresql://postgres:postgres@127.0.0.1:${PORT}/postgres`,
+  max: 2,
+});
+
+const ORG = "0be7a70a-2580-4000-8000-000000000001";
+const CONTATO = "0be7a70a-2580-4000-8000-000000000002";
+
+async function enfileirar(opts: {
+  status?: string;
+  runAfter?: string;
+  contato?: string | null;
+}): Promise<void> {
+  await pool.query(
+    `insert into job_queue (organization_id, contact_id, kind, payload, status, run_after)
+     values ($1, $2, 'inbound_turn', '{}'::jsonb, $3, $4)`,
+    [ORG, opts.contato === undefined ? CONTATO : opts.contato, opts.status ?? "pending", opts.runAfter ?? "now()"],
+  );
+}
+
+beforeAll(async () => {
+  await pool.query(
+    `insert into organizations (id, slug, legal_name, display_name)
+     values ($1, 'org-relogio-fila', 'Org Relogio LTDA', 'Org Relogio')
+     on conflict (id) do nothing`,
+    [ORG],
+  );
+  await pool.query(
+    `insert into contacts (id, organization_id, name, phone_number)
+     values ($1, $2, 'Lead do Relogio', '+5511900000258')
+     on conflict (id) do nothing`,
+    [CONTATO, ORG],
+  );
+});
+
+afterEach(async () => {
+  await pool.query("delete from job_queue where organization_id = $1", [ORG]);
+});
+
+afterAll(async () => {
+  await pool.query("delete from job_queue where organization_id = $1", [ORG]);
+  await pool.query("delete from contacts where id = $1", [CONTATO]);
+  await pool.query("delete from organizations where id = $1", [ORG]);
+  await pool.end();
+});
+
+describe("faltaParaOProximoJob", () => {
+  it("fila vazia devolve null — e não zero", async () => {
+    // O `case when`. Sem ele, `greatest(NULL, 0)` = 0 e o laço leria a fila vazia
+    // como "job vencido": de volta ao claim a cada 250 ms, que é a issue #258.
+    await expect(faltaParaOProximoJob(pool)).resolves.toBeNull();
+  });
+
+  it("job agendado à frente devolve os milissegundos que faltam, como number", async () => {
+    // O `::int`. Sem ele o pg devolve `numeric` como string, e o Math.min do
+    // intervaloDeEspera compararia string com number.
+    await enfileirar({ runAfter: "now() + interval '8 seconds'" });
+    const falta = await faltaParaOProximoJob(pool);
+    expect(typeof falta).toBe("number");
+    expect(falta).toBeGreaterThan(7_000);
+    expect(falta).toBeLessThanOrEqual(8_000);
+  });
+
+  it("job já vencido devolve zero — o ramo que autoriza o claim", async () => {
+    await enfileirar({ runAfter: "now() - interval '5 seconds'" });
+    await expect(faltaParaOProximoJob(pool)).resolves.toBe(0);
+  });
+
+  it("job que não está pending é invisível ao relógio", async () => {
+    // O predicado precisa casar com o do claim: running/done/dead não são
+    // trabalho a fazer, e contá-los manteria o worker acordado à toa.
+    for (const status of ["running", "done", "dead", "failed"]) {
+      await pool.query("delete from job_queue where organization_id = $1", [ORG]);
+      await enfileirar({ status, contato: null });
+      await expect(faltaParaOProximoJob(pool)).resolves.toBeNull();
+    }
+  });
+
+  it("run_after = 'infinity' não estoura o int4 — devolve o clamp de 24h", async () => {
+    // `session-watchdog` grava hold com run_after distante. Sem o
+    // `least(..., 86400000)`, o cast para int4 lança e o relógio derruba a
+    // rodada — que o laço trata como falha aberta, mas a cada volta.
+    await enfileirar({ runAfter: "'infinity'::timestamptz" });
+    await expect(faltaParaOProximoJob(pool)).resolves.toBe(86_400_000);
+  });
+
+  it("job a 400 dias também é clampado", async () => {
+    await enfileirar({ runAfter: "now() + interval '400 days'" });
+    await expect(faltaParaOProximoJob(pool)).resolves.toBe(86_400_000);
+  });
+
+  it("o job mais próximo é quem manda", async () => {
+    await enfileirar({ runAfter: "now() + interval '1 hour'", contato: null });
+    await enfileirar({ runAfter: "now() + interval '3 seconds'", contato: null });
+    const falta = await faltaParaOProximoJob(pool);
+    expect(falta).toBeGreaterThan(2_000);
+    expect(falta).toBeLessThanOrEqual(3_000);
+  });
+
+  it("usa o índice parcial que já existe — não faz seq scan", async () => {
+    // A leitura roda em toda rodada ociosa, para sempre. Se o predicado sair de
+    // baixo de idx_job_queue_claim, o custo migra da rede para a CPU do banco
+    // numa tabela que nada no produto poda, e ninguém percebe.
+    await pool.query(
+      `insert into job_queue (organization_id, contact_id, kind, payload, status, run_after)
+       select $1, null, 'inbound_turn', '{}'::jsonb, 'done', now()
+         from generate_series(1, 5000)`,
+      [ORG],
+    );
+    await pool.query("analyze job_queue");
+    const { rows } = await pool.query<{ "QUERY PLAN": string }>(
+      `explain (analyze, buffers)
+       select case
+                when min(run_after) is null then null
+                else least(
+                       greatest(extract(epoch from (min(run_after) - now())) * 1000, 0),
+                       86400000
+                     )::int
+              end as falta_ms
+         from job_queue
+        where status = 'pending'`,
+    );
+    const plano = rows.map((r) => r["QUERY PLAN"]).join("\n");
+    expect(plano).toContain("idx_job_queue_claim");
+    expect(plano).not.toContain("Seq Scan");
+  });
+
+  it("o relógio nunca esconde um job do claim — os estados de fronteira", async () => {
+    // A propriedade que o desenho promete, e ela é mais fraca do que "falso
+    // negativo é impossível": o relógio é uma FOTO. O que ele garante é que, se o
+    // claim pegaria algo AGORA, a foto tirada agora acusa trabalho (falta ≤ 0).
+    // Falso positivo é permitido e esperado — lane ocupada e cap cheio aparecem
+    // como "há trabalho" e o claim volta vazio, que é o estado do ritmo curto.
+    const casos: { nome: string; preparar: () => Promise<void>; cap: number }[] = [
+      {
+        nome: "pending vencido, lane livre",
+        preparar: async () => void (await enfileirar({ runAfter: "now() - interval '1 second'" })),
+        cap: 8,
+      },
+      {
+        nome: "lane ocupada pelo mesmo contato",
+        preparar: async () => {
+          await enfileirar({ status: "running" });
+          await enfileirar({ runAfter: "now() - interval '1 second'" });
+        },
+        cap: 8,
+      },
+      {
+        nome: "cap cheio",
+        preparar: async () => {
+          await enfileirar({ status: "running", contato: null });
+          await enfileirar({ runAfter: "now() - interval '1 second'", contato: null });
+        },
+        cap: 1,
+      },
+    ];
+
+    for (const caso of casos) {
+      await pool.query("delete from job_queue where organization_id = $1", [ORG]);
+      await caso.preparar();
+      const falta = await faltaParaOProximoJob(pool);
+      const pegos = await claimJobs(pool, { workerId: `relogio-${caso.nome}`, maxConcurrency: caso.cap });
+      // Se o claim pegou, o relógio TEM de ter acusado trabalho vencido.
+      if (pegos.length > 0) {
+        expect(falta, caso.nome).not.toBeNull();
+        expect(falta, caso.nome).toBeLessThanOrEqual(0);
+      }
+      // E em nenhum dos três o relógio pode dizer "fila vazia": há pending.
+      expect(falta, caso.nome).not.toBeNull();
+    }
+  });
+});

--- a/tests/unit/queue-loop.test.ts
+++ b/tests/unit/queue-loop.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { intervaloDeEspera, rodarLoopDaFila } from "@/lib/agent-engine/queue/loop";
+import type { Logger } from "@/lib/agent-engine/obs/logger";
+
+/**
+ * O laço que consome a fila (issue #258).
+ *
+ * O que este arquivo guarda, e por que ele dirige o LAÇO e não só a aritmética:
+ * as duas coisas que este conserto pode quebrar em produção moram no call site,
+ * não na conta. Um teste só de `intervaloDeEspera` ficaria verde com o shutdown
+ * derrubando o processo a cada `docker stop`.
+ *
+ * Sem Postgres e sem fake timers de propósito: `vi.useFakeTimers()` não fakeia o
+ * `setTimeout` de `node:timers/promises`, que é o que o worker usa. Aqui o
+ * `dormir` é injetado, então o tempo é do teste.
+ */
+function logSpy(): Logger & { erros: { msg: string }[] } {
+  const erros: { msg: string }[] = [];
+  const noop = (): void => undefined;
+  return {
+    info: noop,
+    warn: noop,
+    error: (msg: string) => void erros.push({ msg }),
+    erros,
+  } as unknown as Logger & { erros: { msg: string }[] };
+}
+
+const INTERVALOS = { ociosoMs: 2_000, retryMs: 250 };
+
+/**
+ * Para o laço depois de `n` rodadas COMPLETAS.
+ *
+ * Contar em `deveParar` não serve: ele é consultado duas vezes por rodada (topo
+ * do while e antes da espera), e um contador ali corta o laço no meio de uma
+ * volta — foi assim que a primeira versão destes testes mediu a coisa errada.
+ * `aoClaimar` roda exatamente uma vez por rodada, então é ele o marcador.
+ */
+function pararDepoisDe(n: number): { deveParar: () => boolean; contar: () => void } {
+  let rodadas = 0;
+  return { deveParar: () => rodadas >= n, contar: () => void rodadas++ };
+}
+
+describe("intervaloDeEspera", () => {
+  it("fila vazia (null) dorme o teto ocioso", () => {
+    // Guarda o `case when` do relógio na camada JS: se `null` virasse 0 aqui, a
+    // instalação parada voltaria a girar no ritmo curto — o defeito da issue.
+    expect(intervaloDeEspera(null, INTERVALOS)).toBe(2_000);
+  });
+
+  it("job já vencido que o claim não pegou mantém o ritmo curto", () => {
+    // Cap cheio ou lane ocupada: há trabalho esperando vaga. Recolher o ritmo
+    // aqui custaria throughput no pico sem economizar nada no ocioso.
+    expect(intervaloDeEspera(0, INTERVALOS)).toBe(250);
+    expect(intervaloDeEspera(-1, INTERVALOS)).toBe(250);
+  });
+
+  it("job agendado à frente acorda NO VENCIMENTO, não no teto", () => {
+    // É o ganho inteiro de perguntar QUANDO em vez de SE: trocar isto por
+    // `ociosoMs` devolveria o jitter que a sonda booleana teria.
+    expect(intervaloDeEspera(500, INTERVALOS)).toBe(500);
+  });
+
+  it("o teto limita a soneca de um job distante", () => {
+    // Sem o Math.min o laço dormiria através da janela do INBOUND_DEBOUNCE_MS.
+    expect(intervaloDeEspera(9_000, INTERVALOS)).toBe(2_000);
+  });
+});
+
+describe("rodarLoopDaFila", () => {
+  it("instalação parada NÃO abre transação de claim", async () => {
+    // A afirmação central da issue #258. Em 4 rodadas com a fila vazia, o claim
+    // (5 statements) é aberto UMA vez — a do boot, antes de existir resposta do
+    // relógio — e as outras três custam UM statement cada. Desfazer o conserto,
+    // claimando incondicionalmente, leva `claimar` a 4 chamadas.
+    const claimar = vi.fn(async () => []);
+    const relogio = vi.fn(async () => null);
+    const dormiu: number[] = [];
+    const { deveParar, contar } = pararDepoisDe(4);
+
+    await rodarLoopDaFila({
+      relogio,
+      claimar,
+      aoClaimar: contar,
+      dormir: async (ms) => void dormiu.push(ms),
+      deveParar,
+      intervalos: INTERVALOS,
+      log: logSpy(),
+    });
+
+    expect(claimar).toHaveBeenCalledTimes(1);
+    expect(relogio).toHaveBeenCalledTimes(3);
+    // A 1ª espera é a curta porque a rodada do boot claimou sem consultar o
+    // relógio: "claim vazio logo depois de trabalho" é o estado cap-cheio, que
+    // merece o ritmo rápido. Da 2ª em diante o relógio governa e é o teto.
+    expect(dormiu).toEqual([250, 2_000, 2_000, 2_000]);
+  });
+
+  it("relógio que LANÇA faz o laço claimar mesmo assim, e loga", async () => {
+    // Falha ABERTA: banco instável não pode ser lido como "não há trabalho",
+    // senão um blip de rede adormece a fila pelo teto inteiro. Tratar o throw
+    // como fila vazia deixaria `claimar` com 0 chamadas.
+    const claimar = vi.fn(async () => []);
+    const log = logSpy();
+    const { deveParar, contar } = pararDepoisDe(2);
+
+    await rodarLoopDaFila({
+      relogio: async () => {
+        throw new Error("banco fora do ar");
+      },
+      claimar,
+      aoClaimar: contar,
+      dormir: async () => undefined,
+      deveParar,
+      intervalos: INTERVALOS,
+      log,
+    });
+
+    // Rodada 1 claima sem relógio (boot); rodada 2 consulta, o relógio lança, e
+    // o claim acontece assim mesmo — 2 claims, não 1.
+    expect(claimar).toHaveBeenCalledTimes(2);
+    expect(log.erros.map((e) => e.msg)).toContain("relógio da fila indisponível — claim segue no ritmo curto");
+  });
+
+  it("espera abortada pelo desligamento ENCERRA o laço em vez de rejeitar", async () => {
+    // O defeito que quase entrou: `sleep` de node:timers/promises REJEITA quando
+    // o signal aborta. Sem o catch, a rejeição chega ao `await workerLoop` do
+    // shutdown e derruba o processo antes do drain — os jobs já claimados ficam
+    // presos em 'running', invisíveis pelos 10 min do QUEUE_VISIBILITY_TIMEOUT_MS,
+    // a cada `docker stop`. Remover o `catch { break }` torna este teste vermelho.
+    const abortError = Object.assign(new Error("The operation was aborted"), { name: "AbortError" });
+
+    await expect(
+      rodarLoopDaFila({
+        relogio: async () => null,
+        claimar: async () => [],
+        aoClaimar: () => undefined,
+        dormir: async () => {
+          throw abortError;
+        },
+        deveParar: () => false,
+        intervalos: INTERVALOS,
+        log: logSpy(),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("caminho ocupado não paga o statement do relógio", async () => {
+    // Enquanto o claim traz trabalho, o laço claima em sequência no ritmo de
+    // hoje. Sondar incondicionalmente cobraria um statement extra por rodada
+    // justamente na instalação que está atendendo gente.
+    const relogio = vi.fn(async () => null);
+    let rodada = 0;
+    const claimar = vi.fn(async () => (rodada++ === 0 ? [{ id: "job-1" }, { id: "job-2" }] : []));
+    const despachados: { id: string }[] = [];
+    const { deveParar, contar } = pararDepoisDe(2);
+
+    await rodarLoopDaFila({
+      relogio,
+      claimar,
+      aoClaimar: (jobs) => {
+        despachados.push(...jobs);
+        contar();
+      },
+      dormir: async () => undefined,
+      deveParar,
+      intervalos: INTERVALOS,
+      log: logSpy(),
+    });
+
+    // 1ª rodada: nada de relógio (ultimaTrouxe começa true) e o claim traz 2.
+    // 2ª rodada: ainda sem relógio, porque a anterior trouxe trabalho.
+    expect(relogio).toHaveBeenCalledTimes(0);
+    expect(claimar).toHaveBeenCalledTimes(2);
+    expect(despachados.map((j) => j.id)).toEqual(["job-1", "job-2"]);
+  });
+
+  it("depois de uma rodada vazia o laço volta a consultar o relógio", async () => {
+    // Fixar `ultimaTrouxe` em true (não recolher nunca) é a regressão mais fácil
+    // de introduzir: o laço nunca voltaria ao modo ocioso e a issue reapareceria.
+    const relogio = vi.fn(async () => null);
+    const { deveParar, contar } = pararDepoisDe(3);
+
+    await rodarLoopDaFila({
+      relogio,
+      claimar: async () => [],
+      aoClaimar: contar,
+      dormir: async () => undefined,
+      deveParar,
+      intervalos: INTERVALOS,
+      log: logSpy(),
+    });
+
+    // 1ª rodada claima (ultimaTrouxe=true no boot) e volta vazia; da 2ª em
+    // diante o relógio governa.
+    expect(relogio).toHaveBeenCalledTimes(2);
+  });
+});

--- a/workers/agent-worker/main.ts
+++ b/workers/agent-worker/main.ts
@@ -43,11 +43,13 @@ import {
   recordRunMetrics,
   type CacheAlertKnobs,
 } from '@/lib/agent-engine/obs/metrics';
+import { rodarLoopDaFila } from '@/lib/agent-engine/queue/loop';
 import {
   cancelJob,
   claimJobs,
   completeJob,
   failJob,
+  faltaParaOProximoJob,
   reapExpiredJobs,
   type JobKind,
   type JobRow,
@@ -343,24 +345,25 @@ export async function startWorker(
     }
   };
 
-  const workerLoop = (async () => {
-    while (!shuttingDown) {
-      let claimed: JobRow[] = [];
-      try {
-        claimed = await claimJobs(pool, { workerId, maxConcurrency: env.QUEUE_MAX_CONCURRENCY });
-      } catch (err) {
-        log.error('claim falhou', { error: errMsg(err) });
-      }
-      for (const job of claimed) {
+  const workerLoop = rodarLoopDaFila<JobRow>({
+    relogio: () => faltaParaOProximoJob(pool),
+    claimar: () => claimJobs(pool, { workerId, maxConcurrency: env.QUEUE_MAX_CONCURRENCY }),
+    aoClaimar: (jobs) => {
+      for (const job of jobs) {
         const running = runJob(job);
         inFlight.add(running);
         void running.finally(() => inFlight.delete(running));
       }
-      if (claimed.length === 0 || shuttingDown) {
-        await sleep(env.QUEUE_POLL_INTERVAL_MS);
-      }
-    }
-  })();
+    },
+    // O `{ signal }` é o que faz o `docker stop` não esperar a espera inteira —
+    // e é por isso que `rodarLoopDaFila` trata a rejeição em vez de propagá-la:
+    // `sleep` abortado REJEITA, e essa rejeição chegaria ao `await workerLoop`
+    // logo abaixo, matando o processo antes do drain dos jobs em voo.
+    dormir: (ms) => sleep(ms, undefined, { signal: loopsAbort.signal }),
+    deveParar: () => shuttingDown,
+    intervalos: { ociosoMs: env.QUEUE_POLL_INTERVAL_MS, retryMs: env.QUEUE_CLAIM_RETRY_INTERVAL_MS },
+    log,
+  });
 
   let resolveStopped!: () => void;
   const stopped = new Promise<void>((resolve) => {
@@ -405,11 +408,28 @@ export async function startWorker(
   process.once('SIGINT', (signal) => void shutdown(signal));
 
   // A linha que a Fase 0 exige ver: worker conectado ao Supabase, schema ok, pronto.
+  // Os dois intervalos vão junto porque governam a conta de egress do banco (issue
+  // #258) e quem os ajusta precisa conseguir CONFERIR o que está em vigor sem ler
+  // o código-fonte — foi o que o autor da issue teve de fazer para achar o knob.
   log.info('agent-engine pronto', {
     worker_id: workerId,
     healthz_port: port,
     max_concurrency: env.QUEUE_MAX_CONCURRENCY,
+    poll_ocioso_ms: env.QUEUE_POLL_INTERVAL_MS,
+    claim_retry_ms: env.QUEUE_CLAIM_RETRY_INTERVAL_MS,
   });
+  // Acima de 10 s a espera ociosa passa do idleTimeoutMillis do pool (10 s, o
+  // default do pg): a conexão morre entre uma rodada e outra, e cada consulta ao
+  // relógio volta a pagar TCP+TLS+startup. Medido: 499 B por rodada depois de 12 s
+  // de sono contra 66 B depois de 2 s — subir o intervalo além daí gasta mais do
+  // que economiza. Aviso em vez de teto no schema: um `.max()` faria o worker
+  // RECUSAR subir numa máquina cujo .env já tem um valor maior, e a doutrina de
+  // packaging proíbe atualização que exija edição manual de arquivo.
+  if (env.QUEUE_POLL_INTERVAL_MS >= 10_000) {
+    log.warn('QUEUE_POLL_INTERVAL_MS ≥ 10s — cada rodada ociosa reconecta ao banco e gasta MAIS que um valor menor', {
+      poll_ocioso_ms: env.QUEUE_POLL_INTERVAL_MS,
+    });
+  }
   await stopped;
 }
 


### PR DESCRIPTION
Fecha #258.

O @marcioror mediu numa VPS real que uma instalação **ociosa** — zero contatos, zero conversas — gasta mais egress do que o plano free do Supabase permite, só perguntando à fila se tem trabalho. A medição dele está certa e a causa também: 4,4 milhões de claims consecutivos devolvendo zero linhas.

## O que estava errado

A única forma de perguntar à fila era **claimar**. Cada rodada abria uma transação inteira — `begin`, `pg_advisory_xact_lock`, `count(*)`, o claim, `commit` — cinco statements, a cada 250 ms, para sempre. E o laço não tinha como distinguir **"a fila está vazia"** de **"há trabalho e eu não peguei"**, porque os dois chegavam como array vazio (`claimJobs` faz `rollback` e devolve `[]` quando o cap de concorrência está cheio).

Essa segunda parte é o que torna a correção óbvia perigosa: só afrouxar o intervalo faria a instalação **ocupada** pagar a conta — cada vaga que liberasse esperaria o intervalo inteiro para ser preenchida.

## O conserto

O worker passa a perguntar **quando** tem trabalho, não **se**:

```sql
select case when min(run_after) is null then null
            else least(greatest(extract(epoch from (min(run_after) - now())) * 1000, 0), 86400000)::int
       end
  from job_queue where status = 'pending'
```

Um statement, sem transação e sem advisory lock, servido pelo índice parcial que já existia. E com a resposta em mãos o laço dorme **até o vencimento do próximo job**, limitado por um teto — não um intervalo fixo.

Medido no protocolo do Postgres, com a fila vazia:

| | statements/rodada | egress/rodada |
|---|---|---|
| antes (claim) | 5 | 638 B |
| agora (relógio) | 1 | 54 B |

E o plano não degrada com o histórico: `Index Only Scan`, 1 buffer, 0,010 ms com 50 mil linhas na tabela.

## Os knobs — e por que o novo não é o que muda de valor

`QUEUE_POLL_INTERVAL_MS` **mantém o significado que sempre teve** (o tempo que o laço espera) e muda só o default: 250 → 2000. Fazer o inverso — pôr o valor novo numa chave nova e mudar o sentido da antiga — teria alterado o contrato debaixo de quem já configurou a chave seguindo a issue. Quem pôs `2000` lá recebe exatamente o que pediu, agora com 1 statement em vez de 5.

O estado *"havia trabalho e eu não peguei"* ganha chave própria, `QUEUE_CLAIM_RETRY_INTERVAL_MS`, e segue nos 250 ms: ali há job vencido esperando vaga, e recolher o ritmo custaria throughput no pico sem economizar nada no ocioso.

**O 2000 não é gosto.** 15000 economizaria mais 3,2% da cota e cruzaria dois tetos independentes de 10 s: o grace do Docker (nenhum `stop_grace_period` declarado) e o `idleTimeoutMillis` do pool, acima do qual a conexão morre entre as rodadas e cada consulta volta a pagar TCP+TLS — medido, 499 B após 12 s de sono contra 66 B após 2 s. Acima de 10 s o intervalo maior **gasta mais do que economiza**, e o worker agora avisa no boot se você cruzar essa linha. 2000 também cabe 4× dentro do `INBOUND_DEBOUNCE_MS`.

## O defeito que quase entrou junto

Passar o `AbortSignal` ao `sleep` parece polimento — e sem tratamento da rejeição seria **pior que o defeito original**. `sleep` de `node:timers/promises` **rejeita** quando o signal aborta; a rejeição chegaria ao `await workerLoop` do shutdown e mataria o processo antes do drain, deixando os jobs já claimados presos em `running`, invisíveis pelos 10 minutos do visibility timeout — a cada `docker stop`. Reproduzido e coberto por teste.

Foi por isso que o laço saiu de dentro do `main.ts` para `queue/loop.ts` com as dependências injetadas: as duas coisas que ele pode quebrar em produção são do **call site**, não da aritmética. Um teste só da conta de espera ficaria verde com o shutdown quebrado. Nenhum teste tocava esse laço até agora.

## A garantia, dita com a força que ela tem

O relógio é uma **foto**, não uma promessa: um job que vence entre a foto e o despertar espera. O que ele garante é mais fraco e é o que basta — **nunca mais que um `QUEUE_POLL_INTERVAL_MS`**, porque nada no produto tira uma linha de `pending`+vencida. Verificado em 1.300 estados de fronteira, em fuzz diferencial contra o `claimJobs` real: zero casos de job escondido.

## O que este PR **não** promete

Não prometo que a instalação do @marcioror volta para dentro dos 5 GB. Este PR mede e conserta o worker; o `app` dele consumia ~1 GB/mês pelos crons HTTP do contêiner `scheduler`, e **isso aqui não toca nisso**. O que dá para afirmar: o worker deixa de emitir ~17 statements/s e passa a ~0,5/s no ocioso.

## Fora de escopo, virando issue

- **Índice parcial para `count(*) where status='running'`** — real e forte (178× em tempo, 238× em buffers com a tabela inchada; e o custo não vem de linhas vivas, vem de bloat). Fica de fora porque é CPU do banco, não egress, e arrastaria migration + baseline + MANIFEST para um PR que hoje não tem SQL nenhum.
- **Poda de `job_queue`** — nada no produto apaga job `done`; a tabela cresce contra os 500 MB do mesmo plano free.
- **LISTEN/NOTIFY** (sugestão 3 da issue) — recusada por ora, e não pela ideia: o validador do `install.sh` aceita a porta `6543`, onde a notificação some **em silêncio**. A condição para ela voltar está escrita na issue.

## Verificação

- `typecheck` zerado, `lint` limpo nos arquivos tocados
- `test:unit`: 434 arquivos / 4909 testes verdes
- `test:db`: o invariante novo do relógio + a suíte de invariantes
- `build`
- **Sabotagem**, com a contagem prevista antes de rodar: desfazer o conserto → 3 falhas exatas; remover o tratamento da rejeição → 1; matar o acordar-no-vencimento → 1

Zero SQL, zero migration, zero mudança em `install.sh`/`update.sh`/compose — a correção chega a quem já instalou por imagem, num `bash hostgator-setup-kit/update.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185XyGqvHsL4hjeZzRxQuwP
