### PR TITLE
fix(test): invariants reprovava por hora do dia — ninguém fazia merge à noite

### DIFF
--- a/tests/invariants/agent-no-credential.test.ts
+++ b/tests/invariants/agent-no-credential.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import pg from "pg";
+import { abreJanelaDeEnvio } from "./janela-de-envio";
 
 /**
  * Fase 4B (robustez BYOK) — turno SEM credencial nenhuma (nem env, nem BYOK).
@@ -70,6 +71,10 @@ beforeAll(async () => {
      values ($1, $2, 'nocred-session', 'WORKING', '\\x00'::bytea) on conflict (id) do nothing`,
     [SESSION, ORG],
   );
+  // Sem isto o turno é ADIADO fora de 7h–22h e este arquivo mede a janela em vez
+  // do que ele diz medir — verde de dia, vermelho de madrugada. Ver o cabeçalho
+  // de janela-de-envio.ts.
+  await abreJanelaDeEnvio(pool, ORG, SESSION);
   await pool.query(
     `insert into conversations (id, organization_id, contact_id, channel_session_id, status, is_group)
      values ($1, $2, $3, $4, 'open', false) on conflict (id) do nothing`,

--- a/tests/invariants/agent-send-template-turn.test.ts
+++ b/tests/invariants/agent-send-template-turn.test.ts
@@ -5,6 +5,7 @@ import type * as InboundTurn from "@/lib/agent-engine/agent/inbound-turn";
 import type * as Providers from "@/lib/agent-engine/edge/llm/providers";
 import type * as Queue from "@/lib/agent-engine/queue/queue";
 import type * as ObsLogger from "@/lib/agent-engine/obs/logger";
+import { abreJanelaDeEnvio } from "./janela-de-envio";
 
 /**
  * O turno COMPLETO enviando template — o que `send-template-wiring.test.ts` declarava
@@ -236,6 +237,10 @@ beforeAll(async () => {
      on conflict (id) do nothing`,
     [SESSION_META, ORG],
   );
+  // Sem isto o turno é ADIADO fora de 7h–22h e este arquivo mede a janela em vez
+  // do que ele diz medir — verde de dia, vermelho de madrugada. Ver o cabeçalho
+  // de janela-de-envio.ts.
+  await abreJanelaDeEnvio(pool, ORG, SESSION_META);
   await pool.query(
     `insert into channel_sessions (id, organization_id, provider, waha_session_name,
                                    status, webhook_secret_encrypted)

--- a/tests/invariants/janela-de-envio.ts
+++ b/tests/invariants/janela-de-envio.ts
@@ -1,0 +1,54 @@
+/**
+ * Abre a janela anti-ban para os invariantes que NÃO são sobre a janela.
+ *
+ * Desde que o turno do agente passou a ADIAR fora da janela (7h–22h por padrão,
+ * `inbound-turn.ts`), todo teste que faz o agente falar com o lead passou a
+ * depender do RELÓGIO DA MÁQUINA — e a falhar à noite, com uma mensagem que não
+ * tem nada a ver com o que ele mede:
+ *
+ *     expected 'fora da janela anti-ban — job reagend…' to match /credencial LLM/
+ *
+ * MEDIDO em 2026-08-25: o CI da `main` (SHA bc079649, sem nenhuma alteração)
+ * passou às 23:28 UTC e o RERUN do MESMO commit às 01:46 UTC reprovou com 8
+ * falhas — as mesmas 8 de um PR que só tocava shell e markdown. Conjunto
+ * idêntico, arquivo e linha: a diferença entre verde e vermelho era a hora.
+ * Na prática, `invariants` é status check obrigatório, então ninguém conseguia
+ * fazer merge à noite — e cada PR noturno acusava o autor de ter quebrado algo.
+ *
+ * O adiamento é CORRETO em produção e não se conserta lá: o lead que escreve
+ * 22h56 tem de receber resposta às 7h, e não um silêncio. Quem está errado é o
+ * fixture, que herda o default 7h–22h e por isso mede uma coisa de dia e outra
+ * de noite.
+ *
+ * A janela é um KNOB por canal (`channel_knobs`, coluna NULL = default do
+ * código), então abrir 0–24 no fixture é usar o mecanismo que já existe — não
+ * furar o comportamento. Testes que medem A JANELA continuam definindo os
+ * próprios knobs e não chamam isto.
+ */
+import type { Pool } from "pg";
+
+/**
+ * Deixa a janela de envio SEMPRE aberta para este canal — 0h–24h, domingo
+ * incluído, em UTC. Idempotente: pode ser chamada em `beforeAll` que re-roda.
+ *
+ * O timezone é fixado em UTC de propósito: com 0–24 a hora local não muda mais
+ * o veredito, e deixar o default (fuso do tenant) faria o teste depender de
+ * qual máquina o roda.
+ */
+export async function abreJanelaDeEnvio(
+  pool: Pool,
+  organizationId: string,
+  channelSessionId: string,
+): Promise<void> {
+  await pool.query(
+    `insert into channel_knobs
+       (organization_id, channel_session_id, window_start_hour, window_end_hour, allow_sunday, timezone)
+     values ($1, $2, 0, 24, true, 'UTC')
+     on conflict (organization_id, channel_session_id) do update
+       set window_start_hour = 0,
+           window_end_hour   = 24,
+           allow_sunday      = true,
+           timezone          = 'UTC'`,
+    [organizationId, channelSessionId],
+  );
+}

--- a/tests/invariants/limite-de-envios-por-turno.test.ts
+++ b/tests/invariants/limite-de-envios-por-turno.test.ts
@@ -5,6 +5,7 @@ import type * as InboundTurn from "@/lib/agent-engine/agent/inbound-turn";
 import type * as Providers from "@/lib/agent-engine/edge/llm/providers";
 import type * as Queue from "@/lib/agent-engine/queue/queue";
 import type * as ObsLogger from "@/lib/agent-engine/obs/logger";
+import { abreJanelaDeEnvio } from "./janela-de-envio";
 
 /**
  * O turno COMPLETO chamando `send_message` VÁRIAS vezes — defeito medido em
@@ -200,6 +201,10 @@ beforeAll(async () => {
      values ($1,$2,'limite-envios-session','WORKING','\\x00'::bytea) on conflict (id) do nothing`,
     [SESSION, ORG],
   );
+  // Sem isto o turno é ADIADO fora de 7h–22h e este arquivo mede a janela em vez
+  // do que ele diz medir — verde de dia, vermelho de madrugada. Ver o cabeçalho
+  // de janela-de-envio.ts.
+  await abreJanelaDeEnvio(pool, ORG, SESSION);
   await pool.query(
     `insert into conversations (id, organization_id, contact_id, channel_session_id, status, is_group)
      values ($1,$2,$3,$4,'ai_handling',false) on conflict (id) do nothing`,


### PR DESCRIPTION
Aplica o patch da #324, com autorização explícita do dono para tocar em `tests/invariants/**` (congelado pelo pre-commit).

## O que acontecia

`invariants` — status check **obrigatório** — reprovava toda madrugada, com uma mensagem que acusa quem abriu o PR:

```
expected 'fora da janela anti-ban — job reagend…' to match /credencial LLM/
expected job_settled: fora da janela anti-ban — jo… to be null   (×7)
```

## Prova de que era o relógio, não o código

Mesmo commit, horários diferentes:

| execução | SHA | horário | resultado |
|---|---|---|---|
| CI original | `bc079649` (main) | 23:28 UTC | ✅ |
| **rerun do mesmo run** | `bc079649` (main) | 01:46 UTC | ❌ |

E o #320 — que toca **só shell e markdown** — reprovou com as mesmas 8 falhas. `comm -13` entre os conjuntos (arquivo:linha) devolveu **vazio**: nenhuma exclusiva do diff.

## Causa

`inbound-turn.ts` passou a **adiar** o turno fora da janela anti-ban (7h–22h, `PACING_DEFAULTS`). Todo invariante que faz o agente falar com o lead herda o default e passa a depender do relógio — o adiamento roda **antes** do que o arquivo diz medir.

**Produção está certa e não muda:** o lead que escreve 22h56 tem de ser respondido às 7h, não ignorado. Quem estava errado é o fixture.

## O conserto

A janela é knob por canal (`channel_knobs`, coluna `NULL` = default do código). O fixture abre `0–24` em UTC pelo mecanismo que já existe — não fura comportamento, não toca produção. Testes que medem **a janela** definem os próprios knobs e não usam o helper.

## Verificação — com a ressalva da régua

- `pnpm test:db` local → **114 arquivos, 849 testes, exit 0**. Rodou às **07:47 BRT, DENTRO da janela**: isso prova que nada quebrou, **não** que a madrugada foi consertada.
- Quem prova a madrugada é a medição hora a hora sobre a função real `janelaDeEnvioAberta`:

| knobs | horas abertas | fechadas |
|---|---|---|
| defaults (7h–22h) | 15/24 | **9** — exatamente quando o CI reprovava |
| com os knobs do fixture | **24/24** | 0 |

A hora deixa de decidir o resultado.

## Não medido

Se o `e2e` tem a mesma exposição. Ele passou às 01:20 UTC, mas isso não prova que nenhum caminho dele dependa da janela.

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)