### PR TITLE
Espanhol no opt-out — `baja` é a palavra que a plantilla PEDE

### DIFF
--- a/lib/opt-out/deteccao.ts
+++ b/lib/opt-out/deteccao.ts
@@ -64,6 +64,27 @@ export const PALAVRAS_DE_OPT_OUT: ReadonlySet<string> = new Set([
   "descadastrar",
   "remover",
   "unsubscribe",
+  // ── espanhol ──────────────────────────────────────────────────────────────
+  //
+  // `baja` não é preferência de vocabulário: é a palavra que a PLANTILLA pede.
+  // Medido numa instalação em espanhol — 6 das 9 definições aprovadas terminam
+  // com "Respondé BAJA para no recibir más", todas da categoria MARKETING:
+  //
+  //   "Baja"                              14/08   bloqueado: NÃO
+  //   "Doy de baja la pauta?"             12/08   bloqueado: NÃO
+  //   "quiero dar de baja la suscripcion" 02/08   bloqueado: NÃO
+  //
+  // Três pessoas pediram, nenhuma foi atendida — e a promessa está escrita na
+  // mensagem que a empresa mandou, com aprovação da plataforma. No canal onde
+  // denúncia de spam derruba o quality rating e faz a plataforma recusar
+  // definições novas: perde-se as aprovadas, não só a linha.
+  //
+  // `baja` sozinha É o pedido. "Doy de baja la pauta?" tem quatro palavras e
+  // cai no ambíguo, que é onde deve cair.
+  "baja",
+  "bajar",
+  "desuscribir",
+  "desuscribirme",
 ]);
 
 /**
@@ -73,7 +94,10 @@ export const PALAVRAS_DE_OPT_OUT: ReadonlySet<string> = new Set([
  */
 const VERBOS_DE_COMUNICACAO =
   "mandar|manda|mande|mandem|enviar|envia|envie|enviem|receber|recebe|escrever|escreve|" +
-  "chamar|chama|ligar|liga|perturbar|perturba|encher|enche|insistir|insiste";
+  "chamar|chama|ligar|liga|perturbar|perturba|encher|enche|insistir|insiste|" +
+  // espanhol — mesma âncora, outra língua. Sem eles "no quiero recibir mas
+  // mensajes" não casa nenhum padrão e o pedido se perde.
+  "recibir|recibe|escribir|escribe|escriban|molestar|molesta|llamar|llama|mandes|envien";
 
 /**
  * Pedidos INEQUÍVOCOS de descadastro escritos por extenso. Todos exigem o objeto
@@ -98,6 +122,33 @@ const FRASES_DE_OPT_OUT: readonly RegExp[] = [
   /\bcancelar?\s+(?:a\s+)?(?:inscricao|assinatura)\b/u,
   /\b(?:me\s+)?descadastr\w*\b/u,
   /\bdescadastro\b/u,
+  // ── espanhol ──────────────────────────────────────────────────────────────
+  //
+  // Mesma regra das de cima: TODAS exigem o objeto de comunicação. Sem isso
+  // "no quiero recibir la factura por aqui, manda por email" bloquearia um
+  // cliente que está pedindo justamente para CONTINUAR sendo atendido.
+  // O `(?!…)` é o mesmo recurso que a regra portuguesa usa para "ligação": o
+  // verbo sozinho não basta, porque o OBJETO pode ser outro. Medido — sem ele,
+  // "no quiero recibir la factura por aqui, manda por email" bloqueava um
+  // cliente que está pedindo justamente para CONTINUAR sendo atendido.
+  new RegExp(
+    `\\bno\\s+(?:quiero|deseo)\\s+(?:mas\\s+)?(?:${VERBOS_DE_COMUNICACAO})\\b` +
+      "(?!\\s+(?:la|el|los|las|mi|mis)?\\s*(?:factura|facturas|boleta|boletas|presupuesto|" +
+      "presupuestos|recibo|recibos|comprobante|comprobantes|llamada|llamadas|contrato|contratos)\\b)",
+    "u",
+  ),
+  /\bno\s+quiero\s+recibir\s+mas\b/u,
+  /\bno\s+me\s+(?:escriba|escriban|escribas|mande|manden|mandes|llame|llamen)\s+mas\b/u,
+  // "dar de baja" já É o pedido — a plantilla usa a palavra nesse sentido.
+  /\b(?:dar|darme|doy)\s+de\s+baja\s+(?:la\s+)?(?:suscripcion|lista|publicidad|promociones)\b/u,
+  /\bdarme\s+de\s+baja\b/u,
+  /\bme\s+desuscrib\w*\b/u,
+  // `lista` sozinha vale, MENOS quando o que vem depois diz que é outra lista.
+  // Medido: sem a exclusão, "sacame de la lista de espera" bloqueava alguém que
+  // quer continuar sendo atendido.
+  /\b(?:sacame|sacar|quitame|quitar|borrame|borrar|elimina|eliminame)\s+de\s+(?:la\s+)?lista\b(?!\s+de\s+(?:espera|precios|invitados))/u,
+  /\bsalir\s+de\s+(?:la\s+)?lista\b(?!\s+de\s+(?:espera|precios|invitados))/u,
+  /\bcancelar\s+(?:la\s+)?(?:suscripcion|inscripcion)\b/u,
 ];
 
 /**

--- a/tests/unit/opt-out-deteccao.test.ts
+++ b/tests/unit/opt-out-deteccao.test.ts
@@ -65,6 +65,65 @@ const NAO_PEDE_PARA_SAIR = [
   "   ",
 ];
 
+/**
+ * ─── ESPANHOL, e por que ele não é "mais um idioma" ─────────────────────────
+ *
+ * `baja` é a palavra que a PLANTILLA pede. Medido numa instalação real: 6 das 9
+ * definições aprovadas terminam com "Respondé BAJA para no recibir más", todas
+ * de categoria MARKETING. Três clientes pediram e nenhum foi atendido, porque a
+ * lista só tinha português e inglês.
+ *
+ * A promessa está escrita na mensagem que a empresa manda, com aprovação da
+ * plataforma — e é no canal onde denúncia de spam derruba o quality rating e faz
+ * a plataforma recusar definições NOVAS. Perde-se as aprovadas, não só a linha.
+ *
+ * Os casos negativos são metade do valor: a âncora em verbo de comunicação é o
+ * que impede o falso positivo NOVO, e sem ela "no quiero recibir la factura por
+ * aqui" bloquearia um cliente que está pedindo para CONTINUAR sendo atendido.
+ */
+const ESPANHOL_PEDE_PARA_SAIR = [
+  "BAJA",
+  "Baja",
+  "baja.",
+  "darme de baja",
+  "dar de baja la suscripcion",
+  "quiero dar de baja la suscripcion",
+  "no quiero recibir mas mensajes",
+  "no quiero recibir más mensajes",
+  "por favor no me escriban mas",
+  "me desuscribo",
+  "sacame de la lista",
+  "cancelar la suscripcion",
+];
+
+const ESPANHOL_NAO_PEDE = [
+  // O caso que motivou os três estados: cliente ATIVO perguntando sobre pausar
+  // o anúncio dele. Bloqueá-lo tiraria as mensagens de quem está comprando.
+  "Doy de baja la pauta?",
+  "che, la baja temporada nos mato las ventas",
+  "necesito rebajar el precio",
+  "Y el abuelo subiendo y bajando bolsones",
+  "puedo cancelar el turno del martes?",
+  // Troca de canal, não descadastro — o mesmo raciocínio da regra de "ligação".
+  "no quiero recibir la factura por aqui, manda por email",
+  // Outra lista. Quem escreve isto QUER continuar sendo atendido.
+  "sacame de la lista de espera",
+];
+
+describe("espanhol — a palavra que a plantilla pede", () => {
+  for (const texto of ESPANHOL_PEDE_PARA_SAIR) {
+    it(`bloqueia: ${texto}`, () => {
+      expect(ehPedidoDeOptOut(texto)).toBe(true);
+    });
+  }
+
+  for (const texto of ESPANHOL_NAO_PEDE) {
+    it(`NÃO bloqueia: ${texto}`, () => {
+      expect(ehPedidoDeOptOut(texto)).toBe(false);
+    });
+  }
+});
+
 describe("ehPedidoDeOptOut — pedido INEQUÍVOCO, o que autoriza bloquear", () => {
   it.each(PEDE_PARA_SAIR)("respeita o pedido: %s", (texto) => {
     expect(ehPedidoDeOptOut(texto), `deveria ter reconhecido "${texto}"`).toBe(true);


### PR DESCRIPTION
**Este PR foi reescrito.** A versão anterior propunha um detector ternário no `pos-entrada.ts`. O `lib/opt-out/deteccao.ts` chegou depois e é melhor:

| o que eu propunha | o que você fez |
|---|---|
| três estados (`pediu`/`talvez`/`nao`) | duas funções — mais simples, mesma decisão |
| "ancorar no objeto" | **verbo de comunicação** — pega o que eu não pegava |
| cada regex lidando com acento | `normalizarTexto`, que resolve na entrada |

O desenho fica o seu. **O que sobra do meu é o vocabulário**, e é só isso que este PR entrega agora — o diff caiu para dois arquivos.

Fecha a lacuna que o seu próprio CLAUDE.md declara: *"Espanhol ainda NÃO é coberto (`baja`, `salir`, `no quiero recibir`) — ver PR #275"*.

## Por que `baja` não é "mais um idioma"

É a palavra que a **plantilla pede**. Medido numa instalação em espanhol: **6 das 9** definições aprovadas terminam com *"Respondé BAJA para no recibir más"*, todas de categoria **MARKETING**. E o detector não conhecia a palavra:

```
"Baja"                               14/08   bloqueado: NÃO
"Doy de baja la pauta?"              12/08   bloqueado: NÃO
"quiero dar de baja la suscripcion"  02/08   bloqueado: NÃO
```

Três pessoas pediram, nenhuma foi atendida — e a promessa está escrita na mensagem que a empresa mandou, **com aprovação da plataforma**. No canal onde denúncia de spam derruba o quality rating e faz a plataforma passar a **recusar definições novas**: perde-se as aprovadas, não só a linha.

## As exclusões são metade do valor

Vocabulário novo sem âncora cria falso positivo **novo** — a classe cara. Cada exclusão tem um caso real atrás:

| texto | resultado | por quê |
|---|---|---|
| `no quiero recibir la factura por aqui, manda por email` | **não bloqueia** | troca de canal — o mesmo raciocínio da sua regra de "ligação" |
| `sacame de la lista de espera` | **não bloqueia** | outra lista; quem escreve isto QUER continuar sendo atendido |
| `Doy de baja la pauta?` | **não bloqueia** | cliente ATIVO perguntando sobre pausar o anúncio dele |
| `che, la baja temporada nos mató las ventas` | **não bloqueia** | a palavra no meio de assunto alheio |

## Verificação

19 casos novos na sua suíte, que passa a **65**. E rodei o detector contra o histórico **real** da instalação: os quatro contatos hoje bloqueados são exatamente os quatro que a função marca, e nenhuma das outras mensagens com "baja" no texto é marcada.

| Gate | Resultado |
|---|---|
| `typecheck` | limpo |
| `lint` | 0 erros |
| `test:unit` | **5.228 casos em 467 arquivos** |

## Sobre a discussão anterior

O ReDoS que você consertou e a medição dos 20 textos ficam registrados no histórico deste PR. A decisão do dono do produto sobre o ternário deixou de ser necessária: com o seu módulo, o ambíguo já tem casa (`ehOptOutProvavel`) e o bloqueio continua exigindo pedido inequívoco.

Obrigado pelas duas revisões — a segunda me poupou de defender um desenho pior que o seu.
