### PR TITLE
Release 1.4.0 — o onboarding novo finalmente alcança as VPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,162 @@ Se você roda o DeskcommCRM numa VPS, **leia a seção da versão para a qual es
 
 ## [Não lançado]
 
+## [1.4.0] — 2026-08-24
+
+Esta versão muda o primeiro acesso. Instalar deixou de ser "configurar uma IA" e passou a ser **montar um funcionário e vê-lo atender antes de terminar**: você diz como ele se chama, o jeito dele falar e as regras da casa, monta o quadro de clientes do **seu** ramo — não o de loja virtual que todo mundo ganhava igual — e, no último passo, conversa com ele como se fosse um cliente. Nada sai pelo WhatsApp; você só confere que ele funciona antes de confiar nele. Junto disso, seis causas diferentes que deixavam uma IA publicada **muda** foram medidas num servidor real e consertadas uma a uma; o sistema passou a ser usável no celular; e você pode pôr o seu nome, o seu logo e a sua cor em tudo — pela tela, sem linha de comando.
+
+### ⚠️ Requer atenção
+
+**Desta vez, rodar o `update.sh` UMA vez basta — a instrução da 1.3.0 não vale mais.** A
+versão anterior pedia duas execuções porque a primeira deixava o processo que faz a IA
+atender "solto": acompanhando o desenvolvimento em vez de ficar parado na sua versão, como o
+resto do sistema. Isso acabou. A atualização agora fixa as três partes do sistema na mesma
+versão de uma vez só, e se ainda assim alguma ficar solta — é o caso de quem está vindo de
+uma versão anterior à 1.3.0 — o próprio sistema fecha essa ponta sozinho em até 5 minutos,
+sem você fazer nada. Rodar duas vezes por hábito não estraga nada: a segunda vez responde
+"você já está na versão mais recente" e não toca em nada.
+
+**Antes de ligar a parada automática da IA, confira o número do seu limite.** Ele sempre foi
+em dólar, e a tela dizia real (está explicado acima). Quem escreveu "50" pensando em reais
+tem, na verdade, um limite de US$ 50 — cerca de cinco vezes maior do que imaginava. Seu
+limite não foi alterado; o que mudou é a tela finalmente dizer a verdade. Como a parada
+automática nasce desligada em todo mundo, dá tempo de olhar o número com calma antes de
+armá-la.
+
+Fora isso, nada exige ação sua. O arquivo de configuração criado na sua instalação continua
+valendo como está: tudo que é novo nesta versão já vem com um valor padrão, e a própria
+atualização acrescenta o que faltar. O banco de dados também passa a se limpar sozinho a
+partir daqui, jogando fora registro técnico velho que ninguém lê — conversa, contato,
+mensagem e histórico de atendimento não são tocados, e não há nada para você configurar.
+
+**Se você tem DUAS conexões oficiais do WhatsApp com a mesma conta da Meta, uma delas vai
+mudar de nome.** Era possível cadastrar a mesma conta duas vezes — numa agência com dois
+clientes, ou num número que trocou de empresa — e, enquanto isso durou, as mensagens
+recebidas eram descartadas em silêncio para as **duas**. A atualização mantém a mais antiga e
+marca a outra como conflito, acrescentando `-conflito-` ao identificador dela. **Nada é
+apagado**: se você encontrar uma conexão com esse nome, é essa a razão — confira qual das duas
+deve continuar e apague a que sobra.
+
+**Se você usou o botão "Configurar Catálogo" na tela de conhecimento, confira o que ficou
+gravado.** Ele salvava o que você escrevia como se fosse uma pergunta e resposta, não um
+catálogo — então o conteúdo está lá, mas na gaveta errada. Vale reabrir e refazer.
+
+**Se o seu sistema ainda chama a sua empresa de "Minha Empresa", troque em Configurações.** A
+instalação cria a empresa com esse nome provisório, e o primeiro acesso trazia esse texto já
+escrito no campo — quem seguiu adiante sem apagar ficou com ele. Agora o campo vem vazio, mas
+quem já passou por ali precisa corrigir à mão.
+
 ### Adicionado
 
-- **O agente de atualização passa a fixar sozinho a versão que ficou solta**, em até 5
-  minutos, sem você fazer nada — ele grava a versão que já está rodando. O que ele **nunca**
-  faz é mexer numa configuração que você escreveu à mão: se você escolheu acompanhar um canal
-  de propósito, ele respeita e só avisa.
-
-  Isso **não vale para quem está na 1.3.0** — entrou depois dela. Até a próxima versão sair,
-  a instrução da 1.3.0 continua sendo a única verdadeira: rode o `update.sh` **duas vezes**.
-
+- **Instalar deixou de ser "configurar um sistema": agora você monta um funcionário e o vê
+  atender antes de terminar.** O passo a passo do primeiro acesso foi de 4 para 6 etapas e
+  mudou de assunto. Ele abre mostrando o que a sua instalação já trouxe pronta — servidor e
+  banco de pé, qual inteligência artificial foi contratada, se o WhatsApp está pronto para
+  parear —, em vez de um formulário em branco. O antigo "Configurar IA" virou **"Treine seu
+  funcionário"**: como ele se chama, o jeito dele falar e — o campo que faltava — as regras
+  da casa (horário de atendimento, o que nunca prometer, como chamar o cliente). Ali mesmo a
+  chave da inteligência artificial é testada de verdade: não "a chave foi aceita", que um
+  provedor responde até com a conta zerada, mas uma resposta real, que é a única coisa que
+  prova que há crédito. Se a instalação veio sem chave, o campo para colar a sua está nessa
+  tela, um clique antes de o funcionário nascer com ela. Entrou o passo **"Onde ele
+  organiza"**, que monta o quadro de clientes do **seu ramo**: uma clínica termina com "Quer
+  agendar" e "Consulta marcada", em vez do quadro de loja virtual — "Carrinho abandonado",
+  "Em separação", "Enviado" — que toda instalação ganhava igual, sem nunca ter sido
+  perguntada em que ramo entrou. Você pode renomear, remover e acrescentar colunas antes de
+  gravar. E entrou o passo **"Ver ele atender"**: você escreve como se fosse um cliente e lê
+  a resposta dele antes de terminar, sem nada sair pelo WhatsApp e sem criar conversa nenhuma
+  — antes, o último clique despejava você numa caixa de conversas vazia, depois de montar um
+  funcionário que você nunca tinha visto fazer nada. O funcionário que nasce dali também é
+  outro: deixou de ser um respondedor de perguntas e já vem sabendo mexer no CRM sozinho —
+  procurar o cliente, anotar o que ele informou, criar a oportunidade no funil e mover o
+  cliente de etapa —, apontado para o funil certo e sabendo dizer o que o seu negócio faz. E,
+  no fim, em vez de te largar numa tela vazia, o sistema se apresenta: as seis partes
+  principais, cada uma com uma frase sobre o que ela faz por você.
+- **Ponha o seu nome, o seu logo e a sua cor no sistema — pela tela, sem linha de comando e
+  sem reiniciar nada.** Em *Administração › Marca*, quem é dono da instalação troca o nome do
+  sistema, escolhe a cor da marca e sobe o arquivo do logo (PNG ou JPG, até 512 KB). Salvou,
+  recarregou: a barra lateral, os botões, o destaque que aparece ao redor do campo em que você
+  está digitando, o título da aba e o ícone do navegador já estão repintados. Até esta versão,
+  a única forma de trocar a marca era editar um arquivo no servidor por linha de comando e
+  reiniciar o sistema inteiro — e quem editava o código para conseguir isso perdia a mudança
+  na atualização seguinte, quase sempre sem perceber. A cor não é aplicada crua: o sistema
+  deriva onze tons dela e mostra onde cada coisa vai pousar antes de você salvar; se a cor
+  escolhida deixaria o texto do botão ilegível no tema escuro, ele anda os degraus necessários
+  sozinho. Nada de escolher amarelo e descobrir depois que o botão ficou branco no branco. E
+  cada empresa dentro da mesma instalação pode ter a própria marca, em *Configurações ›
+  Marca*, sem depender de quem instalou o sistema: o que ela deixa em branco é herdado da
+  instalação.
+- **A sua marca sai da tela e alcança o resto do produto.** O ícone da aba do navegador (que
+  simplesmente não existia — a aba ficava sem ícone nenhum), o nome que aparece no aplicativo
+  autenticador de quem liga a verificação em duas etapas, o nome do remetente dos e-mails e,
+  principalmente, os e-mails de confirmação de conta e de recuperação de senha — que até aqui
+  chegavam ao seu cliente com o nome do nosso produto, no primeiro contato dele com o sistema.
+  O instalador também passou a perguntar a cor da marca: antes ele perguntava só o nome e
+  entregava o verde do nosso produto em toda tela e em todo e-mail de acesso, então quem
+  instalava para um cliente entregava a marca dele pintada com a cor de outro. Uma ressalva
+  que vale conhecer: os e-mails de acesso são lidos de fora do CRM, então trocar a cor pela
+  tela depois **não** reescreve esses e-mails — é a resposta dada ao instalador que faz as
+  duas pontas nascerem iguais. Uma exceção é deliberada: **o relatório de dados pessoais em
+  PDF nunca leva a sua marca.** Ele nomeia a empresa que responde legalmente pelos dados,
+  porque é um documento que atende a um direito do titular — pôr ali o nome de quem só
+  hospeda inverteria quem responde pelo quê.
+- **Dá para usar o sistema pelo celular.** A barra lateral fixa era a única navegação
+  existente e nunca sumia: num celular comum ela empurrava o conteúdo para fora da tela, e não
+  havia botão nenhum para escondê-la. Agora ela vira uma gaveta que abre pelo topo e fecha
+  sozinha ao trocar de tela, e todo botão ganha um alvo de toque de dedo no celular, voltando
+  ao tamanho compacto no computador, onde quem aciona é o mouse. Junto veio uma varredura por
+  todo o sistema atrás do que empurrava a tela para o lado: os cabeçalhos das páginas, a lista
+  de funis, a barra de seleção em massa do quadro de vendas, campos de busca de largura fixa,
+  tabelas soltas e os rodapés de "Pular/Continuar" do cadastro inicial. E a página inteira
+  nunca mais desliza de lado: quando algo é largo demais — uma tabela, o quadro de vendas —, é
+  só aquela parte que rola, e o resto da tela fica parado.
+- **A verificação em duas etapas virou escolha, e não uma porta trancada na primeira tela.**
+  O botão "Começar a usar" entregava o dono da instalação num bloqueador de tela cheia
+  pedindo um aplicativo autenticador — um passo extra que o próprio wizard nunca anunciou,
+  bem na hora de finalmente ver o produto funcionando. Agora quem administra decide se ela é
+  obrigatória, em Configurações › Segurança, e o padrão é não exigir. Quem já usa a
+  verificação continua protegido exatamente como está.
+- **O produto passou a falar a sua língua: "Pipeline" e "Kanban" saíram da tela.** Eram cinco
+  nomes para a mesma coisa, e três apareciam juntos na mesma tela. Agora o menu tem **Funis**
+  (onde você abre o funil) e **Etapas do funil** (onde você configura o que cada coluna
+  significa). Nas telas do primeiro acesso, o mesmo: o passo do WhatsApp parou de mostrar
+  códigos internos como "Sessão: org_f3d61bc0" e "Status: INIT", e o passo do time deixou de
+  listar "viewer, agent, manager, admin" em inglês.
+- **Dá para responder "em cima" de uma mensagem, e enviar o contato de alguém, como no
+  WhatsApp.** Passe o mouse (ou toque, no celular) sobre a mensagem, escolha *Responder*, e
+  ela aparece citada logo acima do campo de texto — com um × para desistir. O cliente recebe a
+  sua resposta pendurada na mensagem original, do jeito que ele já conversa no WhatsApp.
+  Funciona nas duas formas de conectar o número, e o botão aparece também no celular — antes
+  de sair, ele só existia para quem tem mouse, ou seja, sumia justamente onde a maior parte do
+  atendimento acontece. Trocar de conversa limpa a citação sozinho, para nenhuma frase sair
+  citando a mensagem de outro cliente. E no "+" ao lado do campo de mensagem existe agora a
+  opção *Contato*: escolha alguém da sua base ou digite nome e telefone na hora, e chega no
+  WhatsApp do cliente como cartão de contato de verdade — ele salva ou chama a pessoa com um
+  toque. Quando um cartão de contato chega para você, ele fica clicável dentro do CRM: um
+  toque abre a conversa com aquela pessoa, criando o contato se ainda não existir. O telefone
+  é conferido antes de sair, para o cartão não levar um número que não existe no WhatsApp (o
+  caso clássico do nono dígito).
+- **Importar contatos de uma planilha.** Botão *Importar* na tela de Contatos: você sobe um
+  arquivo CSV — o que qualquer Excel ou Google Planilhas exporta — e ele entra com nome,
+  telefone, e-mail, CPF, aniversário e etiquetas. Os títulos das colunas podem estar em
+  português (`nome`, `telefone`, `celular`, `aniversário`, `etiquetas`), e o separador pode
+  ser vírgula ou ponto-e-vírgula, que é o que o Excel em português usa. Cada linha tem
+  desfecho próprio na tela: importada, já existia, ou recusada com o motivo escrito — uma
+  linha errada não derruba a planilha inteira. Até 500 linhas por vez. Arquivo `.xlsx` é
+  recusado com a instrução de exportar como CSV, em vez de importar pela metade.
+- **De qual anúncio o contato veio.** Quando alguém chega pelo botão "Enviar mensagem" de um
+  anúncio do Facebook ou do Instagram, o CRM guarda a campanha e o anúncio na ficha do
+  contato, e o negócio nasce etiquetado como vindo de anúncio. É gravado no primeiro contato e
+  nunca reescrito depois — o primeiro toque é o que conta. Compartilhar um post normal, sem
+  impulsão, não é confundido com anúncio pago. Anúncios do Google ainda não são identificados.
+- **O atendimento automático volta a funcionar no domingo.** Até agora a IA ficava calada o
+  domingo inteiro, e quem escrevia no domingo só era respondido na segunda-feira. A regra
+  existia para reduzir risco de bloqueio, mas o que protege disso é o ritmo de envio, não o
+  dia da semana — o custo caía sobre o seu cliente, à toa. Agora o domingo é liberado por
+  padrão. A janela da noite continua valendo (nada sai entre 22h e 7h) e, se você faz
+  prospecção ativa e prefere não incomodar no fim de semana, dá para desligar o domingo em
+  Conexões › **Proteção de envio**, número por número — a chave se chama "Enviar aos
+  domingos".
 - **O limite de gasto com IA passa a valer de verdade — e nasce desligado.** Até agora a tela
   de Uso de IA › Orçamento deixava você escrever um limite mensal, mas quem barrava a chamada
   olhava para outro lugar: nenhuma instalação estava protegida, e a tela dizia que estava.
@@ -28,35 +174,166 @@ Se você roda o DeskcommCRM numa VPS, **leia a seção da versão para a qual es
   (dá para renunciar a essa espera marcando a caixa). **Você não precisa fazer nada** — quem
   não abrir essa tela continua exatamente como está hoje.
 - **Quando o limite para a IA, ninguém fica sem resposta.** As conversas que estavam sendo
-  atendidas vão para a fila de atendimento humano, com um aviso na Central explicando o que
-  aconteceu. Cada uma volta ao automático pelo botão "Devolver ao automático" no
-  cabeçalho da conversa. Aumentar o limite evita paradas novas, mas não devolve sozinho as
-  conversas que já pararam.
-- **Um aviso na Central quando o gasto passa do ponto que você escolheu**, antes de qualquer
-  parada — e ele se apaga sozinho quando o gasto volta para baixo do limite ou o mês vira.
+  atendidas vão para a fila de atendimento humano, com um aviso na Central de avisos
+  explicando o que aconteceu. Cada uma volta ao automático pelo botão "Devolver ao automático"
+  no cabeçalho da conversa. Aumentar o limite evita paradas novas, mas não devolve sozinho as
+  conversas que já pararam. E, antes de qualquer parada, um aviso na Central de avisos aparece
+  quando o gasto passa do ponto que você escolheu — ele se apaga sozinho quando o gasto volta
+  para baixo do limite ou o mês vira.
+- **O banco de dados passou a se limpar sozinho, todo dia.** Três arquivos internos cresciam
+  para sempre e nunca eram podados: o arquivo bruto de tudo o que o WhatsApp envia, a fila de
+  tarefas da IA e o registro de auditoria. Numa instalação real, o arquivo do WhatsApp sozinho
+  era **86% do banco inteiro** — 468 MB de um total de 545 MB, contra menos de 10 MB de
+  mensagens, contatos e leads somados. E o plano gratuito do Supabase acaba em 500 MB, que é
+  onde vive a maior parte de quem instala. Agora, a cada dia: o conteúdo pesado dos eventos do
+  WhatsApp é esvaziado depois de 7 dias e a linha some depois de 90 (o resumo continua lá,
+  para investigar problema antigo); a fila de tarefas já concluídas é apagada depois de 90
+  dias; e a auditoria segue a validade definida no arquivo de configuração da sua instalação,
+  com 5 anos de padrão e um piso de 90 dias que não dá para furar. Nada que ainda tem dono é
+  tocado: tarefa esperando, tarefa rodando agora e tarefa que falhou e virou aviso na Central
+  de avisos ficam onde estão. **Você não precisa configurar nada** — já vem ligado com esses
+  valores.
+- **O agente de atualização passa a fixar sozinho a versão que ficou solta**, em até 5
+  minutos, sem você fazer nada — ele grava a versão que já está rodando. O que ele **nunca**
+  faz é mexer numa configuração que você escreveu à mão: se você escolheu acompanhar um canal
+  de propósito, ele respeita e só avisa.
+
+  Se você veio da 1.3.0 e rodou o `update.sh` uma vez só, é ele que termina o serviço a partir
+  desta versão — a instrução de "rodar duas vezes" deixa de ser necessária daqui em diante.
+- **Da lista de Contatos direto para a conversa.** Na lista de Contatos e na ficha de cada
+  pessoa há agora um botão que leva direto para a conversa dela no Inbox, sem precisar
+  procurá-la na lista de conversas.
+- **Dá para instalar numa VPS que já tem painel (CloudPanel e similares).** Antes, o
+  instalador tentava subir o próprio servidor web nas portas 80 e 443, que já estavam
+  ocupadas pelo painel, e a instalação parava ali. Agora existe um passo a passo oficial para
+  esse caso, na documentação do projeto, em `docs/runbooks/cloudpanel.md` — contribuição de um
+  usuário da comunidade.
+- **Quem usa a OpenRouter parou de ter o próprio consumo creditado ao site de outra pessoa.**
+  Uma versão anterior levava, fixo dentro do sistema, o endereço de um site de terceiro — e o
+  consumo de todo mundo ficava atribuído a um lugar que não é seu. Isso saiu. Se você quiser
+  aparecer com o seu próprio nome no painel da OpenRouter, há dois campos no arquivo de
+  configuração da instalação (`OPENROUTER_APP_URL` e `OPENROUTER_APP_TITLE`), os dois
+  opcionais e vazios por padrão: deixando em branco, nada é enviado junto com as chamadas.
 
 ### Corrigido
 
-- **⚠️ Requer atenção — o valor do orçamento de IA sempre foi em DÓLAR, e a tela dizia real.**
-  Quem lia "R$ 50,00" tinha, na verdade, um limite de **US$ 50,00** — cerca de cinco vezes
-  maior do que imaginava. Nada mudou no seu gasto nem no seu limite: mudou o que a tela
-  confessa. O rótulo agora diz US$ nas telas de Uso de IA, Execuções, Evolução e nos painéis
-  de administração. **Confira o número antes de ligar a parada automática**: se você escolheu
-  "50" pensando em reais, o que está armado é cinco vezes isso.
-- **O gasto exibido era o acumulado desde a instalação, não o do mês.** O contador antigo
-  somava tudo e nunca zerava, então numa instalação com alguns meses de uso o card comparava
-  meses de gasto contra um limite mensal. Agora o número é o do mês corrente, e é o mesmo
-  número que decide se a IA para.
-- **O seletor "Ação ao atingir 100%" saiu da tela.** Ele oferecia "Pausar" e "Desabilitar"
-  como se fossem coisas diferentes; não eram — nada no produto os distinguia, e a escolha não
-  tinha efeito nenhum. Quem quiser que a IA pare no limite usa a opção "Parar a IA" da escada
-  nova.
-- **Os avisos de orçamento apareciam e não sumiam.** O alerta de "limite atingido" ficava
-  aceso mesmo depois de o mês virar ou de você aumentar o limite. Agora ele se retrata
-  sozinho.
-- **No painel de administração, o alerta de orçamento parou de gritar "crítico" sobre um
-  número que não é o do mês.** Ele continua avisando, com o rótulo dizendo que o valor é
-  acumulado, e leva direto para a tela de saúde do cliente, que mostra o número real.
+- **Seis causas diferentes deixavam uma IA publicada muda — e nenhuma aparecia como erro.** Medidas
+  uma a uma num servidor real, com o dono dizendo "a IA não responde": em todas, a tela dizia "IA
+  atendendo" e a mensagem não chegava.
+- **Número de WhatsApp recém-conectado: a IA não respondia a ninguém.** Todo número novo entra com
+  uma trava de segurança nos primeiros dias, para não ser banido — e a trava segurava também as
+  RESPOSTAS a quem escrevia para você. O cliente mandava "Oi" e passavam horas. Agora ela segura só
+  o que o sistema começa sozinho; responder quem escreveu nunca é retido, e as conversas paradas por
+  essa causa voltam à fila sozinhas.
+- **Uma regra de distribuição vazia sequestrava o atendimento inteiro.** Dá para ligar uma regra em
+  dois cliques e não colocar ninguém nela — e aí toda conversa ia para um atendente genérico, sem as
+  suas instruções, morrendo em silêncio enquanto o agente certo esperava do outro lado. Agora isso
+  não tira a conversa de quem já atendia.
+- **Quem escrevia depois das 22h nunca era respondido — nem no dia seguinte.** Fora da faixa em que
+  o sistema pode enviar (7h às 22h), a resposta era perdida: o atendimento era dado como concluído e
+  nada saía. Agora ela é adiada e entregue quando o horário abre. No mesmo caminho, o **horário de
+  funcionamento que você configurava não era lido por ninguém** (medido: 8h às 18h, de segunda a
+  sexta, com o agente respondendo às 21:55 de uma terça), e a **retomada de quem sumiu morria em 25
+  minutos**, dando o contato como perdido antes das 23h. Agora a espera aguenta a noite inteira e a
+  mensagem sai pela manhã.
+- **A tela do agente anunciava uma coisa e o motor rodava outra.** O cartão mostrava a inteligência
+  escolhida no dia da criação, não a publicada; a mesma tela dizia "Publicado" e "Rascunho" ao mesmo
+  tempo, e a resposta tranquilizadora era a errada; e **arquivar um agente antigo não arquivava
+  nada** — ele seguia recebendo conversas. Agora as telas mostram quem realmente atende.
+- **O que você configurava no agente não chegava ao atendimento.** "Abri o agente e o prompt sumiu"
+  era comum: um rascunho antigo vencia a versão publicada, e a tela deixava publicar texto vazio por
+  cima do texto bom. O editor **cortava o fim das instruções coladas, sem avisar** — um agente
+  atendeu clientes de verdade com as instruções cortadas no meio de uma frase. O **tamanho de
+  histórico que você escolhia não valia** (a tela oferecia até 8.000 e o motor usava 1.000), e
+  **nada limitava mensagens seguidas**: o funcionário disparava até 8 sem o cliente responder. Agora
+  vale o que você configurou, e há um teto por atendimento (3 por padrão).
+- **Quem instalou escolhendo a OpenRouter tinha um funcionário que morria em toda mensagem.** Ela é
+  a primeira opção do instalador e estava quebrada em quatro pontos: a chave sumia; o agente do
+  primeiro acesso nascia pedindo uma chave da Anthropic que você nunca teve; o botão de testar
+  recusava justamente o provedor em uso; e o seletor de inteligência abria em branco, trocando o seu
+  provedor no primeiro salvamento. Junto, **"sem saldo" aparecia como erro sem nome nem conserto** —
+  a chave estava sem crédito e o dono caçou defeito por horas no sistema para um problema de fatura.
+  Agora a tela nomeia falta de saldo ou de limite, e quando falta chave ou modelo o agente fica em
+  **rascunho honesto** em vez de nascer com selo de "Publicado" e ficar mudo.
+- **"Tem como parar a dor?" bloqueava o paciente para sempre — e quem respondia "BAJA" em espanhol
+  continuava recebendo.** A regra que reconhece pedido de sair da lista caçava a palavra em qualquer
+  posição da frase. Medido numa clínica em uso real: "tem como parar a dor?" e "posso sair antes das
+  15h?" bloqueavam o contato, que sumia sem ninguém saber — e o mesmo erro deixava passar "não quero
+  mais receber", que é pedido claro. Do outro lado, os modelos em espanhol terminam com "Respondé
+  BAJA para no recibir más" e o CRM só entendia português e inglês: o caminho mais curto para uma
+  denúncia de spam. Agora só bloqueia a palavra sozinha ou o pedido inequívoco, e `baja`, `salir` e
+  `no quiero recibir` descadastram.
+- **Tropeços do primeiro acesso.** O aceite de termos era obrigatório e apontava para duas páginas
+  que não existiam; elas agora existem e nomeiam **quem instalou** como responsável pelos dados. O
+  sistema chamava sua empresa de "Minha Empresa" até você recarregar a página. E a tela do WhatsApp
+  mandava escanear "o código abaixo" quando **não havia código nenhum**, ou dizia "Preparando o
+  código…" para sempre; agora o código aparece e cada situação responde "e agora?", com botão de
+  tentar de novo.
+- **A caixa de conversas contava história errada.** O contador de pendentes só subia — responder não
+  abaixava nada — e uma conversa com **uma** mensagem nova podia mostrar 6. Agora responder zera,
+  abrir marca como lida, e os contadores errados são recalculados na atualização. A coluna *Última
+  atividade* dos Contatos ficava parada, e mensagens novas só apareciam recarregando a página —
+  agora a tela se reconecta sozinha e recupera o que entrou nesse meio-tempo.
+- **A conexão do WhatsApp não voltava sozinha depois de um reinício.** Reiniciar o servidor ou uma
+  falta de memória deixava o número parado — nada entrava, nada saía — até alguém abrir Conexões e
+  clicar em *Reconectar*, às vezes só no dia seguinte. Agora o sistema religa sozinho o número que
+  apenas parou — mas não quando o WhatsApp recusou a conta nem quando o QR Code espera alguém com o
+  celular na mão, porque aí insistir piora.
+- **O WhatsApp ficou três dias fora do ar dizendo apenas "Não foi possível verificar a conexão".**
+  Quando o WhatsApp recusa a credencial, nada entra e nada sai — mas o aviso era a mesma frase
+  morna, em amarelo, de uma oscilação de rede. Foram três dias sem uma única mensagem, e o dono só
+  descobriu ao tentar conectar um número novo. Agora credencial recusada abre aviso próprio, em
+  vermelho, que diz o que fazer — e avisa que escanear o QR Code de novo **não** resolve. A causa
+  daqueles três dias também foi consertada: **duas cópias da pasta de instalação na mesma máquina**
+  trocavam as credenciais uma da outra; agora a atualização automática percebe isso e para antes de
+  estragar. E os **avisos nomeavam o número errado** — o telefone era gravado no primeiro pareamento
+  e nunca mais corrigido —, mandando o dono pegar o celular errado.
+- **Seu número podia aparecer como conectado enquanto não entregava mais nada.** No caminho oficial
+  do WhatsApp, bastava desconectar o aparelho do outro lado: o CRM seguia dizendo "conectado" e o
+  atendimento morria calado. Agora a conferência pergunta se dá para enviar por aquele número AGORA
+  — e "não consegui verificar" segue sendo tratado como não sei, nunca como queda.
+- **O sistema parado gastava mais cota de banco de dados do que o plano gratuito permite.** Uma
+  instalação sem nenhum contato e nenhuma conversa consumia **8,09 GB por mês contra uma cota de 5
+  GB**, só porque o processo que faz a IA atender perguntava à fila quatro vezes por segundo se
+  havia serviço. Agora ele pergunta quando falta pouco para a próxima tarefa vencer e dorme até lá,
+  sem deixar o atendimento mais lento. No mesmo esforço: o WhatsApp parou de mandar avisos que o CRM
+  já jogava fora, e as tarefas automáticas deixaram de registrar na auditoria quando não fizeram
+  nada — num servidor real, **95% da auditoria** era rotina vazia, enterrando o que importa.
+- **A versão publicada subia e morria em seguida, num ciclo sem fim.** Faltavam peças dentro do
+  pacote pronto e o sistema não mostrava uma única tela — enquanto o painel do servidor dizia que
+  estava tudo de pé, porque só conferia se ele atendia o telefone, não se havia alguém do outro
+  lado. Agora cada versão é ligada e testada antes de ser publicada.
+- **A atualização do banco podia falhar em silêncio e você nunca saber.** Partes de uma mudança não
+  chegavam ao seu servidor, o erro era tratado como inofensivo e a tela dizia "atualização
+  concluída". Agora, se falhar, você fica sabendo. O instalador também **acusava a sua chave quando
+  o problema era a internet**, prendendo você num laço do qual não se saía digitando certo. E **quem
+  tem Supabase próprio travava na primeira instalação**, tendo que editar arquivo à mão: agora
+  existe um segundo endereço, **opcional**, só para a estrutura do banco — quem não preencher
+  continua exatamente como está hoje.
+- **Uma leva de correções que você não vai notar — e esse é o ponto.** Uma mensagem preparada de
+  propósito podia congelar o sistema inteiro por segundos; agora é recusada na entrada. Falhas de
+  segurança em programas de terceiros foram fechadas, e um diagnóstico interno que imprimia a chave
+  do seu WhatsApp em texto puro agora mostra só um pedaço. Aviso do WhatsApp fora do formato
+  esperado era descartado em silêncio, com a mensagem se perdendo enquanto o WhatsApp achava que
+  tinha entregue. Telas apertadas ganharam espaço: a barra lateral não cobre mais a lista de
+  conversas, no celular a lista e a conversa não brigam pelo mesmo pedaço de tela, e textos cortados
+  sem jeito de ler o resto — eventos do contato, erros de integração, dados de LGPD — abrem por
+  inteiro. PDFs da base de conhecimento perdiam os parágrafos e agora chegam como no original. E o
+  logo, que demorava meio minuto para aparecer e **aparecia quebrado em toda instalação em Docker**,
+  aparece na hora e no lugar.
+- **⚠️ Requer atenção — o valor do orçamento de IA sempre foi em DÓLAR, e a tela dizia real.** Quem
+  lia "R$ 50,00" tinha, na verdade, um limite de **US$ 50,00** — cerca de cinco vezes maior do que
+  imaginava. Nada mudou no seu gasto nem no seu limite: mudou o que a tela confessa. O rótulo agora
+  diz US$ nas telas de Uso de IA, Execuções, Evolução e nos painéis de administração. **Confira o
+  número antes de ligar a parada automática**: se você escolheu "50" pensando em reais, o que está
+  armado é cinco vezes isso.
+- **O gasto exibido era o acumulado desde a instalação, não o do mês.** O contador nunca zerava, e
+  com alguns meses de uso a tela comparava meses de gasto contra um limite mensal. Agora o número é
+  o do mês corrente, e é o mesmo que decide se a IA para. Junto: o seletor "Ação ao atingir 100%"
+  oferecia "Pausar" e "Desabilitar" sem que nada os distinguisse, e a escolha não tinha efeito
+  nenhum — saiu da tela (quem quiser que a IA pare no limite usa "Parar a IA no limite"). E o alerta
+  de "limite atingido" ficava aceso depois de o mês virar ou de você aumentar o limite; agora se
+  apaga sozinho.
 
 ## [1.3.0] — 2026-08-13
 

--- a/tests/unit/changelog-cabe-na-tela-da-vps.test.ts
+++ b/tests/unit/changelog-cabe-na-tela-da-vps.test.ts
@@ -1,0 +1,116 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { extractChangelogSection } from "@/lib/system/changelog";
+
+/**
+ * A seção mais nova do CHANGELOG é TELA DE PRODUTO, e ela tem um teto.
+ *
+ * O agente que roda por cron na VPS não manda "a seção da versão nova" para o
+ * app: ele manda o CHANGELOG.md INTEIRO cortado em N bytes crus
+ * (`git show <tag>:CHANGELOG.md | head -c N`), e é o app que extrai a seção do
+ * texto recebido. Como o arquivo é lido de cima para baixo e a versão mais nova
+ * fica no topo, isso funciona — até a seção mais nova sozinha passar de N.
+ *
+ * Medido ao cortar a v1.4.0 (2026-08-24): a seção tinha 39.899 bytes contra um
+ * teto de 30.000. O texto chegava DECAPITADO no meio de uma frase e — pior — o
+ * bloco `### ⚠️ Requer atenção` ficava inteiro do lado de fora do corte:
+ * `extractChangelogSection()` sobre o texto truncado devolvia
+ * `requiresAttention: null`. Os dois avisos daquela versão (que rodar o
+ * `update.sh` uma vez passou a bastar, e que o teto de gasto de IA sempre foi em
+ * dólar) simplesmente não existiriam para quem fosse atualizar.
+ *
+ * Nada reprovava isso. O defeito não está no texto nem no script: está em serem
+ * dois artefatos com um contrato de tamanho que ninguém media. Este teste é esse
+ * contrato.
+ *
+ * O teto NÃO é digitado aqui — é lido do próprio `agent.sh`. Um número copiado
+ * para cá viraria uma segunda fonte da verdade, e a que envelhece primeiro é
+ * sempre a cópia.
+ *
+ * CONSERTOS POSSÍVEIS quando este teste ficar vermelho, em ordem de preferência:
+ *   1. enxugar a seção (quase sempre certo — item de changelog longo costuma ser
+ *      explicação que só interessa a quem escreveu o código);
+ *   2. mover `### ⚠️ Requer atenção` para logo depois do parágrafo de abertura —
+ *      `findAttentionRange()` acha o bloco em qualquer posição da seção, então o
+ *      aviso passa a sobreviver ao corte mesmo se o corpo for truncado.
+ * Aumentar o teto no `agent.sh` conserta as versões futuras e NÃO conserta esta:
+ * quem corta é o script que já está instalado na VPS do cliente, não o da `main`.
+ */
+
+const RAIZ = process.cwd();
+const CHANGELOG = path.join(RAIZ, "CHANGELOG.md");
+const AGENT_SH = path.join(RAIZ, "hostgator-setup-kit", "agent.sh");
+
+/** O teto real, lido de onde ele é aplicado. */
+function tetoDoAgente(): number {
+  const sh = fs.readFileSync(AGENT_SH, "utf8");
+  const m = /git show\s+"?\$\{?LATEST_TAG\}?"?:CHANGELOG\.md[^\n]*head -c (\d+)/.exec(sh);
+  if (!m) {
+    throw new Error(
+      "não achei o corte do CHANGELOG em agent.sh — se o mecanismo mudou, este teste precisa " +
+        "acompanhar em vez de ser apagado: o contrato de tamanho continua existindo.",
+    );
+  }
+  return Number(m[1]);
+}
+
+/** A primeira versão numerada do arquivo — "Não lançado" não é publicável. */
+function secaoMaisNova(raw: string): { versao: string; inicio: number; fim: number } {
+  const linhas = raw.split("\n");
+  const rx = /^##\s+\[(\d+\.\d+\.\d+)\]/;
+  let inicio = -1;
+  let versao = "";
+  let offset = 0;
+
+  for (const linha of linhas) {
+    const m = rx.exec(linha);
+    if (m && inicio === -1) {
+      inicio = offset;
+      versao = m[1]!;
+    } else if (inicio !== -1 && /^##\s+\[/.test(linha)) {
+      return { versao, inicio, fim: offset };
+    }
+    offset += Buffer.byteLength(linha, "utf8") + 1; // +1 = o \n
+  }
+  if (inicio === -1) throw new Error("nenhuma versão numerada no CHANGELOG.md");
+  return { versao, inicio, fim: Buffer.byteLength(raw, "utf8") };
+}
+
+/** Exatamente o que o agente manda: os primeiros N bytes do arquivo. */
+function comoChegaNaVps(raw: string, teto: number): string {
+  return Buffer.from(raw, "utf8").subarray(0, teto).toString("utf8");
+}
+
+describe("o CHANGELOG da versão nova cabe no que a VPS recebe", () => {
+  const raw = fs.readFileSync(CHANGELOG, "utf8");
+  const teto = tetoDoAgente();
+  const { versao, fim } = secaoMaisNova(raw);
+
+  it("a seção mais nova termina antes do corte do agente", () => {
+    expect(
+      fim,
+      `A seção [${versao}] termina no byte ${fim}, além do corte de ${teto} bytes que o ` +
+        `agent.sh aplica. O dono da VPS receberia o texto cortado no meio. Enxugue a seção ` +
+        `(veja o cabeçalho deste arquivo).`,
+    ).toBeLessThanOrEqual(teto);
+  });
+
+  it("o aviso de ação manual sobrevive ao corte", () => {
+    const inteiro = extractChangelogSection(raw, versao);
+    expect(inteiro, `a seção [${versao}] não foi extraída do arquivo completo`).not.toBeNull();
+
+    // Só cobra o que existe: versão sem ação manual não precisa do bloco.
+    if (inteiro!.requiresAttention === null) return;
+
+    const cortado = extractChangelogSection(comoChegaNaVps(raw, teto), versao);
+    expect(
+      cortado?.requiresAttention,
+      `A seção [${versao}] tem "⚠️ Requer atenção", mas o bloco fica FORA dos ${teto} bytes ` +
+        `que chegam à VPS — o aviso não apareceria para quem vai atualizar. Enxugue a seção, ` +
+        `ou mova o bloco para logo depois do parágrafo de abertura.`,
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## O que este PR faz

Escreve a seção `[1.4.0]` do CHANGELOG e traz a guarda que faltava, para que a tag `v1.4.0` possa ser cortada.

## Por que ele existe

O onboarding novo (PR #250) entrou na `main` em **14/08 às 10:11**. A v1.3.0 foi cortada em **13/08 às 19:58** — 14 horas antes. Nenhuma release saiu desde então, e toda a cadeia de atualização aponta para a última tag `v*`:

| peça | regra |
|---|---|
| `docker-compose.prod.yml` | `${APP_IMAGE:-…:stable}` |
| `publish-image.yml` | move `stable` **só** em push de tag `v*` |
| `update.sh:45`, `agent.sh:111` | `git tag -l 'v*' --sort=-v:refname \| head -1` |

Provado no artefato, não no git — labels da imagem no GHCR:

```
stable → revision 9bd59e93  version 1.3.0  created 2026-08-13T19:58
latest → revision e815b434  version main   created 2026-08-24T18:15
```

`9bd59e93` é anterior ao onboarding. **Nenhuma VPS podia recebê-lo por caminho nenhum** — não é instalação atrasada, a versão nunca existiu. São 330 commits, 53 PRs e 14 migrations parados há 11 dias.

## A guarda que vem junto

Redigir a seção revelou um segundo defeito, na entrega do próprio aviso. O agente da VPS não manda a seção da versão: manda o `CHANGELOG.md` inteiro cortado em **30.000 bytes crus**, e o app extrai a seção do que recebeu. Funciona enquanto a seção mais nova couber — e esta, com **39.899 bytes**, não cabia.

Medido rodando `extractChangelogSection()` sobre o texto truncado: `requiresAttention` vinha `null`. Os dois avisos desta versão (que rodar o `update.sh` uma vez passou a bastar; que o teto de gasto de IA sempre foi em dólar com a tela dizendo real) não chegariam a quem fosse atualizar.

`tests/unit/changelog-cabe-na-tela-da-vps.test.ts` é o contrato que faltava. Ele **lê o teto do próprio `agent.sh`** em vez de copiar o número, e cobra as duas pontas: seção além do corte, e bloco de atenção fora dele.

Conferido contra a `main` antes de entrar: **verde lá** (a 1.3.0 cabe), **vermelho** sobre a 1.4.0 inflada. Não nasce vermelha nem alcança quem já passou.

A seção saiu de 39.899 → **28.826 bytes**, com o bloco de atenção movido para logo depois da abertura: `findAttentionRange()` o acha em qualquer posição, e ali ele sobrevive a qualquer corte futuro.

## Verificação local

- `pnpm typecheck` — limpo
- `pnpm lint` — 0 erros
- `pnpm test:unit` — **5329 testes, 478 arquivos, todos passando**
- simulação do caminho de produção: os 5 avisos chegam completos ao texto de 30.000 bytes, terminando em frase inteira

## Depois do merge

`git tag -a v1.4.0` no commit de merge e push da tag. O CI publica `1.4.0`, `1.4` e move `stable` nas três imagens; o `agent.sh` que **já roda hoje** nas VPS na v1.3.0 enxerga a tag em até 5 minutos e anuncia na tela.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126ezJHDNKTi7J1EM2GpfvJ