### PR TITLE
test(marca): a spec media a prévia numa tela que o login dela já tinha trocado

### DIFF
--- a/tests/e2e/marca-logo.spec.ts
+++ b/tests/e2e/marca-logo.spec.ts
@@ -140,24 +140,87 @@ const SVG_DISFARCADO = Buffer.from(
 
 // ── Helpers de tela ─────────────────────────────────────────────────────────
 
+/**
+ * Entra com senha + TOTP, e só volta quando a tentativa TERMINOU.
+ *
+ * ⚠️ O LAÇO ANTERIOR DESISTIA NO RELÓGIO E REDIGITAVA EM CIMA DE UMA TELA QUE
+ * JÁ TINHA IDO EMBORA. Ele esperava a URL virar `/app/…` por 8s e, no estouro,
+ * dormia até a janela do TOTP virar e clicava em `Dígito 1` de novo. Mas 8s é um
+ * palpite sobre a MÁQUINA, não sobre o produto: numa máquina carregada o
+ * `verifyMfa` demora mais que isso e o código entra DEPOIS do estouro — aí a
+ * página já é `/app/inbox`, `input[aria-label="Dígito 1"]` não existe mais, e
+ * como `playwright.config.ts` não define `actionTimeout` (o default do
+ * Playwright é 0, ou seja SEM teto) esse clique espera até o timeout do CASO.
+ *
+ * MEDIDO neste worktree, com o mesmo laço antigo numa sonda que replica o caso
+ * (1) sob `Emulation.setCPUThrottlingRate` — 2 reprovações em 18 execuções
+ * (rate 8 e rate 4), as duas idênticas:
+ *
+ *   Error: locator.click: Test timeout of 180000ms exceeded.
+ *     - waiting for locator('input[aria-label="Dígito 1"]')
+ *   NAV http://localhost:3001/app/inbox   (+30862ms)
+ *   FIM url=http://localhost:3001/app/inbox
+ *
+ * E a captura do momento da falha é a CASCA DO TENANT (`navigation
+ * "Navegação principal"`, "Inbox" sob "Atendimento") — exatamente o
+ * `test-failed-1.png` que a issue #274 descreve como "o navegador está no inbox
+ * do tenant, não em /admin/marca". Não há desvio de modo no produto: quem larga
+ * a página lá é este helper.
+ *
+ * O conserto não é um teto maior — um relógio maior continua sendo um relógio.
+ * É esperar um ESTADO TERMINAL, e só existem dois depois de digitar os 6
+ * dígitos: ou a sessão subiu (a URL vira `/app/…`), ou o formulário disse não
+ * (`MfaForm.tsx` renderiza um `role="alert"` dentro do `<form>`; o `TOTPInput`
+ * fica `disabled` enquanto a ação está em voo, então antes disso NENHUM dos
+ * dois é verdade). Os dois são disjuntos: o sucesso redireciona sem nunca
+ * escrever o alerta, e a recusa nunca troca a URL.
+ *
+ * A única espera por relógio que fica é a da JANELA do TOTP, e ela não é aposta
+ * na máquina: dentro da mesma janela de 30s o `generateTotp` devolve o MESMO
+ * código que o servidor acabou de recusar, então o que muda o próximo código é
+ * o relógio do protocolo, e só ele.
+ */
 async function loginComTotp(page: Page, email: string, secret: string): Promise<void> {
   await page.goto("/login");
   await page.locator("#email").fill(email);
   await page.locator("#password").fill(creds.password);
-  await page.getByRole("button", { name: /entrar/i }).click();
+  await page.getByRole("button", { name: /entrar/i }).click({ timeout: 15_000 });
   await page.waitForURL(/\/login\/mfa/);
+
+  const digito1 = page.locator('input[aria-label="Dígito 1"]');
+  // Escopado no `<form>` de propósito: o `<Toaster/>` do layout raiz também
+  // emite elementos com papel de aviso, e um toast de outra tela seria lido
+  // aqui como recusa do desafio.
+  const recusa = page.locator("form").getByRole("alert");
+
   for (let tentativa = 0; tentativa < 2; tentativa++) {
     if (msUntilNextTotpWindow() < 3_000) await page.waitForTimeout(msUntilNextTotpWindow() + 200);
-    await page.locator('input[aria-label="Dígito 1"]').click();
+    // Teto EXPLÍCITO no clique: sem `actionTimeout` no config, um controle que
+    // sumiu esperaria até o timeout do caso e a reprovação sairia como "Test
+    // timeout" apontando para o clique — sem dizer que o login já tinha entrado.
+    await digito1.click({ timeout: 15_000 });
     await page.keyboard.type(generateTotp(secret), { delay: 40 });
-    try {
-      await page.waitForURL(/\/app\//, { timeout: 8_000 });
-      return;
-    } catch {
-      await page.waitForTimeout(msUntilNextTotpWindow() + 200);
+
+    const desfecho = await Promise.race([
+      page.waitForURL(/\/app\//, { timeout: 60_000 }).then(
+        () => "entrou" as const,
+        () => "sem-desfecho" as const,
+      ),
+      recusa.waitFor({ state: "visible", timeout: 60_000 }).then(
+        () => "recusado" as const,
+        () => "sem-desfecho" as const,
+      ),
+    ]);
+    if (desfecho === "entrou") return;
+    if (desfecho === "sem-desfecho") {
+      throw new Error(
+        `o desafio de MFA de ${email} não terminou em 60s: a URL não virou /app/… ` +
+          `e o formulário não recusou. url=${page.url()}`,
+      );
     }
+    await page.waitForTimeout(msUntilNextTotpWindow() + 200);
   }
-  throw new Error(`MFA falhou depois de 2 tentativas para ${email}`);
+  throw new Error(`MFA falhou depois de 2 tentativas para ${email} (url=${page.url()})`);
 }
 
 type Escopo = "instalacao" | "organizacao";
@@ -297,6 +360,35 @@ function baixou(logo: LogoNaTela, onde: string): void {
 }
 
 /**
+ * Prova que a medição SEGUINTE acontece na tela que o caso diz medir.
+ *
+ * ⚠️ O TOAST NÃO PROVA ISSO, e é essa confusão que a issue #274 custou. O
+ * `<Toaster/>` mora no layout RAIZ (`app/layout.tsx`), irmão de `{children}` e
+ * com `duration={4000}`: ele sobrevive a qualquer troca de rota do lado do
+ * cliente. E `enviar()` (`CampoDeLogo.tsx`) chama `toast.success` de dentro de
+ * uma função async solta — o toast aparece mesmo que o campo JÁ tenha
+ * desmontado. Ou seja "Logo atualizado." verde + prévia ausente é EXATAMENTE o
+ * que se vê quando a página não é mais a de marca, e sem esta âncora a
+ * reprovação sai como `element(s) not found`, que manda quem lê procurar
+ * defeito na prévia — que foi o que aconteceu.
+ *
+ * Mesma lição de `logoDaBarra()` logo acima, aplicada ao outro lado da tela: a
+ * asserção não fica mais frouxa (a prévia continua sendo exigida), ela só passa
+ * a dizer QUAL das duas coisas aconteceu.
+ */
+async function aindaNaTelaDeMarca(page: Page, rota: RegExp, escopo: Escopo): Promise<void> {
+  await expect(
+    page,
+    `a página não é mais ${rota} — url=${page.url()}. O toast de sucesso não desmente ` +
+      `isto: ele mora no layout raiz e sobrevive à troca de rota.`,
+  ).toHaveURL(rota, { timeout: 15_000 });
+  await expect(
+    page.locator(`[data-campo-de-logo='${escopo}']`),
+    `a rota é ${rota} mas o campo de logo da camada "${escopo}" não está montado`,
+  ).toBeAttached({ timeout: 15_000 });
+}
+
+/**
  * O logo da FACHADA (as telas de antes de entrar), visto por quem não entrou.
  *
  * O seletor é o `data-testid` do `<img>` de `app/(public)/layout.tsx`, e não "a
@@ -391,6 +483,11 @@ test.describe("o logo subido pela tela chega à tela", () => {
     // foi afrouxada em nada — continua exigindo `<img>` na prévia; o que mudou é
     // que o produto passou a prometê-la de forma determinística. Os 15s ficam
     // como folga de máquina carregada, não como aposta no refresh.
+    //
+    // A ÂNCORA VEM ANTES DA MEDIÇÃO, e não é zelo: o toast acima é do layout
+    // raiz e sobrevive à troca de rota, então ele sozinho não prova que ainda
+    // estamos aqui. Ver `aindaNaTelaDeMarca` (issue #274).
+    await aindaNaTelaDeMarca(page, /\/admin\/marca(\/|$)/, "instalacao");
     await expect(page.locator("[data-previa-do-logo='claro'] img")).toBeVisible({
       timeout: 15_000,
     });

--- a/tests/unit/marca-logo-spec-ancora-a-rota.test.ts
+++ b/tests/unit/marca-logo-spec-ancora-a-rota.test.ts
@@ -1,0 +1,139 @@
+/**
+ * A SPEC DO LOGO NÃO PODE MEDIR UMA TELA QUE JÁ TROCOU — NEM ESPERAR SEM TETO.
+ *
+ * ── O defeito que este arquivo guarda (issue #274) ──────────────────────────
+ *
+ * O caso (1) de `tests/e2e/marca-logo.spec.ts` reprovou 2 de 3 execuções de CI
+ * com `element(s) not found` na prévia, e a captura do momento da falha estava
+ * na CASCA DO TENANT — não em `/admin/marca`. A leitura natural ("o produto tem
+ * um desvio de modo plataforma↔tenant") não se sustenta: nenhum `redirect` para
+ * rota de tenant existe fora de `app/app/**`, o `proxy.ts` só desvia `/admin/*`
+ * para `/login` ou `/admin/forbidden`, e o fallback de MPA do Next devolve a URL
+ * ORIGINAL. Quem larga a página no tenant é o próprio helper de login da spec.
+ *
+ * MEDIDO neste repositório, com o helper ANTIGO numa sonda que replica o caso
+ * (1) sob `Emulation.setCPUThrottlingRate` — 2 reprovações em 18 execuções:
+ *
+ *   Error: locator.click: Test timeout of 180000ms exceeded.
+ *     - waiting for locator('input[aria-label="Dígito 1"]')
+ *   FIM url=http://localhost:3001/app/inbox
+ *
+ * A cadeia: `waitForURL(/\/app\//, { timeout: 8_000 })` desiste enquanto o
+ * `verifyMfa` ainda está em voo; o código entra depois; a página vira
+ * `/app/inbox`; a retentativa clica num `Dígito 1` que não existe mais; e como
+ * `playwright.config.ts` não define `actionTimeout` (default 0 = SEM teto), esse
+ * clique espera até o timeout do caso.
+ *
+ * ── Por que a guarda é sobre o TEXTO da spec ────────────────────────────────
+ *
+ * O artefato consertado é um TESTE. Não há como cobri-lo por comportamento sem
+ * subir o mesmo rig que ele mesmo é (Supabase local + build + Playwright), que é
+ * o que o job `e2e` faz uma vez por PR e o `test:unit` não faz nunca. A régua
+ * possível aqui é a fonte — mesmo caminho de `tests/unit/branding.test.ts` e
+ * `tests/unit/e2e-cobertura-completa.test.ts`. O que ela cobra são PROPRIEDADES
+ * (esperar estado terminal, ter teto, ancorar a rota antes de medir), não a
+ * escrita exata das linhas.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const RAIZ = process.cwd();
+const CAMINHO_SPEC = path.join(RAIZ, "tests/e2e/marca-logo.spec.ts");
+const CAMINHO_CONFIG = path.join(RAIZ, "playwright.config.ts");
+
+const SPEC = readFileSync(CAMINHO_SPEC, "utf8");
+const CONFIG = readFileSync(CAMINHO_CONFIG, "utf8");
+
+/** O corpo de uma função de topo de arquivo, do `{` ao `\n}` da coluna zero. */
+function corpoDaFuncao(fonte: string, assinatura: string): string {
+  const inicio = fonte.indexOf(assinatura);
+  expect(inicio, `não achei \`${assinatura}\` em ${CAMINHO_SPEC}`).toBeGreaterThan(-1);
+  const fim = fonte.indexOf("\n}\n", inicio);
+  expect(fim, `\`${assinatura}\` não fecha na coluna zero`).toBeGreaterThan(inicio);
+  return fonte.slice(inicio, fim);
+}
+
+describe("marca-logo.spec.ts: o desafio de MFA espera um estado terminal", () => {
+  const corpo = corpoDaFuncao(SPEC, "async function loginComTotp(");
+
+  it("decide por corrida entre os DOIS desfechos, e não por relógio", () => {
+    expect(
+      corpo,
+      "sem `Promise.race`, o helper voltou a apostar num relógio para decidir se o " +
+        "login entrou — que é o defeito da issue #274",
+    ).toContain("Promise.race");
+    expect(
+      corpo,
+      "a recusa do formulário (`role=alert` do MfaForm) é um dos dois estados terminais; " +
+        "sem ela a corrida tem um lado só e volta a ser um relógio",
+    ).toContain('getByRole("alert")');
+  });
+
+  it("não redigita um código antes de a tentativa anterior terminar", () => {
+    // Uma segunda digitação por caminho de exceção é a assinatura exata do
+    // helper antigo: `try { waitForURL } catch { dorme; redigita }`.
+    expect(
+      corpo.match(/page\.keyboard\.type\(/g)?.length ?? 0,
+      "o helper voltou a ter mais de um ponto de digitação fora do laço de tentativas",
+    ).toBe(1);
+    expect(
+      corpo,
+      "o `catch` que engolia o estouro do `waitForURL` voltou: ele é o que permitia " +
+        "digitar por cima de uma tela que já tinha navegado",
+    ).not.toMatch(/}\s*catch\s*(\([^)]*\))?\s*{/);
+  });
+
+  it("nenhuma espera pela URL aposta num teto curto", () => {
+    for (const chamada of corpo.match(/waitForURL\([^;]*?\)/gs) ?? []) {
+      const teto = chamada.match(/timeout:\s*([0-9_]+)/);
+      if (!teto) continue;
+      expect(
+        Number(teto[1]!.replace(/_/g, "")),
+        `\`${chamada.replace(/\s+/g, " ")}\` desiste cedo demais: numa máquina carregada ` +
+          "o verifyMfa demora mais que isso e a página navega depois do estouro",
+      ).toBeGreaterThanOrEqual(30_000);
+    }
+  });
+
+  it("todo clique tem teto — o config do Playwright não dá nenhum", () => {
+    const configTemTeto = /actionTimeout\s*:/.test(CONFIG);
+    if (configTemTeto) return; // o teto passou a vir do config; a guarda local perde a razão
+    for (const clique of corpo.match(/\.click\([^)]*\)/g) ?? []) {
+      expect(
+        clique,
+        "sem `actionTimeout` no playwright.config.ts (default 0 = sem teto), um clique sem " +
+          "teto próprio espera até o timeout do CASO quando o controle sumiu",
+      ).toMatch(/timeout:\s*[0-9_]+/);
+    }
+  });
+});
+
+describe("marca-logo.spec.ts: a prévia só é medida depois de a rota ser provada", () => {
+  it("a âncora fica ENTRE o toast de sucesso e a medição da prévia", () => {
+    const iPrevia = SPEC.indexOf("[data-previa-do-logo='claro'] img");
+    expect(iPrevia, "não achei a medição da prévia clara").toBeGreaterThan(-1);
+
+    const iToast = SPEC.lastIndexOf("logo atualizado", iPrevia);
+    expect(iToast, "não achei a asserção do toast antes da prévia").toBeGreaterThan(-1);
+
+    const iAncora = SPEC.lastIndexOf("aindaNaTelaDeMarca(page", iPrevia);
+    expect(
+      iAncora,
+      "a prévia é medida sem provar a rota antes. O toast NÃO serve de âncora: o " +
+        "`<Toaster/>` mora no layout raiz e sobrevive à troca de rota, então " +
+        '"Logo atualizado" verde + prévia ausente é o que se vê quando a página já é outra',
+    ).toBeGreaterThan(iToast);
+  });
+
+  it("a âncora prova a URL E o campo montado", () => {
+    const corpo = corpoDaFuncao(SPEC, "async function aindaNaTelaDeMarca(");
+    expect(corpo, "a âncora parou de provar a rota").toContain("toHaveURL");
+    expect(
+      corpo,
+      "a âncora parou de provar que o campo de logo está montado — só a URL deixaria passar " +
+        "uma casca trocada na mesma rota",
+    ).toContain("toBeAttached");
+  });
+});


### PR DESCRIPTION
A issue #274 reportou o caso (1) de `marca-logo.spec.ts` reprovando 2 de 3
execuções com `element(s) not found` na prévia, e a captura do momento da
falha na casca do TENANT — não em `/admin/marca`. A pergunta aberta era se
isso é corrida do teste ou desvio de modo do produto.

É corrida do teste, e ela mora no helper de login.

MEDIDO, com o helper antigo numa sonda que replica o caso (1) sob
`Emulation.setCPUThrottlingRate` — 2 reprovações em 18 execuções (rate 8 e
rate 4), as duas idênticas:

  Error: locator.click: Test timeout of 180000ms exceeded.
    - waiting for locator('input[aria-label="Dígito 1"]')
  NAV http://localhost:3001/app/inbox   (+30862ms)
  FIM url=http://localhost:3001/app/inbox

e a captura da falha é `navigation "Navegação principal"` com "Inbox" sob
"Atendimento" — a casca do tenant que a issue descreve. A cadeia:
`waitForURL(/\/app\//, { timeout: 8_000 })` desiste enquanto o `verifyMfa`
ainda está em voo; o código entra depois; a página vira `/app/inbox`; a
retentativa clica num `Dígito 1` que não existe mais; e como
`playwright.config.ts` não define `actionTimeout` (default 0 = sem teto),
esse clique espera até o timeout do caso.

O conserto não é um teto maior — relógio maior continua sendo relógio. O
laço passa a esperar um ESTADO TERMINAL, e só há dois depois de digitar os
6 dígitos: a URL vira `/app/…` (entrou) ou o `<form>` mostra o `role=alert`
(recusou). São disjuntos, e nenhum é um relógio. A única espera por tempo
que fica é a da janela de 30s do TOTP, que é o que muda o próximo código.

E a segunda metade: o toast NÃO prova a rota. O `<Toaster/>` mora no layout
raiz (`app/layout.tsx`), irmão de `{children}`, `duration={4000}`, e
`enviar()` chama `toast.success` de uma função async solta — o toast aparece
mesmo com o campo já desmontado. "Logo atualizado" verde + prévia ausente é
exatamente o que se vê quando a página já é outra. A prévia agora é medida
depois de `aindaNaTelaDeMarca()`, que prova URL + campo montado, mesma
lição que `logoDaBarra()` já tinha aprendido do outro lado da tela.

Duas correções à leitura da issue, medidas:

- `test-failed-2.png` NÃO é uma retentativa: `retries: 0`. Reproduzido num
  Playwright mínimo — um caso que falha num describe serial gera
  `test-failed-1.png` da própria página e `test-failed-2.png` da página
  criada no `test.afterAll`, mesmo quando o hook PASSA. Aquela captura em
  `/admin/marca` com "No file chosen" é a limpeza, não evidência da falha.
- Não há desvio de modo plataforma↔tenant no produto: todo `redirect` para
  rota de tenant vive em `app/app/**`; `proxy.ts` só desvia `/admin/*` para
  `/login` ou `/admin/forbidden`; `requirePlatformAdmin` idem; e o fallback
  de MPA do Next devolve a URL ORIGINAL (`fetch-server-response.js:242`).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V3qmqo4AZU1NFSz9oNPzke

---

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3qmqo4AZU1NFSz9oNPzke