### PR TITLE
fix(agente): a tela dizia "Publicado" para quem o runtime não atende

### DIFF
--- a/app/app/ai/agents/[id]/page.tsx
+++ b/app/app/ai/agents/[id]/page.tsx
@@ -141,7 +141,7 @@ export default async function AgentEditorPage({
   // sempre — inclusive quando era mais antigo que a publicada — e um agente
   // pausado (sem rascunho e sem publicada) abria no texto padrão, que é como o
   // prompt "sumia".
-  const { draft, published, base, draftObsoleto } = escolherVersoesDaTela(versions);
+  const { draft, published, base, draftObsoleto } = escolherVersoesDaTela(versions, agent.published_version_id ?? null);
 
   return (
     <div className="flex h-full flex-col gap-6 p-6">

--- a/lib/ai/agents/versoes-da-tela.ts
+++ b/lib/ai/agents/versoes-da-tela.ts
@@ -65,8 +65,25 @@ function maisNova<T extends VersaoParaEscolha>(versoes: readonly T[]): T | null 
 
 export function escolherVersoesDaTela<T extends VersaoParaEscolha>(
   versoes: readonly T[],
+  /**
+   * `ai_agents.published_version_id` — o ponteiro, que é a fonte da verdade do
+   * RUNTIME (`agent-config.ts` faz `join … on v.id = a.published_version_id`).
+   *
+   * Sem ele, a escolha caía em `status === "published"`, e os dois divergem: há
+   * agente em produção com uma versão marcada `published` e o ponteiro NULO. A
+   * tela dizia "Publicado v1" para um agente que o runtime não atende — e o
+   * badge de status ao lado, que já lia o ponteiro, dizia "Rascunho". Duas
+   * respostas contraditórias na mesma tela, e a errada era a otimista.
+   *
+   * Opcional para o chamador que ainda não o passa; nesse caso vale o
+   * comportamento antigo, que é melhor que não ter versão nenhuma.
+   */
+  publishedVersionId?: string | null,
 ): VersoesDaTela<T> {
-  const published = versoes.find((v) => v.status === "published") ?? null;
+  const published =
+    publishedVersionId !== undefined
+      ? (versoes.find((v) => v.id === publishedVersionId) ?? null)
+      : (versoes.find((v) => v.status === "published") ?? null);
   const rascunho = maisNova(versoes.filter((v) => v.status === "draft"));
 
   // Rascunho anterior à publicada foi superado por ela: não abre, não publica.

--- a/tests/unit/versoes-da-tela-do-agente.test.ts
+++ b/tests/unit/versoes-da-tela-do-agente.test.ts
@@ -64,3 +64,27 @@ describe("qual versão o editor do agente abre", () => {
     expect(r.draft?.id).toBe("v10");
   });
 });
+
+describe("quem é a versão publicada: o PONTEIRO, não o rótulo", () => {
+  // Medido em produção: um agente com `ai_agent_versions.status = 'published'` e
+  // `ai_agents.published_version_id` NULO. O runtime não o atende (o join é pelo
+  // ponteiro), mas a tela dizia "Publicado v1" — e o badge ao lado, que já lia o
+  // ponteiro, dizia "Rascunho". Duas respostas contraditórias, e a errada era a
+  // que tranquilizava.
+  it("ignora o rótulo quando o ponteiro está vazio", () => {
+    const r = escolherVersoesDaTela([v(1, "published")], null);
+    expect(r.published, "a tela diria 'no ar' um agente que o runtime não atende").toBeNull();
+    expect(r.base?.id, "mesmo assim o editor abre a última versão").toBe("v1");
+  });
+
+  it("segue o ponteiro mesmo que o rótulo aponte para outra", () => {
+    const r = escolherVersoesDaTela([v(2, "superseded"), v(3, "published")], "v2");
+    expect(r.published?.id).toBe("v2");
+  });
+
+  it("sem o ponteiro informado, mantém o comportamento antigo", () => {
+    // Chamador que ainda não passa o argumento não perde a versão publicada.
+    const r = escolherVersoesDaTela([v(4, "published")]);
+    expect(r.published?.id).toBe("v4");
+  });
+});


### PR DESCRIPTION
Achado varrendo os agentes de uma organização real depois do conserto do PR #295:
um deles tem `ai_agent_versions.status = 'published'` e
`ai_agents.published_version_id` **nulo**.

Os dois não são a mesma coisa. Quem manda é o **ponteiro** — `agent-config.ts`
faz `join ai_agent_versions v on v.id = a.published_version_id`. O rótulo na
linha da versão pode ficar para trás.

`escolherVersoesDaTela` escolhia pelo rótulo, então a tela anunciava
`Publicado v1` para um agente que o runtime **não atende** — enquanto o badge de
status ao lado, que já lia o ponteiro, dizia `Rascunho`. Duas respostas
contraditórias na mesma tela, e a errada era a otimista.

A função passa a receber o ponteiro e a segui-lo. O argumento é opcional para não
quebrar chamador que ainda não o passa.

O editor continua abrindo a última versão existente nesse estado: muda o que a
tela **afirma**, não o que ela mostra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjMegCk8TACN4SijTgPdG6