### PR TITLE
fix(ia): "Configurar Catálogo" criava uma FAQ, e a colisão saía como 500 mudo

### DIFF
--- a/app/api/v1/ai/knowledge/sources/route.ts
+++ b/app/api/v1/ai/knowledge/sources/route.ts
@@ -38,6 +38,27 @@ const sourceTypeEnum = z.enum([
   "nuvemshop_catalog",
 ]);
 
+type SourceType = z.infer<typeof sourceTypeEnum>;
+
+/**
+ * Tipos cujo conteúdo colado (`items` / `markdown_blob`) esta rota realmente
+ * ingere. Os outros valores existem no CHECK do banco, mas são preenchidos por
+ * pipeline: `conversations` nasce da ingestão anonimizada
+ * (`lib/ai/rag/ingest/conversations.ts`, via cron `kb-conversations-batch`) e
+ * `catalog` vem da sincronização do e-commerce.
+ */
+const TIPOS_QUE_INGEREM_TEXTO: ReadonlySet<SourceType> = new Set<SourceType>(["faq", "policy"]);
+
+/** Nome do tipo em português, para mensagem de erro que alguém lê na tela. */
+const ROTULO_DO_TIPO: Record<SourceType, string> = {
+  faq: "FAQ",
+  policy: "política",
+  conversation: "conversas",
+  conversations: "conversas",
+  catalog: "catálogo",
+  nuvemshop_catalog: "catálogo",
+};
+
 const createSourceSchema = z.object({
   agent_id: z.string().uuid(),
   source_type: sourceTypeEnum,
@@ -112,6 +133,21 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   const input = parsed.data;
 
+  // Conteúdo mandado para um tipo que esta rota não ingere era ACEITO e
+  // descartado em silêncio: a fonte nascia vazia, com 201, e ninguém entendia
+  // por que o agente não sabia nada dali. Recusar alto é a única resposta
+  // honesta — o mesmo defeito que o bloco de `policy` abaixo já pagou uma vez.
+  const temConteudo =
+    (input.items?.length ?? 0) > 0 || (input.markdown_blob?.trim().length ?? 0) > 0;
+  if (temConteudo && !TIPOS_QUE_INGEREM_TEXTO.has(input.source_type)) {
+    return fail(
+      "unprocessable_entity",
+      `Fonte de ${ROTULO_DO_TIPO[input.source_type]} não recebe conteúdo colado — ela é preenchida automaticamente.`,
+      422,
+      { requestId },
+    );
+  }
+
   // Validate agent_id belongs to org (using user-scoped client — RLS enforces tenant).
   const supabase = await createClient();
   const { data: agent, error: agentErr } = await supabase
@@ -176,6 +212,19 @@ export async function POST(req: NextRequest): Promise<Response> {
     .single();
 
   if (ksErr || !ks) {
+    // `ai_knowledge_sources_unique_per_agent` (agent_id, source_type) WHERE
+    // is_active: UMA fonte ativa de cada tipo por agente. Sem esta tradução o
+    // 23505 saía como 500 "Erro ao criar fonte de conhecimento." — quem tentou
+    // cadastrar a segunda não tinha como descobrir que o motivo era a primeira.
+    if (ksErr?.code === "23505") {
+      return fail(
+        "knowledge_source_type_in_use",
+        `Já existe uma fonte de ${ROTULO_DO_TIPO[input.source_type]} ativa para este agente. ` +
+          `Edite ou arquive a existente em vez de criar outra.`,
+        409,
+        { requestId },
+      );
+    }
     console.error("[ai-knowledge-sources] insert knowledge source failed:", ksErr?.message);
     return fail("internal_error", "Erro ao criar fonte de conhecimento.", 500, { requestId });
   }

--- a/components/ai/KnowledgeSourceCard.tsx
+++ b/components/ai/KnowledgeSourceCard.tsx
@@ -21,29 +21,47 @@ interface Props {
   onCriada?: () => void;
 }
 
+/**
+ * `comoSePreenche: null` = o conteúdo é colado à mão, e o cartão vazio oferece
+ * o diálogo de cadastro. Os outros dois são preenchidos por pipeline e NÃO têm
+ * o que colar: `conversations` vem da ingestão anonimizada
+ * (cron `kb-conversations-batch`) e `catalog` da sincronização do e-commerce.
+ * Oferecer "Configurar" neles obrigava o diálogo a mentir o tipo no envio.
+ */
 const TYPE_META: Record<
   KnowledgeSourceType,
-  { label: string; Icon: typeof HelpCircle; description: string }
+  {
+    label: string;
+    Icon: typeof HelpCircle;
+    description: string;
+    comoSePreenche: string | null;
+  }
 > = {
   faq: {
     label: "FAQ",
     Icon: HelpCircle,
     description: "Perguntas frequentes do tenant.",
+    comoSePreenche: null,
   },
   policy: {
     label: "Política",
     Icon: ShieldCheck,
     description: "Documento PDF de políticas (troca, devolução, privacidade).",
+    comoSePreenche: null,
   },
   conversations: {
     label: "Conversas opt-in",
     Icon: MessageSquare,
     description: "Conversas anonimizadas para aprendizado.",
+    comoSePreenche:
+      "Entra sozinha: conversas resolvidas que alguém marcar como aproveitáveis pela IA são anonimizadas e indexadas em lote. Não há conteúdo para colar aqui.",
   },
   catalog: {
     label: "Catálogo",
     Icon: Package,
     description: "Produtos sincronizados do e-commerce.",
+    comoSePreenche:
+      "Os produtos vêm da sincronização com o e-commerce, não de conteúdo digitado aqui.",
   },
 };
 
@@ -71,6 +89,10 @@ export function KnowledgeSourceCard({
 
   // Empty state.
   if (!source) {
+    // Sem `agentId` o diálogo nem era montado e o botão abria coisa nenhuma —
+    // controle decorativo. Só oferece cadastro quem tem os dois: tipo que
+    // aceita texto colado e agente para amarrar a fonte.
+    const cadastroManual = (type === "faq" || type === "policy") && !!agentId;
     return (
       <Card className="flex h-full flex-col">
         <CardHeader>
@@ -81,24 +103,28 @@ export function KnowledgeSourceCard({
           <p className="text-sm text-text-muted">{meta.description}</p>
         </CardHeader>
         <CardContent className="flex-1">
-          <p className="text-sm text-text-muted">Nenhuma fonte configurada.</p>
+          <p className="text-sm text-text-muted">
+            {meta.comoSePreenche ?? "Nenhuma fonte configurada."}
+          </p>
         </CardContent>
         <CardFooter>
           {/* Onde havia um botão `disabled` fixo com um toast "Em breve." que,
               por estar desabilitado, nunca aparecia. A API sempre existiu;
               faltava a tela. */}
-          <Button variant="secondary" size="sm" onClick={() => setNovaAberta(true)}>
-            Configurar {meta.label}
-          </Button>
-          {agentId ? (
-            <NovaFonteDialog
-              agentId={agentId}
-              tipo={type}
-              rotulo={meta.label}
-              aberto={novaAberta}
-              onFechar={() => setNovaAberta(false)}
-              onCriada={() => onCriada?.()}
-            />
+          {cadastroManual ? (
+            <>
+              <Button variant="secondary" size="sm" onClick={() => setNovaAberta(true)}>
+                Configurar {meta.label}
+              </Button>
+              <NovaFonteDialog
+                agentId={agentId}
+                tipo={type}
+                rotulo={meta.label}
+                aberto={novaAberta}
+                onFechar={() => setNovaAberta(false)}
+                onCriada={() => onCriada?.()}
+              />
+            </>
           ) : null}
         </CardFooter>
       </Card>

--- a/components/ai/NovaFonteDialog.tsx
+++ b/components/ai/NovaFonteDialog.tsx
@@ -34,9 +34,17 @@ const EXEMPLO = `## Pergunta: Qual o prazo de entrega?
 ## Pergunta: Vocês fazem troca?
 ## Resposta: Sim, em até 30 dias, com o produto sem uso.`;
 
+/**
+ * Só os dois tipos cujo conteúdo colado a API ingere de fato. `conversations` e
+ * `catalog` são preenchidos por pipeline (ingestão anonimizada e sincronização
+ * do e-commerce) e não têm o que colar — oferecê-los aqui obrigava a mentir o
+ * tipo no envio, que é o que produzia a colisão do índice único.
+ */
+type TipoComTextoColado = "faq" | "policy";
+
 interface Props {
   agentId: string;
-  tipo: "faq" | "policy" | "conversations" | "catalog";
+  tipo: TipoComTextoColado;
   rotulo: string;
   aberto: boolean;
   onFechar: () => void;
@@ -60,10 +68,11 @@ export function NovaFonteDialog({ agentId, tipo, rotulo, aberto, onFechar, onCri
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           agent_id: agentId,
-          // 'conversations'/'catalog' não têm ingestão de texto colado; o que a
-          // API converte é o formato de FAQ, então o tipo enviado é o que ela
-          // sabe tratar. O rótulo do cartão continua sendo o do slot.
-          source_type: tipo === "policy" ? "policy" : "faq",
+          // O tipo escolhido é o tipo enviado. Aqui havia
+          // `tipo === "policy" ? "policy" : "faq"`: "Catálogo" e "Conversas
+          // opt-in" viravam `faq`, e com uma FAQ ativa o segundo insert batia
+          // no índice único (agent_id, source_type) — 500 sem explicação.
+          source_type: tipo,
           name: nome.trim(),
           markdown_blob: conteudo,
         }),

--- a/lib/api/errors.ts
+++ b/lib/api/errors.ts
@@ -41,6 +41,7 @@ export const ApiErrorCodes = {
   next_action_absent: "next_action_absent", // decisão sobre proposta que não existe (mais) [wave 4]
   next_action_changed: "next_action_changed", // o agente reescreveu a proposta entre o render e o clique
   channel_archived: "channel_archived", // ação sobre canal que o usuário excluiu (a linha só sobrevive como âncora das FKs)
+  knowledge_source_type_in_use: "knowledge_source_type_in_use", // já existe fonte ATIVA daquele tipo para o agente (índice ai_knowledge_sources_unique_per_agent)
 
   // 422 — semântica
   unprocessable_entity: "unprocessable_entity",

--- a/tests/unit/ai-knowledge-sources-post.test.ts
+++ b/tests/unit/ai-knowledge-sources-post.test.ts
@@ -1,0 +1,185 @@
+/**
+ * POST /api/v1/ai/knowledge/sources — o que a rota responde quando o banco
+ * recusa, e o que ela faz com conteúdo que não sabe ingerir (issue #265).
+ *
+ * O índice `ai_knowledge_sources_unique_per_agent` (agent_id, source_type)
+ * WHERE is_active deixa UMA fonte ativa de cada tipo por agente. A segunda
+ * tentativa volta 23505 do Postgres, e isso saía como
+ * `500 internal_error "Erro ao criar fonte de conhecimento."` — quem reportou a
+ * issue não tinha como descobrir que o motivo era a fonte que já existia.
+ *
+ * A outra metade: `items`/`markdown_blob` mandados para um tipo que esta rota
+ * não ingere (`catalog`, `conversations` — preenchidos por pipeline) eram
+ * ACEITOS e descartados em silêncio, criando fonte vazia com 201.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { requireRole } from "@/lib/auth/require-role";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { AuthUser } from "@/lib/auth/types";
+
+vi.mock("@/lib/auth/require-role", () => ({ requireRole: vi.fn() }));
+vi.mock("@/lib/auth/server", () => ({
+  loadAuthUser: vi.fn(),
+  resolveActiveOrg: vi.fn(),
+}));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
+
+const ORG_ID = "22222222-2222-4222-8222-222222222222";
+const AGENT_ID = "11111111-1111-4111-8111-111111111111";
+const KS_ID = "33333333-3333-4333-8333-333333333333";
+
+const MARKDOWN = "## Pergunta: Qual o prazo?\n## Resposta: Dois dias.";
+
+interface ErroDoBanco {
+  code?: string;
+  message: string;
+}
+
+/** Sessão manager válida — o gate de role não é o assunto deste arquivo. */
+function sessaoOk(): void {
+  const user = { id: "user-1", email: "u@example.com" } as unknown as AuthUser;
+  vi.mocked(requireRole).mockResolvedValue({
+    ok: true,
+    user,
+    org: { orgId: ORG_ID, name: "Org", role: "manager" },
+  });
+}
+
+/**
+ * Dubla os dois clients. `erroDoInsert` só afeta a escrita em
+ * `ai_knowledge_sources` — é onde a colisão do índice acontece.
+ */
+function dublarBanco(opts: { agenteExiste?: boolean; erroDoInsert?: ErroDoBanco | null } = {}) {
+  const { agenteExiste = true, erroDoInsert = null } = opts;
+
+  const cadeiaDeLeitura = {
+    select: () => cadeiaDeLeitura,
+    eq: () => cadeiaDeLeitura,
+    maybeSingle: async () => ({ data: agenteExiste ? { id: AGENT_ID } : null, error: null }),
+  };
+  vi.mocked(createClient).mockResolvedValue({
+    from: () => cadeiaDeLeitura,
+  } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+  const escritas: Array<{ tabela: string; linhas: unknown }> = [];
+  const admin = {
+    from: (tabela: string) => ({
+      insert: (linhas: unknown) => {
+        escritas.push({ tabela, linhas });
+        const erro = tabela === "ai_knowledge_sources" ? erroDoInsert : null;
+        const resultado = { data: erro ? null : { id: KS_ID }, error: erro };
+        return {
+          select: () => ({ single: async () => resultado }),
+          // `ai_faq_items` é aguardado direto, sem `.select()`.
+          then: (f: (v: unknown) => unknown) => Promise.resolve({ error: null }).then(f),
+        };
+      },
+    }),
+    rpc: async () => ({ error: null }),
+  };
+  vi.mocked(createAdminClient).mockReturnValue(admin as unknown as ReturnType<typeof createAdminClient>);
+
+  return { escritas };
+}
+
+function req(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/v1/ai/knowledge/sources", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/v1/ai/knowledge/sources — colisão do índice único", () => {
+  it("23505 vira 409 knowledge_source_type_in_use, em português e sem texto do Postgres", async () => {
+    sessaoOk();
+    dublarBanco({
+      erroDoInsert: {
+        code: "23505",
+        message:
+          'duplicate key value violates unique constraint "ai_knowledge_sources_unique_per_agent"',
+      },
+    });
+    const { POST } = await import("@/app/api/v1/ai/knowledge/sources/route");
+    const res = await POST(
+      req({ agent_id: AGENT_ID, source_type: "faq", name: "FAQ da loja", markdown_blob: MARKDOWN }),
+    );
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("knowledge_source_type_in_use");
+    expect(body.error.message).toContain("FAQ");
+    // Sem esta metade, um 500 devolvendo a mensagem crua do Postgres também
+    // citaria "FAQ" (está no nome da constraint) e passaria.
+    expect(body.error.message).not.toContain("unique");
+    expect(body.error.message).not.toContain("constraint");
+    expect(body.error.message).not.toContain("duplicate");
+  });
+
+  it("outro erro do banco continua 500 — a tradução é só do conflito", async () => {
+    sessaoOk();
+    dublarBanco({ erroDoInsert: { code: "08006", message: "connection failure" } });
+    const erroDoConsole = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { POST } = await import("@/app/api/v1/ai/knowledge/sources/route");
+    const res = await POST(
+      req({ agent_id: AGENT_ID, source_type: "faq", name: "FAQ da loja", markdown_blob: MARKDOWN }),
+    );
+    erroDoConsole.mockRestore();
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("internal_error");
+  });
+});
+
+describe("POST /api/v1/ai/knowledge/sources — tipo pedido é o tipo gravado", () => {
+  it("grava o source_type que veio no corpo, sem reescrever", async () => {
+    sessaoOk();
+    const { escritas } = dublarBanco();
+    const { POST } = await import("@/app/api/v1/ai/knowledge/sources/route");
+    const res = await POST(
+      req({ agent_id: AGENT_ID, source_type: "policy", name: "Política de troca", markdown_blob: MARKDOWN }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(escritas[0]).toMatchObject({
+      tabela: "ai_knowledge_sources",
+      linhas: { source_type: "policy", organization_id: ORG_ID, agent_id: AGENT_ID },
+    });
+    expect(escritas[1]?.tabela).toBe("ai_faq_items");
+  });
+
+  it("tipo sem ingestão de texto + conteúdo colado → 422, e NADA é gravado", async () => {
+    sessaoOk();
+    const { escritas } = dublarBanco();
+    const { POST } = await import("@/app/api/v1/ai/knowledge/sources/route");
+    const res = await POST(
+      req({ agent_id: AGENT_ID, source_type: "catalog", name: "Catálogo", markdown_blob: MARKDOWN }),
+    );
+
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("unprocessable_entity");
+    expect(body.error.message).toContain("catálogo");
+    // O defeito antigo era 201 com fonte vazia: recusar sem gravar é o ponto.
+    expect(escritas).toHaveLength(0);
+  });
+
+  it("tipo sem ingestão de texto e SEM conteúdo continua podendo ser criado", async () => {
+    sessaoOk();
+    const { escritas } = dublarBanco();
+    const { POST } = await import("@/app/api/v1/ai/knowledge/sources/route");
+    const res = await POST(req({ agent_id: AGENT_ID, source_type: "catalog", name: "Catálogo" }));
+
+    expect(res.status).toBe(201);
+    expect(escritas[0]).toMatchObject({ linhas: { source_type: "catalog" } });
+  });
+});

--- a/tests/unit/fonte-de-conhecimento-cadastro.test.tsx
+++ b/tests/unit/fonte-de-conhecimento-cadastro.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Cadastro de fonte de conhecimento pela tela (issue #265).
+ *
+ * Dois defeitos moravam aqui, e o segundo escondia o primeiro:
+ *
+ *  1. O diálogo mandava `tipo === "policy" ? "policy" : "faq"`. Quem clicava em
+ *     "Configurar Catálogo" criava uma fonte `faq`; com uma FAQ já ativa, o
+ *     índice `ai_knowledge_sources_unique_per_agent` (agent_id, source_type)
+ *     WHERE is_active recusava o INSERT e a tela devolvia um 500 genérico.
+ *  2. O diálogo nunca deveria ter sido oferecido a "Catálogo" e "Conversas
+ *     opt-in": a rota só ingere texto colado de `faq` e `policy` — os outros
+ *     dois são preenchidos por pipeline. Era controle decorativo, e mentir o
+ *     tipo no envio foi o remendo que produziu (1).
+ *
+ * O que este arquivo vigia é COMPORTAMENTO de tela: o tipo que a pessoa
+ * escolheu é o tipo que chega na API, e o cartão só oferece cadastro onde há
+ * cadastro. Um teste sobre a constante `TYPE_META` passaria com o diálogo
+ * remontado por engano no cartão errado.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const toastErro = vi.fn();
+const toastOk = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { success: (m: string) => toastOk(m), error: (m: string) => toastErro(m) },
+}));
+
+import { NovaFonteDialog } from "@/components/ai/NovaFonteDialog";
+import { KnowledgeSourceCard } from "@/components/ai/KnowledgeSourceCard";
+
+const AGENT_ID = "11111111-1111-4111-8111-111111111111";
+
+const CONTEUDO = [
+  "## Pergunta: Qual o prazo de entrega?",
+  "## Resposta: De 2 a 3 dias úteis.",
+].join("\n");
+
+/** Substitui o `fetch` global e devolve o spy, para ler o corpo enviado. */
+function dublarFetch() {
+  const spy = vi.fn(
+    async (_url: string, _init?: RequestInit) =>
+      new Response(JSON.stringify({ data: { id: "ks-1", items_count: 1 } }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      }),
+  );
+  vi.stubGlobal("fetch", spy);
+  return spy;
+}
+
+/** Corpo JSON da primeira chamada ao fetch. */
+function corpoEnviado(spy: ReturnType<typeof dublarFetch>): Record<string, unknown> {
+  const init = spy.mock.calls[0]?.[1];
+  return JSON.parse(String(init?.body)) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  toastErro.mockReset();
+  toastOk.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("NovaFonteDialog — o tipo escolhido é o tipo enviado", () => {
+  for (const tipo of ["faq", "policy"] as const) {
+    it(`tipo "${tipo}" chega na API como "${tipo}"`, async () => {
+      const spy = dublarFetch();
+      render(
+        <NovaFonteDialog
+          agentId={AGENT_ID}
+          tipo={tipo}
+          rotulo="Fonte"
+          aberto
+          onFechar={() => {}}
+          onCriada={() => {}}
+        />,
+      );
+
+      fireEvent.change(screen.getByLabelText("Conteúdo"), { target: { value: CONTEUDO } });
+      fireEvent.click(screen.getByRole("button", { name: "Criar fonte" }));
+
+      await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+      expect(spy.mock.calls[0]?.[0]).toBe("/api/v1/ai/knowledge/sources");
+      expect(corpoEnviado(spy)).toMatchObject({ source_type: tipo, agent_id: AGENT_ID });
+    });
+  }
+
+  it("erro da API vira a mensagem do servidor, não um texto fixo", async () => {
+    const spy = vi.fn(
+      async (_url: string, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: "knowledge_source_type_in_use",
+              message: "Já existe uma fonte de FAQ ativa para este agente.",
+            },
+          }),
+          { status: 409, headers: { "content-type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", spy);
+
+    render(
+      <NovaFonteDialog
+        agentId={AGENT_ID}
+        tipo="faq"
+        rotulo="FAQ"
+        aberto
+        onFechar={() => {}}
+        onCriada={() => {}}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("Conteúdo"), { target: { value: CONTEUDO } });
+    fireEvent.click(screen.getByRole("button", { name: "Criar fonte" }));
+
+    await waitFor(() => expect(toastErro).toHaveBeenCalledTimes(1));
+    expect(toastErro.mock.calls[0]?.[0]).toContain("Já existe uma fonte de FAQ ativa");
+    expect(toastOk).not.toHaveBeenCalled();
+  });
+});
+
+describe("KnowledgeSourceCard — só oferece cadastro onde existe cadastro", () => {
+  for (const tipo of ["faq", "policy"] as const) {
+    it(`"${tipo}" vazio oferece o botão, e o botão abre o formulário`, () => {
+      render(<KnowledgeSourceCard type={tipo} source={null} agentId={AGENT_ID} />);
+
+      const botao = screen.getByRole("button", { name: /^Configurar / });
+      fireEvent.click(botao);
+      expect(screen.getByLabelText("Conteúdo")).toBeInTheDocument();
+    });
+  }
+
+  for (const tipo of ["conversations", "catalog"] as const) {
+    it(`"${tipo}" não oferece cadastro à mão e explica como se preenche`, () => {
+      render(<KnowledgeSourceCard type={tipo} source={null} agentId={AGENT_ID} />);
+
+      expect(screen.queryByRole("button", { name: /^Configurar / })).toBeNull();
+      // Tirar o botão sem dizer nada deixaria um cartão vazio sem saída: a
+      // explicação é o que sobra no lugar do controle que não existia.
+      expect(screen.queryByText("Nenhuma fonte configurada.")).toBeNull();
+      const explicacao =
+        tipo === "catalog" ? /sincronização com o e-commerce/i : /anonimizadas e indexadas/i;
+      expect(screen.getByText(explicacao)).toBeInTheDocument();
+    });
+  }
+
+  it("sem agentId nenhum botão é oferecido — ele não teria formulário para abrir", () => {
+    render(<KnowledgeSourceCard type="faq" source={null} />);
+    expect(screen.queryByRole("button", { name: /^Configurar / })).toBeNull();
+  });
+});


### PR DESCRIPTION
O diálogo de cadastro de fonte de conhecimento mandava
`source_type: tipo === "policy" ? "policy" : "faq"`. Quem clicava em
"Configurar Catálogo" ou "Configurar Conversas opt-in" criava uma fonte
`faq` — e, com uma FAQ já ativa, o índice
`ai_knowledge_sources_unique_per_agent` (agent_id, source_type) WHERE
is_active recusava o INSERT. A tela mostrava "Erro ao criar fonte de
conhecimento." e nada mais.

Medido antes de consertar: `catalog` e `conversations` SÃO valores
válidos no `sourceTypeEnum` da rota e no CHECK do banco — mas a rota só
converte `items`/`markdown_blob` em conteúdo para `faq` e `policy`
(route.ts), não existe módulo de ingestão manual para os outros
(`ls lib/ai/rag/ingest/` = conversations, faq, policy), a fonte
`conversations` é criada sozinha pelo cron `kb-conversations-batch` e
nenhum código do repo cria fonte `catalog`. Ou seja: o botão era
decorativo nesses dois slots, e mentir o tipo no envio foi o remendo que
produziu a colisão.

- o diálogo aceita só os dois tipos cujo texto colado a rota ingere, e
  manda o tipo escolhido;
- os cartões de Catálogo e Conversas opt-in param de oferecer um
  formulário que não existe e dizem como o slot se preenche de verdade;
- 23505 vira 409 `knowledge_source_type_in_use` com a razão em português,
  em vez de 500 genérico;
- conteúdo mandado para tipo sem ingestão vira 422 em vez de nascer fonte
  vazia com 201 (era descarte silencioso).

Sem mudança de schema.

---

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3qmqo4AZU1NFSz9oNPzke