### PR TITLE
Os handlers do event_log saem da fila de 1 minuto do cron (reconcilia #340, de @scademir)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,8 +125,14 @@ OPENAI_API_KEY=
 AI_BUDGET_ENFORCEMENT=on
 
 # --- Workers -----------------------------------------------------------------
-# Opt-in pra rodar consumers de event_log. Default false em dev; true em prod cron.
-EVENT_LOG_WORKER_ENABLED=false
+# Ritmo com que o WORKER roda os handlers do event_log (mídia, branding,
+# follow-up…). Antes destes knobs os handlers só rodavam pelo cron
+# `event-log-drain`, 1×/min — e a cadeia persist→derive de um áudio levava
+# 103-188s contra os 45s que o turno espera pela transcrição. O cron continua
+# ligado como rede de segurança. Vazio = os defaults abaixo.
+EVENT_LOG_DRAIN_INTERVAL_MS=2000
+EVENT_LOG_DRAIN_IDLE_INTERVAL_MS=10000
+EVENT_LOG_DRAIN_BATCH_SIZE=50
 # Stub do endpoint de teste do agente: 'true' devolve trace fabricado em vez de
 # executar o agente. Deixe false — o runtime real já existe. Só ligue para
 # exercitar o render da UI sem gastar token.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ Se você roda o DeskcommCRM numa VPS, **leia a seção da versão para a qual es
   equipe descobrir o silêncio depois, sem saber por quê. Recusa é informação, não ausência
   de informação.
 
+### Corrigido
+
+- **O agente voltou a ouvir os áudios que chegam.** Quem mandava um áudio ouvia de volta
+  "não consigo ouvir mensagens de voz" — e a transcrição ficava pronta no sistema meio
+  minuto depois, sem ninguém para usá-la. A causa era de ritmo: as tarefas de bastidor
+  (baixar o áudio, transcrever, tratar mídia) só eram acordadas uma vez por minuto, e a
+  resposta ao cliente não espera tanto. Medido numa instalação real: a cadeia levava de
+  103 a 188 segundos, e passou a levar 18. A transcrição em si sempre levou 4 segundos —
+  o resto era fila. Nada para você fazer: vale assim que atualizar.
+
 
 ## [1.5.0] — 2026-08-25
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -431,8 +431,13 @@ LGPD_EXPORT_EXPIRES_HOURS=72
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_ADMIN_URL=http://localhost:3000
 
-# Workers — opt-in pra rodar consumers de event_log. Default false em dev.
-EVENT_LOG_WORKER_ENABLED=false
+# Workers — ritmo com que o worker roda os handlers do event_log. Vazio = os
+# defaults (2s com trabalho, 10s ocioso, 50 por lote). Não há mais opt-in: o
+# `EVENT_LOG_WORKER_ENABLED` que ficava aqui nunca teve leitor e saiu em
+# 2026-08-25, junto com a chegada do laço de verdade no worker.
+EVENT_LOG_DRAIN_INTERVAL_MS=2000
+EVENT_LOG_DRAIN_IDLE_INTERVAL_MS=10000
+EVENT_LOG_DRAIN_BATCH_SIZE=50
 ```
 
 ---

--- a/docs/design/teto-de-orcamento.md
+++ b/docs/design/teto-de-orcamento.md
@@ -170,7 +170,8 @@ Só depois: `gastoCents >= tetoCents` → `bloquear`. Entre `teto*limiar/100` e 
 Isto existe porque `lib/env.ts:204-224` faz `safeParse` e **lança** quando o schema recusa
 (`:222`). Um `z.enum` para o kill switch transformaria a alavanca de emergência em um
 derrubador do app inteiro no dia em que o operador escrevesse `false` — o idioma dos
-vizinhos `AGENT_DISPATCH_CONSUMER` (`:104`) e `EVENT_LOG_WORKER_ENABLED` (`:107`). O
+vizinho `AGENT_DISPATCH_CONSUMER` (`:104`). (O outro exemplo citado aqui era
+`EVENT_LOG_WORKER_ENABLED`, removido em 2026-08-25 por nunca ter tido leitor.) O
 precedente correto no mesmo arquivo é `APP_ACCENT_HEX: z.string().optional().default("")`
 (`:201`): string crua no env, normalização no código. E aceitar as grafias falsas comuns
 como `off` é dar ao operador de VPS às 2h da manhã o que ele quis dizer.

--- a/docs/stories/epics/EPIC-06-ai-rag.md
+++ b/docs/stories/epics/EPIC-06-ai-rag.md
@@ -52,7 +52,7 @@ Entregar a camada de IA conversacional do DeskcommCRM: bot que responde inbounds
 - Epics anteriores completos: `EPIC-00`, `EPIC-01`, `EPIC-03`
 - Migrations Supabase aplicadas: 0001-0007 + nova migration deste epic com tabelas `ai_agents`, `ai_knowledge_sources`, `ai_chunks`, `ai_knowledge_versions`, `ai_invocations`, `ai_pricing`, `ai_budgets` (Spec 05 §3)
 - Extensions Postgres: `vector`, `pg_trgm`, `pgcrypto` habilitadas
-- Variáveis de env: `AI_GATEWAY_API_KEY`, `AI_GATEWAY_BASE_URL`, `OPENAI_API_KEY` (fallback embedding), `SUPABASE_SERVICE_ROLE_KEY`, `EVENT_LOG_WORKER_ENABLED=true`
+- Variáveis de env: `AI_GATEWAY_API_KEY`, `AI_GATEWAY_BASE_URL`, `OPENAI_API_KEY` (fallback embedding), `SUPABASE_SERVICE_ROLE_KEY` (o `EVENT_LOG_WORKER_ENABLED` que esta linha pedia foi removido em 2026-08-25 — nunca teve leitor, e o laço dos handlers hoje vive no worker, com ritmo em `EVENT_LOG_DRAIN_*`)
 - Buckets Storage: `ai-policy/` (privado), `ai-logs/` (privado, 90d hot)
 - Dev server rodando em `localhost:3001`
 - Playwright MCP conectado pra QA

--- a/lib/agent-engine/edge/llm/orcamento.ts
+++ b/lib/agent-engine/edge/llm/orcamento.ts
@@ -292,8 +292,9 @@ const GRAFIAS_DE_DESLIGADO = new Set([
  * arquivo faz `safeParse` (`:204`) e LANÇA quando o schema recusa (`:223`). Um
  * `z.enum` para o kill switch transformaria a alavanca de emergência num
  * derrubador do app inteiro no dia em que o operador escrevesse `false` — o
- * idioma dos vizinhos `AGENT_DISPATCH_CONSUMER` (`:104`) e
- * `EVENT_LOG_WORKER_ENABLED` (`:107`). O precedente correto no mesmo arquivo é
+ * idioma do vizinho `AGENT_DISPATCH_CONSUMER`. (O outro exemplo citado aqui era
+ * `EVENT_LOG_WORKER_ENABLED`, removido em 2026-08-25 por nunca ter tido
+ * leitor.) O precedente correto no mesmo arquivo é
  * `APP_ACCENT_HEX: z.string().optional().default("")` (`:201`): string crua no
  * env, normalização no código.
  */

--- a/lib/agent-engine/env.ts
+++ b/lib/agent-engine/env.ts
@@ -109,6 +109,14 @@ const envSchema = z.object({
   CRM_DRAIN_IDLE_INTERVAL_MS: z.coerce.number().int().positive().default(15_000),
   // Evento 'processing' órfão (crash do worker) volta a 'pending' após isto.
   CRM_EVENT_REAP_TIMEOUT_MS: z.coerce.number().int().positive().default(300_000),
+  // Drain dos HANDLERS do event_log (mídia, branding, follow-up…), à parte do
+  // CRM_DRAIN_* acima: aquele é o dispatch do agente e fala Postgres direto;
+  // este roda os handlers de `register-handlers.ts` pelo admin client.
+  // Até 2026-08-25 este laço não existia e os handlers só rodavam pelo cron
+  // `event-log-drain` (1×/min) — ver o cabeçalho de lib/event-log/drain-loop.ts.
+  EVENT_LOG_DRAIN_INTERVAL_MS: z.coerce.number().int().positive().default(2_000),
+  EVENT_LOG_DRAIN_IDLE_INTERVAL_MS: z.coerce.number().int().positive().default(10_000),
+  EVENT_LOG_DRAIN_BATCH_SIZE: z.coerce.number().int().positive().default(50),
   // Coalescência de rajada inbound: mensagens do MESMO contato dentro desta
   // janela viram UM job (responder em rajada é gatilho de ban). 0 = sem debounce.
   INBOUND_DEBOUNCE_MS: z.coerce.number().int().min(0).default(8_000),

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -203,12 +203,17 @@ const schema = z.object({
    */
   AI_BUDGET_ENFORCEMENT: z.string().optional().default("on"),
 
-  // Workers — opt-in via env so dev doesn't run loops. Production cron sets it.
-  EVENT_LOG_WORKER_ENABLED: z
-    .enum(["true", "false"])
-    .optional()
-    .default("false")
-    .transform((v) => v === "true"),
+  // `EVENT_LOG_WORKER_ENABLED` viveu aqui até 2026-08-25 e NUNCA teve leitor: o
+  // campo era declarado, documentado no `.env.example` com `false` e lido por
+  // ninguém (medido: zero ocorrências fora da própria declaração). Saiu junto
+  // com a chegada do laço de verdade (`lib/event-log/drain-loop.ts`), e o ritmo
+  // dele agora mora nos `EVENT_LOG_DRAIN_*` de `lib/agent-engine/env.ts` — o
+  // schema do processo que roda o laço, e não o do app.
+  //
+  // Não virou o liga/desliga do laço novo de propósito: o default publicado era
+  // `false`, então respeitá-lo faria o conserto não chegar a NENHUMA instalação
+  // já existente — que é o item 15 do Definition of Done ("a mudança chega a
+  // quem já instalou"). O worker existe para rodar laços; este liga sempre.
 
   // O endpoint :test devolve um trace fake quando esta flag = 'true'.
   // Default 'false' desde que a S-13.08 landou: `callInternalRuntime` executa

--- a/lib/event-log/drain-loop.ts
+++ b/lib/event-log/drain-loop.ts
@@ -8,10 +8,11 @@
  * `* * * * *` em `docker/scheduler/entrypoint.sh`. Um tick por minuto.
  *
  * Isso é caro quando a cadeia tem mais de um salto. Medido nesta VPS em
- * 2026-08-25, com um áudio de WhatsApp:
+ * 2026-08-25, com um áudio recebido pelo canal:
  *
- *   áudio chega → media.persist_requested → (até 60s de fila) → baixa do WAHA
- *   → media.derive_requested → (até 60s de fila) → Whisper transcreve em 3,9s
+ *   áudio chega → media.persist_requested → (até 60s de fila) → baixa do
+ *   provedor do canal → media.derive_requested → (até 60s de fila) →
+ *   Whisper transcreve em 3,9s
  *
  * Total real: 103s e 188s em duas medições. Enquanto isso, o drain do turno
  * (`lib/agent-engine/edge/crm/drain.ts`) espera no máximo 45s pela derivação e

--- a/lib/event-log/drain-loop.ts
+++ b/lib/event-log/drain-loop.ts
@@ -1,0 +1,143 @@
+/**
+ * O laço que roda os handlers do `event_log` DENTRO do worker.
+ *
+ * ─── Por que ele existe ──────────────────────────────────────────────────────
+ *
+ * Os 12 handlers de `register-handlers.ts` (mídia, branding, follow-up…) só
+ * tinham UM acionador: o cron `app/api/v1/cron/event-log-drain`, agendado
+ * `* * * * *` em `docker/scheduler/entrypoint.sh`. Um tick por minuto.
+ *
+ * Isso é caro quando a cadeia tem mais de um salto. Medido nesta VPS em
+ * 2026-08-25, com um áudio de WhatsApp:
+ *
+ *   áudio chega → media.persist_requested → (até 60s de fila) → baixa do WAHA
+ *   → media.derive_requested → (até 60s de fila) → Whisper transcreve em 3,9s
+ *
+ * Total real: 103s e 188s em duas medições. Enquanto isso, o drain do turno
+ * (`lib/agent-engine/edge/crm/drain.ts`) espera no máximo 45s pela derivação e
+ * então despacha SEM o texto — e o agente responde "não consigo ouvir áudio"
+ * com a transcrição chegando ao banco meio minuto depois. Os 3,9s provam que a
+ * lentidão não é do Whisper: é fila de cron.
+ *
+ * 45s é menor que UM tick de cron. Com dois saltos, perder a janela não é azar,
+ * é aritmética. Este laço tira o cron do caminho crítico.
+ *
+ * ─── Por que o cron continua ─────────────────────────────────────────────────
+ *
+ * Ele vira rede de segurança: worker fora do ar não pode significar event_log
+ * parado. Rodar os dois em paralelo é seguro porque `drainEventLog` reivindica
+ * cada linha com um claim otimista (`update … where id = $1 and status =
+ * 'pending'`) e pula o que outra instância já pegou — ver `drain.ts`.
+ *
+ * ─── Por que os imports são dinâmicos ────────────────────────────────────────
+ *
+ * A cadeia `drain → register-handlers → handlers → createAdminClient` termina em
+ * `@/lib/env`, que valida ~15 variáveis obrigatórias e faz `throw` no topo do
+ * módulo (`lib/env.ts:339`). Importada estaticamente aqui, uma instalação com
+ * `.env` mais enxuto veria o WORKER INTEIRO morrer no boot — fila durável, cron
+ * e turnos junto — por causa de um laço acessório. É a mesma lei que o CLAUDE.md
+ * já escreve para a marca ("resolvedor NUNCA lança"), aplicada onde também vale:
+ * o laço se desliga sozinho, avisa, e o resto do worker sobe.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type { Logger } from '@/lib/agent-engine/obs/logger';
+// `import type` e nunca import de valor: em runtime esta linha desaparece, e é
+// isso que mantém a cadeia que termina em `@/lib/env` fora do boot do worker.
+import type { DrainSummary } from '@/lib/event-log/drain';
+
+export interface EventLogDrainKnobs {
+  /** Espera entre ticks que FIZERAM trabalho. */
+  intervalMs: number;
+  /** Espera entre ticks ociosos — o event_log costuma estar vazio. */
+  idleIntervalMs: number;
+  /** Teto de eventos por tick. */
+  batchSize: number;
+}
+
+// Assinatura escrita à mão em vez de `typeof import(...)`: a regra
+// `consistent-type-imports` proíbe a anotação `import()`. A atribuição em
+// `carregarDeps` é o que mantém as duas honestas — divergiu, o typecheck acusa.
+type DrainFn = (admin: SupabaseClient, opts?: { limit?: number }) => Promise<DrainSummary>;
+
+interface Deps {
+  drainEventLog: DrainFn;
+  admin: SupabaseClient;
+}
+
+/**
+ * Carrega a cadeia do drain sem deixar que ela derrube o worker.
+ *
+ * `null` = o laço não roda (e o porquê já foi para o log). Nunca lança.
+ */
+async function carregarDeps(log: Logger): Promise<Deps | null> {
+  try {
+    const { drainEventLog } = await import('@/lib/event-log/drain');
+    const { ensureHandlersRegistered } = await import('@/lib/event-log/register-handlers');
+    const { createAdminClient } = await import('@/lib/supabase/admin');
+    ensureHandlersRegistered();
+    return { drainEventLog, admin: createAdminClient() };
+  } catch (err) {
+    log.warn(
+      'event-log drain OFF — não consegui montar o admin client; os handlers seguem só pelo cron event-log-drain',
+      { error: (err instanceof Error ? err.message : String(err)).slice(0, 300) },
+    );
+    return null;
+  }
+}
+
+/**
+ * A regra de ritmo, sem relógio: tick que MEXEU em alguma linha mantém o laço
+ * rápido; tick ocioso recua.
+ *
+ * `scanned` fica de fora da conta de propósito. Linha que outra instância (o
+ * cron, outro worker) reivindicou primeiro é varrida e NÃO processada —
+ * contá-la manteria o laço no ritmo rápido girando à toa toda vez que o cron
+ * chegasse antes.
+ */
+export function proximaEspera(resumo: DrainSummary, knobs: EventLogDrainKnobs): number {
+  const feitos = resumo.done + resumo.retried + resumo.failed + resumo.dead;
+  return feitos > 0 ? knobs.intervalMs : knobs.idleIntervalMs;
+}
+
+function esperar(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}
+
+export async function runEventLogDrainLoop(
+  knobs: EventLogDrainKnobs,
+  log: Logger,
+  signal: AbortSignal,
+): Promise<void> {
+  const deps = await carregarDeps(log);
+  if (!deps) return;
+
+  while (!signal.aborted) {
+    // Tick que EXPLODE não pode acelerar o laço: sem resumo, vale a espera
+    // ociosa. Um banco fora do ar lançaria a cada iteração, e o ritmo rápido
+    // transformaria a indisponibilidade numa tempestade de tentativas.
+    let espera = knobs.idleIntervalMs;
+    try {
+      const resumo = await deps.drainEventLog(deps.admin, { limit: knobs.batchSize });
+      espera = proximaEspera(resumo, knobs);
+      if (resumo.done + resumo.retried + resumo.failed + resumo.dead > 0) {
+        log.info('event-log drain: tick', { ...resumo });
+      }
+    } catch (err) {
+      log.error('event-log drain: tick falhou', {
+        error: (err instanceof Error ? err.message : String(err)).slice(0, 300),
+      });
+    }
+    await esperar(espera, signal);
+  }
+}

--- a/tests/unit/event-log-drain-loop.test.ts
+++ b/tests/unit/event-log-drain-loop.test.ts
@@ -1,0 +1,100 @@
+/**
+ * O laço que roda os handlers do event_log dentro do worker.
+ *
+ * O que estes testes protegem, e por quê (medido em VPS, 2026-08-25): os
+ * handlers só rodavam pelo cron `event-log-drain`, 1×/min. A cadeia
+ * persist→derive de um áudio levava 103-188s — dois saltos de cron — enquanto o
+ * drain do turno espera 45s pela transcrição e então responde sem ela. O agente
+ * dizia "não consigo ouvir áudio" com o texto chegando ao banco meio minuto
+ * depois. A transcrição em si levava 3,9s.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { DrainSummary } from '@/lib/event-log/drain';
+
+const drainEventLog = vi.fn();
+const ensureHandlersRegistered = vi.fn();
+const createAdminClient = vi.fn(() => ({ marcador: 'admin' }));
+
+vi.mock('@/lib/event-log/drain', () => ({ drainEventLog }));
+vi.mock('@/lib/event-log/register-handlers', () => ({ ensureHandlersRegistered }));
+vi.mock('@/lib/supabase/admin', () => ({ createAdminClient }));
+
+const { proximaEspera, runEventLogDrainLoop } = await import('@/lib/event-log/drain-loop');
+
+const knobs = { intervalMs: 2_000, idleIntervalMs: 10_000, batchSize: 50 };
+const vazio: DrainSummary = { scanned: 0, done: 0, retried: 0, failed: 0, dead: 0 };
+const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createAdminClient.mockReturnValue({ marcador: 'admin' });
+});
+
+describe('proximaEspera — a regra de ritmo', () => {
+  it('tick que processou alguma linha mantém o laço rápido', () => {
+    for (const campo of ['done', 'retried', 'failed', 'dead'] as const) {
+      expect(proximaEspera({ ...vazio, scanned: 1, [campo]: 1 }, knobs)).toBe(knobs.intervalMs);
+    }
+  });
+
+  it('tick ocioso recua para a espera longa', () => {
+    expect(proximaEspera(vazio, knobs)).toBe(knobs.idleIntervalMs);
+  });
+
+  it('linha varrida mas NÃO processada conta como ocioso', () => {
+    // É o caso de concorrência com o cron: o claim otimista de drainEventLog
+    // devolve `scanned` alto e zero processado quando a outra instância chegou
+    // antes. Contar isso como trabalho faria o laço girar rápido à toa toda vez
+    // que o cron passasse.
+    expect(proximaEspera({ ...vazio, scanned: 50 }, knobs)).toBe(knobs.idleIntervalMs);
+  });
+});
+
+describe('runEventLogDrainLoop', () => {
+  it('drena com o batchSize dos knobs e para quando abortado', async () => {
+    const abort = new AbortController();
+    drainEventLog.mockImplementation(() => {
+      abort.abort();
+      return Promise.resolve({ ...vazio, done: 1 });
+    });
+
+    await runEventLogDrainLoop({ ...knobs, intervalMs: 0, idleIntervalMs: 0 }, log, abort.signal);
+
+    expect(ensureHandlersRegistered).toHaveBeenCalledOnce();
+    expect(drainEventLog).toHaveBeenCalledWith({ marcador: 'admin' }, { limit: 50 });
+  });
+
+  it('admin client indisponível DESLIGA o laço sem derrubar o worker', async () => {
+    // `@/lib/supabase/admin` importa `@/lib/env`, que faz throw no topo do
+    // módulo quando falta variável obrigatória. Num `.env` enxuto, um import
+    // estático mataria o worker INTEIRO — fila durável, cron e turnos — por
+    // causa de um laço acessório. Ele tem que se desligar sozinho e avisar.
+    createAdminClient.mockImplementation(() => {
+      throw new Error('env inválido — verifique no .env: INTERNAL_SECRET');
+    });
+    const abort = new AbortController();
+
+    await expect(
+      runEventLogDrainLoop(knobs, log, abort.signal),
+    ).resolves.toBeUndefined();
+
+    expect(drainEventLog).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledOnce();
+  });
+
+  it('erro num tick não interrompe o laço nem acelera as tentativas', async () => {
+    const abort = new AbortController();
+    let ticks = 0;
+    drainEventLog.mockImplementation(() => {
+      ticks += 1;
+      if (ticks >= 3) abort.abort();
+      return Promise.reject(new Error('banco fora do ar'));
+    });
+
+    await runEventLogDrainLoop({ ...knobs, intervalMs: 0, idleIntervalMs: 0 }, log, abort.signal);
+
+    expect(ticks).toBe(3);
+    expect(log.error).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/unit/event-log-drain-loop.test.ts
+++ b/tests/unit/event-log-drain-loop.test.ts
@@ -10,6 +10,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { Logger } from '@/lib/agent-engine/obs/logger';
 import type { DrainSummary } from '@/lib/event-log/drain';
 
 const drainEventLog = vi.fn();
@@ -24,7 +25,12 @@ const { proximaEspera, runEventLogDrainLoop } = await import('@/lib/event-log/dr
 
 const knobs = { intervalMs: 2_000, idleIntervalMs: 10_000, batchSize: 50 };
 const vazio: DrainSummary = { scanned: 0, done: 0, retried: 0, failed: 0, dead: 0 };
-const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never;
+// O dublê mantém o tipo do MOCK (`log.warn` é um `vi.fn()` que as asserções
+// interrogam); o cast para `Logger` fica no ponto em que ele CRUZA a fronteira
+// da função. `as never` apagava o objeto inteiro e derrubava o typecheck do
+// CI, que roda `-p tsconfig.typecheck.json` e inclui `tests/`.
+const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+const logger = log as unknown as Logger;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -59,7 +65,7 @@ describe('runEventLogDrainLoop', () => {
       return Promise.resolve({ ...vazio, done: 1 });
     });
 
-    await runEventLogDrainLoop({ ...knobs, intervalMs: 0, idleIntervalMs: 0 }, log, abort.signal);
+    await runEventLogDrainLoop({ ...knobs, intervalMs: 0, idleIntervalMs: 0 }, logger, abort.signal);
 
     expect(ensureHandlersRegistered).toHaveBeenCalledOnce();
     expect(drainEventLog).toHaveBeenCalledWith({ marcador: 'admin' }, { limit: 50 });
@@ -76,7 +82,7 @@ describe('runEventLogDrainLoop', () => {
     const abort = new AbortController();
 
     await expect(
-      runEventLogDrainLoop(knobs, log, abort.signal),
+      runEventLogDrainLoop(knobs, logger, abort.signal),
     ).resolves.toBeUndefined();
 
     expect(drainEventLog).not.toHaveBeenCalled();
@@ -92,7 +98,7 @@ describe('runEventLogDrainLoop', () => {
       return Promise.reject(new Error('banco fora do ar'));
     });
 
-    await runEventLogDrainLoop({ ...knobs, intervalMs: 0, idleIntervalMs: 0 }, log, abort.signal);
+    await runEventLogDrainLoop({ ...knobs, intervalMs: 0, idleIntervalMs: 0 }, logger, abort.signal);
 
     expect(ticks).toBe(3);
     expect(log.error).toHaveBeenCalledTimes(3);

--- a/tests/unit/orcamento-chave-de-emergencia.test.ts
+++ b/tests/unit/orcamento-chave-de-emergencia.test.ts
@@ -18,7 +18,7 @@
  * transformaria a alavanca de emergência no derrubador do app inteiro no dia em
  * que o operador, às 2h da manhã, escrevesse `false` em vez de `off`.
  *
- * O idioma dos vizinhos (`AGENT_DISPATCH_CONSUMER`, `EVENT_LOG_WORKER_ENABLED`)
+ * O idioma do vizinho `AGENT_DISPATCH_CONSUMER`
  * é `z.enum`, e para eles está certo: são knobs de arquitetura, escritos uma vez
  * na instalação. Este é o oposto — é mexido justamente quando algo já deu
  * errado. O precedente correto no mesmo arquivo é `APP_ACCENT_HEX`: string crua

--- a/workers/agent-worker/main.ts
+++ b/workers/agent-worker/main.ts
@@ -29,6 +29,7 @@ import { seedPlatformPlaybook } from '@/lib/agent-engine/agent/playbook-seed';
 import { runCronLoop } from '@/lib/agent-engine/cron/scheduler';
 import { createPool } from '@/lib/agent-engine/db/pool';
 import { runDrainLoop } from '@/lib/agent-engine/edge/crm/drain';
+import { runEventLogDrainLoop } from '@/lib/event-log/drain-loop';
 import { crmEdgeConfigFromEnv } from '@/lib/agent-engine/edge/crm/mcp-client';
 import { enforceHolds, sessionHealthMetrics } from '@/lib/agent-engine/edge/crm/session-watchdog';
 import { runSessionWatchdogLoop } from '@/lib/agent-engine/edge/crm/session-reconciler';
@@ -241,6 +242,22 @@ export async function startWorker(
     loopsAbort.signal,
   );
 
+  // Handlers do event_log (mídia, branding, follow-up…) no ritmo do worker.
+  // Antes disto eles só rodavam pelo cron `event-log-drain`, 1×/min: a cadeia
+  // persist→derive de um áudio levava 103-188s contra os 45s que o drain do
+  // turno espera, e o agente respondia "não consigo ouvir" com a transcrição
+  // pronta segundos depois. O cron continua como rede de segurança — o claim
+  // otimista do `drainEventLog` torna os dois seguros em paralelo.
+  const eventLogLoop = runEventLogDrainLoop(
+    {
+      intervalMs: env.EVENT_LOG_DRAIN_INTERVAL_MS,
+      idleIntervalMs: env.EVENT_LOG_DRAIN_IDLE_INTERVAL_MS,
+      batchSize: env.EVENT_LOG_DRAIN_BATCH_SIZE,
+    },
+    log,
+    loopsAbort.signal,
+  );
+
   // Watchdog de sessão (4A-2): reconcilia channel_sessions×WAHA + redrive de
   // queued. Liga só com as credenciais do WAHA no env (sem elas: warn + off).
   const sessionWatchdogLoop =
@@ -382,7 +399,7 @@ export async function startWorker(
     server.close();
     server.closeIdleConnections();
     loopsAbort.abort();
-    await Promise.all([drainLoop, healthLoop, cronLoop, sessionWatchdogLoop, flywheelLoop]);
+    await Promise.all([drainLoop, eventLogLoop, healthLoop, cronLoop, sessionWatchdogLoop, flywheelLoop]);
     await workerLoop;
     let graceTimer: NodeJS.Timeout | undefined;
     const grace = new Promise<'grace'>((resolve) => {


### PR DESCRIPTION
Reconciliação do **#340**, de @scademir. **O conserto é dele** — este PR é o dele mais as três coisas que barravam o merge e uma que o repo cobra.

Abro em branch própria em vez de empurrar na branch do fork: é a fronteira da triagem deste repositório. Os commits dele vêm inteiros, com autoria preservada (`efa154db`, `Ademir Santos <scademir@gmail.com>`).

Fecha #339. Substitui #340.

---

## O que o @scademir consertou

Os 12 handlers de `lib/event-log/register-handlers.ts` tinham um acionador só: o cron `event-log-drain`, `* * * * *`. A cadeia de mídia dá **dois saltos de evento**, e o drain do turno espera no máximo 45 s pela derivação — menos que **um** tick de cron. O agente respondia "não consigo ouvir mensagens de voz" com a transcrição chegando ao banco meio minuto depois.

Ele mediu numa VPS real, mesma instalação, antes e depois:

| Etapa | Antes | Depois |
|---|---|---|
| `media.persist_requested` | 42,6 s · 183,9 s | 11,6 s |
| `media.derive_requested` | 60,4 s · 3,9 s | 5,9 s |
| **cadeia até `ready`** | **103,4 s · 188,3 s** | **18,1 s** |

E isolou a causa dentro da própria medição: o mesmo `derive` levou 3,9 s numa vez e 60,4 s na outra — 15× de diferença na mesma operação. **A diferença inteira era fila de cron, não Whisper.** É o tipo de medição que separa causa de sintoma, e ele ainda deixou o `TETO_ESPERA_DERIVACAO_MS` intocado de propósito, para não mexer nos dois ao mesmo tempo sem saber qual funcionou.

Dois desenhos dele que merecem ficar registrados:

- **O cron continua ligado** como rede de segurança. Worker fora do ar não pode significar `event_log` parado. Roda em paralelo com segurança porque `drainEventLog` reivindica cada linha com claim otimista (`update … where id = $1 and status = 'pending'`) — garantia que já existia e que **nada vigiava**; agora tem teste.
- **Os imports do laço são dinâmicos.** A cadeia `drain → register-handlers → handlers → createAdminClient` termina em `@/lib/env`, que faz `throw` no topo do módulo. Estático, uma instalação com `.env` enxuto veria o **worker inteiro** morrer no boot por causa de um laço acessório. É a mesma lei que o `CLAUDE.md` já escreve para a marca ("resolvedor NUNCA lança"), aplicada onde também vale.

---

## O que eu acrescentei, e por quê

**1. O `verify` reprovava no primeiro passo — e por isso ninguém tinha visto o segundo.**

```console
$ tsc --noEmit -p tsconfig.typecheck.json
tests/unit/event-log-drain-loop.test.ts(83,16): error TS2339: Property 'warn' does not exist on type 'never'.
tests/unit/event-log-drain-loop.test.ts(98,16): error TS2339: Property 'error' does not exist on type 'never'.
```

`const log = {...} as never` apaga o objeto para o typechecker, e as asserções interrogam `log.warn`. **Não é descuido do @scademir, e a armadilha é nossa:** `tsc --noEmit` sem `-p` usa outro projeto e devolve **exit 0**. Quem inclui `tests/` é `tsconfig.typecheck.json` — o que `pnpm typecheck` roda. Medi os dois modos, lado a lado:

```console
$ tsc --noEmit                             ; echo $?   →  0    (régua errada)
$ tsc --noEmit -p tsconfig.typecheck.json  ; echo $?   →  2    (as 2 do CI)
```

**2. `pnpm lint:channels` também reprovava**, e o `verify` só chegaria nele depois do typecheck:

```console
Nome de provider fora de lib/channels/ (doutrina restricao-de-canal, invariante 1):
  lib/event-log/drain-loop.ts
```

Eram **duas palavras num comentário** ("áudio de WhatsApp", "baixa do WAHA"). A catraca lê o arquivo inteiro de propósito — ela mesma escreve que precisa citar os nomes proibidos para poder proibi-los. Reescrevi sem perder a medição.

**3. `docs/stories/epics/EPIC-06-ai-rag.md`** ainda mandava configurar `EVENT_LOG_WORKER_ENABLED=true`, que este PR remove. O @scademir perguntou no corpo se devia ajustar — ajustado. Quem copiasse a linha configuraria uma variável morta.

**4. Entrada no CHANGELOG.** A mudança é visível para quem usa, e o #335 acabou de entrar na `main` exatamente porque comportamento sem linha no CHANGELOG não chega a quem instala.

---

## Medido (prévia do merge, não a branch)

`git merge origin/main pr-340` sobre a **main `1b30d9ff`**, árvore limpa:

| gate | comando | resultado |
|---|---|---|
| typecheck | `tsc --noEmit -p tsconfig.typecheck.json` | **exit 0** |
| lint | `eslint .` | **exit 0** — 0 erros, 263 warnings, **nenhum** nos arquivos deste PR |
| catraca de canal | `tsx scripts/lint-channels.ts` | **exit 0** — 60 arquivos de dívida conhecida, nenhum novo |
| unit | `vitest run` | **exit 0** — 491 arquivos, **5491 testes, 0 falhas** |
| shell | os 4 scripts de `test:shell` | **exit 0** em cada um |
| gate do CHANGELOG | `changelog-cabe-na-tela-da-vps.test.ts` | 5/5 |

Exit code medido **direto**, nunca por pipe.

**Sobre as "5 falhas pré-existentes":** o corpo do #340 relata 5484/5489 com 5 falhas em `lib/ai/dispatcher/rate-limit.test.ts`. Aqui os **5491 passaram**. Aquelas 5 são timeout de 15 s por Redis inalcançável — ambiente, não a `main`. Vale como correção de registro, não como cobrança: o próprio PR já as tinha classificado como não-suas.

## NÃO MEDIDO

- **`test:db`, `e2e`, `build-and-size`, `imagens-ok`** — não rodei localmente. Nenhum toca schema, RLS ou UI, mas isso é inferência. O CI decide.
- **A medição de VPS (103-188 s → 18,1 s)** — não repeti: não tenho a instalação do @scademir. Confio no relato porque ele traz a peça que isola a causa (o mesmo `derive` em 3,9 s e 60,4 s), não só o número final.
- **Variância do "depois".** Amostra de uma. Não sei o p95 — o próprio autor já tinha escrito isso.
- **A composição dos 11,6 s do `persist`**, que virou a perna mais lenta da cadeia.

## Dívida que ele nomeou e não entra aqui (passe 11 da triagem)

Duas, ambas descritas na #339 e nenhuma criada por este PR:

1. O backoff de `2^n` **minutos** de `lib/event-log/drain.ts` faz sentido para webhook e não para mídia no caminho crítico de uma resposta. Um `fetch failed` isolado joga o retry para 1-2 min.
2. A granularidade real das checagens de derivação é ~17 s, não os 4 s pretendidos: o evento adiado volta com `next_attempt_at = +4s`, o tick de 2 s não o pega, `drained = 0`, e o laço dorme os 15 s de `idleIntervalMs`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwL2igBPaSmhtu5LvSGMDq
