### PR TITLE
test:db vazava 2 volumes do Docker por rodada — 24 GB até o disco encher

### DIFF
--- a/scripts/smoke-llm.sh
+++ b/scripts/smoke-llm.sh
@@ -11,7 +11,10 @@ IMAGE="pgvector/pgvector:pg17"
 
 [ -n "${ANTHROPIC_API_KEY:-}" ] || { echo "FATAL: exporte ANTHROPIC_API_KEY (o smoke usa o modelo real)" >&2; exit 1; }
 
-cleanup() { docker rm -f "$CONTAINER" >/dev/null 2>&1 || true; }
+# `-v`: a imagem declara `VOLUME /var/lib/postgresql/data`, então sem ele cada
+# rodada deixa um volume anônimo para trás. Mesmo defeito de `test-db.sh`, mesma
+# imagem — ver o comentário de lá para a medição.
+cleanup() { docker rm -fv "$CONTAINER" >/dev/null 2>&1 || true; }
 trap cleanup EXIT
 
 echo "==> subindo $IMAGE como $CONTAINER (porta $PORT)"

--- a/scripts/test-db.sh
+++ b/scripts/test-db.sh
@@ -31,7 +31,24 @@ TEMPLATE="inv_baseline"
 
 cleanup() {
   echo "==> teardown: removendo container $CONTAINER"
-  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  # `-v` REMOVE OS VOLUMES ANÔNIMOS, e sem ele cada rodada vazava ~68 MB.
+  #
+  # `pgvector/pgvector:pg17` declara `VOLUME /var/lib/postgresql/data` no
+  # Dockerfile (`docker image inspect … .Config.Volumes`), então todo container
+  # criado sem `-v` explícito ganha um volume ANÔNIMO. O `--rm` do `docker run`
+  # cuidaria disso ao término normal, mas quem chega primeiro é este trap, e
+  # `docker rm -f` sem `-v` remove o container e DEIXA o volume.
+  #
+  # Medido, com contagem antes/depois: `docker rm -f` → +1 volume órfão;
+  # `docker rm -fv` → nenhum. Numa máquina de desenvolvimento onde esta suíte
+  # roda dezenas de vezes por dia, isso somou **355 volumes órfãos e 24 GB** —
+  # o suficiente para encher o disco e derrubar o daemon do Docker, que é como
+  # o defeito apareceu (2026-08-25: `No space left on device` em toda escrita,
+  # inclusive a do próprio harness).
+  #
+  # O sintoma não aponta para cá: o disco enche horas depois, e quem paga é a
+  # próxima sessão a rodar qualquer coisa.
+  docker rm -fv "$CONTAINER" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
## O sintoma não apontava para a causa

Numa sessão de trabalho o disco da máquina encheu, o daemon do Docker caiu, e **toda escrita** passou a falhar com `No space left on device` — inclusive a do harness que roda os comandos. Quem paga não é quem rodou a suíte; é a próxima sessão a tentar qualquer coisa.

## A causa, medida

`pgvector/pgvector:pg17` declara `VOLUME` no Dockerfile:

```console
$ docker image inspect pgvector/pgvector:pg17 --format '{{json .Config.Volumes}}'
{"/var/lib/postgresql/data":{}}
```

Todo container criado sem `-v` explícito ganha um volume **anônimo**. O `--rm` do `docker run` cuidaria disso ao término normal — mas quem chega primeiro é o trap de `cleanup`, e `docker rm -f` **sem `-v`** remove o container e **deixa** o volume.

Provado isolado, com contagem antes/depois:

```
docker rm -f  <container pgvector>  →  +1 volume órfão
docker rm -fv <container pgvector>  →  nenhum
```

E medido no caminho real, rodando a suíte de verdade:

| | delta de volumes |
|---|---|
| com o conserto, rodada 1 | **+0** |
| com o conserto, rodada 2 | **+0** |
| script da `main` (sem o `-v`) | **+2** |

São **dois por rodada**, não um: o script sobe o Postgres e o banco-molde. Numa máquina onde a suíte roda dezenas de vezes por dia, isso somou **355 volumes órfãos e 24 GB**.

## Por que a primeira medição não valeu

A primeira rodada deu delta **−1**, não 0. Terminar com *menos* volumes do que começou não confirma o conserto — confirma que o ambiente ainda estava se estabilizando (containers de outras sessões parando durante a medição). Um resultado favorável pelo motivo errado é o pior tipo de verde, então refiz com o ambiente parado. É a tabela acima que vale.

## A classe, não só a instância

`grep -rn 'docker rm -f' scripts/ tests/ hostgator-setup-kit/ .github/` devolve três lugares:

- `scripts/test-db.sh` — consertado (é o que causou o incidente)
- `scripts/smoke-llm.sh` — **mesmo defeito**, mesma imagem, mesmo padrão. Consertado
- `.github/workflows/publish-image.yml:237` — imagem do app em runner efêmero do GitHub: o disco morre com o job, não há acúmulo. Fica como está

## Limpeza feita para destravar

Os 355 volumes órfãos foram removidos. Os **5 nomeados** (Supabase local, WAHA) foram preservados — só os anônimos saíram, e os 2 que estavam em uso o próprio Docker recusou. Build cache zerado. Espaço livre: 12 GB → **37 GB**.

`pnpm test:db tests/invariants/rls-isolation.test.ts` → 25 testes, exit 0, nas duas rodadas com o conserto.