### PR TITLE
A barra lateral passava POR CIMA da lista de conversas

### DIFF
--- a/app/app/_components/AppShell.tsx
+++ b/app/app/_components/AppShell.tsx
@@ -2,7 +2,6 @@
 import type { ReactNode } from "react";
 import { Sidebar } from "@/components/shell/Sidebar";
 import { TopBar } from "@/components/shell/TopBar";
-import { cn } from "@/lib/utils";
 
 interface AppShellProps {
   sidebarCollapsed: boolean;
@@ -27,7 +26,14 @@ export function AppShell({ sidebarCollapsed, children }: AppShellProps) {
         cabeçalho, presente também em telas que não têm abas (a lista de agentes
         estoura 236px). Isolado ancestral por ancestral: é este o que decide.
       */}
-      <div className={cn("flex min-h-screen min-w-0 flex-1 flex-col transition-[margin] duration-200", sidebarCollapsed ? "md:ml-16" : "md:ml-60")}>
+      {/*
+        Sem `md:ml-*`: a barra voltou a ocupar lugar na linha (ver o comentário
+        em `Sidebar.tsx`), então o que sobra para esta coluna é exatamente o que
+        ela não usou. A margem existia para compensar uma barra `fixed`, e era a
+        SEGUNDA medida da mesma coisa — a que discordava e deixava a barra por
+        cima da lista.
+      */}
+      <div className="flex min-h-screen min-w-0 flex-1 flex-col">
         <TopBar />
         <main className="flex-1 overflow-auto p-6">{children}</main>
       </div>

--- a/components/shell/Sidebar.tsx
+++ b/components/shell/Sidebar.tsx
@@ -220,7 +220,26 @@ export function Sidebar({ collapsed }: { collapsed: boolean }) {
   return (
     <aside
       className={cn(
-        "fixed inset-y-0 left-0 z-30 flex flex-col border-r bg-card transition-[width] duration-200",
+        // ⚠️ `sticky`, e NUNCA `fixed`.
+        //
+        // Com `fixed` a barra sai do fluxo: ela não ocupa lugar nenhum na linha,
+        // e quem afastava o conteúdo era um `md:ml-16`/`md:ml-60` do lado de lá.
+        // Duas medidas para a mesma coisa, em componentes diferentes — e no dia
+        // em que discordassem (largura de 60 com margem de 16), a barra passava
+        // POR CIMA da lista de conversas, escondendo o começo de cada linha.
+        //
+        // Foi assim que apareceu numa instalação real: a barra expandida, com as
+        // etiquetas legíveis, e a lista atrás dela cortada. Um F5 "consertava",
+        // que é a assinatura de servidor e navegador terem pintado estados
+        // diferentes — e `AppShell` e `Sidebar` são ambos `"use client"`.
+        //
+        // `sticky top-0 h-screen` dá o mesmo efeito visual (a barra não rola com
+        // a página) e ela VOLTA a ocupar lugar: sobra para o conteúdo exatamente
+        // o que ela não usou, e não há segunda medida para discordar.
+        //
+        // `shrink-0` porque item de flex encolhe por padrão, e uma barra de 60
+        // espremida para caber é o mesmo defeito por outro caminho.
+        "sticky top-0 z-30 flex h-screen shrink-0 flex-col border-r bg-card transition-[width] duration-200",
         collapsed ? "w-16" : "w-60",
       )}
     >

--- a/tests/unit/barra-lateral-nao-flutua.test.ts
+++ b/tests/unit/barra-lateral-nao-flutua.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * A BARRA LATERAL PASSAVA POR CIMA DA LISTA DE CONVERSAS.
+ *
+ * ─── O defeito, visto por quem usa ──────────────────────────────────────────
+ *
+ * Abrir o inbox e encontrar a barra expandida — com as etiquetas legíveis — e a
+ * lista de conversas ATRÁS dela, com o começo de cada linha escondido. Um F5
+ * "consertava", que é a assinatura clássica de servidor e navegador terem
+ * pintado estados diferentes.
+ *
+ * ─── A causa, e por que ela é estrutural ────────────────────────────────────
+ *
+ * A barra era `fixed`: saía do fluxo e não ocupava lugar nenhum na linha. Quem
+ * afastava o conteúdo era um `ml-16`/`ml-60` do lado de lá, em OUTRO componente.
+ *
+ * Duas medidas para a mesma coisa. Enquanto concordam, ninguém vê nada; no
+ * instante em que discordam — largura de 60 com margem de 16 — a barra cobre a
+ * lista. E as duas nascem do mesmo booleano em componentes de CLIENTE, então
+ * basta um render fora de sincronia para elas divergirem.
+ *
+ * Consertar o valor não conserta a classe: enquanto houver duas medidas, existe
+ * o dia em que discordam. `sticky` devolve a barra ao fluxo, e aí sobra para o
+ * conteúdo exatamente o que ela não usou — não há segunda medida.
+ *
+ * ─── O que este teste NÃO prova ─────────────────────────────────────────────
+ *
+ * Ele lê CLASSES, não geometria. A prova de verdade é medir
+ * `getBoundingClientRect` das duas caixas num browser e mostrar que não se
+ * sobrepõem — o que a doutrina de QA Visual pede e um teste de unidade não
+ * alcança. Esta é a rede possível: impede a volta do PADRÃO que causou o
+ * defeito.
+ */
+
+const BARRA = readFileSync("components/shell/Sidebar.tsx", "utf8")
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/\/\/.*$/gm, "");
+const CASCA = readFileSync("app/app/_components/AppShell.tsx", "utf8")
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/\/\/.*$/gm, "");
+
+describe("a barra ocupa lugar, em vez de flutuar", () => {
+  it("não é `fixed`", () => {
+    // `fixed` é o que a tira do fluxo e obriga alguém a compensar por fora.
+    expect(BARRA, "a barra voltou a flutuar").not.toMatch(/\bfixed\b/);
+  });
+
+  it("é `sticky` e ocupa a altura da tela", () => {
+    // O efeito visual precisa continuar: a barra não rola com a página.
+    expect(BARRA).toMatch(/\bsticky\b/);
+    expect(BARRA).toMatch(/h-screen/);
+  });
+
+  it("não encolhe", () => {
+    // Item de flex encolhe por padrão. Uma barra de 60 espremida para caber é o
+    // mesmo defeito por outro caminho.
+    expect(BARRA).toMatch(/shrink-0/);
+  });
+
+  it("a casca NÃO compensa com margem", () => {
+    // Esta é a asserção que importa: enquanto existir a segunda medida, existe
+    // o dia em que ela discorda da primeira.
+    const margens = [...CASCA.matchAll(/\bml-(?:16|60)\b/g)].map((m) => m[0]);
+    expect(margens, "voltou a segunda medida da mesma coisa").toEqual([]);
+  });
+});


### PR DESCRIPTION
A barra é `fixed`: sai do fluxo e não ocupa lugar nenhum na linha. Quem afasta o conteúdo é um `md:ml-16`/`md:ml-60` **em outro componente**. Duas medidas para a mesma coisa — e no dia em que discordam (largura de 60 com margem de 16), a barra cobre a lista de conversas.

**Aconteceu numa instalação real:** a barra expandida, com as etiquetas legíveis, e a lista atrás dela, com o começo de cada linha escondido. Um F5 "consertava" — a assinatura de servidor e navegador terem pintado estados diferentes. E `AppShell` e `Sidebar` são ambos `"use client"`: basta um render fora de sincronia.

## Por que o conserto não é acertar o valor

Enquanto houver **duas medidas**, existe o dia em que discordam. `sticky top-0 h-screen` devolve a barra ao fluxo com o mesmo efeito visual (não rola com a página) e faz sobrar para o conteúdo **exatamente o que ela não usou** — não há segunda medida. `shrink-0` porque item de flex encolhe por padrão.

A margem `md:ml-*` sai da casca. O `hidden md:block` que embrulha a barra (o seu, do cajón móvel) fica intacto — no celular ela continua não ocupando coluna.

## O teste

Lê classes, não geometria — a prova de verdade seria `getBoundingClientRect` das duas caixas num browser, como a doutrina de QA Visual pede. A rede que ele dá é impedir a volta do **padrão**: `fixed` na barra ou `ml-*` na casca reprovam, com o porquê escrito.

Rodando nesta forma numa instalação real há dois dias, com o cajón móvel e o recolher funcionando.