### PR TITLE
A captação pelo Respondi entrou sem uma linha que a anuncie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ Se você roda o DeskcommCRM numa VPS, **leia a seção da versão para a qual es
 
 ## [Não lançado]
 
+### Adicionado
+
+- **Formulários do Respondi entram como lead, com as respostas na ficha.** Antes, quem ligava
+  um formulário do Respondi ao CRM recebia um erro e **nenhum lead era criado** — o webhook
+  chegava com as respostas dentro de uma estrutura que o CRM não sabia ler, e a captação era
+  recusada inteira. Agora o nome, o telefone, o e-mail e cada pergunta respondida chegam na
+  ficha do contato, e o lead nasce no funil como qualquer outro. **Telefone sem código de
+  país é lido como brasileiro** (`(11) 99999-8888` vira `+5511999998888`, a mesma regra que o
+  WhatsApp já usava); número de fora do Brasil precisa vir com o `+` e o código do país.
+- **Quem recusa contato no formulário aparece na linha do tempo.** Se a pessoa marcou que
+  **não** aceita receber mensagens, isso vira um evento visível na ficha dela — em vez de a
+  equipe descobrir o silêncio depois, sem saber por quê. Recusa é informação, não ausência
+  de informação.
+
+
 ## [1.5.0] — 2026-08-25
 
 O histórico de quem chega pelos seus formulários agora existe — inclusive de quem **não**


### PR DESCRIPTION
Buraco da minha triagem, apontado pelo @MaestroConexoes **depois** do merge do #326.

## Medido

```console
$ gh pr view 326 --json files | filtro CHANGELOG    →  0 arquivos
$ [Não lançado] na main depois do merge             →  0 linhas com conteúdo
$ menções a "Respondi" no CHANGELOG inteiro         →  0
```

A normalização do payload do Respondi entrou na `main` sem entrada nenhuma. Como a tela de atualização mostra **só a seção da versão-alvo** (`extractChangelogSection(raw, latest)`), a próxima release sairia com a feature dentro dela e fora do texto — e quem instala nunca saberia que passou a existir.

## Por que passou

**Nenhum gate cobra isso.** Mudança de comportamento sem entrada no CHANGELOG é de graça no repositório hoje. O #326 passou por quatro lentes de triagem e treze achados sobreviventes, e nenhuma perguntou *"isto tem linha no CHANGELOG?"*.

O @MaestroConexoes registrou que o PR dele quase saiu pelo mesmo buraco, e só não saiu por acaso de coordenação.

## As entradas

Descrevem o que muda **para quem usa**, não o que mudou no código:

- a captação que era recusada inteira agora vira lead com as respostas na ficha — e a regra de telefone brasileiro **declarada**, porque ela altera o dado do cliente em silêncio;
- a recusa de contato vira evento visível na linha do tempo, em vez de a equipe descobrir o silêncio depois sem saber por quê.

`tests/unit/changelog-cabe-na-tela-da-vps.test.ts`: **5 casos verdes** — com conteúdo no `[Não lançado]`, ele vira uma segunda candidata e passa a ser medido contra o corte de 30.000 bytes.