### PR TITLE
A chave podia estar boa e o número morto — a saúde do canal intermediado pergunta pelo elo com a Meta

### DIFF
--- a/lib/channels/adapters/zernio.ts
+++ b/lib/channels/adapters/zernio.ts
@@ -361,21 +361,49 @@ export const zernioAdapter: ChannelAdapter = {
    * (`account.disconnected`, `number.suspended`); cego mesmo ele era para a
    * falha CALADA, que é justamente a que ninguém percebe.
    *
-   * Reusa a MESMA chamada da validação de credencial (`GET /v1/accounts`), com
-   * o mesmo casamento de conta (`_id ?? id`) — medido contra a API, não lido da
-   * doc: o endpoint por id aceita só `PUT` e responde 405 ao GET.
+   * ─── Perguntar pela CONTA não responde pela LINHA ──────────────────────────
    *
-   * ─── Os quatro desfechos, e por que a diferença importa ────────────────────
+   * A primeira versão varria `GET /v1/accounts` e dava WORKING quando a conta
+   * aparecia na lista. Isso responde "a chave presta e a conta existe" — e a
+   * pergunta do cron é outra: "dá para enviar por este número AGORA?". As duas
+   * divergem no caso que mais importa, e a própria doc do provedor o nomeia:
+   * *"The OAuth token can be perfectly valid while Meta refuses to serve the
+   * phone-number object (for example after a phone-side coexistence
+   * disconnect), so `tokenStatus` alone is not a liveness signal for
+   * WhatsApp."* Alguém desliga o aparelho do lado de lá, a conta segue na
+   * lista, e o CRM diz "conectado" para um número que não entrega mais nada.
    *
-   *   401/403      → a chave foi recusada. É FAILED: a credencial existe e não
-   *                  vale mais, que é exatamente a falha calada que se procura.
-   *   conta ausente→ a chave presta mas não alcança mais esta conta. STOPPED:
-   *                  a sessão não existe mais do lado de lá.
-   *   respondeu ok → WORKING.
-   *   qualquer erro→ NÃO sabemos. `reachable: false`, sem status. Inventar um
-   *                  faria uma oscilação de rede virar "canal caído", e o
-   *                  operador aprenderia a ignorar o aviso — que é pior que não
-   *                  ter aviso nenhum.
+   * `GET /v1/accounts/{id}/health` sonda o elo com a Meta na hora do pedido
+   * (`checkedAt` é sempre o agora, nunca cache). MEDIDO contra a API desta
+   * instalação, não lido da doc — que é a regra que o comentário anterior já
+   * seguia, e o motivo de ele registrar que o endpoint por id respondia 405 ao
+   * GET quando foi escrito. Hoje responde 200:
+   *
+   *   status: "healthy"
+   *   platformConnection: {"status":"connected","phoneStatus":"CONNECTED","metaError":null}
+   *
+   * ─── Os desfechos, e por que `unknown` não vira queda ──────────────────────
+   *
+   *   401/403        → a chave foi recusada. FAILED: a credencial existe e não
+   *                    vale mais — a falha calada que se procura.
+   *   404            → a conta sumiu do lado de lá. STOPPED. (O caminho existe:
+   *                    foi medido respondendo 200, então 404 aqui é sobre a
+   *                    CONTA, não sobre a rota.)
+   *   `disconnected` → a Meta recusou servir o objeto do número (Graph 100/33).
+   *                    FAILED, com o código dela no detalhe: é o que distingue
+   *                    "desligaram o aparelho" de "a chave venceu", e sem isso
+   *                    o operador lê "falhou" e não sabe o que fazer.
+   *   `unknown`      → a sonda não concluiu (timeout, erro transitório da Meta).
+   *                    A doc é explícita: *"not evidence either way"*. Então
+   *                    `reachable: false` e status NENHUM — o mesmo tratamento
+   *                    de uma oscilação de rede, que `julgarQueda` já absorve
+   *                    exigindo DUAS observações ruins seguidas. Traduzir
+   *                    "não sei" para "caiu" faria um soluço da Meta abrir aviso
+   *                    crítico, e aviso que grita à toa ensina a ignorar aviso.
+   *   sem o campo    → conta que não é WhatsApp, ou provedor que ainda não
+   *                    publicou a sonda. Cai no `status` geral em vez de falhar:
+   *                    campo ausente é ausência de informação, não más notícias.
+   *   qualquer outro → NÃO sabemos. `reachable: false`, sem status.
    */
   async checkHealth(
     input: ChannelTenantScope & { sessionRef: string },
@@ -391,10 +419,13 @@ export const zernioAdapter: ChannelAdapter = {
     try {
       // Teto de espera: sem ele, um provedor que pendura a conexão pendura o
       // cron junto, e a varredura de saúde deixa de rodar para TODAS as sessões.
-      res = await fetch(`${creds.baseUrl}/v1/accounts`, {
-        headers: { Authorization: `Bearer ${creds.apiKey}` },
-        signal: AbortSignal.timeout(15_000),
-      });
+      res = await fetch(
+        `${creds.baseUrl}/v1/accounts/${encodeURIComponent(creds.accountId)}/health`,
+        {
+          headers: { Authorization: `Bearer ${creds.apiKey}` },
+          signal: AbortSignal.timeout(15_000),
+        },
+      );
     } catch (err) {
       const detail = err instanceof Error ? err.message : "erro_desconhecido";
       return { reachable: false, status: null, detail: detail.slice(0, 200) };
@@ -403,19 +434,42 @@ export const zernioAdapter: ChannelAdapter = {
     if (res.status === 401 || res.status === 403) {
       return { reachable: true, status: "FAILED", detail: null };
     }
+    if (res.status === 404) {
+      return { reachable: true, status: "STOPPED", detail: null };
+    }
     if (!res.ok) {
       return { reachable: false, status: null, detail: `provedor_respondeu_${res.status}` };
     }
 
     const json = (await res.json().catch(() => null)) as {
-      accounts?: Record<string, unknown>[];
+      status?: string;
+      platformConnection?: {
+        status?: string;
+        phoneStatus?: string | null;
+        metaError?: { code?: number; subcode?: number; message?: string } | null;
+      } | null;
     } | null;
-    const contas = Array.isArray(json?.accounts) ? json.accounts : [];
-    const conta = contas.find((c) => String(c._id ?? c.id) === creds.accountId) ?? null;
 
-    return conta
-      ? { reachable: true, status: "WORKING", detail: null }
-      : { reachable: true, status: "STOPPED", detail: null };
+    const elo = json?.platformConnection;
+
+    if (elo?.status === "disconnected") {
+      const e = elo.metaError;
+      // O código da Meta no detalhe, NUNCA a mensagem crua inteira: ela é longa
+      // e às vezes carrega identificadores que não têm por que entrar num aviso.
+      const detail = e?.code ? `meta_${e.code}${e.subcode ? `_${e.subcode}` : ""}` : "meta_recusou_o_numero";
+      return { reachable: true, status: "FAILED", detail };
+    }
+    if (elo?.status === "unknown") {
+      return { reachable: false, status: null, detail: "sonda_do_elo_meta_inconclusiva" };
+    }
+    if (elo?.status === "connected") {
+      return { reachable: true, status: "WORKING", detail: null };
+    }
+
+    // Sem `platformConnection`: decide pelo veredito geral da conta.
+    return json?.status === "error"
+      ? { reachable: true, status: "FAILED", detail: "conta_em_erro" }
+      : { reachable: true, status: "WORKING", detail: null };
   },
 
   /** Gestão das definições aprovadas — ver `../zernio/templates.ts`. */

--- a/tests/unit/saude-dos-canais-oficiais.test.ts
+++ b/tests/unit/saude-dos-canais-oficiais.test.ts
@@ -72,8 +72,19 @@ describe("canal intermediado", () => {
     return zernioAdapter.checkHealth!({ organizationId: ORG, sessionRef: "conta-1" });
   }
 
-  it("conta na lista → está de pé", async () => {
-    globalThis.fetch = respondeCom({ accounts: [{ _id: "conta-1", platform: "whatsapp" }] });
+  /**
+   * A forma abaixo é a MEDIDA nesta instalação, não uma inventada para o teste:
+   *
+   *   status: "healthy"
+   *   platformConnection: {"status":"connected","phoneStatus":"CONNECTED",...}
+   */
+  const ELO_VIVO = {
+    status: "healthy",
+    platformConnection: { status: "connected", phoneStatus: "CONNECTED", metaError: null },
+  };
+
+  it("elo com a Meta vivo → está de pé", async () => {
+    globalThis.fetch = respondeCom(ELO_VIVO);
     expect(await saude()).toEqual({ reachable: true, status: "WORKING", detail: null });
   });
 
@@ -84,17 +95,70 @@ describe("canal intermediado", () => {
     expect(await saude()).toMatchObject({ reachable: true, status: "FAILED" });
   });
 
-  it("chave válida mas conta sumiu da lista → STOPPED, não FAILED", async () => {
+  it("conta que sumiu do lado de lá → STOPPED, não FAILED", async () => {
     // São coisas diferentes e o operador faz coisas diferentes: credencial
     // recusada se troca, conta removida se reconecta. Um status só para os dois
     // mandaria metade das pessoas para o lugar errado.
-    globalThis.fetch = respondeCom({ accounts: [{ _id: "outra-conta" }] });
+    globalThis.fetch = respondeCom({}, { status: 404 });
     expect(await saude()).toMatchObject({ reachable: true, status: "STOPPED" });
   });
 
-  it("casa a conta por `_id` OU `id` — a API usa os dois", async () => {
-    globalThis.fetch = respondeCom({ accounts: [{ id: "conta-1" }] });
-    expect(await saude()).toMatchObject({ status: "WORKING" });
+  it("token VÁLIDO com o número desligado do lado do aparelho → FAILED", async () => {
+    // O caso que a varredura da lista de contas NÃO enxergava, e que a própria
+    // doc do provedor nomeia: a chave presta, a conta está lá, e a Meta recusa
+    // servir o objeto do número. Antes disto o CRM dizia "conectado" para um
+    // número que não entregava mais nada — em silêncio, para sempre.
+    globalThis.fetch = respondeCom({
+      status: "error",
+      platformConnection: {
+        status: "disconnected",
+        phoneStatus: null,
+        metaError: { code: 100, subcode: 33, message: "Unsupported get request" },
+      },
+    });
+    const r = await saude();
+    expect(r.status).toBe("FAILED");
+    expect(r.detail, "o código da Meta é o que diz ao operador o que fazer").toBe("meta_100_33");
+  });
+
+  it("o detalhe NÃO carrega a mensagem crua da Meta", async () => {
+    // Ela é longa e às vezes leva identificadores que não têm por que entrar
+    // num aviso que vai para a tela.
+    globalThis.fetch = respondeCom({
+      platformConnection: {
+        status: "disconnected",
+        metaError: { code: 100, subcode: 33, message: "objeto 1234567890 do usuário fulano" },
+      },
+    });
+    expect((await saude()).detail).not.toContain("fulano");
+  });
+
+  it("sonda inconclusiva é NÃO SEI — jamais 'caiu'", async () => {
+    // `unknown` é, nas palavras da doc, "not evidence either way". Traduzi-lo
+    // para queda faria um soluço da Meta abrir aviso crítico, e aviso que grita
+    // à toa ensina o operador a ignorar aviso — que é pior que não ter nenhum.
+    //
+    // Como `reachable: false`, `julgarQueda` ainda exige DUAS observações ruins
+    // seguidas antes de acreditar: um soluço isolado não escala.
+    globalThis.fetch = respondeCom({
+      status: "warning",
+      platformConnection: { status: "unknown", phoneStatus: null, metaError: null },
+    });
+    const r = await saude();
+    expect(r.reachable, "'não sei' virou queda de canal").toBe(false);
+    expect(r.status, "inventou um status que não mediu").toBeNull();
+  });
+
+  it("sem o campo do elo, decide pelo veredito geral — e ausência não é má notícia", async () => {
+    // Conta que não é WhatsApp, ou provedor que ainda não publicou a sonda.
+    // Falhar aqui derrubaria canais saudáveis no dia em que a resposta mudasse.
+    globalThis.fetch = respondeCom({ status: "healthy" });
+    expect(await saude()).toMatchObject({ reachable: true, status: "WORKING" });
+  });
+
+  it("sem o campo do elo, mas a conta em erro → FAILED", async () => {
+    globalThis.fetch = respondeCom({ status: "error", issues: ["token expiring"] });
+    expect(await saude()).toMatchObject({ reachable: true, status: "FAILED" });
   });
 
   it("rede caída é NÃO SEI, nunca 'canal caído'", async () => {
@@ -115,6 +179,25 @@ describe("canal intermediado", () => {
   it("sessão sem credencial não vira alarme de queda", async () => {
     zernioCreds.mockResolvedValue(null as never);
     expect(await saude()).toMatchObject({ reachable: false, status: null });
+  });
+
+  it("pergunta pela CONTA, no caminho de saúde — não varre a lista", async () => {
+    // A varredura de `GET /v1/accounts` respondia "a conta existe", que é outra
+    // pergunta. Se alguém voltar a ela, os casos acima passam a ser encenação.
+    // Restaura a credencial explicitamente: `mockClear` zera CHAMADAS, não a
+    // implementação, e o caso anterior deixou `null` — sem isto o teste passaria
+    // a depender da ordem de execução, que é o jeito de um teste mentir.
+    zernioCreds.mockResolvedValue({
+      accountId: "conta-1",
+      apiKey: "chave",
+      baseUrl: "https://z.example",
+      source: "session",
+    } as never);
+    const espia = respondeCom(ELO_VIVO);
+    globalThis.fetch = espia;
+    await saude();
+    const url = String((espia as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]![0]);
+    expect(url).toContain("/v1/accounts/conta-1/health");
   });
 });
 


### PR DESCRIPTION
`checkHealth` do canal intermediado varre `GET /v1/accounts` e dá `WORKING` quando a conta aparece na lista. Isso responde *"a chave presta e a conta existe"*. A pergunta do cron é outra: **dá para enviar por este número agora?**

As duas divergem no caso que mais importa, e a doc do provedor o nomeia:

> *"The OAuth token can be perfectly valid while Meta refuses to serve the phone-number object (for example after a phone-side coexistence disconnect), so `tokenStatus` alone is not a liveness signal for WhatsApp."*

Alguém desconecta o aparelho do lado de lá, a conta segue na lista, e o CRM diz "conectado" para um número que não entrega mais nada — em silêncio, para sempre.

## Medido antes de escrever

`GET /v1/accounts/{id}/health` (publicado pelo provedor em 15/08) sonda o elo com a Meta no instante do pedido. Sondado contra a API de uma instalação real:

```
HTTP 200
status: "healthy"
platformConnection: {"status":"connected","phoneStatus":"CONNECTED","metaError":null}
```

## A decisão que mais importa: `unknown` não vira queda

| resposta | desfecho | por quê |
|---|---|---|
| 401 / 403 | `FAILED` | credencial recusada |
| 404 | `STOPPED` | a conta sumiu (a rota existe — medida em 200) |
| `disconnected` | `FAILED` + `meta_100_33` | o código diz ao operador o que fazer |
| `unknown` | `reachable:false`, sem status | *"not evidence either way"* — mesmo tratamento de oscilação de rede |
| campo ausente | veredito geral | conta não-WhatsApp não pode virar canal derrubado |

O detalhe **não** carrega a mensagem crua da Meta — às vezes leva identificador que não tem por que ir para a tela. Há caso vigiando isso.

## Testes

**22** — os antigos foram **reescritos, não adaptados**: um deixou de existir porque a lista não é mais lida, e o último vigia a URL — se alguém voltar a varrer `/v1/accounts`, os outros 21 viram encenação sem nada ficar vermelho.

Rodando em produção numa instalação real há dois dias, com o anti-flap do cron absorvendo os `unknown` como devem.