### PR TITLE
fix(marca): o logo subido some da tela por até 30s atrás de um toast verde

### DIFF
--- a/components/branding/CampoDeLogo.tsx
+++ b/components/branding/CampoDeLogo.tsx
@@ -31,7 +31,7 @@
  * alguém clicar em Salvar, e perder o arquivo em toda navegação acidental.
  */
 
-import { useRef, useState, useTransition } from "react";
+import { useRef, useState, useSyncExternalStore, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
@@ -104,6 +104,29 @@ export function CampoDeLogo({
   const router = useRouter();
   const entrada = useRef<HTMLInputElement>(null);
   const [enviando, setEnviando] = useState(false);
+  /**
+   * Marcador de HIDRATAÇÃO, lido pelo e2e antes de `setInputFiles`.
+   *
+   * `setInputFiles` só espera o elemento estar ANEXADO — e o input existe no
+   * HTML do SSR antes de o React atar o `onChange`. Um arquivo posto nessa
+   * janela não dispara requisição nenhuma, e o teste espera 15s por um toast
+   * que nunca teve emissor. Medido no run 32404132717 do CI: `load` às
+   * 472156ms, `setInputFiles` 46ms depois, e ZERO POST para
+   * `/api/v1/marca/logo` no trace inteiro (controle positivo: os POSTs de
+   * `/login` e `/login/mfa` estão lá).
+   *
+   * Esperar o input "visível" NÃO resolve — visível é propriedade do SSR.
+   *
+   * `useSyncExternalStore` e não `useState`+`useEffect`: é o padrão canônico
+   * para "estou no cliente?" e não dispara o aviso `react-hooks/set-state-in-effect`.
+   * O `subscribe` devolve um no-op de propósito — o valor nunca muda depois de
+   * hidratar.
+   */
+  const hidratado = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  );
   const [, startTransition] = useTransition();
 
   /**
@@ -230,7 +253,7 @@ export function CampoDeLogo({
   }
 
   return (
-    <div className="space-y-4" data-campo-de-logo={escopo}>
+    <div className="space-y-4" data-campo-de-logo={escopo} data-hidratado={hidratado ? "" : undefined}>
       <div className="space-y-2">
         <Label htmlFor={`logo-${escopo}`}>Logo</Label>
         <div className="flex flex-wrap items-center gap-3">

--- a/lib/branding/instalacao.ts
+++ b/lib/branding/instalacao.ts
@@ -277,6 +277,17 @@ type Memoria = { readonly linha: LinhaDaMarca | null; readonly expiraEm: number 
  */
 declare global {
   var __memoDaMarcaDaInstalacao: Memoria | null | undefined;
+  /**
+   * Contador de escritas. Mora em `globalThis` pelo MESMO motivo que o memo — e
+   * o motivo está escrito acima: a rota que grava e a tela que renderiza são
+   * duas instâncias do módulo, e um `let` de arquivo falharia calado.
+   *
+   * Ele existe porque zerar o memo não basta: uma leitura que já estava em voo
+   * quando a escrita aconteceu volta com a linha PRÉ-ESCRITA e a reinstala por
+   * um TTL inteiro, desfazendo a invalidação. Ver o comentário de
+   * `marcaDaInstalacao`.
+   */
+  var __geracaoDaMarcaDaInstalacao: number | undefined;
 }
 
 function memoEmVigor(): Memoria | null {
@@ -289,6 +300,9 @@ function guardarMemo(valor: Memoria | null): void {
 
 /** Chamada por quem ESCREVE a marca — server action ou rota. */
 export function invalidarMarcaDaInstalacao(): void {
+  // A geração sobe ANTES de zerar: quem estiver lendo agora fica marcado como
+  // anterior a esta escrita e não poderá reinstalar o que leu.
+  globalThis.__geracaoDaMarcaDaInstalacao = (globalThis.__geracaoDaMarcaDaInstalacao ?? 0) + 1;
   guardarMemo(null);
 }
 
@@ -317,12 +331,29 @@ function avisarUmaVez(chave: string, mensagem: string, contexto: Record<string, 
  * ninguém aplicar migration. Ele degrada para o `.env` igual, com um aviso.
  */
 export async function marcaDaInstalacao(): Promise<LinhaDaMarca | null> {
-  const agora = Date.now();
   const memoria = memoEmVigor();
-  if (memoria && memoria.expiraEm > agora) return memoria.linha;
+  if (memoria && memoria.expiraEm > Date.now()) return memoria.linha;
 
+  // A geração é lida ANTES do await, e conferida depois. Sem isso o memo sofre
+  // lost-update: uma leitura que entrou em voo antes de `invalidarMarcaDaInstalacao()`
+  // volta com a linha PRÉ-ESCRITA e a grava com TTL novo, desfazendo a
+  // invalidação da rota — e a tela passa a negar o logo por até TTL_MS inteiros,
+  // ATRÁS DE UM TOAST VERDE.
+  //
+  // Não é hipótese: medido no trace do CI em 2026-08-20. Um POST 200 em
+  // `/api/v1/marca/logo` às 462851ms; 19,6s depois, num contexto NOVO com login
+  // NOVO, a tela de marca ainda renderizava "Sem logo próprio, o sistema usa o
+  // logo do arquivo de instalação do servidor" e o botão Remover da camada de
+  // instalação não existia. A rajada de prefetch RSC que envenenou o memo tinha
+  // começado 53ms ANTES do POST.
+  //
+  // O `Date.now()` do TTL também passa a ser lido DEPOIS da ida ao banco: antes
+  // ele era capturado antes, e a espera do banco descontava do próprio TTL.
+  const geracao = globalThis.__geracaoDaMarcaDaInstalacao ?? 0;
   const linha = await lerOuSemear();
-  guardarMemo({ linha, expiraEm: agora + TTL_MS });
+  if ((globalThis.__geracaoDaMarcaDaInstalacao ?? 0) === geracao) {
+    guardarMemo({ linha, expiraEm: Date.now() + TTL_MS });
+  }
   return linha;
 }
 

--- a/tests/e2e/marca-logo.spec.ts
+++ b/tests/e2e/marca-logo.spec.ts
@@ -230,6 +230,16 @@ async function subir(page: Page, escopo: Escopo, arquivo: {
   mime: string;
   bytes: Buffer;
 }): Promise<void> {
+  // A hidratação, e não a visibilidade. `setInputFiles` espera o elemento estar
+  // ANEXADO, e o input existe no HTML do SSR antes de o React atar o `onChange`
+  // — arquivo posto nessa janela não dispara requisição nenhuma, e o caso morre
+  // esperando 15s por um toast sem emissor. Foi o vermelho medido no run
+  // 32404132717 (att.1): `load` às 472156ms, `setInputFiles` 46ms depois, e ZERO
+  // POST para /api/v1/marca/logo no trace inteiro.
+  await expect(
+    page.locator(`[data-campo-de-logo='${escopo}'][data-hidratado]`),
+    `o campo de logo da camada "${escopo}" não hidratou — pôr o arquivo agora não dispara nada`,
+  ).toBeVisible({ timeout: 15_000 });
   await page.locator(`#logo-${escopo}`).setInputFiles({
     name: arquivo.nome,
     mimeType: arquivo.mime,
@@ -347,7 +357,20 @@ async function logoDaBarra(page: Page): Promise<LogoNaTela | null> {
   ).toBeAttached({ timeout: 15_000 });
 
   const img = casca.locator("img").first();
-  if ((await img.count()) === 0) return null;
+  // `count()` é a ÚNICA leitura sem auto-espera do helper, e por isso era ela
+  // que media durante a troca de documento: `goto("/app")` cai num
+  // `redirect("/app/inbox")` (app/app/page.tsx tem 3 linhas), o Next serve /app
+  // com 200 e HTML completo, e emite a redireção depois — o `count()` corria no
+  // documento novo ainda vazio e devolvia 0 com a barra CERTA a caminho.
+  // Medido no run 32403198687: `queryCount` levou 541ms e voltou 0; 44ms depois
+  // o bitmap do logo baixou, e o `test-failed-1.png` mostra a barra com o logo.
+  // `toBeAttached` com teto preserva a ausência como resposta legítima — só que
+  // agora ela significa "5s sem <img>", não "não havia <img> naquele milissegundo".
+  try {
+    await expect(img).toBeAttached({ timeout: 5_000 });
+  } catch {
+    return null;
+  }
   return medirImagem(img);
 }
 
@@ -404,8 +427,14 @@ async function logoDoLogin(browser: Browser): Promise<LogoNaTela | null> {
     await pagina.goto("/login");
     const img = pagina.getByTestId("logo-da-fachada");
     // Ausência é resposta legítima: sem logo em nenhuma camada, o layout não
-    // renderiza `<img>` nenhum e a fachada aparece com o nome em texto.
-    if ((await img.count()) === 0) return null;
+    // renderiza `<img>` nenhum e a fachada aparece com o nome em texto. Mas
+    // `count()` puro tornava "ausente" indistinguível de "ainda não montou" —
+    // é a mesma classe do helper da barra, consertada junto por isso.
+    try {
+      await expect(img).toBeAttached({ timeout: 5_000 });
+    } catch {
+      return null;
+    }
     return await medirImagem(img);
   } finally {
     await contexto.close();
@@ -496,7 +525,7 @@ test.describe("o logo subido pela tela chega à tela", () => {
     });
     await page.screenshot({ path: evidencia("1-admin-marca-previa.png"), fullPage: true });
 
-    await page.goto("/app");
+    await page.goto("/app/inbox");
     const barra = await logoDaBarra(page);
     expect(barra, "nenhuma <img> na barra lateral depois do upload").not.toBeNull();
     expect(barra!.src).toContain(`${PREFIXO_PUBLICO}platform/`);
@@ -536,7 +565,7 @@ test.describe("o logo subido pela tela chega à tela", () => {
     });
     await expect(page.getByText(/logo atualizado/i)).toBeVisible({ timeout: 15_000 });
 
-    await page.goto("/app");
+    await page.goto("/app/inbox");
     const barra = await logoDaBarra(page);
     expect(barra, "nenhuma <img> na barra lateral depois do upload da empresa").not.toBeNull();
     expect(barra!.src).toContain(`${PREFIXO_PUBLICO}${creds.org_id}/`);
@@ -555,7 +584,7 @@ test.describe("o logo subido pela tela chega à tela", () => {
   test("(4) SVG renomeado para .png é recusado pelos BYTES, com a razão dita", async ({ page }) => {
     await loginComTotp(page, creds.users.admin!.email, creds.admin_totp!.secret);
 
-    await page.goto("/app");
+    await page.goto("/app/inbox");
     const antes = await logoDaBarra(page);
     // O estado de partida é o logo que o caso (3) subiu. A asserção é explícita
     // porque `antes!.src` lá embaixo, com `antes` nulo, reprova como
@@ -598,7 +627,7 @@ test.describe("o logo subido pela tela chega à tela", () => {
     await expect(recusa).toBeVisible({ timeout: 15_000 });
     await page.screenshot({ path: evidencia("5-svg-recusado.png"), fullPage: true });
 
-    await page.goto("/app");
+    await page.goto("/app/inbox");
     const depois = await logoDaBarra(page);
     // ⚠️ As mensagens NÃO acusam mais a gravação. A versão anterior dizia "a
     // recusa apagou o logo — a gravação não foi atômica", e isso é impossível
@@ -629,7 +658,7 @@ test.describe("o logo subido pela tela chega à tela", () => {
     await remover.click();
     await expect(page.getByText(/logo removido/i)).toBeVisible({ timeout: 15_000 });
 
-    await page.goto("/app");
+    await page.goto("/app/inbox");
     const barra = await logoDaBarra(page);
     expect(barra, "a barra ficou sem logo — a camada de baixo não assumiu").not.toBeNull();
     expect(barra!.src).toContain(`${PREFIXO_PUBLICO}platform/`);

--- a/tests/unit/branding-memo-da-instalacao.test.ts
+++ b/tests/unit/branding-memo-da-instalacao.test.ts
@@ -48,6 +48,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const banco = vi.hoisted(() => ({
   linha: null as Record<string, unknown> | null,
   leituras: 0,
+  /**
+   * Portão para segurar UMA leitura em voo. `null` = leitura resolve na hora
+   * (comportamento de todos os casos que já existiam aqui). Com o portão
+   * armado, `maybeSingle` espera — e é isso que torna a corrida do
+   * lost-update observável sem `sleep` e sem depender de timing.
+   */
+  portao: null as { liberar: () => void; esperar: Promise<void> } | null,
 }));
 
 vi.mock("@/lib/supabase/admin", () => ({
@@ -57,7 +64,15 @@ vi.mock("@/lib/supabase/admin", () => ({
         eq: () => ({
           maybeSingle: async () => {
             banco.leituras += 1;
-            return { data: banco.linha, error: null };
+            // A linha é capturada AGORA, antes de esperar o portão — é o que um
+            // banco real faz: a consulta sai antes da escrita, e a resposta que
+            // volta é a de antes dela. Ler `banco.linha` depois do `await` faria
+            // a leitura "em voo" enxergar o valor NOVO e o caso não reproduziria
+            // corrida nenhuma (foi o primeiro jeito que escrevi, e a asserção de
+            // controle o pegou).
+            const capturada = banco.linha;
+            if (banco.portao) await banco.portao.esperar;
+            return { data: capturada, error: null };
           },
         }),
       }),
@@ -151,5 +166,78 @@ describe("o memo da marca da instalação atravessa instâncias do módulo", () 
     banco.linha = COM_LOGO;
     expect((await tela.marcaDaInstalacao())?.logo_path).toBeNull();
     expect(banco.leituras, "o memo deixou de ser memo").toBe(1);
+  });
+});
+
+/**
+ * ═══ LOST-UPDATE: a leitura EM VOO reinstalava o valor pré-escrita ═══
+ *
+ * Zerar o memo não bastava. `marcaDaInstalacao()` lia a geração do banco DEPOIS
+ * de um `await`, e gravava o resultado INCONDICIONALMENTE — então uma leitura
+ * que tinha começado ANTES da escrita voltava com a linha velha e a reinstalava
+ * por um TTL inteiro (30s), desfazendo o `invalidarMarcaDaInstalacao()` da rota.
+ *
+ * O efeito para gente real: o dono da VPS sobe o logo, recebe 200 e um toast
+ * verde, e a tela continua dizendo "Sem logo próprio" por até 30 segundos.
+ *
+ * MEDIDO no trace do CI em 2026-08-20 (run 32404132717, tentativa 2): a rajada
+ * de prefetch RSC começou 53ms ANTES do POST, e 19,6s depois do POST — num
+ * contexto NOVO, com login NOVO — a tela de marca ainda renderizava "Sem logo
+ * próprio…" e o botão Remover da camada de instalação não existia.
+ *
+ * A corrida é reproduzida pelo PORTÃO do dublê, não por `sleep`: o teste
+ * controla exatamente o instante em que a leitura volta.
+ */
+describe("uma escrita DURANTE a leitura não pode ser desfeita pela leitura", () => {
+  beforeEach(async () => {
+    banco.linha = SEM_LOGO;
+    banco.leituras = 0;
+    banco.portao = null;
+    (await instancia()).invalidarMarcaDaInstalacao();
+  });
+
+  it("a leitura que começou antes da escrita NÃO reinstala o valor velho", async () => {
+    const tela = await instancia();
+    const rota = await instancia();
+
+    // 1. A tela começa a ler e fica presa no portão, ainda vendo SEM_LOGO.
+    let liberar!: () => void;
+    banco.portao = { liberar: () => {}, esperar: new Promise<void>((r) => (liberar = r)) };
+    const emVoo = tela.marcaDaInstalacao();
+
+    // 2. A rota grava o logo e invalida — exatamente o que o upload faz.
+    banco.linha = COM_LOGO;
+    rota.invalidarMarcaDaInstalacao();
+
+    // 3. A leitura presa volta AGORA, com o valor de antes da escrita.
+    liberar();
+    const velha = await emVoo;
+    expect(velha?.logo_path, "controle: a leitura em voo tem mesmo de voltar velha").toBeNull();
+
+    // 4. A próxima leitura precisa IR AO BANCO. Se a leitura em voo tiver
+    //    reinstalado o memo, ela devolve o valor velho sem ler nada — que é o
+    //    defeito: tela negando o logo atrás de um toast de sucesso.
+    banco.portao = null;
+    const leiturasAntes = banco.leituras;
+    const depois = await tela.marcaDaInstalacao();
+    expect(
+      banco.leituras,
+      "a leitura seguinte tem de ir ao banco — o memo não pode ter sido reinstalado",
+    ).toBeGreaterThan(leiturasAntes);
+    expect(depois?.logo_path, "a tela precisa enxergar o logo recém-subido").toBe(CAMINHO_SUBIDO);
+  });
+
+  it("sem escrita no meio, a leitura memoiza normalmente — o conserto não desligou o memo", () => {
+    // Controle NEGATIVO do caso acima: se o conserto tivesse desarmado o memo em
+    // geral, este caso viraria "vai ao banco toda vez" e ninguém notaria a perda.
+    return (async () => {
+      const tela = await instancia();
+      const primeira = banco.leituras;
+      await tela.marcaDaInstalacao();
+      const depoisDaPrimeira = banco.leituras;
+      await tela.marcaDaInstalacao();
+      expect(banco.leituras, "a segunda leitura tem de vir do memo").toBe(depoisDaPrimeira);
+      expect(depoisDaPrimeira, "a primeira tem de ter ido ao banco").toBeGreaterThan(primeira);
+    })();
   });
 });

--- a/tests/unit/campo-de-logo-marca-hidratacao.test.tsx
+++ b/tests/unit/campo-de-logo-marca-hidratacao.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * O marcador de hidratação do campo de logo é CONTRATO com o e2e.
+ *
+ * `tests/e2e/marca-logo.spec.ts` espera `[data-campo-de-logo][data-hidratado]`
+ * antes de `setInputFiles`, porque `setInputFiles` só exige o elemento anexado
+ * — e o input existe no HTML do SSR antes de o React atar o `onChange`. Arquivo
+ * posto nessa janela não dispara requisição nenhuma.
+ *
+ * Sem este teste, o atributo sumiria num refactor e o e2e voltaria a ser
+ * instável com um sintoma que não fala do defeito ("esperei 15s por um toast").
+ */
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+
+import { CampoDeLogo } from "@/components/branding/CampoDeLogo";
+
+describe("o campo de logo anuncia que hidratou", () => {
+  it("depois de montar, o wrapper tem data-hidratado", () => {
+    render(
+      <CampoDeLogo
+        escopo="instalacao"
+        logoDaCamada={{ url: null }}
+        logoHerdado={null}
+        origemDoHerdado="do sistema"
+        nomeEmVigor="DeskcommCRM"
+      />,
+    );
+    const campo = document.querySelector("[data-campo-de-logo='instalacao']");
+    expect(campo, "o wrapper com data-campo-de-logo é a âncora do e2e").not.toBeNull();
+    expect(
+      campo!.hasAttribute("data-hidratado"),
+      "o e2e espera [data-hidratado] antes de setInputFiles — sem ele, volta a instabilidade",
+    ).toBe(true);
+  });
+
+  it("o input do arquivo continua com o id que o e2e usa", () => {
+    render(
+      <CampoDeLogo
+        escopo="organizacao"
+        logoDaCamada={{ url: null }}
+        logoHerdado={null}
+        origemDoHerdado="da instalação"
+        nomeEmVigor="Empresa"
+      />,
+    );
+    expect(document.querySelector("#logo-organizacao")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Saiu do diagnóstico de por que `tests/e2e/marca-logo.spec.ts` reprovava em PRs que **não tocam nada de marca** — inclusive num que só mexe em SQL (#283) e na **própria `main`**. Achei três defeitos independentes no mesmo caminho. **Um é de produto**, dois são da régua, e nenhum explica sozinho as 7 falhas medidas: cada execução sorteia um.

Isto destrava o #271 e o #283, que estão prontos e travados pelo check obrigatório `e2e`.

## A — PRODUTO: lost-update no memo da marca da instalação

`lib/branding/instalacao.ts` gravava `guardarMemo` **incondicionalmente depois do `await`**. Uma leitura em voo que começou **antes** de `invalidarMarcaDaInstalacao()` volta com a linha pré-escrita e a reinstala por um TTL inteiro (30 s), desfazendo a invalidação da rota.

Para gente real: **o dono da VPS sobe o logo, recebe 200 e um toast verde, e a tela continua dizendo "Sem logo próprio" por até meio minuto.**

Medido no trace do CI (run 32404132717, tentativa 2):

```
462798ms  rajada de prefetch RSC começa — 53ms ANTES do POST
462851ms  POST 200 /api/v1/marca/logo → {"logo_path":"platform/101c7594-….png"}
463421ms  GET 200 do bitmap — a <img> existiu e baixou
482474ms  afterAll abre /admin/marca em contexto NOVO, login NOVO — 19,6s depois
          do POST — e a tela ainda diz "Sem logo próprio, o sistema usa o logo
          do arquivo de instalação do servidor". O botão Remover não existe.
```

Conserto: contador de geração em `globalThis` — mesmo endereço do memo, e pelo mesmo motivo que o arquivo já documenta (route runtime e ssr runtime instanciam o módulo duas vezes). A leitura anota a geração antes do `await` e só grava se ela não mudou.

**Prova determinística**, sem banco e sem timing: o dublê ganhou um portão que segura uma leitura em voo. Sabotado — removendo o `if (geracao === …)`, o caso falha exatamente em *"a leitura seguinte tem de ir ao banco"*. Com controle negativo junto: sem escrita no meio, o memo continua memoizando (senão o conserto poderia tê-lo desligado sem ninguém notar).

## B — RÉGUA: `logoDaBarra()` media durante a troca de documento

`if ((await img.count()) === 0) return null` era a **única** leitura sem auto-espera do helper. E `page.goto("/app")` cai num `redirect("/app/inbox")` — `app/app/page.tsx` tem três linhas.

```
464093ms  aside anexado                 OK
464134ms  GET 200 /app/inbox            ← documento NOVO
464142ms  count(aside>>img) → 0         (541ms depois)
464727ms  GET 200 do bitmap do logo
```

O `test-failed-1.png` desse mesmo teste mostra `/app/inbox` com a barra e o logo azul recém-subido. **O produto estava certo; a régua leu zero.**

Vira `toBeAttached` com teto de 5 s — ausência continua legítima, mas passa a significar "5 s sem `<img>`". O gêmeo `logoDoLogin` tinha o mesmo defeito e foi junto (classe, não instância), e os cinco `goto("/app")` vão ao destino real.

## C — RÉGUA: o caso (4) subia o arquivo antes da hidratação

`setInputFiles` espera o elemento **anexado**, e o input existe no HTML do SSR antes de o React atar o `onChange`.

Medido (run 32404132717, att. 1): `load` às 472156ms, `setInputFiles` **46ms depois**, e **zero POST** para `/api/v1/marca/logo` no trace inteiro — controle positivo: os POSTs de `/login` e `/login/mfa` estão lá. O caso esperou 15 s por um toast sem emissor.

`CampoDeLogo` passa a anunciar `data-hidratado` (via `useSyncExternalStore`, padrão canônico e sem o aviso `react-hooks/set-state-in-effect`), e `subir()` espera por ele. Esperar o input "visível" não serviria — visível é propriedade do SSR. O marcador é contrato com o e2e, então tem guarda unitária própria, também sabotada.

## Verificação

`tsc --noEmit` exit 0 · `eslint` nos 5 arquivos exit 0 e **zero aviso** · 47 casos verdes nas cinco suítes de marca.

## Não medido

Não rodei a spec e2e localmente com `--repeat-each` num rig fresco. **A** tem prova determinística; **B** e **C** são consertos de régua cuja prova final é o `e2e` parar de sortear vermelho — e uma execução verde **não** distingue "consertou" de "não caiu desta vez". Se voltar a reprovar, os traces dirão qual das três assinaturas, porque agora elas estão nomeadas neste PR.