### PR TITLE
fix(kit): a mesma string era o app e o dono do banco — o self-host travava na 1ª instalação

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -176,6 +176,14 @@ NEXT_PUBLIC_ADMIN_URL=http://localhost:3000
 # dedicada com login (ex.: agent_worker) — nunca a service_role key aqui.
 SUPABASE_DB_URL=
 
+# A conexão que MEXE NO SCHEMA — e SÓ o kit (install.sh/update.sh/backup.sh) a
+# usa; nenhum código do app lê esta chave. OPCIONAL: vazia, tudo roda pela de
+# cima, que é o caso da nuvem (a string do pooler já vem privilegiada).
+# Preencha quando o banco for um Supabase PRÓPRIO e a de cima for a role menor:
+# `create extension`, o `baseline.sql` e a promoção do dono exigem o dono do
+# banco. Ver docs/deploy-selfhost/README.md §2.
+SUPABASE_DB_ADMIN_URL=
+
 # --- Ritmo da fila do worker (custo de banco) --------------------------------
 # Os dois governam quanto o worker conversa com o Postgres quando NÃO há trabalho
 # — a conta que estourou a cota de egress do plano free do Supabase na issue #258.

--- a/.env.hostgator.example
+++ b/.env.hostgator.example
@@ -85,7 +85,16 @@ NEXT_PUBLIC_SUPABASE_URL=https://SEU-PROJETO.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=            # anon key (Settings → API)
 # RUNTIME:
 SUPABASE_SERVICE_ROLE_KEY=               # service_role key — BYPASSA RLS, só server
-SUPABASE_DB_URL=                         # connection string (Settings → Database) — usada p/ baseline + bootstrap
+SUPABASE_DB_URL=                         # connection string (Settings → Database) — a do APP (vai para os contêineres)
+# Só para Supabase PRÓPRIO: a conexão do DONO do banco, que roda o schema
+# (create extension, baseline.sql, promoção do dono, pg_dump do backup). Na
+# nuvem não preencha — a de cima já é privilegiada. O install.sh NÃO grava esta
+# chave; descomentar aqui é uma escolha sua, e vale a pena para que o update.sh
+# (que roda sozinho pelo cron) continue conseguindo aplicar migration nova.
+# Atenção: o compose entrega o .env inteiro ao app e ao worker (env_file), então
+# declará-la aqui a expõe aos contêineres — se preferir não expor, passe-a só no
+# comando: SUPABASE_DB_ADMIN_URL='...' bash hostgator-setup-kit/update.sh
+#SUPABASE_DB_ADMIN_URL=
 
 # -----------------------------------------------------------------------------
 # 3) APP URLs (BUILD-TIME — precisam bater com o DOMAIN acima; trocar = rebuild)

--- a/docs/deploy-selfhost/README.md
+++ b/docs/deploy-selfhost/README.md
@@ -32,6 +32,11 @@ Edite o `.env` e preencha (mínimo):
 - **Supabase** (Settings → API do seu projeto): `NEXT_PUBLIC_SUPABASE_URL`,
   `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
 - **Banco direto** (Settings → Database → connection string): `SUPABASE_DB_URL`
+  > É a conexão do **app**. Quem mexe no **schema** — `create extension`, o
+  > `baseline.sql`, a promoção do dono, o `pg_dump` do backup — pode ser outra:
+  > `SUPABASE_DB_ADMIN_URL`. Ela é **opcional** e, vazia, tudo roda pela de cima
+  > (é o caso da nuvem: a string do pooler já vem privilegiada). Preencha quando
+  > o Postgres for **seu** e a de cima for uma role menor — ver §2.
 - **Domínio**: `DOMAIN`, `NEXT_PUBLIC_APP_URL=https://SEU_DOMINIO`,
   `WAHA_WEBHOOK_BASE_URL=https://SEU_DOMINIO`
   > Rodando SEM TLS (ex.: `http://IP:PORTA`, sem o Caddy)? Basta o
@@ -57,11 +62,12 @@ Edite o `.env` e preencha (mínimo):
 ```bash
 # uma vez, do seu computador ou da VPS (precisa do psql):
 # projeto Supabase NOVO: habilite antes as extensões que o schema usa
-psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -c \
+DDL="${SUPABASE_DB_ADMIN_URL:-$SUPABASE_DB_URL}"   # a do dono do banco, se houver
+psql "$DDL" -v ON_ERROR_STOP=1 -c \
   'create extension if not exists vector with schema public;
    create extension if not exists citext with schema public;
    create extension if not exists pg_trgm with schema public;'
-psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f supabase/baseline.sql
+psql "$DDL" -v ON_ERROR_STOP=1 -f supabase/baseline.sql
 ```
 
 O `baseline.sql` é idempotente — cria o CRM inteiro + as tabelas do agente
@@ -90,7 +96,34 @@ grant usage, select on all sequences in schema public to agent_worker;
 grant execute on all functions in schema public to agent_worker;
 ```
 
-E aponte `SUPABASE_DB_URL` do `.env` para ela.
+Aponte `SUPABASE_DB_URL` do `.env` para ela — e deixe a conexão do **dono** em
+`SUPABASE_DB_ADMIN_URL`. Antes isto era uma recomendação sem encaixe: o
+`install.sh` e o `update.sh` usavam a MESMA string para o app e para o schema, e
+quem seguia este parágrafo via o `baseline.sql` falhar por falta de permissão —
+com a saída de editar o `.env` na mão entre uma etapa e outra (issue #192).
+
+Para conferir quem é quem na sua instalação, sem acreditar neste texto:
+
+```bash
+# cada linha diz "chamada ao Postgres → com qual string"
+grep -nE '(psql|pg_dump) "' hostgator-setup-kit/*.sh
+```
+
+`url_do_schema` (em `hostgator-setup-kit/_common.sh`) é a resolução: usa
+`SUPABASE_DB_ADMIN_URL` e, ausente ou vazia, cai em `SUPABASE_DB_URL`.
+
+Duas consequências que valem saber antes de escolher onde declarar:
+
+- O `docker-compose.prod.yml` entrega o `.env` inteiro ao `app` e ao `worker`
+  (`env_file: .env`). Declarar `SUPABASE_DB_ADMIN_URL` ali a expõe aos
+  contêineres. Para não expor, passe-a só no comando:
+  `SUPABASE_DB_ADMIN_URL='...' bash hostgator-setup-kit/install.sh`.
+- Em compensação, o `update.sh` roda **sozinho** (cron do `agent.sh`) e é ele
+  que entrega migration nova ao clone. Sem a chave no `.env`, cada atualização
+  precisa da sua mão. Escolha consciente, não descuido.
+
+O `install.sh` **nunca grava** `SUPABASE_DB_ADMIN_URL` no `.env` — se ela estiver
+lá, foi você que pôs.
 
 ## 3. Subir
 
@@ -202,7 +235,9 @@ e é preciso repetir o comando quando a marca mudar.
 
 - **Backup diário** (do seu crontab na VPS):
   `0 3 * * * /caminho/repo/scripts/backup-db.sh /var/backups/deskcomm`
-  (restaure com `pg_restore --clean --no-owner -d "$SUPABASE_DB_URL" arquivo.dump`)
+  (restaure com
+  `pg_restore --clean --no-owner -d "${SUPABASE_DB_ADMIN_URL:-$SUPABASE_DB_URL}" arquivo.dump`
+  — `--clean` derruba e recria objetos, o que é trabalho de dono do banco)
 - **Flywheel** (auto-melhoria): o worker julga conversas reais a cada 6h
   (`FLYWHEEL_INTERVAL_MS`) e grava PROPOSTAS de melhoria de prompt em
   `flywheel_distiller_proposals`. Nada é aplicado sozinho: revise e cole o

--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -307,8 +307,42 @@ enter_project() {
   PROJECT_DIR="$(pwd)"
 }
 
-# psql efêmero via container (não exige psql no host).
-psql_run() { docker run --rm -i postgres:17-alpine psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 "$@"; }
+# ── As DUAS conexões: a do app e a do schema ─────────────────────────────────
+# `SUPABASE_DB_URL` tinha dois papéis numa string só: ela vai para o `.env` dos
+# contêineres (o app fala com o banco por ela) E era a mesma que rodava
+# `create extension`, o `baseline.sql` e a promoção do dono.
+#
+# Na nuvem isso não dói — a string do pooler já vem privilegiada. Num Supabase
+# PRÓPRIO dói na primeira instalação: o baseline exige o dono do banco, o app
+# quer a role menor (é o que `docs/deploy-selfhost/README.md` §2 recomenda), e a
+# única saída era editar o `.env` na mão entre uma etapa e outra (issue #192).
+#
+# Daqui em diante: quem mexe no schema (e quem faz backup/restore, que precisam
+# ler tudo) passa por esta função; o `.env` continua recebendo só a do app.
+# `SUPABASE_DB_ADMIN_URL` ausente OU vazia cai na de sempre — quem já instalou
+# não muda de comportamento.
+#
+# É FUNÇÃO, e não uma atribuição no topo deste arquivo, porque o `_common.sh` é
+# *sourced* ANTES do `load_env` nos dois scripts (install.sh e update.sh), e ele
+# abre com `set -euo pipefail`: uma linha `X="${SUPABASE_DB_ADMIN_URL:-$SUPABASE_DB_URL}"`
+# aqui morre em "variável não associada" e leva o kit inteiro junto (medido: a
+# suíte de shell inteira foi a EXIT=1 com 0 casos executados). E com guarda
+# (`${SUPABASE_DB_URL:-}`) seria pior: o valor CONGELA vazio e todo sítio de DDL
+# passa a rodar `psql ""`. A resolução tem de acontecer na hora do uso.
+#
+# `:?` e não `:-`: sem NENHUMA das duas, o certo é parar com uma frase que diz o
+# que fazer, não seguir para um `psql ""` que erra longe da causa. O limite é
+# honesto — isto roda em substituição de comando, e um subshell não derruba o
+# pai; o que a mensagem garante é que a causa apareça na tela antes do erro de
+# conexão que os chamadores já tratam.
+url_do_schema() {
+  printf '%s' "${SUPABASE_DB_ADMIN_URL:-${SUPABASE_DB_URL:?sem connection string de banco no .env — rode o install.sh}}"
+}
+
+# psql efêmero via container (não exige psql no host). Usa a conexão de schema:
+# os chamadores mexem em `auth.mfa_factors` e `private.app_secrets`, fora do
+# alcance de uma role de app com grants só em `public`.
+psql_run() { docker run --rm -i postgres:17-alpine psql "$(url_do_schema)" -v ON_ERROR_STOP=1 "$@"; }
 
 # ── As três imagens que NÓS publicamos ───────────────────────────────────────
 # O namespace é constante e literal de propósito: ele está gravado no .env de

--- a/hostgator-setup-kit/backup.sh
+++ b/hostgator-setup-kit/backup.sh
@@ -12,7 +12,11 @@ mkdir -p "$BACKUP_DIR"
 ts="$(date +%Y%m%d-%H%M%S)"
 
 step "Dump do banco → $BACKUP_DIR/db-$ts.sql.gz"
-docker run --rm postgres:17-alpine pg_dump "$SUPABASE_DB_URL" --no-owner --no-privileges \
+# Pela conexão de SCHEMA (url_do_schema), não pela do app: `pg_dump` só despeja
+# o que a role enxerga, e com uma role menor — a que recomendamos no `.env` de
+# quem usa Supabase próprio — o backup sai PARCIAL e sai verde. Falha silenciosa
+# de backup é a pior das falhas: só aparece na hora de restaurar.
+docker run --rm postgres:17-alpine pg_dump "$(url_do_schema)" --no-owner --no-privileges \
   | gzip > "$BACKUP_DIR/db-$ts.sql.gz"
 c_grn "✓ banco: $(du -h "$BACKUP_DIR/db-$ts.sql.gz" | awk '{print $1}')"
 

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -1527,16 +1527,23 @@ fi
 
 # ── 7. Aplica o schema (baseline) no Supabase — via container postgres ───────
 step "Aplicando o schema no Supabase (baseline.sql)"
+# Tudo daqui até o fim da etapa 8 fala com o banco por `url_do_schema`
+# (_common.sh), não pela string que vai para o `.env`: criar extensão, aplicar o
+# baseline e promover o dono exigem o DONO do banco, e num Supabase próprio a
+# string do app é — por recomendação nossa — uma role menor. Sem
+# `SUPABASE_DB_ADMIN_URL` declarada as duas são a mesma, que é o caso da nuvem.
 if [ -f supabase/baseline.sql ]; then
   # O baseline é um pg_dump: referencia public.vector, public.citext e gin_trgm_ops
   # (pg_trgm) mas NÃO cria as extensões. Supabase não as habilita no schema public por
   # padrão — criamos aqui, senão o schema quebra no meio (ex.: "type public.vector does
   # not exist"). Idempotente (if not exists).
-  docker run --rm postgres:17-alpine psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -c \
+  docker run --rm postgres:17-alpine psql "$(url_do_schema)" -v ON_ERROR_STOP=1 -c \
     "create extension if not exists vector with schema public; create extension if not exists citext with schema public; create extension if not exists pg_trgm with schema public;" \
     >/dev/null 2>&1 \
     && c_grn "✓ extensões (vector, citext, pg_trgm) habilitadas no public" \
-    || c_ylw "⚠ não consegui habilitar as extensões — o schema pode falhar abaixo."
+    || { c_ylw "⚠ não consegui habilitar as extensões — o schema pode falhar abaixo."
+         c_ylw "  Supabase próprio? Criar extensão exige o dono do banco: rode de novo com"
+         c_ylw "  SUPABASE_DB_ADMIN_URL='postgresql://<dono>:<senha>@<host>:5432/postgres'"; }
   SCHEMA_LOG="$PROJECT_DIR/baseline-apply.log"
   # Banco novo ou re-execução? Re-aplicar com ON_ERROR_STOP pararia no primeiro
   # "já existe" (ex.: multiple primary keys) e PULARIA o resto do arquivo —
@@ -1547,13 +1554,13 @@ if [ -f supabase/baseline.sql ]; then
   # dentro da substituição e, com `set -e` + `pipefail`, derruba o instalador sem
   # imprimir nada (o 2>/dev/null já tinha engolido a causa). Preferimos seguir e
   # deixar o erro aparecer no ponto em que dá para explicá-lo.
-  has_schema="$(docker run --rm postgres:17-alpine psql "$SUPABASE_DB_URL" -tAc \
+  has_schema="$(docker run --rm postgres:17-alpine psql "$(url_do_schema)" -tAc \
     "select 1 from information_schema.tables where table_schema='public' and table_name='organizations' limit 1" 2>/dev/null | tr -d '[:space:]' || true)"
 
   if [ "$has_schema" = "1" ]; then
     c_ylw "• schema já existe — re-aplicando em modo update (erros 'já existe' são esperados e ficam no log)"
     raw="$(docker run --rm -i -v "$PROJECT_DIR/supabase/baseline.sql:/baseline.sql:ro" \
-          postgres:17-alpine psql "$SUPABASE_DB_URL" -q -f /baseline.sql 2>&1 || true)"
+          postgres:17-alpine psql "$(url_do_schema)" -q -f /baseline.sql 2>&1 || true)"
     printf '%s\n' "$raw" > "$SCHEMA_LOG"
     benign='already exists|multiple primary keys|multiple default values|is already a member|already a partition'
     unexpected="$(printf '%s\n' "$raw" | grep -iE 'ERROR|FATAL' | grep -viE "$benign" || true)"
@@ -1565,17 +1572,20 @@ if [ -f supabase/baseline.sql ]; then
     fi
   else
     if docker run --rm -i -v "$PROJECT_DIR/supabase/baseline.sql:/baseline.sql:ro" \
-        postgres:17-alpine psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f /baseline.sql \
+        postgres:17-alpine psql "$(url_do_schema)" -v ON_ERROR_STOP=1 -f /baseline.sql \
         > "$SCHEMA_LOG" 2>&1; then
       c_grn "✓ schema aplicado (log: $SCHEMA_LOG)"
     else
       tail -5 "$SCHEMA_LOG"
-      die "baseline falhou num banco NOVO — o schema ficaria incompleto (sem RLS). Log completo: $SCHEMA_LOG"
+      die "baseline falhou num banco NOVO — o schema ficaria incompleto (sem RLS). Log completo: $SCHEMA_LOG
+     Se o erro fala em permissão: o baseline exige o DONO do banco. Num Supabase próprio,
+     rode de novo com SUPABASE_DB_ADMIN_URL='postgresql://<dono>:<senha>@<host>:5432/postgres'
+     — ela roda só o schema e NÃO é gravada no .env dos contêineres."
     fi
   fi
 
   # Verificação real, não wishful thinking: o app precisa das tabelas core.
-  n_tables="$(docker run --rm postgres:17-alpine psql "$SUPABASE_DB_URL" -tAc \
+  n_tables="$(docker run --rm postgres:17-alpine psql "$(url_do_schema)" -tAc \
     "select count(*) from information_schema.tables where table_schema='public'" 2>/dev/null | tr -d '[:space:]')"
   if [ "${n_tables:-0}" -ge 30 ]; then
     c_grn "✓ verificação: ${n_tables} tabelas no schema public"
@@ -1614,9 +1624,11 @@ curl -fsS -X POST "${NEXT_PUBLIC_SUPABASE_URL}/auth/v1/admin/users" \
 # 2) Resolve o id direto do auth.users e cria org + membership + platform_admin.
 #    Resolver o uid DENTRO do SQL evita parsing frágil de JSON e funciona tanto para
 #    usuário recém-criado quanto para um que já existia (re-execução).
-docker run --rm -i postgres:17-alpine psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 <<SQL \
+docker run --rm -i postgres:17-alpine psql "$(url_do_schema)" -v ON_ERROR_STOP=1 <<SQL \
   && c_grn "✓ dono criado e promovido a super-admin" \
-  || die "Não consegui promover o admin. Confira a service_role key, a URL e a connection string do Supabase."
+  || die "Não consegui promover o admin. Confira a service_role key, a URL e a connection string do Supabase.
+     Este passo lê auth.users e escreve em public: num Supabase próprio ele precisa do dono do
+     banco — declare SUPABASE_DB_ADMIN_URL e rode de novo."
 do \$\$
 declare v_org uuid; v_uid uuid;
 begin

--- a/hostgator-setup-kit/restore.sh
+++ b/hostgator-setup-kit/restore.sh
@@ -14,7 +14,7 @@ read -r -p "Digite 'RESTAURAR' para confirmar: " a
 [ "$a" = "RESTAURAR" ] || die "Cancelado."
 
 step "Restaurando $DUMP"
-gunzip -c "$DUMP" | docker run --rm -i postgres:17-alpine psql "$SUPABASE_DB_URL" \
+gunzip -c "$DUMP" | docker run --rm -i postgres:17-alpine psql "$(url_do_schema)" \
   && c_grn "✓ banco restaurado" || die "Falha na restauração — veja o log acima."
 
 c_ylw "Reinicie o app: docker compose $(dc_files) restart app"

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -1916,6 +1916,199 @@ STUB
 ) || fail=1
 rm -rf "$TMP5"
 
+echo "DDL: a conexão do schema é separada da que vai para os contêineres (issue #192)"
+# `SUPABASE_DB_URL` acumulava dois papéis numa string só: ela vai para o `.env`
+# — e o compose entrega o `.env` inteiro ao `app` e ao `worker` (`env_file`) —
+# E era a mesma que rodava `create extension`, o `baseline.sql` e a promoção do
+# dono. Na nuvem passa despercebido: a string do pooler já vem privilegiada. Num
+# Supabase PRÓPRIO trava a primeira instalação, e a única saída era editar o
+# `.env` na mão entre uma etapa e outra (issue #192, achada instalando de verdade).
+#
+# Os dois cenários abaixo são um par, e um sozinho não prova nada: SEM a variável
+# nova nada pode mudar (o parque já instalado), e COM ela o DDL tem de ir por uma
+# string enquanto o `.env` recebe a outra. Só a diferença entre os dois mostra
+# que a resolução existe — um cenário sozinho fica verde com a variável ignorada.
+#
+# A fixture precisa do `supabase/baseline.sql`: sem esse arquivo o install.sh
+# pula a etapa 7 inteira e o log não teria psql nenhum para medir. É por isso que
+# nenhum cenário anterior desta suíte tocava neste caminho.
+
+# As connection strings que chegaram ao psql/pg_dump no cenário, sem repetir.
+strings_de_banco() { grep -oE '(psql|pg_dump) [^ ]+' "$VPS_LOG" | awk '{print $2}' | sort -u; }
+# Idem, tirando a sonda do validador (`psql <url> -tAc select 1`): ela existe
+# justamente para testar a conexão DO APP, então usar a string do app ali é o
+# comportamento certo — é o que a pessoa acabou de responder. Sem esta distinção
+# o caso mediria "trocaram tudo", que é outra coisa (e um defeito).
+strings_de_schema() {
+  grep -E '(psql|pg_dump) ' "$VPS_LOG" | grep -v -- '-tAc select 1$' \
+    | grep -oE '(psql|pg_dump) [^ ]+' | awk '{print $2}' | sort -u
+}
+# Derivada do BASE_ENV, não copiada: duas cópias do mesmo literal desincronizam
+# no dia em que o cenário-base trocar de string, e aí o teste reprova por engano.
+URL_DO_APP="$(printf '%s\n' "$BASE_ENV" | sed -n "s/^SUPABASE_DB_URL='\(.*\)'$/\1/p")"
+URL_DO_DONO='postgresql://supabase_admin:senhadodono@db-proprio.exemplo.com.br:5432/postgres'
+
+TMP_DDL_A="$(mktemp -d)"
+(
+  montar_vps "$TMP_DDL_A" "crmddla" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$DOCKER_LOG"
+case "$1" in
+  compose) case "$*" in *" exec "*) printf 'healthy\n{"data":{"status":"healthy"}}\n' ;; esac; exit 0 ;;
+esac
+exit 0
+STUB
+  mkdir -p "$VPS_PROJ/supabase"; : > "$VPS_PROJ/supabase/baseline.sql"
+  rodar install.sh --yes >/dev/null
+
+  # Vacuidade: sem chamada ao Postgres não há o que medir, e a lista vazia de
+  # "strings erradas" seria lida como aprovação.
+  n="$(grep -cE '(psql|pg_dump) ' "$VPS_LOG")"
+  if [ "${n:-0}" -lt 5 ]; then
+    printf '  ✗ o install.sh falou %s vez(es) com o Postgres — teste inconclusivo, não verde\n' "${n:-0}"
+    printf '     (esperadas: extensões, sonda de schema, baseline, contagem de tabelas, promoção do dono)\n'; exit 1
+  fi
+  vistas="$(strings_de_banco)"
+  if [ "$vistas" != "$URL_DO_APP" ]; then
+    printf '  ✗ sem SUPABASE_DB_ADMIN_URL o kit deixou de usar a string de sempre — quem já instalou quebra:\n'
+    printf '%s\n' "$vistas" | sed 's/^/       /'; exit 1
+  fi
+  printf '  ✓ sem a variável nova: as %s conversas com o Postgres usam a string de sempre\n' "$n"
+) || fail=1
+rm -rf "$TMP_DDL_A"
+
+TMP_DDL_B="$(mktemp -d)"
+(
+  montar_vps "$TMP_DDL_B" "crmddlb" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$DOCKER_LOG"
+case "$1" in
+  compose) case "$*" in *" exec "*) printf 'healthy\n{"data":{"status":"healthy"}}\n' ;; esac; exit 0 ;;
+esac
+exit 0
+STUB
+  mkdir -p "$VPS_PROJ/supabase"; : > "$VPS_PROJ/supabase/baseline.sql"
+  # Pelo AMBIENTE, e não por uma linha no `.env`: é o caminho que NÃO deixa a
+  # credencial do dono no arquivo que o compose entrega aos contêineres. Se o
+  # cenário a declarasse no `.env`, o laço de preservação do install.sh a
+  # copiaria de volta e a asserção de baixo mediria o teste, não o kit.
+  export SUPABASE_DB_ADMIN_URL="$URL_DO_DONO"
+  rodar install.sh --yes >/dev/null
+  unset SUPABASE_DB_ADMIN_URL
+
+  n="$(grep -cE '(psql|pg_dump) ' "$VPS_LOG")"
+  if [ "${n:-0}" -lt 5 ]; then
+    printf '  ✗ o install.sh falou %s vez(es) com o Postgres — teste inconclusivo, não verde\n' "${n:-0}"; exit 1
+  fi
+  vistas="$(strings_de_schema)"
+  if [ "$vistas" != "$URL_DO_DONO" ]; then
+    printf '  ✗ com SUPABASE_DB_ADMIN_URL declarada, o schema NÃO foi por ela:\n'
+    printf '%s\n' "$vistas" | sed 's/^/       /'
+    printf '     esperava só: %s\n' "$URL_DO_DONO"
+    grep -nE '(psql|pg_dump) ' "$VPS_LOG" | sed 's/^/       /'; exit 1
+  fi
+  printf '  ✓ com a variável nova: todo trabalho de schema vai pela conexão do dono\n'
+
+  # O outro lado, e é ele que distingue a correção de um "trocaram tudo": na
+  # MESMA execução, a sonda que confere a connection string do app tem de
+  # continuar usando a do app. Um patch que substituísse a variável em bloco
+  # deixaria a asserção de cima verde e esta vermelha.
+  if ! grep -qF -- "psql $URL_DO_APP -tAc select 1" "$VPS_LOG"; then
+    printf '  ✗ a sonda que valida a conexão do APP deixou de usar a string do app\n'
+    printf '     — ela passaria a aprovar uma credencial que o app nunca vai usar.\n'
+    grep -nE 'psql .* -tAc select 1$' "$VPS_LOG" | sed 's/^/       /'; exit 1
+  fi
+  printf '  ✓ e a conferência da conexão do app continua sendo feita com a do app\n'
+
+  gravada="$(valor_no_env "$VPS_PROJ/.env" SUPABASE_DB_URL)"
+  if [ "$gravada" != "$URL_DO_APP" ]; then
+    printf '  ✗ o .env não recebeu a string do APP: [%s]\n' "$gravada"; exit 1
+  fi
+  printf '  ✓ e o .env continua recebendo a string do app\n'
+
+  # A metade que dá sentido à separação: se a credencial do dono for parar no
+  # `.env`, o compose a entrega ao app e ao worker por `env_file` — e o app volta
+  # a ter na mão o poder que esta issue tirou dele.
+  if grep -q 'SUPABASE_DB_ADMIN_URL' "$VPS_PROJ/.env"; then
+    printf '  ✗ a credencial do DONO foi gravada no .env — o compose a entrega aos contêineres:\n'
+    printf '       %s\n' "$(grep -m1 'SUPABASE_DB_ADMIN_URL' "$VPS_PROJ/.env")"; exit 1
+  fi
+  printf '  ✓ e NÃO grava a do dono no .env (que o compose entregaria aos contêineres)\n'
+) || fail=1
+rm -rf "$TMP_DDL_B"
+
+echo "DDL: o update.sh reaplica o baseline pela conexão do dono"
+# O update.sh é a metade que mais dói e a que ninguém vê: ele roda sozinho pelo
+# cron do agent.sh, e é ele que entrega migration nova ao clone. Com a role menor
+# no `.env` — que é o que `docs/deploy-selfhost/README.md` §2 recomenda — o
+# `baseline.sql` passava a falhar a cada atualização, sem ninguém lendo a tela.
+#
+# Aqui a variável vem do `.env` de propósito: é o único jeito de o cron ter a
+# credencial, e é o que a documentação manda para quem quer atualização sozinha.
+# O backup entra junto (sem `--skip-backup`) porque o `pg_dump` tem o mesmo
+# problema com cara pior: com role menor ele despeja só o que ela enxerga e sai
+# VERDE — backup parcial que só aparece na hora de restaurar.
+TMP_DDL_C="$(mktemp -d)"
+(
+  montar_vps "$TMP_DDL_C" "crmddlc" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$DOCKER_LOG"
+case "$1" in
+  compose) case "$*" in *" exec "*) printf 'healthy\n{"data":{"status":"healthy"}}\n' ;; esac; exit 0 ;;
+esac
+exit 0
+STUB
+  mkdir -p "$VPS_PROJ/supabase"; : > "$VPS_PROJ/supabase/baseline.sql"
+  # O update.sh decide o que instalar por TAG: sem versão publicada ele para
+  # antes do banco, e o teste passaria vazio.
+  (cd "$VPS_PROJ" && git init -q -b main . \
+    && git -c user.email=t@exemplo -c user.name=teste add -A \
+    && git -c user.email=t@exemplo -c user.name=teste commit -qm base \
+    && git tag v9.9.9) >/dev/null 2>&1
+
+  saida="$(rodar update.sh "" "SUPABASE_DB_ADMIN_URL='$URL_DO_DONO'
+INTERNAL_SECRET='segredo-de-teste'
+NEXT_PUBLIC_APP_URL='https://crm.exemplo.com.br'")"
+
+  n_dump="$(grep -cE 'pg_dump ' "$VPS_LOG")"
+  n_psql="$(grep -cE 'psql ' "$VPS_LOG")"
+  if [ "${n_dump:-0}" -lt 1 ] || [ "${n_psql:-0}" -lt 2 ]; then
+    printf '  ✗ o update.sh não chegou ao banco (pg_dump=%s psql=%s) — inconclusivo, não verde\n' \
+      "${n_dump:-0}" "${n_psql:-0}"
+    printf '     última linha da saída: %s\n' "$(printf '%s' "$saida" | tail -1)"; exit 1
+  fi
+  vistas="$(strings_de_banco)"
+  if [ "$vistas" != "$URL_DO_DONO" ]; then
+    printf '  ✗ a atualização não usou a conexão do dono:\n'
+    printf '%s\n' "$vistas" | sed 's/^/       /'; exit 1
+  fi
+  printf '  ✓ baseline (%s psql) e backup (%s pg_dump) pela conexão do dono\n' "$n_psql" "$n_dump"
+) || fail=1
+rm -rf "$TMP_DDL_C"
+
+echo "DDL: nenhum script do kit manda a string do APP para o Postgres"
+# A guarda de CLASSE. Os três cenários acima provam o install.sh e o update.sh
+# pelo comportamento; esta linha alcança os irmãos que nenhuma fixture roda
+# (backup.sh, restore.sh, reset-mfa.sh via psql_run) — onde o mesmo defeito
+# reapareceria sem ninguém ver. Um sítio que volte a `psql "$SUPABASE_DB_URL"`
+# reprova aqui.
+# `--exclude` para não casar as próprias frases deste arquivo — que fala do
+# defeito para explicá-lo, e ficaria eternamente vermelho por citar o que vigia.
+sobrando="$(grep -nE --exclude='test-validators.sh' '(psql|pg_dump) "\$SUPABASE_DB_URL"' ./*.sh 2>/dev/null || true)"
+convertidos="$(grep -hoE --exclude='test-validators.sh' '(psql|pg_dump) "\$\(url_do_schema\)"' ./*.sh 2>/dev/null | grep -c . || true)"
+if [ -n "$sobrando" ]; then
+  printf '  ✗ script do kit ainda manda a string do app para o Postgres:\n'
+  printf '%s\n' "$sobrando" | sed 's/^/       /'
+  fail=1
+elif [ "${convertidos:-0}" -lt 10 ]; then
+  # Vacuidade: uma varredura que não achasse NADA devolveria a mesma lista vazia
+  # de infratores. O número é piso, não igualdade — sítio novo não deve reprovar.
+  printf '  ✗ a varredura só achou %s sítio(s) convertido(s) — ela está cega, não limpa\n' "${convertidos:-0}"
+  fail=1
+else
+  printf '  ✓ %s sítio(s) pela conexão do schema, nenhum pela do app\n' "$convertidos"
+fi
+
 echo "integração: update.sh quando a rede do proxy sumiu"
 # O guard da rede nasceu só no install.sh, e o `dc up -d` do update.sh corre o
 # mesmo risco: a bridge é um artefato como outro qualquer e some num

--- a/hostgator-setup-kit/update.sh
+++ b/hostgator-setup-kit/update.sh
@@ -127,15 +127,19 @@ fi
 # gera erros do tipo "já existe" / "multiple primary keys" — isso é ESPERADO e
 # inofensivo (são objetos que já estavam lá). Filtramos esse ruído e só
 # mostramos problemas de verdade.
+# Re-aplicar o baseline é DDL, então vai por `url_do_schema` (_common.sh) e não
+# pela string do app: numa instalação em Supabase próprio, com a role menor no
+# `.env` como recomendamos, este passo passava a falhar em silêncio a cada
+# atualização — e é o update.sh que entrega migration nova ao clone (issue #192).
 step "Atualizando o banco de dados"
 if [ -f supabase/baseline.sql ]; then
   # Extensões que o schema exige (idempotente; iguais ao install.sh).
-  docker run --rm postgres:17-alpine psql "$SUPABASE_DB_URL" -c \
+  docker run --rm postgres:17-alpine psql "$(url_do_schema)" -c \
     "create extension if not exists vector with schema public; create extension if not exists citext with schema public; create extension if not exists pg_trgm with schema public;" \
     >/dev/null 2>&1 || true
 
   raw="$(docker run --rm -i -v "$PROJECT_DIR/supabase/baseline.sql:/b.sql:ro" \
-        postgres:17-alpine psql "$SUPABASE_DB_URL" -f /b.sql 2>&1 || true)"
+        postgres:17-alpine psql "$(url_do_schema)" -f /b.sql 2>&1 || true)"
 
   # Erros benignos ao re-aplicar sobre uma base existente:
   benign='already exists|multiple primary keys|multiple default values|is already a member|already a partition'
@@ -145,6 +149,11 @@ if [ -f supabase/baseline.sql ]; then
     c_ylw "⚠ Apareceram avisos no banco que NÃO são os esperados:"
     printf '%s\n' "$unexpected" | head -20
     c_ylw "  O app pode ainda funcionar. Se algo estiver errado, restaure o backup (restore.sh)."
+    case "$unexpected" in
+      *permission\ denied*|*must\ be\ owner*|*permissão\ negada*)
+        c_ylw "  Os erros são de PERMISSÃO: a conexão do .env não é o dono do banco. Num Supabase"
+        c_ylw "  próprio, declare SUPABASE_DB_ADMIN_URL no .env — é ela que roda o schema." ;;
+    esac
   else
     c_grn "✓ banco atualizado (e conversas reorganizadas, se havia bagunça)."
   fi

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -63,6 +63,17 @@ const schema = z.object({
   // Postgres direto do Supabase (Settings → Database) — só as rotas de skills
   // instaláveis (import/install) usam `pg` cru (mesmo pool do agent-engine).
   SUPABASE_DB_URL: required("SUPABASE_DB_URL"),
+  /**
+   * A conexão de DDL do KIT (install.sh/update.sh/backup.sh), não do app —
+   * declarada aqui só porque o `docker-compose.prod.yml` entrega o `.env`
+   * inteiro ao app e ao worker (`env_file`), e uma chave que chega ao processo
+   * merece estar no contrato em vez de ser um desconhecido tolerado.
+   *
+   * NENHUM código de app pode lê-la: ela é o DONO do banco quando a instalação
+   * é num Supabase próprio, e `SUPABASE_DB_URL` é a role menor de propósito
+   * (issue #192). Vigiado por `tests/unit/env-ddl-fora-do-app.test.ts`.
+   */
+  SUPABASE_DB_ADMIN_URL: z.string().optional().default(""),
 
   // WAHA
   WAHA_API_BASE_URL: required("WAHA_API_BASE_URL"),

--- a/tests/unit/env-ddl-fora-do-app.test.ts
+++ b/tests/unit/env-ddl-fora-do-app.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const RAIZ = process.cwd();
+
+/**
+ * `SUPABASE_DB_ADMIN_URL` é a conexão de DDL do KIT (issue #192): num Supabase
+ * próprio ela é o DONO do banco, enquanto `SUPABASE_DB_URL` é a role menor que
+ * o app usa — a separação inteira existe para que o app NÃO tenha esse poder.
+ *
+ * Só que o `docker-compose.prod.yml` entrega o `.env` inteiro ao `app` e ao
+ * `worker` (`env_file: .env`), e `lib/env.ts` a declara. Ou seja: a chave está
+ * ao alcance da mão de qualquer código do app, e um `env.SUPABASE_DB_ADMIN_URL`
+ * escrito por engano devolveria ao processo exatamente o privilégio que a
+ * issue tirou dele — sem erro nenhum, porque funciona.
+ *
+ * O comentário em `lib/env.ts` pede que ninguém a use. Este arquivo é a guarda:
+ * comentário não reprova build.
+ */
+const RAIZES = ["app", "components", "lib", "workers", "hooks"];
+/** O único lugar que pode nomeá-la: a declaração do contrato de ambiente. */
+const DECLARACAO = "lib/env.ts";
+
+function arquivosVarridos(dir: string): string[] {
+  const alvos: string[] = [];
+  for (const entrada of fs.readdirSync(path.join(RAIZ, dir), { withFileTypes: true })) {
+    const rel = path.posix.join(dir, entrada.name);
+    if (entrada.isDirectory()) alvos.push(...arquivosVarridos(rel));
+    else if (rel.endsWith(".ts") || rel.endsWith(".tsx")) alvos.push(rel);
+  }
+  return alvos;
+}
+
+describe("a conexão de DDL não vaza para o código do app", () => {
+  const porRaiz = new Map(RAIZES.map((r) => [r, arquivosVarridos(r)]));
+  const alvos = [...porRaiz.values()].flat();
+  const citam = alvos.filter((f) =>
+    fs.readFileSync(path.join(RAIZ, f), "utf8").includes("SUPABASE_DB_ADMIN_URL"),
+  );
+
+  it("a varredura alcança as cinco raízes e enxerga a chave onde ela está", () => {
+    // Vacuidade em dois eixos: uma varredura que não descesse em lugar nenhum
+    // devolveria a mesma lista vazia de infratores, e uma que descesse sem saber
+    // procurar a string também. A declaração em lib/env.ts é o controle
+    // positivo — se ela não aparecer, a sonda está cega e o resto não vale.
+    for (const [raiz, arquivos] of porRaiz) {
+      expect(arquivos.length, `${raiz}/ não devolveu arquivo nenhum`).toBeGreaterThan(0);
+    }
+    expect(citam).toContain(DECLARACAO);
+  });
+
+  it("nenhum arquivo além da declaração nomeia SUPABASE_DB_ADMIN_URL", () => {
+    expect(citam.filter((f) => f !== DECLARACAO)).toEqual([]);
+  });
+});


### PR DESCRIPTION
`SUPABASE_DB_URL` acumulava dois papéis. Ela vai para o `.env`, e o
`docker-compose.prod.yml` entrega o `.env` inteiro ao `app` e ao `worker`
(`env_file`) — e era a MESMA string que rodava `create extension`, o
`baseline.sql`, a promoção do dono e o `pg_dump` do backup.

Na nuvem não dói: a string do pooler já vem privilegiada. Num Supabase próprio
dói na primeira instalação — e dói justamente em quem seguiu a nossa
documentação, porque `docs/deploy-selfhost/README.md` §2 recomenda criar uma
role dedicada e apontar `SUPABASE_DB_URL` para ela. A doutrina escrita e o
instalador discordavam, e a saída era editar o `.env` na mão entre uma etapa e
outra (issue #192, achada por @ygorebos instalando numa VPS).

Agora são duas: `SUPABASE_DB_URL` (o app) e `SUPABASE_DB_ADMIN_URL` (o schema),
a segunda OPCIONAL e caindo na primeira quando ausente ou vazia — quem já
instalou não muda de comportamento, e o `.env` continua recebendo só a do app.

A resolução é a função `url_do_schema` em `_common.sh`, e ser função é
load-bearing: o `_common.sh` é *sourced* ANTES do `load_env` nos dois scripts e
abre com `set -euo pipefail`, então uma atribuição no topo mataria o kit inteiro
em "variável não associada" — e, com guarda, congelaria vazia, fazendo todo
sítio de DDL rodar `psql ""`.

11 sítios convertidos, e não só os 8 do install/update: `psql_run` (que mexe em
`auth.mfa_factors` e `private.app_secrets`), o `pg_dump` do `backup.sh` — que
com role menor despeja só o que ela enxerga e sai VERDE, backup parcial que só
aparece na hora de restaurar — e o `psql` do `restore.sh`.

Testes: 7 casos novos em `test-validators.sh` (o par sem/com a variável, o
update.sh pelo dono, e a varredura de classe) e uma guarda unitária de que
nenhum código de app lê a chave nova.

---

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3qmqo4AZU1NFSz9oNPzke