### PR TITLE
1.4.1 — a release contou errado duas mudanças, e o gate que a guarda mede a grandeza errada

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,50 @@ Se você roda o DeskcommCRM numa VPS, **leia a seção da versão para a qual es
 
 ## [Não lançado]
 
+## [1.4.1] — 2026-08-24
+
+Correção de **texto de aviso**, não de comportamento: a seção da 1.4.0 descreveu errado uma
+mudança que chega a todo mundo e inverteu a instrução de outra. Como a tela de atualização lê
+o texto congelado na versão, o conserto só alcança quem atualizou pela publicação de uma
+versão nova — é isto. Junto vai um conserto de código pequeno e real, no descadastro em
+espanhol.
+
+### ⚠️ Requer atenção
+
+**A IA passa a atender aos domingos, e antes não atendia. A 1.4.0 fez essa mudança e não
+avisou.** O padrão de fábrica da janela anti-banimento mudou: domingo era dia mudo e passou a
+ser dia normal (a faixa de horário continua a mesma). Quem nunca mexeu nessa configuração —
+que é a maioria — recebeu a mudança na atualização, sem escolher. Se o seu negócio depende de
+silêncio no domingo, desligue em **Conexões › Proteção de envio › "Enviar aos domingos"**, por
+canal. Se você já tinha mexido ali, a sua escolha foi respeitada e nada mudou.
+
+**Se você tem duas conexões oficiais do WhatsApp com a mesma conta da Meta, a 1.4.0 disse o
+contrário do que acontece — confira antes de apagar qualquer uma.** O texto dizia que a
+atualização "mantém a mais antiga". É o inverso: **fica com o identificador a conexão MAIS
+RECENTE** (criá-la exigiu provar posse da conta na tela), e é a **mais antiga** que recebe o
+sufixo `-conflito-`. Nada foi apagado. A conexão com o identificador limpo é a que continua
+recebendo; a marcada como conflito aparece como falha na verificação de saúde, e isso é
+esperado. **Se você apagou a conexão sem o sufixo por causa daquela frase, é a que estava
+funcionando** — reconecte o número pela tela de Conexões.
+
+Fora isso, nada exige ação sua. Não há mudança de banco de dados nesta versão.
+
+### Corrigido
+
+- **`salir` sozinho não descadastrava.** A 1.4.0 anunciou que "`baja`, `salir` e
+  `no quiero recibir` descadastram"; medido com a função real, `baja` e `no quiero recibir`
+  funcionavam e `salir` não — a palavra estava fora da lista. `salir` é o `sair` em espanhol,
+  que já estava lá desde sempre. Continua valendo só a palavra **sozinha**: "voy a salir
+  ahora" tem três palavras e não bloqueia ninguém.
+- **A importação de planilha assume Brasil, e isso não estava escrito em lugar nenhum.**
+  Telefone sem código de país entra como brasileiro: `(11) 99999-8888` vira
+  `+5511999998888` — a mesma regra que o WhatsApp já usava ao receber mensagem. Se a sua
+  planilha tem números de fora do Brasil, escreva-os com o `+` e o código do país (`+351…`),
+  que aí são respeitados como estão. O comportamento não mudou; o que faltava era a frase.
+- **Um controle citado pelo nome errado.** A 1.4.0 mandava procurar "Parar a IA no limite" na
+  tela de orçamento de IA. O rótulo real mostra o seu número: "Parar a IA ao chegar em
+  US$ 50,00". Nada mudou na tela — mudou a descrição.
+
 ## [1.4.0] — 2026-08-24
 
 Esta versão muda o primeiro acesso. Instalar deixou de ser "configurar uma IA" e passou a ser **montar um funcionário e vê-lo atender antes de terminar**: você diz como ele se chama, o jeito dele falar e as regras da casa, monta o quadro de clientes do **seu** ramo — não o de loja virtual que todo mundo ganhava igual — e, no último passo, conversa com ele como se fosse um cliente. Nada sai pelo WhatsApp; você só confere que ele funciona antes de confiar nele. Junto disso, seis causas diferentes que deixavam uma IA publicada **muda** foram medidas num servidor real e consertadas uma a uma; o sistema passou a ser usável no celular; e você pode pôr o seu nome, o seu logo e a sua cor em tudo — pela tela, sem linha de comando.

--- a/lib/agent-engine/agent/inbound-turn.ts
+++ b/lib/agent-engine/agent/inbound-turn.ts
@@ -1029,6 +1029,16 @@ async function executarTurnoDoAgente(
   if (leadId === null) {
     throw new Error('job de turno sem contact_id — o CHECK da fila deveria impedir');
   }
+  // O RELÓGIO, declarado antes de qualquer guarda de janela.
+  //
+  // Ele já existia — 330 linhas ABAIXO, depois das duas guardas que mais
+  // dependem dele. O contrato de `InboundTurnDeps.clock` diz "a janela horária
+  // do gate anti-ban é avaliada nele", e as duas guardas chamavam `new Date()`
+  // cru: o relógio injetado não alcançava justamente o que ele existe para
+  // fixar. Em produção dá no mesmo; no CI, a hora real do runner decidia, e a
+  // suíte de invariantes ficava vermelha das 22h às 7h (fuso do tenant) — nove
+  // horas por dia em que um PR reprova por causa do relógio de parede.
+  const clock = deps.clock ?? ((): Date => new Date());
   const contextKnobs = { historyLimit: deps.knobs.historyLimit, maxTokens: deps.knobs.maxContextTokens };
   // Contexto do RUN em toda linha de log do turno (F2-16): job_id É o run id.
   const runLog = withFields(deps.log, { job_id: job.id, tenant_id: tenantId, lead_id: leadId });
@@ -1074,7 +1084,7 @@ async function executarTurnoDoAgente(
   // hora do envio, teria passado.
   if (turnoVaiFalarComOLead(job)) {
     const { knobs } = await loadChannelKnobs(pool, tenantId, input.channelSessionId, runLog);
-    const agora = new Date();
+    const agora = clock();
     if (!janelaDeEnvioAberta(agora, knobs)) {
       const abertura = proximaAberturaDaJanela(agora, knobs);
       await rescheduleJob(pool, job.id, ctx.workerId, {
@@ -1166,7 +1176,7 @@ async function executarTurnoDoAgente(
   // attempts (`rescheduleJob`) — quem escreveu 22h é atendido às 8h. O throw é
   // o contrato de `JobSettledError`: o run já dispôs do job, main.ts no-opa.
   if (job.kind === 'inbound_turn' && agentConfig?.janelaDeAtendimento != null) {
-    const esperaMs = msAteAJanelaAbrir(agentConfig.janelaDeAtendimento, new Date());
+    const esperaMs = msAteAJanelaAbrir(agentConfig.janelaDeAtendimento, clock());
     if (esperaMs !== null) {
       await rescheduleJob(pool, job.id, ctx.workerId, {
         delayMs: esperaMs,
@@ -1408,7 +1418,6 @@ async function executarTurnoDoAgente(
   const turnCrmCfg =
     agentConfig !== null ? { ...deps.crmCfg, agentActorId: agentConfig.agentId } : deps.crmCfg;
   const channel = (deps.channel ?? ((p: pg.Pool) => new WahaChannelAdapter(p, turnCrmCfg)))(pool);
-  const clock = deps.clock ?? ((): Date => new Date());
   // STOP lido no turno (fonte: CRM via get_lead_context) — combinado com o cache
   // durável leads.is_opted_out no gate 1 da cadeia (F2-13).
   const optedOutThisTurn = openingContext.context.contact.is_blocked;

--- a/lib/agent-engine/pacing/engine.ts
+++ b/lib/agent-engine/pacing/engine.ts
@@ -6,7 +6,7 @@
  * I/O nenhum. Clock e RNG são injetáveis (testes com clock fake e jitter
  * determinístico); em produção o chamador passa `new Date()` e omite o rng.
  *
- * Ordem de avaliação: janela horária (tz do tenant, domingo evitado) → caps
+ * Ordem de avaliação: janela horária (tz do tenant, domingo conforme `allowSunday`) → caps
  * diários (warm-up por idade do número; limite do CRM injetado) → throttle+jitter.
  */
 import type { PacingKnobs, WarmupStep } from './defaults';

--- a/lib/opt-out/deteccao.ts
+++ b/lib/opt-out/deteccao.ts
@@ -83,6 +83,18 @@ export const PALAVRAS_DE_OPT_OUT: ReadonlySet<string> = new Set([
   // cai no ambíguo, que é onde deve cair.
   "baja",
   "bajar",
+  // `salir` é o `sair` em espanhol, e `sair` está nesta lista desde sempre —
+  // faltar aqui era assimetria, não decisão. O CHANGELOG da 1.4.0 chegou a
+  // prometer que "`baja`, `salir` e `no quiero recibir` descadastram"; medido
+  // com as funções reais, `baja` e `no quiero recibir` devolviam `true` e
+  // `salir` devolvia `false`. Quem respondesse a palavra solta continuava
+  // recebendo — no idioma em que a plantilla é a fonte do pedido.
+  //
+  // Não alarga a regra: continua valendo só a palavra SOZINHA (mensagem inteira
+  // = a palavra). "Voy a salir ahora" tem três palavras e cai no ambíguo, que é
+  // onde deve cair — a mesma proteção que faz "tem como parar a dor?" não
+  // bloquear paciente de clínica.
+  "salir",
   "desuscribir",
   "desuscribirme",
 ]);

--- a/supabase/baseline.sql
+++ b/supabase/baseline.sql
@@ -6753,7 +6753,7 @@ create table if not exists channel_knobs (
   jitter_max_ms integer,              -- teto do jitter randômico somado ao throttle
   window_start_hour smallint,         -- janela [start, end) na hora local da org
   window_end_hour smallint,
-  allow_sunday boolean,               -- domingo evitado por default
+  allow_sunday boolean,               -- NULL = default do código (hoje: enviar)
   timezone text,                      -- IANA tz da org (a janela é avaliada nela)
   -- degraus [{"minAgeDays":N,"cap":M|null}, ...]; CHECK (array NÃO-VAZIO) +
   -- validação de shape no load — NULL cai no default; `[]` é rejeitado.

--- a/tests/invariants/agent-no-credential.test.ts
+++ b/tests/invariants/agent-no-credential.test.ts
@@ -122,6 +122,16 @@ describe("4B — turno sem credencial NENHUMA (nem env, nem BYOK)", () => {
           noProgressBlock: 5,
         },
       },
+      // Terça, 15h BRT: dentro da janela anti-ban (7h-22h). Sem fixar o
+      // relógio, este teste mede o motivo ERRADO quando a suíte roda fora da
+      // janela — a guarda de horário vem ANTES da checagem de credencial no
+      // fluxo, então o turno é adiado e nunca chega ao `credencial LLM` que a
+      // asserção procura. Medido: rodando às 22:20 BRT, a mensagem vinha
+      // `fora da janela anti-ban — job reagendado`. Os arquivos irmãos
+      // (`limite-de-envios-por-turno`, `agent-send-template-turn`) já faziam
+      // isso; este ficou de fora, e a suíte de invariantes reprovava das 22h
+      // às 7h por causa do relógio de parede.
+      clock: () => new Date("2026-07-28T18:00:00Z"),
       log,
     });
 

--- a/tests/invariants/janela-usa-o-relogio-injetado.test.ts
+++ b/tests/invariants/janela-usa-o-relogio-injetado.test.ts
@@ -1,0 +1,286 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import pg from "pg";
+
+import type * as InboundTurn from "@/lib/agent-engine/agent/inbound-turn";
+import type * as Providers from "@/lib/agent-engine/edge/llm/providers";
+import type * as Queue from "@/lib/agent-engine/queue/queue";
+import type * as ObsLogger from "@/lib/agent-engine/obs/logger";
+
+/**
+ * A JANELA DE HORÁRIO É DECIDIDA PELO RELÓGIO INJETADO — nunca pelo de parede.
+ *
+ * ─── O defeito que este arquivo existe para impedir ─────────────────────────
+ *
+ * `InboundTurnDeps.clock` documenta o próprio uso: "a janela horária do gate
+ * anti-ban é avaliada nele. Default `() => new Date()`; os testes fixam um
+ * instante dentro da janela para determinismo."
+ *
+ * O gate lia `new Date()` direto, contra esse contrato. O efeito não era um
+ * teste frouxo: era um CHECK OBRIGATÓRIO (`invariants`) que dependia da hora
+ * em que alguém abrisse o PR — reprovava entre 22h e 7h, passava no resto do
+ * dia. Medido em 2026-08-24, mesmo commit, mesma máquina, com o conserto no
+ * meio: 22:48 BRT sem o conserto → 3 casos de
+ * `limite-de-envios-por-turno.test.ts` reprovados; 22:50 BRT com ele → verdes.
+ * As sete rodadas verdes da `main` naquele dia caíram todas entre 09:58 e
+ * 15:14 BRT: o defeito viveu escondido no horário comercial de quem trabalha
+ * neste repo.
+ *
+ * ─── Por que um arquivo NOVO, e não mais casos no arquivo vizinho ───────────
+ *
+ * `tests/invariants/**` é congelado (`loop/hooks/freeze-invariants.sh`):
+ * acrescentar arquivo é permitido, modificar um existente é bloqueado. A regra
+ * está certa e é ela que impede o movimento "invariante incômodo → editar
+ * invariante". Acrescentar é o caminho sancionado — e aqui ele também é a
+ * separação certa: o vizinho mede o TETO DE ENVIOS por turno e fixa o relógio
+ * só para o horário não atrapalhar; este mede o HORÁRIO em si.
+ *
+ * ─── Por que DOIS casos, e não só o que pegaria o defeito ───────────────────
+ *
+ * Os casos do vizinho injetam um instante DENTRO da janela. Com o defeito de
+ * volta, eles só reprovam À NOITE — uma guarda que dorme das 7h às 22h, que é
+ * justamente quando o time trabalha. O primeiro caso daqui é o espelho: injeta
+ * um instante FORA e exige o adiamento, então reprova DE DIA. Medido,
+ * sabotando o conserto nas duas condições:
+ *
+ *                      vizinho (3)   "fora→adia" (aqui)  "dentro→corre" (aqui)
+ *   defeito à noite      PEGAM       passa (motivo         PEGA
+ *                                     errado)
+ *   defeito de dia       passam       PEGA                 passa
+ *                        (motivo
+ *                         errado)
+ *
+ * De dia, o primeiro caso daqui é a ÚNICA coisa entre o defeito e um CI verde.
+ * O segundo existe pela razão oposta: um gate que adiasse SEMPRE também
+ * satisfaria o primeiro, e "adia sempre" é outro jeito de o produto emudecer.
+ *
+ * Harness igual ao do vizinho: handler real, modelo fake, canal que CAPTURA em
+ * vez de enviar, `sleep` no-op. Os ids são PRÓPRIOS: o `setupFile` recria o
+ * banco por arquivo, mas ids distintos deixam o log legível quando os dois
+ * arquivos aparecem na mesma corrida.
+ */
+
+const container = process.env.TEST_DB_CONTAINER;
+if (!container) {
+  throw new Error("TEST_DB_CONTAINER not set — rode via `pnpm test:db` (scripts/test-db.sh)");
+}
+
+process.env.NEXT_PUBLIC_SUPABASE_URL ??= "https://placeholder.supabase.co";
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "placeholder-anon";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "placeholder-service";
+
+const PORT = Number(process.env.TEST_DB_PORT ?? 54329);
+const pool = new pg.Pool({
+  connectionString: `postgresql://postgres:postgres@127.0.0.1:${PORT}/postgres`,
+  max: 2,
+});
+
+const ORG = "dddddddd-0000-4000-8000-0000000000a1";
+const CONTACT = "dddddddd-0000-4000-8000-0000000000a2";
+const SESSION = "dddddddd-0000-4000-8000-0000000000a3";
+const CONV = "dddddddd-0000-4000-8000-0000000000a4";
+const MSG = "dddddddd-0000-4000-8000-0000000000a5";
+const CRM_EVENT = "dddddddd-0000-4000-8000-0000000000a6";
+
+/** Terça, 15h BRT — dentro da janela anti-ban padrão (7h–22h). */
+const DENTRO_DA_JANELA = new Date("2026-07-28T18:00:00Z");
+/** Terça, 3h BRT — fora dela, com folga dos dois lados. */
+const FORA_DA_JANELA = new Date("2026-07-28T06:00:00Z");
+
+interface EnvioCapturado {
+  body: string;
+}
+
+type Modules = {
+  createInboundTurnHandler: typeof InboundTurn.createInboundTurnHandler;
+  queue: typeof Queue;
+  createLogger: typeof ObsLogger.createLogger;
+  createFakeRegistry: typeof Providers.createFakeRegistry;
+};
+let m: Modules;
+
+let enviados: EnvioCapturado[] = [];
+
+const CHECKPOINT = JSON.stringify({
+  commitments: [],
+  objections: [],
+  next_action: null,
+  rolling_summary: "turno de teste",
+});
+
+const USO = {
+  inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 1, text: 1, reasoning: 0 },
+};
+
+/**
+ * Modelo fake que manda UMA mensagem e encerra. `rotulo` é único por caso: os
+ * dois compartilham a mesma conversa, e o gate `spinning` veta corpo repetido
+ * entre turnos — sem o rótulo, o segundo caso seria bloqueado por um motivo
+ * que não é o deste arquivo.
+ */
+function modeloQueManda(rotulo: string) {
+  let mandou = false;
+  return async () => {
+    if (!mandou) {
+      mandou = true;
+      return {
+        content: [
+          {
+            type: "tool-call" as const,
+            toolCallId: "c1",
+            toolName: "send_message",
+            input: JSON.stringify({ body: `oi, tudo bem? (${rotulo})` }),
+          },
+        ],
+        finishReason: { unified: "tool-calls" as const, raw: undefined },
+        usage: USO,
+        warnings: [],
+      };
+    }
+    return {
+      content: [{ type: "text" as const, text: CHECKPOINT }],
+      finishReason: { unified: "stop" as const, raw: undefined },
+      usage: USO,
+      warnings: [],
+    };
+  };
+}
+
+function montaHandler(doGenerate: unknown, instante: Date) {
+  return m.createInboundTurnHandler({
+    crmCfg: { supabase: {} as never },
+    llmCfg: { anthropicApiKey: "fake" } as never,
+    knobs: {
+      historyLimit: 10,
+      maxContextTokens: 1000,
+      notesIndexMaxTokens: 500,
+      maxSteps: 12,
+      queuedRetryDelayMs: 1000,
+      breaker: {
+        exactFailureWarn: 2,
+        exactFailureBlock: 5,
+        sameToolFailureWarn: 3,
+        sameToolFailureHalt: 8,
+        noProgressWarn: 3,
+        noProgressBlock: 5,
+      },
+    },
+    log: m.createLogger(),
+    registry: m.createFakeRegistry(doGenerate as never),
+    channel: () =>
+      ({
+        channel: "captura",
+        send: async (i: EnvioCapturado) => {
+          enviados.push(i);
+          return {
+            kind: "sent" as const,
+            idempotencyKey: `k${enviados.length}`,
+            messageId: `m${enviados.length}`,
+          };
+        },
+        sessionHealth: async () => ({ healthy: true, status: "WORKING" }),
+        capabilities: () => ({ freeform: true, media: true, audio: true }),
+        costPerMessage: () => ({ currency: "BRL", cents: 0 }),
+      }) as never,
+    // O ponto do arquivo: é ESTE instante que decide a janela, e não a hora em
+    // que a suíte por acaso rodou.
+    clock: () => instante,
+    sleep: async () => {},
+  });
+}
+
+async function rodaTurno(handler: ReturnType<typeof montaHandler>): Promise<Error | null> {
+  await pool.query("update job_queue set status = 'done' where status = 'pending'");
+  const { job } = await m.queue.enqueueJob(pool, ORG, {
+    kind: "inbound_turn",
+    leadId: CONTACT,
+    payload: {
+      conversation_id: CONV,
+      contact_id: CONTACT,
+      channel_session_id: SESSION,
+      inbound_message_id: MSG,
+      crm_event_id: CRM_EVENT,
+    },
+    maxAttempts: 1,
+  });
+  const [claimed] = await m.queue.claimJobs(pool, { workerId: "janela", maxConcurrency: 1 });
+  expect(claimed?.id).toBe(job.id);
+  try {
+    await handler(claimed!, pool, { workerId: "janela" });
+    await m.queue.completeJob(pool, claimed!.id, "janela");
+    return null;
+  } catch (err) {
+    await m.queue.failJob(pool, claimed!.id, "janela", err);
+    return err as Error;
+  }
+}
+
+beforeAll(async () => {
+  m = {
+    createInboundTurnHandler: (await import("@/lib/agent-engine/agent/inbound-turn"))
+      .createInboundTurnHandler,
+    queue: await import("@/lib/agent-engine/queue/queue"),
+    createLogger: (await import("@/lib/agent-engine/obs/logger")).createLogger,
+    createFakeRegistry: (await import("@/lib/agent-engine/edge/llm/providers")).createFakeRegistry,
+  };
+
+  await pool.query(
+    `insert into organizations (id, slug, legal_name, display_name)
+     values ($1,'janela-relogio','Janela Relogio','Janela Relogio') on conflict (id) do nothing`,
+    [ORG],
+  );
+  await pool.query(
+    `insert into contacts (id, organization_id, name, phone_number)
+     values ($1,$2,'Lead da Janela','+5511900000777') on conflict (id) do nothing`,
+    [CONTACT, ORG],
+  );
+  await pool.query(
+    `insert into channel_sessions (id, organization_id, waha_session_name, status, webhook_secret_encrypted)
+     values ($1,$2,'janela-relogio-session','WORKING','\\x00'::bytea) on conflict (id) do nothing`,
+    [SESSION, ORG],
+  );
+  await pool.query(
+    `insert into conversations (id, organization_id, contact_id, channel_session_id, status, is_group)
+     values ($1,$2,$3,$4,'ai_handling',false) on conflict (id) do nothing`,
+    [CONV, ORG, CONTACT, SESSION],
+  );
+  await pool.query(
+    `insert into messages (id, organization_id, conversation_id, channel_session_id, contact_id,
+       type, direction, status, body, sent_via, sent_at)
+     values ($1,$2,$3,$4,$5,'text','inbound','delivered','Oi','external_device', now())
+     on conflict (id) do nothing`,
+    [MSG, ORG, CONV, SESSION, CONTACT],
+  );
+  await pool.query(
+    `with v as (
+       insert into playbook_versions (organization_id, layer, content)
+       select null, 'platform', E'## Identidade\nAssistente de teste.'
+       where not exists (select 1 from playbook_pointers where organization_id is null and layer = 'platform')
+       returning id)
+     insert into playbook_pointers (organization_id, layer, version_id)
+     select null, 'platform', id from v`,
+  );
+});
+
+beforeEach(() => {
+  enviados = [];
+});
+
+describe("a janela de horário é decidida pelo relógio injetado", () => {
+  it("relógio FORA da janela: o turno é adiado, não importa a hora real", async () => {
+    const erro = await rodaTurno(montaHandler(modeloQueManda("noturno"), FORA_DA_JANELA));
+
+    // Adiado, não gasto: `JobSettledError` é o contrato de "o run já dispôs do
+    // job". Quem escreveu às 3h é atendido às 7h — e nada sai agora.
+    expect(erro).not.toBeNull();
+    expect(String(erro?.message)).toMatch(/fora da janela anti-ban/);
+    expect(enviados).toHaveLength(0);
+  });
+
+  it("relógio DENTRO da janela: o turno corre — o gate não vira muro", async () => {
+    const erro = await rodaTurno(montaHandler(modeloQueManda("diurno"), DENTRO_DA_JANELA));
+
+    expect(erro).toBeNull();
+    expect(enviados).toHaveLength(1);
+  });
+});

--- a/tests/unit/changelog-cabe-na-tela-da-vps.test.ts
+++ b/tests/unit/changelog-cabe-na-tela-da-vps.test.ts
@@ -18,17 +18,38 @@ import { extractChangelogSection } from "@/lib/system/changelog";
  * teto de 30.000. O texto chegava DECAPITADO no meio de uma frase e — pior — o
  * bloco `### ⚠️ Requer atenção` ficava inteiro do lado de fora do corte:
  * `extractChangelogSection()` sobre o texto truncado devolvia
- * `requiresAttention: null`. Os dois avisos daquela versão (que rodar o
- * `update.sh` uma vez passou a bastar, e que o teto de gasto de IA sempre foi em
- * dólar) simplesmente não existiriam para quem fosse atualizar.
+ * `requiresAttention: null`. Os dois avisos daquela versão simplesmente não
+ * existiriam para quem fosse atualizar.
  *
- * Nada reprovava isso. O defeito não está no texto nem no script: está em serem
- * dois artefatos com um contrato de tamanho que ninguém media. Este teste é esse
- * contrato.
+ * ─── O QUE SE MEDE, e por que não é o arquivo do disco ─────────────────────
+ *
+ * O que chega à VPS é `git show <TAG>:CHANGELOG.md`, e num arquivo TAGUEADO o
+ * bloco `## [Não lançado]` está VAZIO — o conteúdo dele virou a seção numerada
+ * no ato de cortar a release. Medido nas cinco tags do origin: 20 bytes, sempre.
+ *
+ * A primeira versão deste teste somava o offset ABSOLUTO do fim da seção mais
+ * nova no working tree, o que embute o `[Não lançado]` do momento. Essas duas
+ * coisas nunca coexistem num arquivo tagueado, e o efeito é datado: com 720
+ * bytes de folga depois da v1.4.0, o primeiro ciclo normal de desenvolvimento
+ * deixaria o `verify` — status check OBRIGATÓRIO — vermelho na `main` por uma
+ * condição que nenhum cliente enxerga. Reproduzido antes do conserto: 3.645
+ * bytes em `[Não lançado]` (o repo já teve 3.632 dois dias depois da v1.3.0)
+ * davam `AssertionError: A seção [1.4.0] termina no byte 34288`, mandando
+ * enxugar uma seção JÁ LANÇADA cuja cópia taggeada está correta.
+ *
+ * Então aqui se mede o arquivo **como ele estará na tag**, e as duas seções que
+ * podem estourar são cobradas separadamente:
+ *
+ *   1. a seção numerada mais nova — o que já foi lançado (guarda retroativa);
+ *   2. o `[Não lançado]` de agora — o que a PRÓXIMA release vai publicar, que é
+ *      a única das duas que ainda dá para consertar enxugando.
  *
  * O teto NÃO é digitado aqui — é lido do próprio `agent.sh`. Um número copiado
  * para cá viraria uma segunda fonte da verdade, e a que envelhece primeiro é
- * sempre a cópia.
+ * sempre a cópia. (Isso tem um custo declarado: subir o `head -c` do `agent.sh`
+ * silencia este teste. Não conserta ninguém — quem corta é o script que JÁ está
+ * instalado na VPS do cliente —, então subir o número para calar o CI é trocar
+ * um vermelho honesto por um cliente sem aviso.)
  *
  * CONSERTOS POSSÍVEIS quando este teste ficar vermelho, em ordem de preferência:
  *   1. enxugar a seção (quase sempre certo — item de changelog longo costuma ser
@@ -36,8 +57,6 @@ import { extractChangelogSection } from "@/lib/system/changelog";
  *   2. mover `### ⚠️ Requer atenção` para logo depois do parágrafo de abertura —
  *      `findAttentionRange()` acha o bloco em qualquer posição da seção, então o
  *      aviso passa a sobreviver ao corte mesmo se o corpo for truncado.
- * Aumentar o teto no `agent.sh` conserta as versões futuras e NÃO conserta esta:
- * quem corta é o script que já está instalado na VPS do cliente, não o da `main`.
  */
 
 const RAIZ = process.cwd();
@@ -57,60 +76,138 @@ function tetoDoAgente(): number {
   return Number(m[1]);
 }
 
-/** A primeira versão numerada do arquivo — "Não lançado" não é publicável. */
-function secaoMaisNova(raw: string): { versao: string; inicio: number; fim: number } {
-  const linhas = raw.split("\n");
-  const rx = /^##\s+\[(\d+\.\d+\.\d+)\]/;
-  let inicio = -1;
-  let versao = "";
-  let offset = 0;
+interface Secao {
+  /** `1.4.0`, ou `null` para o bloco `[Não lançado]`. */
+  versao: string | null;
+  /** O texto da seção, do `## [` até o `## [` seguinte (exclusive). */
+  texto: string;
+}
 
-  for (const linha of linhas) {
-    const m = rx.exec(linha);
-    if (m && inicio === -1) {
-      inicio = offset;
-      versao = m[1]!;
-    } else if (inicio !== -1 && /^##\s+\[/.test(linha)) {
-      return { versao, inicio, fim: offset };
-    }
-    offset += Buffer.byteLength(linha, "utf8") + 1; // +1 = o \n
-  }
-  if (inicio === -1) throw new Error("nenhuma versão numerada no CHANGELOG.md");
-  return { versao, inicio, fim: Buffer.byteLength(raw, "utf8") };
+/** Quebra o arquivo em cabeçalho + seções, na ordem em que aparecem. */
+function fatiar(raw: string): { cabecalho: string; secoes: Secao[] } {
+  const linhas = raw.split("\n");
+  const cortes: number[] = [];
+  linhas.forEach((linha, i) => {
+    if (/^##\s+\[/.test(linha)) cortes.push(i);
+  });
+  if (cortes.length === 0) throw new Error("nenhuma seção `## [...]` no CHANGELOG.md");
+
+  const cabecalho = linhas.slice(0, cortes[0]!).join("\n") + "\n";
+  const secoes: Secao[] = cortes.map((inicio, i) => {
+    const fim = cortes[i + 1] ?? linhas.length;
+    const m = /^##\s+\[([^\]]+)\]/.exec(linhas[inicio]!);
+    const rotulo = m?.[1] ?? "";
+    return {
+      versao: /^\d+\.\d+\.\d+$/.test(rotulo) ? rotulo : null,
+      texto: linhas.slice(inicio, fim).join("\n") + (fim < linhas.length ? "\n" : ""),
+    };
+  });
+  return { cabecalho, secoes };
+}
+
+/**
+ * O arquivo como ele fica DEPOIS de cortar a release — que é a única forma em
+ * que a VPS o vê. O `[Não lançado]` esvazia e o conteúdo dele vira a seção
+ * numerada nova, no mesmo lugar.
+ */
+function comoFicaNaTag(raw: string, versaoFutura: string): string {
+  const { cabecalho, secoes } = fatiar(raw);
+  const naoLancado = secoes.find((s) => s.versao === null);
+  const numeradas = secoes.filter((s) => s.versao !== null);
+  const corpo = naoLancado
+    ? naoLancado.texto.split("\n").slice(1).join("\n").replace(/^\n+/, "")
+    : "";
+  return (
+    cabecalho +
+    "## [Não lançado]\n\n" +
+    `## [${versaoFutura}] — 2099-01-01\n\n` +
+    corpo +
+    numeradas.map((s) => s.texto).join("")
+  );
 }
 
 /** Exatamente o que o agente manda: os primeiros N bytes do arquivo. */
-function comoChegaNaVps(raw: string, teto: number): string {
-  return Buffer.from(raw, "utf8").subarray(0, teto).toString("utf8");
+function comoChegaNaVps(texto: string, teto: number): string {
+  return Buffer.from(texto, "utf8").subarray(0, teto).toString("utf8");
+}
+
+/** Onde a seção `versao` termina, em bytes, dentro de `texto`. */
+function fimDaSecao(texto: string, versao: string): number {
+  const { cabecalho, secoes } = fatiar(texto);
+  let offset = Buffer.byteLength(cabecalho, "utf8");
+  for (const s of secoes) {
+    const tam = Buffer.byteLength(s.texto, "utf8");
+    if (s.versao === versao) return offset + tam;
+    offset += tam;
+  }
+  throw new Error(`seção [${versao}] não encontrada`);
+}
+
+const RAW = fs.readFileSync(CHANGELOG, "utf8");
+const TETO = tetoDoAgente();
+
+/** As duas seções que podem estourar, cada uma no arquivo em que ela é publicada. */
+const CANDIDATAS: Array<{ nome: string; versao: string; texto: string; conserto: string }> = [];
+{
+  const { secoes } = fatiar(RAW);
+  const maisNova = secoes.find((s) => s.versao !== null);
+  if (maisNova) {
+    CANDIDATAS.push({
+      nome: `a seção numerada mais nova [${maisNova.versao}]`,
+      versao: maisNova.versao!,
+      texto: RAW,
+      // A mensagem não afirma se esta seção já foi taggeada — ela não sabe, e o
+      // conserto certo depende disso: antes da tag, enxugar resolve; depois, o
+      // texto já congelou e só uma versão nova alcança quem leu.
+      conserto:
+        "Se a tag desta versão ainda NÃO foi cortada, enxugue a seção. Se já foi, o texto " +
+        "congelou na tag e o conserto é uma versão nova — editar aqui não alcança quem já leu.",
+    });
+  }
+  const naoLancado = secoes.find((s) => s.versao === null);
+  const temConteudo =
+    naoLancado !== undefined &&
+    naoLancado.texto.split("\n").slice(1).join("").trim().length > 0;
+  if (temConteudo) {
+    CANDIDATAS.push({
+      nome: "o [Não lançado], como ele sairá na PRÓXIMA release",
+      versao: "9.9.9",
+      texto: comoFicaNaTag(RAW, "9.9.9"),
+      conserto: "Enxugue os itens de [Não lançado] (veja o cabeçalho deste arquivo).",
+    });
+  }
 }
 
 describe("o CHANGELOG da versão nova cabe no que a VPS recebe", () => {
-  const raw = fs.readFileSync(CHANGELOG, "utf8");
-  const teto = tetoDoAgente();
-  const { versao, fim } = secaoMaisNova(raw);
-
-  it("a seção mais nova termina antes do corte do agente", () => {
-    expect(
-      fim,
-      `A seção [${versao}] termina no byte ${fim}, além do corte de ${teto} bytes que o ` +
-        `agent.sh aplica. O dono da VPS receberia o texto cortado no meio. Enxugue a seção ` +
-        `(veja o cabeçalho deste arquivo).`,
-    ).toBeLessThanOrEqual(teto);
+  it("há o que medir — o arquivo tem ao menos uma seção candidata", () => {
+    // Guarda de vacuidade: se `fatiar()` quebrar, os `it.each` abaixo somem e a
+    // suíte fica verde por não haver caso — o modo de falha mais silencioso que
+    // um gate tem.
+    expect(CANDIDATAS.length, "nenhuma seção candidata: o parser deste teste quebrou").toBeGreaterThan(0);
   });
 
-  it("o aviso de ação manual sobrevive ao corte", () => {
-    const inteiro = extractChangelogSection(raw, versao);
+  it.each(CANDIDATAS)("$nome termina antes do corte do agente", ({ versao, texto, conserto }) => {
+    const fim = fimDaSecao(texto, versao);
+    expect(
+      fim,
+      `A seção termina no byte ${fim}, além do corte de ${TETO} bytes que o agent.sh aplica ` +
+        `sobre o arquivo TAGUEADO. O dono da VPS receberia o texto cortado no meio. ${conserto}`,
+    ).toBeLessThanOrEqual(TETO);
+  });
+
+  it.each(CANDIDATAS)("o aviso de ação manual de $nome sobrevive ao corte", ({ versao, texto, conserto }) => {
+    const inteiro = extractChangelogSection(texto, versao);
     expect(inteiro, `a seção [${versao}] não foi extraída do arquivo completo`).not.toBeNull();
 
     // Só cobra o que existe: versão sem ação manual não precisa do bloco.
     if (inteiro!.requiresAttention === null) return;
 
-    const cortado = extractChangelogSection(comoChegaNaVps(raw, teto), versao);
+    const cortado = extractChangelogSection(comoChegaNaVps(texto, TETO), versao);
     expect(
       cortado?.requiresAttention,
-      `A seção [${versao}] tem "⚠️ Requer atenção", mas o bloco fica FORA dos ${teto} bytes ` +
-        `que chegam à VPS — o aviso não apareceria para quem vai atualizar. Enxugue a seção, ` +
-        `ou mova o bloco para logo depois do parágrafo de abertura.`,
+      `A seção tem "⚠️ Requer atenção", mas o bloco fica FORA dos ${TETO} bytes que chegam à ` +
+        `VPS — o aviso não apareceria para quem vai atualizar. ${conserto} Ou mova o bloco ` +
+        `para logo depois do parágrafo de abertura.`,
     ).not.toBeNull();
   });
 });

--- a/tests/unit/opt-out-deteccao.test.ts
+++ b/tests/unit/opt-out-deteccao.test.ts
@@ -88,6 +88,13 @@ const ESPANHOL_PEDE_PARA_SAIR = [
   "darme de baja",
   "dar de baja la suscripcion",
   "quiero dar de baja la suscripcion",
+  // `salir` é o `sair` em espanhol, e `sair` já estava na lista em português.
+  // Faltava, e a promessa do CHANGELOG da 1.4.0 ("`baja`, `salir` e
+  // `no quiero recibir` descadastram") era falsa exatamente nesta palavra —
+  // medido com as funções reais antes do conserto: `baja` true, `salir` false.
+  "salir",
+  "SALIR",
+  "Salir.",
   "no quiero recibir mas mensajes",
   "no quiero recibir más mensajes",
   "por favor no me escriban mas",
@@ -108,6 +115,12 @@ const ESPANHOL_NAO_PEDE = [
   "no quiero recibir la factura por aqui, manda por email",
   // Outra lista. Quem escreve isto QUER continuar sendo atendido.
   "sacame de la lista de espera",
+  // CONTROLE de `salir`: a palavra só vale SOZINHA. Sem estes casos, alguém
+  // poderia "consertar" o positivo com um `includes("salir")` e a suíte ficaria
+  // verde bloqueando quem só avisou que vai sair de casa.
+  "voy a salir ahora",
+  "puedo salir mas temprano?",
+  "el pedido va a salir hoy?",
 ];
 
 describe("espanhol — a palavra que a plantilla pede", () => {


### PR DESCRIPTION
Forward-fix da **v1.4.0**, cortada hoje às 20:29. Saiu de uma triagem de 5 lentes independentes sobre a prévia do merge do #318, com um cético tentando derrubar cada achado: 50 achados, 12 sobreviveram. Quatro foram reverificados à mão antes deste commit.

## Por que é uma versão nova, e não uma edição na main

A tag é imutável e o `agent.sh` roda **a cada 5 minutos**. Da tag até a abertura deste PR passaram ~14 ciclos: toda VPS de pé já leu o texto da 1.4.0. `git show v1.4.0:CHANGELOG.md` está congelado — editar a seção dela aqui não alcança ninguém.

## O que estava errado

**1. O aviso das conexões duplicadas estava invertido.** O texto diz que a atualização "mantém a mais antiga". O SQL faz o oposto:

```sql
order by created_at desc nulls last, id desc   -- baseline.sql:13923
and a.posicao > 1                              -- baseline.sql:13933
```

Fica com o identificador limpo a **mais recente**; a antiga recebe `-conflito-`. O comentário do próprio código, doze linhas acima, já dizia isso. O aviso termina com *"apague a que sobra"* — quem acreditasse na frase apagaria a conexão que está recebendo. Ação irreversível num WhatsApp de produção.

**2. O domingo mudou para toda instalação, sem uma linha de aviso.** `allowSunday` foi de `false` para `true`. A coluna é nullable, sem DEFAULT, nenhuma migration faz backfill: quem nunca tocou a chave tem NULL, e o `??` resolve para `true` no instante do `update.sh`. O bloco `⚠️ Requer atenção` da 1.4.0 tem **zero** ocorrências de "domingo" (controle: 5 no arquivo, fora do bloco) — e termina dizendo *"Fora isso, nada exige ação sua"*.

**3. `salir` não descadastrava, e a release disse que sim.** Medido com as funções reais, com controle de vivacidade:

```
"baja"                  pedido=true   provavel=true
"salir"                 pedido=false  provavel=false   ← a promessa
"no quiero recibir"     pedido=true   provavel=true
"tem como parar a dor?" pedido=false  provavel=false   ← controle
```

`salir` é o `sair` em espanhol, que está na lista desde sempre. Sabotado removendo-o: **3 falhas, exatamente as previstas**.

**4. Um controle citado por um nome que não existe na tela.** "Parar a IA no limite" → zero ocorrências em `components|app|lib`. O real é `Parar a IA ao chegar em ${fmtCents(teto)}` (`BudgetCard.tsx:399`). Dois dos três rótulos batiam e o terceiro não, o que é pior que errar os três.

**5. O import assume Brasil e isso não estava escrito.** `normalizaTelefone("(11) 99999-8888")` → `+5511999998888`. Comportamento correto e decidido; faltava a frase — e a mesma release adicionou opt-out em espanhol, o que prova que o público não-brasileiro existe.

## E o gate da própria release media a grandeza errada

`changelog-cabe-na-tela-da-vps.test.ts` somava o offset **absoluto** no working tree, embutindo o `[Não lançado]` do momento. Num arquivo tagueado essas duas coisas nunca coexistem: medido nas cinco tags do origin, `[Não lançado]` tem 20 bytes, sempre.

Com 720 bytes de folga, reproduzi com 3.645 bytes de changelog de um ciclo normal (o repo já teve 3.632 dois dias depois da v1.3.0):

```
AssertionError: A seção [1.4.0] termina no byte 34288, além do corte de 30000
```

O `verify` — check **obrigatório** — ficaria vermelho na `main` em dias, por uma condição que nenhum cliente enxerga, mandando enxugar uma seção já congelada. Agora mede o arquivo **como fica na tag** e cobra as duas seções separadamente. Folga de volta a 26.587 bytes.

Previsões declaradas antes de rodar, ambas batidas: `[Não lançado]` com 3.645 bytes → **5 verdes**; seção nova inflada → **1 falha**, a do tamanho.

## Verificação

`typecheck` exit 0 · `lint` 0 erros · `lint:channels` ok · `pnpm test:unit` **478 arquivos, 5336 testes, verdes**.

Caminho de produção com o extrator real sobre os 30.000 bytes crus: `requiresAttention` = 1.315 bytes com os dois avisos inteiros, `body` terminando em frase completa.

## NÃO MEDIDO

- Nada foi visto numa VPS real nem pela tela de atualização num browser (DoD 12).
- `pnpm test:shell` não foi rodado — é o único gate que exercita o kit, e nenhum job de PR o invoca.
- Não sei quantas instalações existem nem em que versão estão: sei que o texto errado alcança todas as que leram a v1.4.0, não quantas são.

## Depois do merge

Cortar `v1.4.1` é o que leva estes avisos à tela de quem já atualizou — e isso é decisão sua, não deste PR.