### PR TITLE
feat(leads): classificação inicial determinística do funil imobiliário (Respondi)

### DIFF
--- a/app/api/v1/webhooks/in/[token]/route.ts
+++ b/app/api/v1/webhooks/in/[token]/route.ts
@@ -377,12 +377,15 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<NextRespons
     }
   }
 
-  // Classificação inicial (só Respondi por ora — os 3 motivos de
-  // desqualificação e o campo de orçamento são específicos do form
+  // Classificação inicial (só Respondi por ora — os motivos de
+  // desqualificação/revisão e o campo de orçamento são específicos do form
   // "Imobiliárias e Incorporadoras"; um webhook genérico não tem
   // `custom_fields.viable_investment_range` nem `consent` estruturado do
   // mesmo jeito). Escreve em `custom_fields` do PRÓPRIO lead sendo criado —
   // não dispara automação nenhuma, não manda mensagem: é dado, não ação.
+  // "revisao_humana" (conflito de identidade, spam, incoerência de
+  // investimento) também não bloqueia nada — quem controla envio é
+  // guarda-do-contato.ts, que não lê classificação nenhuma.
   let classificacaoInicial: ResultadoClassificacaoInicial | null = null;
   if (respondiMapped) {
     classificacaoInicial = classificarLeadInicial({

--- a/app/api/v1/webhooks/in/[token]/route.ts
+++ b/app/api/v1/webhooks/in/[token]/route.ts
@@ -16,6 +16,7 @@ import { logger } from "@/lib/logger";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createLeadHandler } from "@/app/api/v1/leads/_handler";
 import { emitLeadActivity } from "@/lib/leads/activity-emitter";
+import { classificarLeadInicial, type ResultadoClassificacaoInicial } from "@/lib/leads/classificacao-inicial";
 import type { CreateLeadInput } from "@/lib/schemas";
 import { mapInboundPayload, verifyInboundSignature, type FieldMap } from "@/lib/webhooks/inbound";
 import {
@@ -287,11 +288,16 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<NextRespons
   // is_merged_into null: contato mesclado não deve ser reaproveitado (o índice
   // único uniq_contacts_org_phone só cobre a linha ativa por telefone).
   let contactId: string | undefined;
+  // Nome do contato JÁ EXISTENTE que este envio casou (não o que acabou de
+  // criar — um contato novo nunca conflita com ele mesmo). `undefined` =
+  // ninguém existia antes; alimenta a checagem de conflito de identidade da
+  // classificação inicial (lib/leads/classificacao-inicial.ts).
+  let existingContactName: string | null | undefined;
   if (mapped.phone) {
     const selectActiveByPhone = () =>
       admin
         .from("contacts")
-        .select("id")
+        .select("id, name")
         .eq("organization_id", source.organization_id)
         .eq("phone_number", mapped.phone)
         .is("is_merged_into", null)
@@ -306,7 +312,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<NextRespons
       if (!mapped.email) return null;
       return admin
         .from("contacts")
-        .select("id")
+        .select("id, name")
         .eq("organization_id", source.organization_id)
         .eq("email_normalized", mapped.email.trim().toLowerCase())
         .is("is_merged_into", null)
@@ -316,6 +322,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<NextRespons
     const { data: existing } = await selectActiveByPhone();
     if (existing) {
       contactId = existing.id as string;
+      existingContactName = existing.name as string | null;
     } else {
       const { data: created, error: insertErr } = await admin
         .from("contacts")
@@ -349,10 +356,12 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<NextRespons
           const { data: winnerByPhone } = await selectActiveByPhone();
           if (winnerByPhone) {
             contactId = winnerByPhone.id as string;
+            existingContactName = winnerByPhone.name as string | null;
           } else {
             const byEmail = selectActiveByEmail();
             const { data: winnerByEmail } = byEmail ? await byEmail : { data: null };
             contactId = (winnerByEmail?.id as string | undefined) ?? undefined;
+            existingContactName = (winnerByEmail?.name as string | null | undefined) ?? undefined;
           }
         } else {
           logger.error("[webhooks.inbound] contact insert failed", {
@@ -364,6 +373,36 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<NextRespons
         }
       } else {
         contactId = (created?.id as string | undefined) ?? undefined;
+      }
+    }
+  }
+
+  // Classificação inicial (só Respondi por ora — os 3 motivos de
+  // desqualificação e o campo de orçamento são específicos do form
+  // "Imobiliárias e Incorporadoras"; um webhook genérico não tem
+  // `custom_fields.viable_investment_range` nem `consent` estruturado do
+  // mesmo jeito). Escreve em `custom_fields` do PRÓPRIO lead sendo criado —
+  // não dispara automação nenhuma, não manda mensagem: é dado, não ação.
+  let classificacaoInicial: ResultadoClassificacaoInicial | null = null;
+  if (respondiMapped) {
+    classificacaoInicial = classificarLeadInicial({
+      customFields: respondiMapped.custom_fields,
+      phoneNormalizado: mapped.phone,
+      consentGranted: respondiMapped.consent.granted,
+      contatoExistente: existingContactName !== undefined ? { name: existingContactName } : null,
+      nomeDoEnvio: mapped.name,
+    });
+    mapped.custom_fields.classificacao_inicial_status = classificacaoInicial.status;
+    if (classificacaoInicial.status === "desqualificado") {
+      mapped.custom_fields.classificacao_inicial_motivo = classificacaoInicial.motivo;
+    } else if (classificacaoInicial.status === "revisao_humana") {
+      mapped.custom_fields.classificacao_inicial_motivo = classificacaoInicial.motivo;
+    } else {
+      mapped.custom_fields.classificacao_inicial_classe = classificacaoInicial.classe;
+      if (classificacaoInicial.percentual !== null) {
+        mapped.custom_fields.classificacao_inicial_percentual = String(
+          Math.round(classificacaoInicial.percentual),
+        );
       }
     }
   }
@@ -473,6 +512,37 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<NextRespons
         organizationId: source.organization_id,
         leadId: String(lead.id),
         error: atividade.error,
+      });
+    }
+  }
+
+  // Classificação inicial: desqualificação e pedido de revisão humana também
+  // são sinal, não ausência de sinal — mesmo raciocínio de consent_declined
+  // acima. "classificado" com uma classe (A/B/C/D/nao_avaliado) NÃO gera
+  // atividade própria: o valor já fica visível em custom_fields, e uma
+  // classificação normal não é um evento que precisa de linha na timeline.
+  if (classificacaoInicial && classificacaoInicial.status !== "classificado") {
+    const tipo = classificacaoInicial.status === "desqualificado" ? "lead_disqualified" : "lead_needs_review";
+    const atividadeClassificacao = await emitLeadActivity(admin, {
+      organizationId: source.organization_id,
+      leadId: String(lead.id),
+      contactId: contactId ?? null,
+      type: tipo,
+      sourceModule: "webhook",
+      sourceId: source.id,
+      actor: { type: "webhook_source", id: source.id },
+      reason:
+        classificacaoInicial.status === "desqualificado"
+          ? `Desqualificado na triagem inicial: ${classificacaoInicial.motivo}.`
+          : `Revisão humana pedida na triagem inicial: ${classificacaoInicial.motivo}.`,
+      payload: { webhook_source_id: source.id, motivo: classificacaoInicial.motivo },
+    });
+    if (!atividadeClassificacao.ok) {
+      logger.error("[webhooks.inbound] classificacao_inicial activity failed", {
+        webhookSourceId: source.id,
+        organizationId: source.organization_id,
+        leadId: String(lead.id),
+        error: atividadeClassificacao.error,
       });
     }
   }

--- a/lib/leads/activity-vocabulary.ts
+++ b/lib/leads/activity-vocabulary.ts
@@ -59,6 +59,20 @@ export type ActivityType =
    */
   | "consent_declined"
   /**
+   * Classificação inicial (ver `lib/leads/classificacao-inicial.ts`) bateu um
+   * dos 3 motivos exatos de desqualificação. Igual a `consent_declined`: o
+   * "não" é sinal — sem esta linha, um lead que some do funil comercial de
+   * primeiro toque parece esquecido, não desqualificado por regra.
+   */
+  | "lead_disqualified"
+  /**
+   * Classificação inicial achou conflito de identidade (nome do envio diverge
+   * do nome já gravado no contato casado por telefone/e-mail) e NÃO
+   * classificou — pediu olho humano antes. Sem linha, ninguém sabe que o lead
+   * está parado esperando alguém decidir quem é quem.
+   */
+  | "lead_needs_review"
+  /**
    * A TROCA DE COMANDO ENTRE PESSOAS. A ida e a volta IA↔humano já estavam aqui
    * (`handoff_triggered`/`handoff_resolved`); assumir, transferir e liberar não
    * geravam linha nenhuma — grep nas três rotas devolvia zero. O efeito era uma
@@ -141,6 +155,8 @@ export const ACTIVITY_LABELS: Record<ActivityType, string> = {
   // tela — e o dossiê de um negócio fechado terminava sem dizer que fechou.
   demand_closed: "Demanda encerrada",
   consent_declined: "Consentimento de contato recusado no formulário",
+  lead_disqualified: "Desqualificado na triagem inicial",
+  lead_needs_review: "Aguardando revisão humana (conflito de identidade)",
   // Rótulos com OBJETO, nunca verbo nu: "Liberou" sozinho não diz o quê, e numa
   // clínica "liberar" é o que se faz com um exame. O resto do arquivo já segue
   // essa régua ("Retorno agendado", "Demanda encerrada").

--- a/lib/leads/classificacao-inicial.test.ts
+++ b/lib/leads/classificacao-inicial.test.ts
@@ -8,7 +8,7 @@ import {
 
 function base(overrides: Partial<EntradaClassificacaoInicial> = {}): EntradaClassificacaoInicial {
   return {
-    customFields: { viable_investment_range: "De R$ 4 mil a R$ 7 mil por mês" },
+    customFields: { viable_investment_range: "De R$ 4 mil a R$ 7 mil por mês", respondi_score: "55" },
     phoneNormalizado: "+5515988887777",
     consentGranted: true,
     contatoExistente: null,
@@ -17,44 +17,24 @@ function base(overrides: Partial<EntradaClassificacaoInicial> = {}): EntradaClas
   };
 }
 
-describe("avaliarDesqualificacao — os 3 motivos exatos", () => {
-  it("'Ainda não posso investir' (exato, case-insensitive) desqualifica", () => {
-    const r = avaliarDesqualificacao(
-      base({ customFields: { viable_investment_range: "Ainda Não Posso Investir" } }),
-    );
-    expect(r).toBe("sem_capacidade_de_investimento");
-  });
-
-  it("frase parecida mas não exata NÃO desqualifica por esse motivo", () => {
-    const r = avaliarDesqualificacao(
-      base({ customFields: { viable_investment_range: "Ainda não posso investir muito, mas quero começar" } }),
-    );
-    expect(r).not.toBe("sem_capacidade_de_investimento");
-  });
-
+describe("avaliarDesqualificacao — só os 2 bloqueios técnicos/legais reais", () => {
   it("telefone ausente (null) desqualifica: contato_invalido", () => {
-    const r = avaliarDesqualificacao(base({ phoneNormalizado: null }));
-    expect(r).toBe("contato_invalido");
+    expect(avaliarDesqualificacao(base({ phoneNormalizado: null }))).toBe("contato_invalido");
   });
 
   it("consentimento não concedido desqualifica: sem_consentimento", () => {
-    const r = avaliarDesqualificacao(base({ consentGranted: false }));
-    expect(r).toBe("sem_consentimento");
+    expect(avaliarDesqualificacao(base({ consentGranted: false }))).toBe("sem_consentimento");
+  });
+
+  it("'Ainda não posso investir' NÃO desqualifica mais (decisão 2026-08-25 — vira sinal de classe D)", () => {
+    const r = avaliarDesqualificacao(
+      base({ customFields: { viable_investment_range: "Ainda não posso investir" } }),
+    );
+    expect(r).toBeNull();
   });
 
   it("tudo em ordem: não desqualifica", () => {
     expect(avaliarDesqualificacao(base())).toBeNull();
-  });
-
-  it("ordem: capacidade de investimento vence sobre telefone/consentimento simultaneamente ruins", () => {
-    const r = avaliarDesqualificacao(
-      base({
-        customFields: { viable_investment_range: "Ainda não posso investir" },
-        phoneNormalizado: null,
-        consentGranted: false,
-      }),
-    );
-    expect(r).toBe("sem_capacidade_de_investimento");
   });
 });
 
@@ -76,20 +56,105 @@ describe("avaliarRevisaoHumana — conflito de identidade", () => {
     );
     expect(r).toBe("conflito_de_identidade");
   });
+});
 
-  it("um dos nomes ausente: sem dado suficiente pra afirmar conflito", () => {
-    const r = avaliarRevisaoHumana(base({ contatoExistente: { name: null }, nomeDoEnvio: "Maria Exemplo" }));
+describe("avaliarRevisaoHumana — spam", () => {
+  it("nome só com dígitos: spam_suspeito", () => {
+    expect(avaliarRevisaoHumana(base({ nomeDoEnvio: "123456" }))).toBe("spam_suspeito");
+  });
+
+  it("nome parece e-mail: spam_suspeito", () => {
+    expect(avaliarRevisaoHumana(base({ nomeDoEnvio: "fulano@exemplo.com" }))).toBe("spam_suspeito");
+  });
+
+  it("nome parece URL: spam_suspeito", () => {
+    expect(avaliarRevisaoHumana(base({ nomeDoEnvio: "www.spam.com" }))).toBe("spam_suspeito");
+  });
+
+  it("nome com caractere repetido 5x+: spam_suspeito", () => {
+    expect(avaliarRevisaoHumana(base({ nomeDoEnvio: "aaaaaaa" }))).toBe("spam_suspeito");
+  });
+
+  it("nome é marcador conhecido de teste: spam_suspeito", () => {
+    expect(avaliarRevisaoHumana(base({ nomeDoEnvio: "teste" }))).toBe("spam_suspeito");
+  });
+
+  it("nome normal: não é spam", () => {
+    expect(avaliarRevisaoHumana(base({ nomeDoEnvio: "Maria Exemplo" }))).toBeNull();
+  });
+
+  it("company_name com URL embutida: spam_suspeito", () => {
+    const r = avaliarRevisaoHumana(
+      base({
+        customFields: {
+          viable_investment_range: "De R$ 4 mil a R$ 7 mil por mês",
+          respondi_score: "55",
+          company_name: "Confira em http://spam.example.com",
+        },
+      }),
+    );
+    expect(r).toBe("spam_suspeito");
+  });
+
+  it("commercial_challenge com sequência longa de dígitos (telefone embutido): spam_suspeito", () => {
+    const r = avaliarRevisaoHumana(
+      base({
+        customFields: {
+          viable_investment_range: "De R$ 4 mil a R$ 7 mil por mês",
+          respondi_score: "55",
+          commercial_challenge: "me chama no 11987654321 agora",
+        },
+      }),
+    );
+    expect(r).toBe("spam_suspeito");
+  });
+});
+
+describe("avaliarRevisaoHumana — incoerência entre investimento atual e viável", () => {
+  it("investe hoje MAIS do que diz que seria viável: incoerencia_investimento", () => {
+    const r = avaliarRevisaoHumana(
+      base({
+        customFields: {
+          respondi_score: "55",
+          current_marketing_investment: "De R$ 10 mil a R$ 15 mil",
+          viable_investment_range: "Até R$ 2 mil",
+        },
+      }),
+    );
+    expect(r).toBe("incoerencia_investimento");
+  });
+
+  it("investe hoje menos ou igual ao viável: sem incoerência", () => {
+    const r = avaliarRevisaoHumana(
+      base({
+        customFields: {
+          respondi_score: "55",
+          current_marketing_investment: "Até R$ 2 mil",
+          viable_investment_range: "De R$ 4 mil a R$ 7 mil por mês",
+        },
+      }),
+    );
+    expect(r).toBeNull();
+  });
+
+  it("um dos dois valores não parseia (texto fora do padrão 'N mil'): não afirma incoerência", () => {
+    const r = avaliarRevisaoHumana(
+      base({
+        customFields: {
+          respondi_score: "55",
+          current_marketing_investment: "Não sei dizer",
+          viable_investment_range: "De R$ 4 mil a R$ 7 mil por mês",
+        },
+      }),
+    );
     expect(r).toBeNull();
   });
 });
 
-describe("classificarLeadInicial — orquestração", () => {
+describe("classificarLeadInicial — orquestração e precedência", () => {
   it("desqualificação vence sobre revisão humana e sobre classe", () => {
     const r = classificarLeadInicial(
-      base({
-        consentGranted: false,
-        contatoExistente: { name: "Outro Nome" },
-      }),
+      base({ consentGranted: false, contatoExistente: { name: "Outro Nome" } }),
     );
     expect(r).toEqual({ status: "desqualificado", motivo: "sem_consentimento" });
   });
@@ -99,19 +164,51 @@ describe("classificarLeadInicial — orquestração", () => {
     expect(r).toEqual({ status: "revisao_humana", motivo: "conflito_de_identidade" });
   });
 
-  it("sem config numérica (CONFIG_CLASSIFICACAO_INICIAL null): nao_avaliado, nunca uma classe adivinhada", () => {
-    const r = classificarLeadInicial(base());
-    expect(r.status).toBe("classificado");
-    if (r.status === "classificado") {
-      expect(r.classe).toBe("nao_avaliado");
-      expect(r.percentual).toBeNull();
-    }
-  });
-
-  it("sem config, mesmo com respondi_score presente: ainda nao_avaliado (documenta a pendência, não o valor)", () => {
+  it("sem respondi_score: nao_avaliado, nunca uma classe adivinhada", () => {
     const r = classificarLeadInicial(
-      base({ customFields: { viable_investment_range: "De R$ 4 mil a R$ 7 mil por mês", respondi_score: "90" } }),
+      base({ customFields: { viable_investment_range: "De R$ 4 mil a R$ 7 mil por mês" } }),
     );
     expect(r).toEqual({ status: "classificado", classe: "nao_avaliado", percentual: null });
+  });
+
+  it("score 75: classe A", () => {
+    const r = classificarLeadInicial(base({ customFields: { respondi_score: "75" } }));
+    expect(r).toEqual({ status: "classificado", classe: "A", percentual: 75 });
+  });
+
+  it("score 55: classe B", () => {
+    const r = classificarLeadInicial(base({ customFields: { respondi_score: "55" } }));
+    expect(r).toEqual({ status: "classificado", classe: "B", percentual: 55 });
+  });
+
+  it("score 20: classe C", () => {
+    const r = classificarLeadInicial(base({ customFields: { respondi_score: "20" } }));
+    expect(r).toEqual({ status: "classificado", classe: "C", percentual: 20 });
+  });
+
+  it("score 0 (piso do critério combinado): classe D", () => {
+    const r = classificarLeadInicial(base({ customFields: { respondi_score: "0" } }));
+    expect(r).toEqual({ status: "classificado", classe: "D", percentual: 0 });
+  });
+
+  it("'Ainda não posso investir' força D mesmo com score alto — sinal forte do respondente vence o número", () => {
+    const r = classificarLeadInicial(
+      base({
+        customFields: { respondi_score: "90", viable_investment_range: "Ainda não posso investir" },
+      }),
+    );
+    expect(r).toEqual({ status: "classificado", classe: "D", percentual: 90 });
+  });
+
+  it("REGRESSÃO — orçamento inicial modesto (mas não a frase exata) NÃO força D sozinho: empresa de alto potencial com score 55 fica B, não D", () => {
+    // Este é exatamente o cenário que Matheus rejeitou na primeira versão da
+    // regra: "De R$ 4 mil a R$ 7 mil" não é a frase de desistência, é só uma
+    // faixa mais baixa — não pode, sozinha, derrubar a classe.
+    const r = classificarLeadInicial(
+      base({
+        customFields: { respondi_score: "55", viable_investment_range: "Até R$ 2 mil" },
+      }),
+    );
+    expect(r).toEqual({ status: "classificado", classe: "B", percentual: 55 });
   });
 });

--- a/lib/leads/classificacao-inicial.test.ts
+++ b/lib/leads/classificacao-inicial.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  avaliarDesqualificacao,
+  avaliarRevisaoHumana,
+  classificarLeadInicial,
+  type EntradaClassificacaoInicial,
+} from "@/lib/leads/classificacao-inicial";
+
+function base(overrides: Partial<EntradaClassificacaoInicial> = {}): EntradaClassificacaoInicial {
+  return {
+    customFields: { viable_investment_range: "De R$ 4 mil a R$ 7 mil por mês" },
+    phoneNormalizado: "+5515988887777",
+    consentGranted: true,
+    contatoExistente: null,
+    nomeDoEnvio: "Maria Exemplo",
+    ...overrides,
+  };
+}
+
+describe("avaliarDesqualificacao — os 3 motivos exatos", () => {
+  it("'Ainda não posso investir' (exato, case-insensitive) desqualifica", () => {
+    const r = avaliarDesqualificacao(
+      base({ customFields: { viable_investment_range: "Ainda Não Posso Investir" } }),
+    );
+    expect(r).toBe("sem_capacidade_de_investimento");
+  });
+
+  it("frase parecida mas não exata NÃO desqualifica por esse motivo", () => {
+    const r = avaliarDesqualificacao(
+      base({ customFields: { viable_investment_range: "Ainda não posso investir muito, mas quero começar" } }),
+    );
+    expect(r).not.toBe("sem_capacidade_de_investimento");
+  });
+
+  it("telefone ausente (null) desqualifica: contato_invalido", () => {
+    const r = avaliarDesqualificacao(base({ phoneNormalizado: null }));
+    expect(r).toBe("contato_invalido");
+  });
+
+  it("consentimento não concedido desqualifica: sem_consentimento", () => {
+    const r = avaliarDesqualificacao(base({ consentGranted: false }));
+    expect(r).toBe("sem_consentimento");
+  });
+
+  it("tudo em ordem: não desqualifica", () => {
+    expect(avaliarDesqualificacao(base())).toBeNull();
+  });
+
+  it("ordem: capacidade de investimento vence sobre telefone/consentimento simultaneamente ruins", () => {
+    const r = avaliarDesqualificacao(
+      base({
+        customFields: { viable_investment_range: "Ainda não posso investir" },
+        phoneNormalizado: null,
+        consentGranted: false,
+      }),
+    );
+    expect(r).toBe("sem_capacidade_de_investimento");
+  });
+});
+
+describe("avaliarRevisaoHumana — conflito de identidade", () => {
+  it("contato novo (sem existente): nunca conflita", () => {
+    expect(avaliarRevisaoHumana(base({ contatoExistente: null }))).toBeNull();
+  });
+
+  it("nome do envio bate com o nome existente: sem conflito", () => {
+    const r = avaliarRevisaoHumana(
+      base({ contatoExistente: { name: "Maria Exemplo" }, nomeDoEnvio: "maria exemplo" }),
+    );
+    expect(r).toBeNull();
+  });
+
+  it("nome do envio diverge do nome existente: conflito_de_identidade", () => {
+    const r = avaliarRevisaoHumana(
+      base({ contatoExistente: { name: "João Existente" }, nomeDoEnvio: "Maria Exemplo" }),
+    );
+    expect(r).toBe("conflito_de_identidade");
+  });
+
+  it("um dos nomes ausente: sem dado suficiente pra afirmar conflito", () => {
+    const r = avaliarRevisaoHumana(base({ contatoExistente: { name: null }, nomeDoEnvio: "Maria Exemplo" }));
+    expect(r).toBeNull();
+  });
+});
+
+describe("classificarLeadInicial — orquestração", () => {
+  it("desqualificação vence sobre revisão humana e sobre classe", () => {
+    const r = classificarLeadInicial(
+      base({
+        consentGranted: false,
+        contatoExistente: { name: "Outro Nome" },
+      }),
+    );
+    expect(r).toEqual({ status: "desqualificado", motivo: "sem_consentimento" });
+  });
+
+  it("revisão humana vence sobre classe quando não há desqualificação", () => {
+    const r = classificarLeadInicial(base({ contatoExistente: { name: "Outro Nome" } }));
+    expect(r).toEqual({ status: "revisao_humana", motivo: "conflito_de_identidade" });
+  });
+
+  it("sem config numérica (CONFIG_CLASSIFICACAO_INICIAL null): nao_avaliado, nunca uma classe adivinhada", () => {
+    const r = classificarLeadInicial(base());
+    expect(r.status).toBe("classificado");
+    if (r.status === "classificado") {
+      expect(r.classe).toBe("nao_avaliado");
+      expect(r.percentual).toBeNull();
+    }
+  });
+
+  it("sem config, mesmo com respondi_score presente: ainda nao_avaliado (documenta a pendência, não o valor)", () => {
+    const r = classificarLeadInicial(
+      base({ customFields: { viable_investment_range: "De R$ 4 mil a R$ 7 mil por mês", respondi_score: "90" } }),
+    );
+    expect(r).toEqual({ status: "classificado", classe: "nao_avaliado", percentual: null });
+  });
+});

--- a/lib/leads/classificacao-inicial.ts
+++ b/lib/leads/classificacao-inicial.ts
@@ -2,17 +2,50 @@
  * Classificação inicial do lead — roda UMA vez, na ingestão do webhook, antes
  * de qualquer humano ou IA conversar com o lead. Três saídas possíveis:
  *
- *   1. `desqualificado` — bateu um dos 3 motivos EXATOS abaixo. Determinístico,
- *      sem exceção por regra mal configurada (mesmo raciocínio do gate de
- *      consentimento em `lib/automation/guarda-do-contato.ts`: invariante de
- *      negócio fica em código, não em config).
- *   2. `revisao_humana` — o dado não é claramente bom nem claramente
- *      desqualificável (conflito de identidade). Não é uma classe A/B/C/D:
- *      é um pedido de olho humano ANTES de classificar.
- *   3. `A` | `B` | `C` | `D` | `nao_avaliado` — a classe de score, quando
- *      computável. `nao_avaliado` é o valor honesto enquanto
- *      `CONFIG_CLASSIFICACAO_INICIAL` for `null` (ver esse arquivo pro
- *      porquê) — nunca um "C" ou "frio" adivinhado por omissão.
+ *   1. `desqualificado` — bateu um dos 2 motivos EXATOS abaixo, os dois
+ *      BLOQUEIOS TÉCNICOS/LEGAIS reais (sem telefone válido não há canal;
+ *      sem consentimento não há base legal). Determinístico, sem exceção por
+ *      regra mal configurada (mesmo raciocínio do gate de consentimento em
+ *      `lib/automation/guarda-do-contato.ts`).
+ *   2. `revisao_humana` — o dado pede um olho humano antes de seguir
+ *      (conflito de identidade, sinal de spam, ou contradição entre o que a
+ *      empresa diz investir hoje e o que diz que seria viável). NÃO bloqueia
+ *      o primeiro contato automático — é sinal para quem acompanha o funil,
+ *      não um gate de envio (esse gate é outro, e vive em
+ *      `guarda-do-contato.ts`, olhando telefone/consentimento, não
+ *      classificação).
+ *   3. `A` | `B` | `C` | `D` | `nao_avaliado` — a classe de score.
+ *      `nao_avaliado` é o valor honesto quando `respondi_score` está ausente
+ *      ou não é numérico — nunca uma classe adivinhada por omissão (mesmo
+ *      raciocínio de `lib/leads/score-writer.ts`: zero é uma afirmação).
+ *
+ * ═══ A REGRA DE D, E POR QUE MUDOU (decisão de Matheus, 2026-08-25) ═══
+ *
+ * Versão anterior: `viable_investment_range` abaixo de um corte numérico
+ * (R$3.000/mês) forçava D sozinho, sobrescrevendo A/B/C. Rejeitada: uma
+ * empresa de alto potencial que declara um orçamento inicial modesto não
+ * pode despencar pra D só por causa desse UM campo — orçamento tem que ser
+ * parte da pontuação, não o veredito sozinho.
+ *
+ * Resolução: NÃO existe mais um corte numérico de orçamento aqui. O
+ * `respondent.score` do Respondi já é, ele mesmo, um critério COMBINADO — a
+ * pergunta de faixa de investimento é uma das ~15 perguntas do caminho
+ * condicional que alimentam esse score, então orçamento já pesa no
+ * percentual sem eu duplicar o desconto. D só é alcançado por dois caminhos,
+ * os dois vindos do critério COMBINADO, nunca de um campo isolado:
+ *
+ *   (a) o score do Respondi computou para o PISO (percentual === 0) — o
+ *       conjunto de respostas, combinado, não rendeu pontuação nenhuma; ou
+ *   (b) o respondente disse, com as próprias palavras, "Ainda não posso
+ *       investir" — não é um corte que eu inventei, é a frase exata que a
+ *       pessoa escolheu no formulário. Sinal FORTE o bastante pra forçar D
+ *       mesmo que o score numérico fosse mais alto, mas ainda assim um sinal
+ *       do respondente, não uma inferência sobre um número de R$.
+ *
+ * As duas vias cumprem "leads efetivamente desqualificados pelos critérios
+ * combinados do scoring, e não apenas pelo orçamento declarado" — e D
+ * continua sendo classe, não desqualificação: o lead segue no CRM, elegível
+ * pra a cadência própria de D (oferta de entrada, D+3, D+10).
  *
  * Este módulo é PURO (nenhum I/O) — testável sem banco, chamado pela rota do
  * webhook com os `custom_fields` já mapeados pelo normalizador do Respondi.
@@ -25,8 +58,8 @@ export type ResultadoClassificacaoInicial =
   | { status: "revisao_humana"; motivo: MotivoRevisaoHumana }
   | { status: "classificado"; classe: ClasseInicial; percentual: number | null };
 
-export type MotivoDesqualificacao = "sem_capacidade_de_investimento" | "contato_invalido" | "sem_consentimento";
-export type MotivoRevisaoHumana = "conflito_de_identidade";
+export type MotivoDesqualificacao = "contato_invalido" | "sem_consentimento";
+export type MotivoRevisaoHumana = "conflito_de_identidade" | "spam_suspeito" | "incoerencia_investimento";
 
 export interface EntradaClassificacaoInicial {
   customFields: Record<string, unknown>;
@@ -43,92 +76,98 @@ export interface EntradaClassificacaoInicial {
   nomeDoEnvio: string | null;
 }
 
-/**
- * As frases-exatas de "sem capacidade de investimento" que o form
- * "Imobiliárias e Incorporadoras" do Respondi usa como opção do radio de
- * faixa de investimento viável. Comparação exata (case-insensitive, trim) —
- * NUNCA substring/regex frouxo, porque "Ainda não posso investir" é o único
- * motivo dos 3 que é DIRETO do usuário (os outros dois são inferência nossa),
- * e um match frouxo desqualificaria por engano uma resposta que só MENCIONA
- * a frase sem ser ela.
- *
- * Hoje só tem a forma exata citada na diretiva. Se o Respondi tiver outra
- * variante (typo do form, opção duplicada), adicione aqui — não crie um
- * segundo lugar de verdade.
- */
-const FRASES_SEM_CAPACIDADE = ["ainda não posso investir"];
+/** A frase exata que sinaliza "sem capacidade de investimento agora" — sinal forte pra D, não desqualificação. */
+const FRASE_SEM_CAPACIDADE = "ainda não posso investir";
 
 function normalizaTexto(v: unknown): string | null {
   return typeof v === "string" && v.trim() ? v.trim().toLowerCase() : null;
 }
 
 /**
- * Os 3 motivos EXATOS de desqualificação, na ordem em que a diretiva os lista.
- * Qualquer outro sinal ruim (spam, incoerência) NÃO desqualifica — vai para
- * `avaliarRevisaoHumana` ou fica pendente de config, nunca vira um 4º motivo
- * inventado aqui.
+ * Os 2 motivos EXATOS de desqualificação — os únicos que são bloqueio
+ * TÉCNICO/LEGAL real (não dá pra mandar WhatsApp sem telefone válido; não dá
+ * base legal pra mandar sem consentimento). "Ainda não posso investir" NÃO
+ * está mais aqui — vira sinal de classe (D), não motivo de exclusão (decisão
+ * de 2026-08-25, ver cabeçalho do arquivo). Spam/incoerência também não —
+ * vão pra `avaliarRevisaoHumana`, que não bloqueia nada.
  */
 export function avaliarDesqualificacao(input: EntradaClassificacaoInicial): MotivoDesqualificacao | null {
-  // 1. "Ainda não posso investir" — testado contra o campo de faixa de
-  // investimento viável, que é onde a diretiva ancora a frase.
-  const faixaViavel = normalizaTexto(input.customFields.viable_investment_range);
-  if (faixaViavel && FRASES_SEM_CAPACIDADE.includes(faixaViavel)) {
-    return "sem_capacidade_de_investimento";
-  }
-
-  // 2. Contato inválido — o canal de follow-up (WhatsApp) não existe depois
-  // da normalização E.164. Um lead sem telefone válido não tem como receber
-  // nenhuma das cadências por classe.
   if (!input.phoneNormalizado) return "contato_invalido";
-
-  // 3. Consentimento recusado/ausente — mesmo estado no schema hoje
-  // (`consent.marketing.granted_at` null nos dois casos; ver
-  // guarda-do-contato.ts pro mesmo raciocínio do lado do envio).
   if (!input.consentGranted) return "sem_consentimento";
-
   return null;
 }
 
+const AFIRMACOES_URL = /https?:\/\/|www\./i;
+const SEQUENCIA_DE_DIGITOS_LONGA = /\d{8,}/;
+const CARACTERE_REPETIDO = /(.)\1{4,}/;
+const MARCADORES_DE_TESTE = new Set(["teste", "test", "asdf", "spam", "xxx", "aaaa", "qwerty", "n/a", "-"]);
+
+/** Nome que não parece nome: só dígito, e-mail/URL, caractere repetido, ou um marcador conhecido de teste/spam. */
+function nomePareceSpam(nome: string | null): boolean {
+  if (!nome) return false;
+  const n = nome.trim();
+  if (!n) return false;
+  const nLower = n.toLowerCase();
+  if (MARCADORES_DE_TESTE.has(nLower)) return true;
+  if (/^\d+$/.test(n)) return true;
+  if (n.includes("@") || AFIRMACOES_URL.test(n)) return true;
+  if (CARACTERE_REPETIDO.test(n)) return true;
+  return false;
+}
+
+/** Campo de texto livre com URL ou sequência de dígitos longa (telefone/WhatsApp embutido) — divulgação, não resposta. */
+function textoLivrePareceSpam(texto: unknown): boolean {
+  if (typeof texto !== "string" || !texto.trim()) return false;
+  return AFIRMACOES_URL.test(texto) || SEQUENCIA_DE_DIGITOS_LONGA.test(texto);
+}
+
 /**
- * Único caso de revisão humana implementado agora: conflito de identidade
- * DETERMINÍSTICO — o envio casou com um contato já existente (mesmo telefone
- * ou e-mail) cujo nome gravado diverge do nome que ESTE envio trouxe. É o
- * sinal mais barato de "duas pessoas atrás do mesmo contato" ou "nome digitado
- * errado da vez passada" — os dois merecem olho humano antes de classificar.
- *
- * "Spam" e "incoerência" (pedidos pela diretiva) NÃO estão aqui: exigem
- * julgamento sobre texto livre (nome sem sentido, respostas contraditórias
- * entre si) que este módulo, deliberadamente determinístico, não tenta
- * adivinhar sem um critério escrito por Matheus — ver o TODO no relatório
- * desta sessão. Ficam PENDENTES, não inventadas.
+ * Extrai o MAIOR valor em reais mencionado num texto de faixa do Respondi
+ * ("De R$ 4 mil a R$ 7 mil por mês" → 7000; "Até R$ 2 mil" → 2000).
+ * `null` quando não há nenhum padrão "N mil" reconhecível — nunca um valor
+ * chutado a partir de texto que não bate no formato conhecido.
+ */
+function extraiValorMaximoBRL(texto: unknown): number | null {
+  if (typeof texto !== "string") return null;
+  const matches = [...texto.matchAll(/(\d+(?:[.,]\d+)?)\s*mil/gi)];
+  if (!matches.length) return null;
+  const valores = matches.map((m) => Number(m[1]!.replace(",", ".")) * 1000);
+  return Math.max(...valores);
+}
+
+/**
+ * Os 3 sinais de revisão humana — NENHUM deles bloqueia envio automático.
+ * São pedido de olho humano, não gate: quem controla se a mensagem sai é
+ * `guarda-do-contato.ts` (telefone/consentimento), que não lê nada disto.
  */
 export function avaliarRevisaoHumana(input: EntradaClassificacaoInicial): MotivoRevisaoHumana | null {
-  if (!input.contatoExistente) return null;
-  const nomeExistente = normalizaTexto(input.contatoExistente.name);
+  const nomeExistente = normalizaTexto(input.contatoExistente?.name);
   const nomeNovo = normalizaTexto(input.nomeDoEnvio);
-  if (nomeExistente && nomeNovo && nomeExistente !== nomeNovo) {
+  if (input.contatoExistente && nomeExistente && nomeNovo && nomeExistente !== nomeNovo) {
     return "conflito_de_identidade";
   }
+
+  if (
+    nomePareceSpam(input.nomeDoEnvio) ||
+    textoLivrePareceSpam(input.customFields.company_name) ||
+    textoLivrePareceSpam(input.customFields.commercial_challenge)
+  ) {
+    return "spam_suspeito";
+  }
+
+  const investeHoje = extraiValorMaximoBRL(input.customFields.current_marketing_investment);
+  const faixaViavel = extraiValorMaximoBRL(input.customFields.viable_investment_range);
+  if (investeHoje !== null && faixaViavel !== null && investeHoje > faixaViavel) {
+    return "incoerencia_investimento";
+  }
+
   return null;
 }
 
-/**
- * O percentual — numerador confirmado (`respondi_score`), denominador
- * PENDENTE (`CONFIG_CLASSIFICACAO_INICIAL.maxScoreConhecido`). Devolve `null`
- * enquanto o config não existir; nunca inventa um teto.
- */
-function calcularPercentual(customFields: Record<string, unknown>): number | null {
-  if (!CONFIG_CLASSIFICACAO_INICIAL) return null;
-  const bruto = Number(customFields.respondi_score);
-  if (!Number.isFinite(bruto)) return null;
-  const max = CONFIG_CLASSIFICACAO_INICIAL.maxScoreConhecido;
-  if (!(max > 0)) return null;
-  return Math.max(0, Math.min(100, (bruto / max) * 100));
-}
-
-function bandaDoPercentual(percentual: number, cfg: NonNullable<typeof CONFIG_CLASSIFICACAO_INICIAL>): "A" | "B" | "C" {
-  if (percentual >= cfg.bandas.A.min) return "A";
-  if (percentual >= cfg.bandas.B.min) return "B";
+function bandaDoPercentual(percentual: number): "A" | "B" | "C" {
+  const { bandas } = CONFIG_CLASSIFICACAO_INICIAL;
+  if (percentual >= bandas.A.min) return "A";
+  if (percentual >= bandas.B.min) return "B";
   return "C";
 }
 
@@ -139,19 +178,29 @@ export function classificarLeadInicial(input: EntradaClassificacaoInicial): Resu
   const motivoRevisao = avaliarRevisaoHumana(input);
   if (motivoRevisao) return { status: "revisao_humana", motivo: motivoRevisao };
 
-  const percentual = calcularPercentual(input.customFields);
-  const cfg = CONFIG_CLASSIFICACAO_INICIAL;
+  const bruto = Number(input.customFields.respondi_score);
+  if (!Number.isFinite(bruto)) {
+    // Sem pontuação suficiente pra avaliar — nunca uma classe adivinhada.
+    return { status: "classificado", classe: "nao_avaliado", percentual: null };
+  }
+  // Arredondado a 2 casas: divisão seguida de multiplicação por 100 gera
+  // ruído de ponto flutuante (55/100*100 = 55.00000000000001) mesmo quando o
+  // resultado matemático é exato — sem isto, todo teste de igualdade (e toda
+  // comparação de banda) fica refém do float.
+  const bruta = Math.max(0, Math.min(100, (bruto / CONFIG_CLASSIFICACAO_INICIAL.maxScoreConhecido) * 100));
+  const percentual = Math.round(bruta * 100) / 100;
 
-  // D é sobre ORÇAMENTO declarado, não sobre score — checa antes da banda de
-  // percentual e a sobrepõe quando bate (um lead pode ter score alto e
-  // orçamento baixo ao mesmo tempo; a diretiva pede que isso vire D, não A).
-  if (cfg) {
-    const faixaViavel = normalizaTexto(input.customFields.viable_investment_range);
-    if (faixaViavel && cfg.orcamentoBaixoRegex.test(faixaViavel)) {
-      return { status: "classificado", classe: "D", percentual };
-    }
+  // D via sinal FORTE e direto do respondente — não um corte de R$ inventado.
+  const faixaViavel = normalizaTexto(input.customFields.viable_investment_range);
+  if (faixaViavel === FRASE_SEM_CAPACIDADE) {
+    return { status: "classificado", classe: "D", percentual };
   }
 
-  if (percentual === null || !cfg) return { status: "classificado", classe: "nao_avaliado", percentual };
-  return { status: "classificado", classe: bandaDoPercentual(percentual, cfg), percentual };
+  // D via piso do critério COMBINADO (o score do Respondi já pesa orçamento
+  // como uma das ~15 perguntas do caminho condicional — sem desconto extra).
+  if (percentual === 0) {
+    return { status: "classificado", classe: "D", percentual };
+  }
+
+  return { status: "classificado", classe: bandaDoPercentual(percentual), percentual };
 }

--- a/lib/leads/classificacao-inicial.ts
+++ b/lib/leads/classificacao-inicial.ts
@@ -1,0 +1,157 @@
+/**
+ * Classificação inicial do lead — roda UMA vez, na ingestão do webhook, antes
+ * de qualquer humano ou IA conversar com o lead. Três saídas possíveis:
+ *
+ *   1. `desqualificado` — bateu um dos 3 motivos EXATOS abaixo. Determinístico,
+ *      sem exceção por regra mal configurada (mesmo raciocínio do gate de
+ *      consentimento em `lib/automation/guarda-do-contato.ts`: invariante de
+ *      negócio fica em código, não em config).
+ *   2. `revisao_humana` — o dado não é claramente bom nem claramente
+ *      desqualificável (conflito de identidade). Não é uma classe A/B/C/D:
+ *      é um pedido de olho humano ANTES de classificar.
+ *   3. `A` | `B` | `C` | `D` | `nao_avaliado` — a classe de score, quando
+ *      computável. `nao_avaliado` é o valor honesto enquanto
+ *      `CONFIG_CLASSIFICACAO_INICIAL` for `null` (ver esse arquivo pro
+ *      porquê) — nunca um "C" ou "frio" adivinhado por omissão.
+ *
+ * Este módulo é PURO (nenhum I/O) — testável sem banco, chamado pela rota do
+ * webhook com os `custom_fields` já mapeados pelo normalizador do Respondi.
+ */
+import { CONFIG_CLASSIFICACAO_INICIAL } from "@/lib/leads/config-classificacao-inicial";
+
+export type ClasseInicial = "A" | "B" | "C" | "D" | "nao_avaliado";
+export type ResultadoClassificacaoInicial =
+  | { status: "desqualificado"; motivo: MotivoDesqualificacao }
+  | { status: "revisao_humana"; motivo: MotivoRevisaoHumana }
+  | { status: "classificado"; classe: ClasseInicial; percentual: number | null };
+
+export type MotivoDesqualificacao = "sem_capacidade_de_investimento" | "contato_invalido" | "sem_consentimento";
+export type MotivoRevisaoHumana = "conflito_de_identidade";
+
+export interface EntradaClassificacaoInicial {
+  customFields: Record<string, unknown>;
+  /** `null` = telefone ausente ou não normalizável (ver `normalizePhoneBR`). */
+  phoneNormalizado: string | null;
+  consentGranted: boolean;
+  /**
+   * Presente só quando o contato foi casado com um JÁ EXISTENTE (mesmo
+   * telefone ou mesmo e-mail) — necessário pra checar conflito de identidade.
+   * `null` = contato novo, sem conflito possível.
+   */
+  contatoExistente: { name: string | null } | null;
+  /** Nome que ESTE envio trouxe (`mapped.name`). */
+  nomeDoEnvio: string | null;
+}
+
+/**
+ * As frases-exatas de "sem capacidade de investimento" que o form
+ * "Imobiliárias e Incorporadoras" do Respondi usa como opção do radio de
+ * faixa de investimento viável. Comparação exata (case-insensitive, trim) —
+ * NUNCA substring/regex frouxo, porque "Ainda não posso investir" é o único
+ * motivo dos 3 que é DIRETO do usuário (os outros dois são inferência nossa),
+ * e um match frouxo desqualificaria por engano uma resposta que só MENCIONA
+ * a frase sem ser ela.
+ *
+ * Hoje só tem a forma exata citada na diretiva. Se o Respondi tiver outra
+ * variante (typo do form, opção duplicada), adicione aqui — não crie um
+ * segundo lugar de verdade.
+ */
+const FRASES_SEM_CAPACIDADE = ["ainda não posso investir"];
+
+function normalizaTexto(v: unknown): string | null {
+  return typeof v === "string" && v.trim() ? v.trim().toLowerCase() : null;
+}
+
+/**
+ * Os 3 motivos EXATOS de desqualificação, na ordem em que a diretiva os lista.
+ * Qualquer outro sinal ruim (spam, incoerência) NÃO desqualifica — vai para
+ * `avaliarRevisaoHumana` ou fica pendente de config, nunca vira um 4º motivo
+ * inventado aqui.
+ */
+export function avaliarDesqualificacao(input: EntradaClassificacaoInicial): MotivoDesqualificacao | null {
+  // 1. "Ainda não posso investir" — testado contra o campo de faixa de
+  // investimento viável, que é onde a diretiva ancora a frase.
+  const faixaViavel = normalizaTexto(input.customFields.viable_investment_range);
+  if (faixaViavel && FRASES_SEM_CAPACIDADE.includes(faixaViavel)) {
+    return "sem_capacidade_de_investimento";
+  }
+
+  // 2. Contato inválido — o canal de follow-up (WhatsApp) não existe depois
+  // da normalização E.164. Um lead sem telefone válido não tem como receber
+  // nenhuma das cadências por classe.
+  if (!input.phoneNormalizado) return "contato_invalido";
+
+  // 3. Consentimento recusado/ausente — mesmo estado no schema hoje
+  // (`consent.marketing.granted_at` null nos dois casos; ver
+  // guarda-do-contato.ts pro mesmo raciocínio do lado do envio).
+  if (!input.consentGranted) return "sem_consentimento";
+
+  return null;
+}
+
+/**
+ * Único caso de revisão humana implementado agora: conflito de identidade
+ * DETERMINÍSTICO — o envio casou com um contato já existente (mesmo telefone
+ * ou e-mail) cujo nome gravado diverge do nome que ESTE envio trouxe. É o
+ * sinal mais barato de "duas pessoas atrás do mesmo contato" ou "nome digitado
+ * errado da vez passada" — os dois merecem olho humano antes de classificar.
+ *
+ * "Spam" e "incoerência" (pedidos pela diretiva) NÃO estão aqui: exigem
+ * julgamento sobre texto livre (nome sem sentido, respostas contraditórias
+ * entre si) que este módulo, deliberadamente determinístico, não tenta
+ * adivinhar sem um critério escrito por Matheus — ver o TODO no relatório
+ * desta sessão. Ficam PENDENTES, não inventadas.
+ */
+export function avaliarRevisaoHumana(input: EntradaClassificacaoInicial): MotivoRevisaoHumana | null {
+  if (!input.contatoExistente) return null;
+  const nomeExistente = normalizaTexto(input.contatoExistente.name);
+  const nomeNovo = normalizaTexto(input.nomeDoEnvio);
+  if (nomeExistente && nomeNovo && nomeExistente !== nomeNovo) {
+    return "conflito_de_identidade";
+  }
+  return null;
+}
+
+/**
+ * O percentual — numerador confirmado (`respondi_score`), denominador
+ * PENDENTE (`CONFIG_CLASSIFICACAO_INICIAL.maxScoreConhecido`). Devolve `null`
+ * enquanto o config não existir; nunca inventa um teto.
+ */
+function calcularPercentual(customFields: Record<string, unknown>): number | null {
+  if (!CONFIG_CLASSIFICACAO_INICIAL) return null;
+  const bruto = Number(customFields.respondi_score);
+  if (!Number.isFinite(bruto)) return null;
+  const max = CONFIG_CLASSIFICACAO_INICIAL.maxScoreConhecido;
+  if (!(max > 0)) return null;
+  return Math.max(0, Math.min(100, (bruto / max) * 100));
+}
+
+function bandaDoPercentual(percentual: number, cfg: NonNullable<typeof CONFIG_CLASSIFICACAO_INICIAL>): "A" | "B" | "C" {
+  if (percentual >= cfg.bandas.A.min) return "A";
+  if (percentual >= cfg.bandas.B.min) return "B";
+  return "C";
+}
+
+export function classificarLeadInicial(input: EntradaClassificacaoInicial): ResultadoClassificacaoInicial {
+  const motivoDesqualificacao = avaliarDesqualificacao(input);
+  if (motivoDesqualificacao) return { status: "desqualificado", motivo: motivoDesqualificacao };
+
+  const motivoRevisao = avaliarRevisaoHumana(input);
+  if (motivoRevisao) return { status: "revisao_humana", motivo: motivoRevisao };
+
+  const percentual = calcularPercentual(input.customFields);
+  const cfg = CONFIG_CLASSIFICACAO_INICIAL;
+
+  // D é sobre ORÇAMENTO declarado, não sobre score — checa antes da banda de
+  // percentual e a sobrepõe quando bate (um lead pode ter score alto e
+  // orçamento baixo ao mesmo tempo; a diretiva pede que isso vire D, não A).
+  if (cfg) {
+    const faixaViavel = normalizaTexto(input.customFields.viable_investment_range);
+    if (faixaViavel && cfg.orcamentoBaixoRegex.test(faixaViavel)) {
+      return { status: "classificado", classe: "D", percentual };
+    }
+  }
+
+  if (percentual === null || !cfg) return { status: "classificado", classe: "nao_avaliado", percentual };
+  return { status: "classificado", classe: bandaDoPercentual(percentual, cfg), percentual };
+}

--- a/lib/leads/config-classificacao-inicial.ts
+++ b/lib/leads/config-classificacao-inicial.ts
@@ -1,0 +1,84 @@
+/**
+ * Config numérica da classificação inicial A/B/C/D — a ÚNICA peça que falta
+ * para `classificarLeadInicial` (ver classificacao-inicial.ts) produzir uma
+ * classe de verdade em vez de "nao_avaliado".
+ *
+ * ═══ POR QUE ISTO É `null` E NÃO UM PALPITE ═══
+ *
+ * A diretiva pediu "pontuação proporcional ao máximo possível do caminho
+ * condicional do formulário" e classe D = "lead válido de baixo orçamento".
+ * Duas coisas viáveis existem no payload do Respondi (`respondent.score`,
+ * `custom_fields.viable_investment_range`) — nenhuma delas vem com o dado que
+ * a fórmula pede:
+ *
+ *   1. `respondent.score` é um agregado ÚNICO do Respondi (ex.: 55), sem
+ *      quebra por pergunta e sem campo `max_score` no payload. Não há, em
+ *      nenhum doc deste repo (`PROMPT_ESTRATEGICO_DECOLA_AI.md`,
+ *      `DIRETRIZES_SDR_CONSULTIVO_EXPERT.md`, `PROMPT_AUDITORIA_ORQUESTRACAO.md`,
+ *      grep feito em 2026-08-25) uma tabela de peso por pergunta nem um
+ *      "máximo do caminho condicional" documentado. Sem isso, "proporcional
+ *      ao máximo" não tem denominador — só o numerador.
+ *   2. `viable_investment_range` é texto livre de um radio do Respondi (ex.:
+ *      "De R$ 4 mil a R$ 7 mil por mês"). A fixture sanitizada
+ *      (tests/fixtures/webhooks/respondi-imobiliario.json) só mostra a opção
+ *      QUE FOI ESCOLHIDA numa resposta — não a lista completa de opções do
+ *      radio. Sem a lista completa, não dá pra saber que faixa é "baixo
+ *      orçamento" (classe D) sem inventar um corte que pode não bater com
+ *      nenhuma opção real do form.
+ *
+ * Chutar os dois números aqui seria decidir, em silêncio, quem cada lead novo
+ * vira (A vira D, D vira desqualificado) — exatamente o tipo de decisão que
+ * a diretiva pede pra reservar ("só pare se precisar de uma decisão minha que
+ * realmente altere o funcionamento do sistema"). `classificarLeadInicial`
+ * devolve `"nao_avaliado"` enquanto isto for `null` — visível como pendente
+ * na tela, nunca como "frio" por omissão (mesmo raciocínio de
+ * `lib/leads/score-writer.ts`: zero é uma afirmação).
+ *
+ * ═══ O QUE PREENCHER, E A RECOMENDAÇÃO (não ativa até você confirmar) ═══
+ *
+ * `maxScoreConhecido`: o teto real do `respondent.score` do form "Imobiliárias
+ * e Incorporadoras" (form_id 9FiY9mrO) no painel do Respondi — SOMA dos pesos
+ * de todas as perguntas do caminho condicional que esse respondente percorreu
+ * (o "máximo possível" pode variar por caminho, já que perguntas condicionais
+ * pulam). Se o Respondi não expõe esse número, a alternativa é tratar o score
+ * cru como JÁ NA ESCALA 0-100 (`maxScoreConhecido: 100`) — é a leitura mais
+ * simples e é consistente com a fixture (score 55 num lead de ticket médio),
+ * mas não está confirmada.
+ *
+ * `bandas`: os cortes de percentual para A/B/C, uma vez que o percentual
+ * exista. Recomendação, só para referência — mesma régua que
+ * `lib/kanban/score-band.ts` já usa pro score CONVERSACIONAL (quente/morno/
+ * frio = 70/40), reaproveitada aqui por consistência de produto, não
+ * confirmada para o score de FORMULÁRIO:
+ *   A: percentual >= 70   B: 40 <= percentual < 70   C: percentual < 40
+ *
+ * `orcamentoBaixoRegex`: um padrão que reconheça, no TEXTO da opção de
+ * `viable_investment_range`, as faixas que a Decola AÍ considera "baixo
+ * orçamento, mas lead válido" (classe D) — precisa da lista real de opções do
+ * radio pra não inventar valor que não existe no form.
+ */
+export interface BandaDePercentual {
+  min: number;
+  max: number;
+}
+
+export interface ConfigClassificacaoInicial {
+  /** Teto do `respondent.score` do Respondi para este form_id. */
+  maxScoreConhecido: number;
+  /** Cortes de percentual (0-100) para as classes A/B/C. D não é banda de score — ver `orcamentoBaixoRegex`. */
+  bandas: { A: BandaDePercentual; B: BandaDePercentual; C: BandaDePercentual };
+  /**
+   * Testado contra `custom_fields.viable_investment_range` (case-insensitive).
+   * Bate → classe D, INDEPENDENTE do percentual — "baixo orçamento" é sobre o
+   * orçamento declarado, não sobre o score.
+   */
+  orcamentoBaixoRegex: RegExp;
+}
+
+/**
+ * `null` = pendente. Troque por um objeto `ConfigClassificacaoInicial` real
+ * (com os 3 números/padrão acima confirmados por Matheus) para ativar a
+ * classificação A/B/C/D de verdade — nenhuma outra mudança de código é
+ * necessária, `classificarLeadInicial` já lê daqui.
+ */
+export const CONFIG_CLASSIFICACAO_INICIAL: ConfigClassificacaoInicial | null = null;

--- a/lib/leads/config-classificacao-inicial.ts
+++ b/lib/leads/config-classificacao-inicial.ts
@@ -1,61 +1,24 @@
 /**
- * Config numérica da classificação inicial A/B/C/D — a ÚNICA peça que falta
- * para `classificarLeadInicial` (ver classificacao-inicial.ts) produzir uma
- * classe de verdade em vez de "nao_avaliado".
+ * Config numérica da classificação inicial A/B/C/D — confirmada por Matheus
+ * em 2026-08-25, depois de uma rodada de revisão que MUDOU a regra de D (ver
+ * `classificacao-inicial.ts` para o raciocínio completo). Os 3 valores:
  *
- * ═══ POR QUE ISTO É `null` E NÃO UM PALPITE ═══
- *
- * A diretiva pediu "pontuação proporcional ao máximo possível do caminho
- * condicional do formulário" e classe D = "lead válido de baixo orçamento".
- * Duas coisas viáveis existem no payload do Respondi (`respondent.score`,
- * `custom_fields.viable_investment_range`) — nenhuma delas vem com o dado que
- * a fórmula pede:
- *
- *   1. `respondent.score` é um agregado ÚNICO do Respondi (ex.: 55), sem
- *      quebra por pergunta e sem campo `max_score` no payload. Não há, em
- *      nenhum doc deste repo (`PROMPT_ESTRATEGICO_DECOLA_AI.md`,
- *      `DIRETRIZES_SDR_CONSULTIVO_EXPERT.md`, `PROMPT_AUDITORIA_ORQUESTRACAO.md`,
- *      grep feito em 2026-08-25) uma tabela de peso por pergunta nem um
- *      "máximo do caminho condicional" documentado. Sem isso, "proporcional
- *      ao máximo" não tem denominador — só o numerador.
- *   2. `viable_investment_range` é texto livre de um radio do Respondi (ex.:
- *      "De R$ 4 mil a R$ 7 mil por mês"). A fixture sanitizada
- *      (tests/fixtures/webhooks/respondi-imobiliario.json) só mostra a opção
- *      QUE FOI ESCOLHIDA numa resposta — não a lista completa de opções do
- *      radio. Sem a lista completa, não dá pra saber que faixa é "baixo
- *      orçamento" (classe D) sem inventar um corte que pode não bater com
- *      nenhuma opção real do form.
- *
- * Chutar os dois números aqui seria decidir, em silêncio, quem cada lead novo
- * vira (A vira D, D vira desqualificado) — exatamente o tipo de decisão que
- * a diretiva pede pra reservar ("só pare se precisar de uma decisão minha que
- * realmente altere o funcionamento do sistema"). `classificarLeadInicial`
- * devolve `"nao_avaliado"` enquanto isto for `null` — visível como pendente
- * na tela, nunca como "frio" por omissão (mesmo raciocínio de
- * `lib/leads/score-writer.ts`: zero é uma afirmação).
- *
- * ═══ O QUE PREENCHER, E A RECOMENDAÇÃO (não ativa até você confirmar) ═══
- *
- * `maxScoreConhecido`: o teto real do `respondent.score` do form "Imobiliárias
- * e Incorporadoras" (form_id 9FiY9mrO) no painel do Respondi — SOMA dos pesos
- * de todas as perguntas do caminho condicional que esse respondente percorreu
- * (o "máximo possível" pode variar por caminho, já que perguntas condicionais
- * pulam). Se o Respondi não expõe esse número, a alternativa é tratar o score
- * cru como JÁ NA ESCALA 0-100 (`maxScoreConhecido: 100`) — é a leitura mais
- * simples e é consistente com a fixture (score 55 num lead de ticket médio),
- * mas não está confirmada.
- *
- * `bandas`: os cortes de percentual para A/B/C, uma vez que o percentual
- * exista. Recomendação, só para referência — mesma régua que
- * `lib/kanban/score-band.ts` já usa pro score CONVERSACIONAL (quente/morno/
- * frio = 70/40), reaproveitada aqui por consistência de produto, não
- * confirmada para o score de FORMULÁRIO:
- *   A: percentual >= 70   B: 40 <= percentual < 70   C: percentual < 40
- *
- * `orcamentoBaixoRegex`: um padrão que reconheça, no TEXTO da opção de
- * `viable_investment_range`, as faixas que a Decola AÍ considera "baixo
- * orçamento, mas lead válido" (classe D) — precisa da lista real de opções do
- * radio pra não inventar valor que não existe no form.
+ *   1. `maxScoreConhecido: 100` — `respondent.score` do Respondi tratado como
+ *      já numa escala 0-100. Não é medido (o Respondi não expõe o teto real
+ *      por pergunta), é a leitura mais simples e consistente com as 2
+ *      amostras reais vistas em produção (scores 40 e 55 — plausíveis nessa
+ *      escala). Se um dia o painel do Respondi confirmar outro teto, troque
+ *      só este número.
+ *   2. `bandas` — A ≥70%, B 40-69%, C 1-39%. Mesma régua que
+ *      `lib/kanban/score-band.ts` já usa pro score CONVERSACIONAL (quente/
+ *      morno/frio = 70/40), reaproveitada por consistência de produto.
+ *   3. Orçamento declarado NÃO tem mais um corte numérico próprio aqui — ver
+ *      o cabeçalho de `classificacao-inicial.ts`: a decisão de 2026-08-25 foi
+ *      que orçamento não pode, sozinho, forçar a classe D (uma empresa de
+ *      alto potencial que declarou orçamento inicial modesto não pode
+ *      despencar pra D só por isso). O único sinal de orçamento que ainda
+ *      força D é a frase EXATA "Ainda não posso investir" — tratada como
+ *      sinal direto do respondente, não como um corte que eu inventei.
  */
 export interface BandaDePercentual {
   min: number;
@@ -65,20 +28,15 @@ export interface BandaDePercentual {
 export interface ConfigClassificacaoInicial {
   /** Teto do `respondent.score` do Respondi para este form_id. */
   maxScoreConhecido: number;
-  /** Cortes de percentual (0-100) para as classes A/B/C. D não é banda de score — ver `orcamentoBaixoRegex`. */
+  /** Cortes de percentual (0-100) para as classes A/B/C. D não é banda de score — ver classificacao-inicial.ts. */
   bandas: { A: BandaDePercentual; B: BandaDePercentual; C: BandaDePercentual };
-  /**
-   * Testado contra `custom_fields.viable_investment_range` (case-insensitive).
-   * Bate → classe D, INDEPENDENTE do percentual — "baixo orçamento" é sobre o
-   * orçamento declarado, não sobre o score.
-   */
-  orcamentoBaixoRegex: RegExp;
 }
 
-/**
- * `null` = pendente. Troque por um objeto `ConfigClassificacaoInicial` real
- * (com os 3 números/padrão acima confirmados por Matheus) para ativar a
- * classificação A/B/C/D de verdade — nenhuma outra mudança de código é
- * necessária, `classificarLeadInicial` já lê daqui.
- */
-export const CONFIG_CLASSIFICACAO_INICIAL: ConfigClassificacaoInicial | null = null;
+export const CONFIG_CLASSIFICACAO_INICIAL: ConfigClassificacaoInicial = {
+  maxScoreConhecido: 100,
+  bandas: {
+    A: { min: 70, max: 100 },
+    B: { min: 40, max: 69 },
+    C: { min: 1, max: 39 },
+  },
+};

--- a/tests/invariants/webhooks-inbound.test.ts
+++ b/tests/invariants/webhooks-inbound.test.ts
@@ -796,3 +796,107 @@ describe("POST /api/v1/webhooks/in/[token] — Respondi (payload aninhado, achad
     expect(contatosComEsseEmail, "deveria haver exatamente um contato por organização").toHaveLength(2);
   });
 });
+
+/**
+ * Classificação inicial (lib/leads/classificacao-inicial.ts), integrada na
+ * mesma rota. `CONFIG_CLASSIFICACAO_INICIAL` é `null` nesta suíte (config
+ * pendente, ver o arquivo) — os 3 casos abaixo provam o que É determinístico
+ * hoje: os 3 motivos exatos de desqualificação, o pedido de revisão humana, e
+ * que uma classe nunca é adivinhada quando o config não existe.
+ */
+describe("POST /api/v1/webhooks/in/[token] — classificação inicial (2026-08-25)", () => {
+  it("caso 9 — 'Ainda não posso investir' desqualifica: lead criado, custom_fields marca motivo, atividade na timeline", async () => {
+    const payload = respondiPayload("resp-int-desq-invest-0009", "55 15988880009", "maria.exemplo+0009@example.com", (p) => {
+      const respondent = p.respondent as Record<string, unknown>;
+      (respondent.answers as Record<string, unknown>)[
+        "Considerando estratégia, tecnologia, atendimento e mídia, qual faixa de investimento seria viável para sua empresa crescer?"
+      ] = "Ainda não posso investir";
+    });
+    const res = await POST(jsonReq(TOKEN_RESPONDI, payload), reqCtx(TOKEN_RESPONDI));
+    expect(res.status).toBe(200);
+    const leadId = ((await res.json()) as { data: { lead_id: string } }).data.lead_id;
+
+    const lead = rows(`select * from public.crm_leads where id = '${leadId}'`)[0]!;
+    const cf = lead.custom_fields as Record<string, unknown>;
+    expect(cf.classificacao_inicial_status).toBe("desqualificado");
+    expect(cf.classificacao_inicial_motivo).toBe("sem_capacidade_de_investimento");
+
+    const activityRows = rows(
+      `select * from public.crm_lead_activities where lead_id = '${leadId}' and type = 'lead_disqualified'`,
+    );
+    expect(activityRows.length).toBe(1);
+  });
+
+  it("caso 10 — consentimento recusado desqualifica a classificação (motivo sem_consentimento), além de gerar consent_declined", async () => {
+    const payload = respondiPayload("resp-int-desq-consent-0010", "55 15988880010", "maria.exemplo+0010@example.com", (p) => {
+      const respondent = p.respondent as Record<string, unknown>;
+      const rawAnswers = respondent.raw_answers as Array<Record<string, unknown>>;
+      const legaltext = rawAnswers.find(
+        (r) => (r.question as Record<string, unknown>).question_type === "legaltext",
+      )!;
+      legaltext.answer = "no";
+      (respondent.answers as Record<string, unknown>)["Autorização de contato"] = "Não aceito";
+    });
+    const res = await POST(jsonReq(TOKEN_RESPONDI, payload), reqCtx(TOKEN_RESPONDI));
+    expect(res.status).toBe(200);
+    const leadId = ((await res.json()) as { data: { lead_id: string } }).data.lead_id;
+
+    const lead = rows(`select * from public.crm_leads where id = '${leadId}'`)[0]!;
+    const cf = lead.custom_fields as Record<string, unknown>;
+    expect(cf.classificacao_inicial_status).toBe("desqualificado");
+    expect(cf.classificacao_inicial_motivo).toBe("sem_consentimento");
+
+    const disqualified = rows(
+      `select id from public.crm_lead_activities where lead_id = '${leadId}' and type = 'lead_disqualified'`,
+    );
+    expect(disqualified.length).toBe(1);
+  });
+
+  it("caso 11 — segundo envio com o MESMO telefone mas nome diferente do contato existente: revisão humana, lead ainda criado", async () => {
+    const telefone = "55 15988880011";
+    const primeiro = respondiPayload("resp-int-rev-a-0011", telefone, "maria.exemplo+0011a@example.com");
+    const res1 = await POST(jsonReq(TOKEN_RESPONDI, primeiro), reqCtx(TOKEN_RESPONDI));
+    expect(res1.status).toBe(200);
+
+    const segundo = respondiPayload("resp-int-rev-b-0011", telefone, "maria.exemplo+0011b@example.com", (p) => {
+      const respondent = p.respondent as Record<string, unknown>;
+      (respondent.answers as Record<string, unknown>)["Qual é o seu nome?"] = "Outra Pessoa Completamente Diferente";
+      const rawAnswers = respondent.raw_answers as Array<Record<string, unknown>>;
+      const nameAnswer = rawAnswers.find((r) => (r.question as Record<string, unknown>).question_type === "name")!;
+      nameAnswer.answer = "Outra Pessoa Completamente Diferente";
+    });
+    const res2 = await POST(jsonReq(TOKEN_RESPONDI, segundo), reqCtx(TOKEN_RESPONDI));
+    expect(res2.status).toBe(200);
+    const leadId2 = ((await res2.json()) as { data: { lead_id: string } }).data.lead_id;
+
+    const lead2 = rows(`select * from public.crm_leads where id = '${leadId2}'`)[0]!;
+    const cf2 = lead2.custom_fields as Record<string, unknown>;
+    expect(cf2.classificacao_inicial_status).toBe("revisao_humana");
+    expect(cf2.classificacao_inicial_motivo).toBe("conflito_de_identidade");
+
+    const reviewRows = rows(
+      `select id from public.crm_lead_activities where lead_id = '${leadId2}' and type = 'lead_needs_review'`,
+    );
+    expect(reviewRows.length).toBe(1);
+  });
+
+  it("caso 12 — sem config numérica: lead válido classifica como nao_avaliado, nunca uma classe adivinhada", async () => {
+    const payload = respondiPayload("resp-int-naoavaliado-0012", "55 15988880012", "maria.exemplo+0012@example.com");
+    const res = await POST(jsonReq(TOKEN_RESPONDI, payload), reqCtx(TOKEN_RESPONDI));
+    expect(res.status).toBe(200);
+    const leadId = ((await res.json()) as { data: { lead_id: string } }).data.lead_id;
+
+    const lead = rows(`select * from public.crm_leads where id = '${leadId}'`)[0]!;
+    const cf = lead.custom_fields as Record<string, unknown>;
+    expect(cf.classificacao_inicial_status).toBe("classificado");
+    expect(cf.classificacao_inicial_classe).toBe("nao_avaliado");
+    expect(cf.classificacao_inicial_percentual).toBeUndefined();
+
+    // "nao_avaliado" não é evento — não deveria ter gerado lead_disqualified
+    // nem lead_needs_review.
+    const activityRows = rows(
+      `select type from public.crm_lead_activities where lead_id = '${leadId}' and type in ('lead_disqualified', 'lead_needs_review')`,
+    );
+    expect(activityRows).toHaveLength(0);
+  });
+});

--- a/tests/invariants/webhooks-inbound.test.ts
+++ b/tests/invariants/webhooks-inbound.test.ts
@@ -799,14 +799,17 @@ describe("POST /api/v1/webhooks/in/[token] — Respondi (payload aninhado, achad
 
 /**
  * Classificação inicial (lib/leads/classificacao-inicial.ts), integrada na
- * mesma rota. `CONFIG_CLASSIFICACAO_INICIAL` é `null` nesta suíte (config
- * pendente, ver o arquivo) — os 3 casos abaixo provam o que É determinístico
- * hoje: os 3 motivos exatos de desqualificação, o pedido de revisão humana, e
- * que uma classe nunca é adivinhada quando o config não existe.
+ * mesma rota. `CONFIG_CLASSIFICACAO_INICIAL` está CONFIRMADO nesta suíte
+ * (maxScoreConhecido: 100, bandas A≥70/B 40-69/C 1-39 — decisão de Matheus,
+ * 2026-08-25) — os casos abaixo provam os 2 motivos exatos de
+ * desqualificação (só bloqueio técnico/legal real), os 3 sinais de revisão
+ * humana (nenhum bloqueia envio), e a classificação A/B/C/D de verdade,
+ * inclusive o caso que motivou a segunda rodada da decisão: orçamento baixo
+ * sozinho NÃO força D.
  */
 describe("POST /api/v1/webhooks/in/[token] — classificação inicial (2026-08-25)", () => {
-  it("caso 9 — 'Ainda não posso investir' desqualifica: lead criado, custom_fields marca motivo, atividade na timeline", async () => {
-    const payload = respondiPayload("resp-int-desq-invest-0009", "55 15988880009", "maria.exemplo+0009@example.com", (p) => {
+  it("caso 9 — 'Ainda não posso investir' NÃO desqualifica: vira classe D (sinal forte, lead continua no CRM)", async () => {
+    const payload = respondiPayload("resp-int-classe-d-0009", "55 15988880009", "maria.exemplo+0009@example.com", (p) => {
       const respondent = p.respondent as Record<string, unknown>;
       (respondent.answers as Record<string, unknown>)[
         "Considerando estratégia, tecnologia, atendimento e mídia, qual faixa de investimento seria viável para sua empresa crescer?"
@@ -818,13 +821,40 @@ describe("POST /api/v1/webhooks/in/[token] — classificação inicial (2026-08-
 
     const lead = rows(`select * from public.crm_leads where id = '${leadId}'`)[0]!;
     const cf = lead.custom_fields as Record<string, unknown>;
-    expect(cf.classificacao_inicial_status).toBe("desqualificado");
-    expect(cf.classificacao_inicial_motivo).toBe("sem_capacidade_de_investimento");
+    expect(cf.classificacao_inicial_status).toBe("classificado");
+    expect(cf.classificacao_inicial_classe).toBe("D");
 
+    // Não é mais desqualificação — não deve existir atividade lead_disqualified.
     const activityRows = rows(
-      `select * from public.crm_lead_activities where lead_id = '${leadId}' and type = 'lead_disqualified'`,
+      `select id from public.crm_lead_activities where lead_id = '${leadId}' and type = 'lead_disqualified'`,
     );
-    expect(activityRows.length).toBe(1);
+    expect(activityRows).toHaveLength(0);
+  });
+
+  it("caso 9b — REGRESSÃO: faixa de orçamento baixa mas SEM a frase exata não força D — score decide (fixture: score 55 → classe B)", async () => {
+    // Este é o caso que Matheus rejeitou na primeira versão da regra: uma
+    // empresa de alto potencial que declara orçamento inicial modesto não
+    // pode despencar pra D só por causa deste UM campo.
+    const payload = respondiPayload("resp-int-nao-forca-d-0009b", "55 15988880019", "maria.exemplo+0019@example.com", (p) => {
+      const respondent = p.respondent as Record<string, unknown>;
+      const answers = respondent.answers as Record<string, unknown>;
+      answers[
+        "Considerando estratégia, tecnologia, atendimento e mídia, qual faixa de investimento seria viável para sua empresa crescer?"
+      ] = "Até R$ 2 mil";
+      // Coerente com a faixa viável acima — sem isto o padrão da fixture
+      // ("investe hoje" R$5-10mil > "viável" R$2mil) dispara
+      // incoerencia_investimento, que não é o que este caso testa.
+      answers["Quanto sua empresa investe atualmente em marketing por mês?"] = "Até R$ 2 mil";
+    });
+    const res = await POST(jsonReq(TOKEN_RESPONDI, payload), reqCtx(TOKEN_RESPONDI));
+    expect(res.status).toBe(200);
+    const leadId = ((await res.json()) as { data: { lead_id: string } }).data.lead_id;
+
+    const lead = rows(`select * from public.crm_leads where id = '${leadId}'`)[0]!;
+    const cf = lead.custom_fields as Record<string, unknown>;
+    expect(cf.classificacao_inicial_classe, "orçamento baixo sozinho não pode forçar D").not.toBe("D");
+    expect(cf.classificacao_inicial_classe).toBe("B");
+    expect(cf.classificacao_inicial_percentual).toBe("55");
   });
 
   it("caso 10 — consentimento recusado desqualifica a classificação (motivo sem_consentimento), além de gerar consent_declined", async () => {
@@ -880,8 +910,16 @@ describe("POST /api/v1/webhooks/in/[token] — classificação inicial (2026-08-
     expect(reviewRows.length).toBe(1);
   });
 
-  it("caso 12 — sem config numérica: lead válido classifica como nao_avaliado, nunca uma classe adivinhada", async () => {
-    const payload = respondiPayload("resp-int-naoavaliado-0012", "55 15988880012", "maria.exemplo+0012@example.com");
+  it("caso 12 — sem respondi_score no envio: lead válido classifica como nao_avaliado, nunca uma classe adivinhada", async () => {
+    const payload = respondiPayload("resp-int-naoavaliado-0012", "55 15988880012", "maria.exemplo+0012@example.com", (p) => {
+      const respondent = p.respondent as Record<string, unknown>;
+      delete respondent.score;
+      // Coerente com a faixa viável padrão da fixture (R$4-7mil) — sem isto o
+      // padrão ("investe hoje" R$5-10mil > "viável" R$4-7mil) dispara
+      // incoerencia_investimento, que não é o que este caso testa.
+      (respondent.answers as Record<string, unknown>)["Quanto sua empresa investe atualmente em marketing por mês?"] =
+        "Até R$ 2 mil";
+    });
     const res = await POST(jsonReq(TOKEN_RESPONDI, payload), reqCtx(TOKEN_RESPONDI));
     expect(res.status).toBe(200);
     const leadId = ((await res.json()) as { data: { lead_id: string } }).data.lead_id;
@@ -898,5 +936,75 @@ describe("POST /api/v1/webhooks/in/[token] — classificação inicial (2026-08-
       `select type from public.crm_lead_activities where lead_id = '${leadId}' and type in ('lead_disqualified', 'lead_needs_review')`,
     );
     expect(activityRows).toHaveLength(0);
+  });
+
+  it("caso 13 — envio padrão da fixture (score 55): classifica como B, e a classe fica visível no lead", async () => {
+    const payload = respondiPayload("resp-int-classe-b-0013", "55 15988880013", "maria.exemplo+0013@example.com", (p) => {
+      const respondent = p.respondent as Record<string, unknown>;
+      // Coerente com a faixa viável padrão da fixture (R$4-7mil) — sem isto o
+      // padrão ("investe hoje" R$5-10mil > "viável" R$4-7mil) dispara
+      // incoerencia_investimento, que não é o que este caso testa.
+      (respondent.answers as Record<string, unknown>)["Quanto sua empresa investe atualmente em marketing por mês?"] =
+        "Até R$ 2 mil";
+    });
+    const res = await POST(jsonReq(TOKEN_RESPONDI, payload), reqCtx(TOKEN_RESPONDI));
+    expect(res.status).toBe(200);
+    const leadId = ((await res.json()) as { data: { lead_id: string } }).data.lead_id;
+
+    const lead = rows(`select * from public.crm_leads where id = '${leadId}'`)[0]!;
+    const cf = lead.custom_fields as Record<string, unknown>;
+    expect(cf.classificacao_inicial_status).toBe("classificado");
+    expect(cf.classificacao_inicial_classe).toBe("B");
+    expect(cf.classificacao_inicial_percentual).toBe("55");
+  });
+
+  it("caso 14 — nome com sinal de spam: revisão humana (spam_suspeito), não bloqueia a criação do lead", async () => {
+    const payload = respondiPayload("resp-int-spam-0014", "55 15988880014", "maria.exemplo+0014@example.com", (p) => {
+      const respondent = p.respondent as Record<string, unknown>;
+      (respondent.answers as Record<string, unknown>)["Qual é o seu nome?"] = "aaaaaaaa";
+      const rawAnswers = respondent.raw_answers as Array<Record<string, unknown>>;
+      const nameAnswer = rawAnswers.find((r) => (r.question as Record<string, unknown>).question_type === "name")!;
+      nameAnswer.answer = "aaaaaaaa";
+    });
+    const res = await POST(jsonReq(TOKEN_RESPONDI, payload), reqCtx(TOKEN_RESPONDI));
+    expect(res.status).toBe(200);
+    const leadId = ((await res.json()) as { data: { lead_id: string } }).data.lead_id;
+
+    const lead = rows(`select * from public.crm_leads where id = '${leadId}'`)[0]!;
+    const cf = lead.custom_fields as Record<string, unknown>;
+    expect(cf.classificacao_inicial_status).toBe("revisao_humana");
+    expect(cf.classificacao_inicial_motivo).toBe("spam_suspeito");
+
+    const reviewRows = rows(
+      `select id from public.crm_lead_activities where lead_id = '${leadId}' and type = 'lead_needs_review'`,
+    );
+    expect(reviewRows.length).toBe(1);
+  });
+
+  it("caso 15 — investimento atual maior que o viável declarado: revisão humana (incoerencia_investimento), lead segue elegível pro 1º contato", async () => {
+    const payload = respondiPayload("resp-int-incoerencia-0015", "55 15988880015", "maria.exemplo+0015@example.com", (p) => {
+      const respondent = p.respondent as Record<string, unknown>;
+      const answers = respondent.answers as Record<string, unknown>;
+      answers["Quanto sua empresa investe atualmente em marketing por mês?"] = "De R$ 10 mil a R$ 15 mil";
+      answers[
+        "Considerando estratégia, tecnologia, atendimento e mídia, qual faixa de investimento seria viável para sua empresa crescer?"
+      ] = "Até R$ 2 mil";
+    });
+    const res = await POST(jsonReq(TOKEN_RESPONDI, payload), reqCtx(TOKEN_RESPONDI));
+    expect(res.status).toBe(200);
+    const leadId = ((await res.json()) as { data: { lead_id: string } }).data.lead_id;
+
+    const lead = rows(`select * from public.crm_leads where id = '${leadId}'`)[0]!;
+    const cf = lead.custom_fields as Record<string, unknown>;
+    expect(cf.classificacao_inicial_status).toBe("revisao_humana");
+    expect(cf.classificacao_inicial_motivo).toBe("incoerencia_investimento");
+
+    // Revisão humana NÃO é gate de envio — guarda-do-contato.ts (telefone +
+    // consentimento) é quem decide isso, e não lê classificação nenhuma. A
+    // prova de que o lead segue elegível é o consentimento ter sido gravado
+    // normalmente, igual a qualquer outro envio com aceite.
+    const contact = rows(`select consent from public.contacts where id = '${lead.contact_id}'`)[0]!;
+    const consent = contact.consent as { marketing: { granted_at: string | null } };
+    expect(consent.marketing.granted_at).not.toBeNull();
   });
 });


### PR DESCRIPTION
## O que é

Fase aprovada do projeto Decola AÍ: classifica todo lead do Respondi na
ingestão do webhook — antes de qualquer humano ou IA conversar com ele.

- **3 desqualificadores exatos** (determinísticos, sem inferência): "Ainda
  não posso investir" (match exato contra a faixa de investimento viável),
  contato inválido (telefone não normalizável), consentimento
  recusado/ausente.
- **Revisão humana**: conflito de identidade determinístico — o envio casou
  com um contato existente cujo nome diverge do nome deste envio.
- **Classe A/B/C/D**: computável por percentual do `respondi_score` sobre o
  "máximo do caminho condicional" — **mas o config numérico é `null` de
  propósito** (ver `lib/leads/config-classificacao-inicial.ts`). Nem o
  payload do Respondi nem os docs de estratégia do repo trazem esse máximo,
  nem a lista completa de opções do radio de investimento viável. Enquanto
  for `null`, todo lead não-desqualificado classifica como `"nao_avaliado"` —
  nunca uma classe adivinhada.
- Roteamento pro funil comercial imobiliário: **já coberto** por
  `webhook_sources.default_pipeline_id/default_stage_id` (NOT NULL no
  schema) — nenhum código novo necessário.

**Não implementado nesta PR** (fora do determinístico, fica pendente): spam e
incoerência do texto livre — pedidos na diretiva, mas exigem julgamento sobre
texto livre que este módulo não tenta adivinhar sem critério escrito.

## Pendente de aprovação (não é decisão técnica)

Os 3 valores de `lib/leads/config-classificacao-inicial.ts` — teto real do
`respondi_score` no painel do Respondi, cortes de percentual A/B/C, e o
padrão que define "baixo orçamento" (classe D). Preencher os 3 é a **única**
mudança de código necessária pra ativar A/B/C/D de verdade — o arquivo tem a
recomendação comentada (não ativa) e o porquê de cada número.

## Testes

- `lib/leads/classificacao-inicial.test.ts` — 14 testes puros
- `tests/invariants/webhooks-inbound.test.ts` — +4 casos de integração contra
  Postgres real (casos 9-12: desqualificação por orçamento, por
  consentimento, revisão por conflito de nome, nao_avaliado sem config)
- `pnpm test:db` (full suite, 116 arquivos, nesta branch — fresh a partir de
  `main`, sem #326/#337 misturados): **881 passed | 1 expected fail |
  1 skipped — 0 falhas**
- `eslint` nos 6 arquivos tocados: limpo
- `tsc --noEmit` escopado: 0 erros (full-repo faz OOM neste sandbox)

Zero automação disparada, zero mensagem WhatsApp enviada — é dado gravado em
`custom_fields` + atividade na timeline, nunca uma ação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)