### PR TITLE
A 1.4.1 passa a descrever o que ela realmente contém

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,24 +8,31 @@ Se você roda o DeskcommCRM numa VPS, **leia a seção da versão para a qual es
 
 ## [Não lançado]
 
-### Corrigido
+## [1.4.1] — 2026-08-25
 
-- **Instalar numa VPS que já tem o CRM no ar não derruba mais a instalação existente.**
-  O instalador confundia a instalação de outra pasta com ele mesmo sendo rodado de novo e
-  subia por cima: o site seguia no ar, mas passando a usar o banco da pasta nova — e o
-  primeiro sintoma era a senha "parar de funcionar". Agora ele para antes de tocar em
-  nada, diz em que pasta está a instalação que já existe e ensina como atualizá-la. Isso
-  vale em qualquer arranjo de servidor — inclusive nas VPS em que o painel da hospedagem
-  (Hostinger, Coolify, Dokploy) é quem atende as portas, e nas pastas que já tinham
-  concluído uma instalação antes, onde a checagem anterior se desligava sozinha.
+O primeiro acesso passa a **perguntar como você já usa o seu número**, em vez de supor que
+todo mundo conecta lendo um código no celular. Instalar numa máquina que já tem o CRM no ar
+deixou de derrubar a instalação existente. E a seção da 1.4.0 descreveu errado duas mudanças
+que chegam a todo mundo — uma delas invertida: como a tela de atualização lê o texto congelado
+na versão, o conserto do texto só alcança você pela publicação de uma versão nova, que é esta.
 
-## [1.4.1] — 2026-08-24
+### Adicionado
 
-Correção de **texto de aviso**, não de comportamento: a seção da 1.4.0 descreveu errado uma
-mudança que chega a todo mundo e inverteu a instrução de outra. Como a tela de atualização lê
-o texto congelado na versão, o conserto só alcança quem atualizou pela publicação de uma
-versão nova — é isto. Junto vai um conserto de código pequeno e real, no descadastro em
-espanhol.
+- **O primeiro acesso pergunta como você já usa o seu número, em vez de supor.** Existe mais
+  de um jeito de ter WhatsApp para empresa, e cada um conecta de um jeito — mas o passo do
+  telefone só sabia um: ele mostrava o código para ler no celular e pronto. Quem tem conta
+  oficial na Meta, ou contrata o WhatsApp por uma empresa parceira, passava por ali sem nunca
+  ser perguntado; o número entrava cadastrado do jeito errado e a pessoa só descobria depois,
+  em outra tela, com o funcionário já montado por cima. Agora o passo abre com a pergunta e
+  três respostas: **ler um código com o celular** (que é como quase todo mundo faz e segue
+  sendo o caminho mais curto), **conta oficial na Meta**, ou **provedor parceiro** — e cada
+  uma leva ao formulário certo, ali mesmo, sem sair do passo a passo. Escolher errado não
+  tranca nada: dá para voltar e trocar. E nada é criado enquanto você não escolhe — antes, o
+  número era cadastrado como "por código" só de você chegar na tela.
+- **Quem escolhe a conta oficial é avisado ANTES de ir buscar as credenciais.** Esse caminho
+  precisa de duas configurações no servidor que a instalação não cria sozinha, e sem elas o
+  número **envia mas nunca recebe** — sem erro em lugar nenhum, que é o pior jeito de falhar.
+  A tela diz isso antes de você abrir o painel da Meta, e aponta o caminho que funciona hoje.
 
 ### ⚠️ Requer atenção
 
@@ -49,6 +56,14 @@ Fora isso, nada exige ação sua. Não há mudança de banco de dados nesta vers
 
 ### Corrigido
 
+- **Instalar numa VPS que já tem o CRM no ar não derruba mais a instalação existente.**
+  O instalador confundia a instalação de outra pasta com ele mesmo sendo rodado de novo e
+  subia por cima: o site seguia no ar, mas passando a usar o banco da pasta nova — e o
+  primeiro sintoma era a senha "parar de funcionar". Agora ele para antes de tocar em
+  nada, diz em que pasta está a instalação que já existe e ensina como atualizá-la. Isso
+  vale em qualquer arranjo de servidor — inclusive nas VPS em que o painel da hospedagem
+  (Hostinger, Coolify, Dokploy) é quem atende as portas, e nas pastas que já tinham
+  concluído uma instalação antes, onde a checagem anterior se desligava sozinha.
 - **`salir` sozinho não descadastrava.** A 1.4.0 anunciou que "`baja`, `salir` e
   `no quiero recibir` descadastram"; medido com a função real, `baja` e `no quiero recibir`
   funcionavam e `salir` não — a palavra estava fora da lista. `salir` é o `sair` em espanhol,


### PR DESCRIPTION
## Por que

A seção `[1.4.1]` já existia, escrita **antes** de o onboarding entrar na `main`, e dizia de si mesma: *"correção de texto de aviso, não de comportamento"*. Deixou de ser verdade quando o #321 mergeou.

Isso importa porque **a tag aponta para o commit, não para a seção**: cortar a v1.4.1 com aquele texto entregaria ao dono da VPS uma release que muda o primeiro acesso do produto anunciando-se como conserto de redação. E a tela de atualização mostra exatamente essa seção (`git show <tag>:CHANGELOG.md`) — o texto **é** o que ele lê antes de decidir atualizar.

## O que entra

**Adicionado**
- o passo do telefone perguntando como a pessoa já usa o número — as três formas, cada uma levando ao formulário certo, sem sair do passo a passo;
- o aviso de que o caminho oficial precisa de duas configurações de servidor que a instalação não cria: sem elas o número **envia e nunca recebe**, sem erro em lugar nenhum.

**Corrigido**
- o guarda de instalação em cópia irmã, que estava em `[Não lançado]` e sai na mesma release.

O conteúdo que já estava na seção fica **verbatim**: os dois avisos da 1.4.0 que precisavam de correção (domingo e `-conflito-`), o `salir`, a planilha e o rótulo do orçamento. Só a abertura foi reescrita, porque descrevia o escopo antigo.

## O que ficou de fora, de propósito

- **O relógio de parede (#319)** não tem efeito em produção — lá `new Date()` é a hora certa; ele reprovava só o CI.
- **A sonda de canal oficial (`24041b8d`)** corrigiu código que nunca chegou a ser publicado.

Nenhum dos dois muda nada para quem atualiza, e changelog não é registro de commits.

## Verificação

- `changelog-cabe-na-tela-da-vps` — **verde**
- extração real sobre os **30.000 bytes** que o agente da VPS envia: a seção volta inteira, com o onboarding, o instalador, o `salir` e os dois avisos, terminando em frase completa
- seção com **5.188 bytes**; o corte é em 30.000

Depois do merge: `git tag -a v1.4.1` no commit de merge e push da tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126ezJHDNKTi7J1EM2GpfvJ