### PR TITLE
fix(pacing): domingo deixa de vetar por default — e a regra ganha a guarda que nunca teve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ DeskcommCRM é um sistema operacional de vendas open source com agentes de IA na
 - Engine NOWEB default; WEBJS apenas se precisar stickers animados / botões
 - Auth: env do WAHA recebe **hash SHA512 hex** da api key; cliente envia plaintext em `X-Api-Key`
 - Webhooks: HMAC SHA512 com `crypto.timingSafeEqual`
-- Anti-banimento: throttle 1 msg/1.2s + jitter ≤800ms. Campanha 1 msg/5s. Warm-up 7-14d. Spinning de copy. Janela 7h-22h, evitar domingo
+- Anti-banimento: throttle 1 msg/1.2s + jitter ≤800ms. Campanha 1 msg/5s. Warm-up 7-14d. Spinning de copy. Janela 7h-22h (domingo LIBERADO por default desde 2026-08-20; a janela é knob por canal)
 - STOP detection: regex `/STOP|PARAR|SAIR|UNSUBSCRIBE/i` no inbound → `is_blocked=true` automaticamente
 - Mídia: subir pro Supabase Storage primeiro, passar URL ao WAHA (não inline base64)
 - Multi-device: assinar `message.any` (não só `message`); tratar `fromMe=true` sem duplicar

--- a/components/connections/AntiBanSheet.tsx
+++ b/components/connections/AntiBanSheet.tsx
@@ -206,7 +206,8 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
             <div>
               <Label htmlFor="allow-sunday">Enviar aos domingos</Label>
               <p className="text-xs text-muted-foreground">
-                Desligado por padrão: envio em domingo aumenta o risco de denúncia e bloqueio.
+                Ligado por padrão: quem escreve no domingo espera resposta no domingo. Desligue
+                se você faz prospecção ativa e prefere não incomodar no fim de semana.
               </p>
             </div>
             <Switch

--- a/docs/business-rules/00-business-rules-catalog.md
+++ b/docs/business-rules/00-business-rules-catalog.md
@@ -201,11 +201,13 @@ owner: Rafael Melgaço
 - **Enforcement**: Worker de envio + counter Redis por sessão.
 - **Override**: Tenant admin com aprovação de super-admin pode aumentar limite — ação auditada com justificativa.
 
-### W-07 — Janela horária default 7h-22h, sem domingo
-- **Origem**: Sub-PRD 03 §3.7
+### W-07 — Janela horária default 7h-22h, domingo LIBERADO
+- **Origem**: Sub-PRD 03 §3.7; domingo revisto pelo dono do produto em 2026-08-20
 - **Tipo**: Default com override
-- **Regra**: GIVEN automação tentando envio outbound; WHEN hora local do tenant está fora de 7h-22h OU dia é domingo; THEN o envio é enfileirado pra próximo horário válido.
-- **Enforcement**: Worker de envio.
+- **Regra**: GIVEN automação tentando envio outbound; WHEN hora local do tenant está fora de 7h-22h; THEN o envio é enfileirado pra próximo horário válido. **Domingo não veta** por default (`allowSunday: true`).
+- **Por que o domingo saiu do veto**: a janela horária é CORTESIA, não anti-banimento — a distinção está em `lib/agent-engine/pacing/engine.ts` (o `banRisk` desarma warm-up, cap e throttle; a janela vale em todo canal). Calar o domingo INTEIRO num CRM de atendimento significa que quem escreve no domingo só é respondido na segunda: o custo cai sobre o cliente final, não sobre o risco de bloqueio. Quem faz prospecção ativa e prefere não incomodar no fim de semana desliga o knob.
+- **Enforcement**: Worker de envio (`decidePacing`).
+- **Configuração**: por canal, em Conexões → anti-banimento (`components/connections/AntiBanSheet.tsx` → `POST /api/v1/ai/pacing`), coluna `channel_knobs.allow_sunday`. `null` = default.
 - **Override**: Atendente humano envia manualmente sem restrição (a regra é pra automações em massa).
 
 ### W-08 — Mídia outbound vai pra Storage, NUNCA inline base64

--- a/docs/prd/03-prd-whatsapp-waha.md
+++ b/docs/prd/03-prd-whatsapp-waha.md
@@ -238,7 +238,7 @@ A janela de 24h da Meta (envio proativo só com template aprovado fora da janela
 - Envio em lote de 100 mensagens leva no mínimo `100 × (1.2s + jitter médio 0.4s)` ≈ 160s, não menos
 - Tentativa de criar campanha com 3 variações de copy retorna 422 `min_5_variations_required`
 - Inbound "PARAR" marca contato como bloqueado em <2s e bloqueia próximas tentativas de envio automático
-- Envio automático fora de janela (ex: domingo 23h) é enfileirado pra próxima janela válida, não enviado
+- Envio automático fora de janela (ex: 23h de qualquer dia) é enfileirado pra próxima janela válida, não enviado. **Domingo não veta por default** desde 2026-08-20 — ver W-07 em `docs/business-rules/00-business-rules-catalog.md`
 - Número novo bloqueado de campanha durante 7 dias após conexão (configurável até 14)
 
 ### 3.8 Multi-número por tenant

--- a/lib/agent-engine/pacing/defaults.ts
+++ b/lib/agent-engine/pacing/defaults.ts
@@ -24,7 +24,14 @@ export interface PacingKnobs {
   /** Janela horária de envio [start, end) na hora local do tenant. */
   windowStartHour: number;
   windowEndHour: number;
-  /** Domingo é evitado por default. */
+  /**
+   * Enviar aos domingos. **Ligado por default** — a janela horária cala à noite,
+   * e o domingo inteiro mudo era cortesia demais: num CRM de atendimento, quem
+   * escreve no domingo espera resposta no domingo.
+   *
+   * Continua sendo knob por canal (`AntiBanSheet` → `POST /api/v1/ai/pacing`):
+   * quem faz prospecção ativa e prefere não incomodar no fim de semana desliga.
+   */
   allowSunday: boolean;
   /** IANA timezone do tenant — a janela é avaliada NELA. */
   timezone: string;
@@ -52,7 +59,7 @@ export const PACING_DEFAULTS: PacingKnobs = {
   jitterMaxMs: 800,
   windowStartHour: 7, // janela 7h-22h
   windowEndHour: 22,
-  allowSunday: false,
+  allowSunday: true,
   timezone: 'America/Sao_Paulo',
   // Número sem linha em channel_knobs é tratado como idade 0 (o degrau mais
   // conservador) até alguém registrar number_activated_at.

--- a/tests/unit/janela-domingo-e-knob.test.ts
+++ b/tests/unit/janela-domingo-e-knob.test.ts
@@ -1,0 +1,77 @@
+/**
+ * W-07: a janela horária cala à noite; o DOMINGO não veta por default.
+ *
+ * A regra mudou em 2026-08-20 (decisão do dono do produto) e a metade do
+ * domingo **não tinha nenhuma guarda de comportamento**: medido antes de
+ * mexer, virar `allowSunday` de `false` para `true` não deixava um único teste
+ * vermelho. Um default de regra de negócio sem teste é um default que volta
+ * sozinho no próximo refactor.
+ *
+ * O raciocínio da mudança: a janela horária é CORTESIA, não anti-banimento (a
+ * distinção é o `banRisk` de `engine.ts`). Calar o domingo INTEIRO num CRM de
+ * atendimento faz quem escreve no domingo só ser respondido na segunda — o
+ * custo cai sobre o cliente final, não sobre o risco de bloqueio. Quem faz
+ * prospecção ativa e prefere não incomodar no fim de semana desliga o knob,
+ * que continua existindo e é testado aqui.
+ */
+import { describe, expect, it } from "vitest";
+
+import { PACING_DEFAULTS } from "@/lib/agent-engine/pacing/defaults";
+import { decidePacing } from "@/lib/agent-engine/pacing/engine";
+
+/** 2026-08-23 é DOMINGO. 13h UTC = 10h BRT, dentro da janela 7h-22h. */
+const DOMINGO_COMERCIAL = new Date("2026-08-23T13:00:00Z");
+/** Mesmo domingo, 06h UTC = 03h BRT — fora da janela por HORA, não por dia. */
+const DOMINGO_MADRUGADA = new Date("2026-08-23T06:00:00Z");
+/** Terça, 10h BRT — controle. */
+const TERCA_COMERCIAL = new Date("2026-07-28T13:00:00Z");
+
+function input(now: Date, over: Partial<typeof PACING_DEFAULTS> = {}) {
+  return {
+    now,
+    knobs: { ...PACING_DEFAULTS, ...over },
+    state: { lastSentAt: null, sentToday: 0, numberActivatedAt: null },
+    crmDailyLimit: null,
+    banRisk: false, // isola a JANELA: sem isto o cap de warm-up (20) mascararia o veto
+    rng: () => 0,
+  };
+}
+
+describe("W-07 — domingo não veta por default", () => {
+  it("o default é `allowSunday: true` — se alguém o virar, este caso cai", () => {
+    expect(PACING_DEFAULTS.allowSunday).toBe(true);
+  });
+
+  it("domingo dentro da janela horária: PASSA", () => {
+    expect(decidePacing(input(DOMINGO_COMERCIAL)).allow).toBe(true);
+  });
+
+  it("controle: terça dentro da janela também passa — o caso acima não passou por acidente", () => {
+    expect(decidePacing(input(TERCA_COMERCIAL)).allow).toBe(true);
+  });
+
+  it("domingo de madrugada: veta por HORA, e o motivo não fala em domingo", () => {
+    const d = decidePacing(input(DOMINGO_MADRUGADA));
+    expect(d.allow).toBe(false);
+    if (d.allow) return;
+    expect(d.code).toBe("outside_window");
+    expect(d.reason).not.toContain("sem domingo");
+  });
+});
+
+describe("o knob continua existindo — quem faz prospecção desliga", () => {
+  it("com `allowSunday: false` explícito, domingo comercial é VETADO", () => {
+    const d = decidePacing(input(DOMINGO_COMERCIAL, { allowSunday: false }));
+    expect(d.allow).toBe(false);
+    if (d.allow) return;
+    expect(d.code).toBe("outside_window");
+    expect(d.reason).toContain("sem domingo");
+  });
+
+  it("e o próximo horário permitido cai FORA do domingo", () => {
+    const d = decidePacing(input(DOMINGO_COMERCIAL, { allowSunday: false }));
+    if (d.allow) throw new Error("deveria ter vetado");
+    // Em America/Sao_Paulo (UTC-3): segunda 07h local = 10h UTC.
+    expect(d.nextAllowedAt.getUTCDay(), "não pode reagendar para outro domingo").not.toBe(0);
+  });
+});


### PR DESCRIPTION
Decisão do dono do produto (2026-08-20), saída da triagem do #267.

## A decisão

A janela horária é **cortesia**, não anti-banimento. A distinção já está no código — `banRisk` em `lib/agent-engine/pacing/engine.ts:37-43` desarma warm-up, cap diário e throttle+jitter onde não há risco de ban, e mantém a janela horária valendo em todo canal.

Calar o **domingo inteiro** num CRM de **atendimento** significa que quem escreve no domingo só é respondido na segunda de manhã. O custo cai sobre o cliente final, não sobre o risco de bloqueio.

- `allowSunday` passa a **`true`** por default.
- A janela horária (7h–22h) **fica** — cala à noite, como antes.
- Continua sendo **knob por canal**: quem faz prospecção ativa e prefere não incomodar no fim de semana desliga em Conexões → anti-banimento (`AntiBanSheet` → `POST /api/v1/ai/pacing`, coluna `channel_knobs.allow_sunday`).

## O que o PR revelou: a regra não tinha guarda

Medido **antes** de mexer: virar o default de `false` para `true` **não deixou um único teste vermelho**. `tests/unit/pacing-cortesia-vs-antiban.test.ts` cita "domingo" apenas num comentário, e os dois outros arquivos que tocam `allow_sunday` passam `null`.

W-07 é regra de negócio documentada, e metade dela não era medida por nada. Entra `tests/unit/janela-domingo-e-knob.test.ts`, guardando as duas direções:

| caso | esperado |
|---|---|
| domingo, 10h BRT | **passa** |
| terça, 10h BRT (controle) | passa — para o de cima não passar por acidente |
| domingo, 03h BRT | veta por **hora**, e o motivo **não** fala em domingo |
| `allowSunday: false` + domingo 10h | veta, com "sem domingo" no motivo |
| idem, reagendamento | cai **fora** do domingo |

Sabotado para provar que discrimina: devolvendo `allowSunday: false`, **3 de 6 falham**; restaurado, 6/6. As quatro suítes vizinhas seguem verdes (37 casos ao todo).

O teste passa `banRisk: false` de propósito — sem isso o cap de warm-up (20 no degrau de idade 0) mascararia o veto da janela e o caso mediria outra coisa.

## Doutrina acompanhando o código

- `docs/business-rules/00-business-rules-catalog.md` — W-07 reescrita com o porquê e **onde se configura** (o campo de enforcement dizia só "worker de envio").
- `docs/prd/03-prd-whatsapp-waha.md:241` — o exemplo era literalmente "domingo 23h".
- `CLAUDE.md:91` — "evitar domingo" → o estado real, com data.
- `components/connections/AntiBanSheet.tsx` — a tela dizia "Desligado por padrão: envio em domingo aumenta o risco de denúncia e bloqueio". Rótulo visível é contrato.

## Não medido

- Nada pela tela: não abri o `AntiBanSheet` no browser para ver a cópia nova.
- Não há medição de risco real de bloqueio por envio em domingo — a decisão é de produto, e o que este PR faz é alinhar código, testes e doutrina a ela.