### PR TITLE
inbox-tempo-real sai do gate de merge — não discrimina, e reprova PR alheio por sorte

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -205,7 +205,6 @@ jobs:
         historico-de-captacao.spec.ts
         automacao-diz-a-verdade.spec.ts
         inbox-quem-manda.spec.ts
-        inbox-tempo-real.spec.ts
       # Cada item aqui tem o motivo MEDIDO, não presumido — e o gate cobra que a
       # lista exista e some com as outras duas.
       #
@@ -246,8 +245,43 @@ jobs:
       # spec media a sorte do ambiente. `scripts/seed-e2e-catalogo-openrouter.ts`
       # (main, 2026-08-09) semeia o catálogo no job, então a condição que a excluía
       # deixou de existir e ela voltou para a lista de execução.
+      #
+      # `inbox-tempo-real` entrou aqui em 2026-08-26, no dia seguinte ao merge, e o
+      # motivo é medido nos dois eixos que importam — não é "está flaky, tira".
+      #
+      #  (a) ELE NÃO DISCRIMINA O CONSERTO QUE DIZ GUARDAR. Bancada local fiel a
+      #      este job (Supabase local pg17, `baseline.sql`, Realtime reiniciado
+      #      depois do baseline, `next build` de produção, os mesmos seeds),
+      #      revertendo SÓ `lib/supabase/browser.ts` para a versão anterior ao
+      #      #327 — e conferindo no bundle que o conserto saiu
+      #      (`grep -rc realtime-token .next/static` → 0, controle positivo
+      #      `sb-deskcomm-auth` → 1):
+      #
+      #          com o conserto  → 1 passed
+      #          sem o conserto  → 1 passed
+      #
+      #      Causa provável: `useMessagesRealtime` liga `refetchOnWindowFocus:
+      #      true` e o `execFileSync` que injeta a mensagem devolve o foco à
+      #      janela. Dois caminhos, mesma saída. Quem discrimina de verdade é
+      #      `tests/unit/realtime-token-do-socket.test.ts`, no `verify`.
+      #
+      #  (b) ELE REPROVA PR ALHEIO POR SORTE. Desde o conserto do locator:
+      #      #327 `dd58ec7c` pass · #343 `b508208b` pass · #344 `4e5acb21` FAIL ·
+      #      #344 rerun do MESMO sha FAIL. O #344 não toca uma linha de inbox,
+      #      realtime ou socket.
+      #
+      #      Um gate que reprova por moeda é pior que gate nenhum: ele treina o
+      #      time a reexecutar em vez de olhar, e foi assim que a degradação
+      #      silenciosa passou despercebida da primeira vez.
+      #
+      #      A spec CONTINUA no repositório e continua sendo a cerca de ponta a
+      #      ponta contra o sintoma relatado — roda local. Volta para a lista de
+      #      execução quando a issue #347 entregar entrega determinística (o
+      #      caminho provável é desligar o `refetchOnWindowFocus` durante a
+      #      asserção, para sobrar um caminho só).
       FORA_DO_CI: >-
         vps-fresh-onboarding.spec.ts
+        inbox-tempo-real.spec.ts
     steps:
       - uses: actions/checkout@v7
 

--- a/tests/e2e/inbox-tempo-real.spec.ts
+++ b/tests/e2e/inbox-tempo-real.spec.ts
@@ -44,6 +44,17 @@
  * Então o que este spec É: a cerca de ponta a ponta contra o SINTOMA relatado
  * (a mensagem não aparece sem F5), por qualquer causa. É valioso, e é menos do
  * que o cabeçalho acima sugeria antes desta medição.
+ *
+ * ⚠️ E POR ISSO ELE SAIU DO GATE DE MERGE (2026-08-26, issue #347). Ele está em
+ * `FORA_DO_CI` no `.github/workflows/e2e.yml`, com o motivo medido escrito lá:
+ * além de não discriminar, ele reprovou duas vezes o mesmo sha de um PR que não
+ * toca inbox, realtime nem socket, depois de passar em dois outros. Gate que
+ * reprova por moeda treina o time a reexecutar em vez de olhar.
+ *
+ * Ele CONTINUA aqui e continua rodando local — `pnpm exec playwright test
+ * tests/e2e/inbox-tempo-real.spec.ts`. O que a issue #347 precisa entregar para
+ * ele voltar: um caminho só até a mensagem durante a asserção, e a matriz de
+ * sabotagem ficando VERMELHA sem o conserto.
  */
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";


### PR DESCRIPTION
Fecha parcialmente #347. A spec **continua no repositório** e continua rodando local; o que muda é ela deixar de ser gate de merge.

Ela entrou ontem, com o #327, e eu a escrevi. Sai por medição minha, não por incômodo.

## (a) Ela não discrimina o conserto que diz guardar

Bancada local fiel a este job — Supabase local pg17, `baseline.sql` aplicado, Realtime reiniciado **depois** do baseline, `next build` de produção, os mesmos seeds — revertendo **só** `lib/supabase/browser.ts` para a versão anterior ao #327, e conferindo no bundle que o conserto de fato saiu:

```console
$ grep -rc "realtime-token"   .next/static   → 0     # o conserto saiu
$ grep -rc "sb-deskcomm-auth" .next/static   → 1     # controle positivo: o grep está vivo

com o conserto  → 1 passed
sem o conserto  → 1 passed
```

Quem discrimina é `tests/unit/realtime-token-do-socket.test.ts` (reprova 6 de 7 quando a callback some), e ele roda no `verify`, que é obrigatório. **O gate real não se perde.**

## (b) Ela reprova PR alheio por sorte

Desde o conserto do locator (strict mode), no CI:

| PR | SHA | `e2e` |
|---|---|---|
| #327 | `dd58ec7c` | pass |
| #343 | `b508208b` | pass |
| #344 | `4e5acb21` | **fail** |
| #344 (rerun, **mesmo** sha) | `4e5acb21` | **fail** |

O #344 é `lib/leads/`, `lib/webhooks/` e a rota do webhook — não toca uma linha de inbox, realtime ou socket.

Gate que reprova por moeda é pior que gate nenhum: treina o time a reexecutar em vez de olhar, que é o mesmo mecanismo pelo qual a degradação silenciosa passou despercebida da primeira vez.

## A hipótese, marcada como hipótese

`useMessagesRealtime` liga `refetchOnWindowFocus: true` e o `execFileSync` que injeta a mensagem devolve o foco à janela — dois caminhos até a mesma saída visível. Explica (a) diretamente. Explica (b) **só** se o foco variar com a carga do runner, e isso **não foi medido**.

## Medido

```
tests/unit/e2e-cobertura-completa.test.ts   4/4
```

Esse é o teste que importa aqui: a spec continua **declarada**, agora na terceira lista, com motivo escrito. Sumir do gate sem declarar é a dívida entrando pela porta de serviço, e é exatamente o que ele existe para impedir.

## NÃO MEDIDO

- **Se a hipótese do `refetchOnWindowFocus` é a causa de (b).** Não instrumentei o foco no runner do CI. Por isso ela está na issue como caminho provável, não como diagnóstico fechado.
- **Se a spec volta a passar 100% depois do conserto proposto.** Óbvio, mas é o que a #347 tem de provar antes de devolvê-la à lista.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwL2igBPaSmhtu5LvSGMDq