### PR TITLE
fix(handoff): a IA avisa o lead ANTES de sair de campo — nos dois motores de passagem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,24 @@ Se você roda o DeskcommCRM numa VPS, **leia a seção da versão para a qual es
 
 ### Corrigido
 
+- **A IA avisa o cliente antes de chamar uma pessoa — antes ela saía de campo calada.**
+  Quando o atendimento automático parava e a conversa ia para a fila humana, o cliente
+  não recebia mensagem nenhuma: ele falava, e ninguém respondia. Acontecia nos dois
+  caminhos que param a IA, e o pior deles era o silencioso — a IA tinha acabado de
+  **perguntar o e-mail do cliente**, o sistema detectou insatisfação na mensagem dele e
+  desligou o automático; o cliente respondeu a pergunta e ela caiu no vazio. Agora, em
+  qualquer um dos caminhos, sai uma mensagem antes do silêncio, e ela é honesta com o
+  estado da sua equipe: com gente disponível ela convida a aguardar; sem ninguém livre
+  no momento, diz que o pedido ficou registrado; e numa instalação que ainda não
+  configurou atendente nenhum, **não promete contato**. Quem pediu para **parar** de
+  receber mensagens recebe a confirmação da parada, não uma oferta de atendente.
+- **Quem vai assumir a conversa agora sabe se o cliente foi avisado.** O aviso na Central
+  passou a dizer, em uma linha, se a pessoa do outro lado já sabe que alguém está vindo —
+  é o que muda a primeira frase que o atendente digita.
+- **Conversa parada por insatisfação detectada agora abre aviso na Central.** Esse caminho
+  devolvia a conversa à fila e calava a IA sem avisar ninguém: o cliente sem resposta e a
+  equipe sem sinal de que havia alguém esperando. Agora ele abre o mesmo aviso que os
+  outros caminhos já abriam, e sem duplicar quando dois motivos disparam na mesma conversa.
 - **O agente voltou a ouvir os áudios que chegam.** Quem mandava um áudio ouvia de volta
   "não consigo ouvir mensagens de voz" — e a transcrição ficava pronta no sistema meio
   minuto depois, sem ninguém para usá-la. A causa era de ritmo: as tarefas de bastidor

--- a/HANDOFF-handoff-avisa-o-lead.md
+++ b/HANDOFF-handoff-avisa-o-lead.md
@@ -76,7 +76,29 @@ garantia; o desarme é. Congelado em `tests/unit/aviso-ao-lead.test.ts`.
 - `tests/unit/handoff-por-orcamento.test.ts` 24/24 (3 casos novos).
 - `pnpm typecheck` 0, `pnpm lint:channels` ok.
 
+## O corte de release — o trabalho NÃO termina no merge
+
+Instrução do Rafael (2026-08-26): *"toda nova atualização deve respeitar a
+doutrina de packaging e releases, senão os usuários não conseguem atualizar na
+VPS deles."* Merge na `main` não chega a instalação nenhuma — o self-hoster puxa
+IMAGEM PUBLICADA por número de versão.
+
+**Esta entrega é MINOR: v1.5.0 → v1.6.0** (muda comportamento visível ao cliente).
+
+Checklist em `docs/doctrine/packaging.md` (12 itens). Já verificado ANTES do merge:
+
+| Item | Estado |
+|---|---|
+| 1 — seção no CHANGELOG | ✅ três entradas na voz de quem opera |
+| 2 — nenhuma variável nova obrigatória | ✅ `git diff ... -- .env.example` vazio |
+| 3 — o número nunca foi publicado | ✅ tag local vazia; `ghcr_status deskcommcrm 1.6.0` → 404, com controle positivo (1.5.0 → 200) e negativo (9.9.9 → 404) |
+| 4 — pins upstream revisitados | ⬜ fazer no corte |
+| 5..12 | ⬜ dependem do merge |
+
+O item 12 (ensaio de `update.sh` numa instalação real) é o único que exige VPS e
+**é ele que responde a pergunta do Rafael** — se o cliente consegue atualizar.
+
 ## O que NÃO foi provado ainda
 
-- Envio real por WhatsApp: só na VPS (próximo passo).
+- Envio real por WhatsApp: só na VPS, depois do corte da v1.6.0.
 - E2E de tela: não escrito.

--- a/HANDOFF-handoff-avisa-o-lead.md
+++ b/HANDOFF-handoff-avisa-o-lead.md
@@ -1,0 +1,82 @@
+# HANDOFF — o handoff avisa o lead antes de silenciar
+
+> ⚠️ **INSTRUÇÃO PERMANENTE:** ler no INÍCIO de toda sessão que trabalhe nesta
+> feature e ATUALIZAR + COMMITAR a cada avanço. Progresso só conta com PROVA
+> VISÍVEL (output de teste real, log de produção, screenshot). Commitar este
+> arquivo junto — mudança só no working tree se perde.
+
+## O defeito (relatado pelo dono do produto, com 2 screenshots)
+
+O agente faz o handoff CORRETAMENTE, mas não manda mensagem nenhuma avisando o
+lead. A pessoa fala e ninguém responde.
+
+## Causa raiz — MEDIDA no banco de produção, e são DUAS
+
+```
+$ psql "$SUPABASE_DB_URL" -c "select c.status, c.bot_silenced_until, c.last_handoff_reason, ct.force_human
+                                from conversations c join contacts ct on ct.id=c.contact_id
+                               where c.contact_id in ('d9e198c1…','4435a78d…')"
+status  | bot_silenced_until | last_handoff_reason | force_human
+open    | infinity           | requested_human     | t            <- screenshot 2 (Lucas)
+pending | infinity           | low_sentiment       | f            <- screenshot 1 (Dennis)
+```
+
+| Screenshot | Motor | Gatilho | Arquivo |
+|---|---|---|---|
+| 2 — "preciso de falar com atendente" | `performHumanHandoff` (`pg`) | regex determinístico | `lib/agent-engine/agent/inbound-turn.ts` — `return` com "bot silencia: sem modelo, sem envio" |
+| 1 — não conseguia acessar o curso | `triggerHandoff` (`supabase-js`) | worker de SENTIMENTO | `workers/ai-handoff-from-sentiment.handler.ts` → `lib/ai/handoff/orchestrator.ts` |
+
+Log da VPS (`evidence/handoff-avisa-antes/producao-2026-08-26.txt`) — o pior caso
+é o Dennis: às 14:50:32 o agente PERGUNTOU o e-mail dele; às 14:51:01 o
+sentimento disparou o handoff; às 14:51:27 o e-mail chegou e o turno foi pulado.
+Ele respondeu uma pergunta da própria IA para o vazio.
+
+**São dois motores, em dois mundos de banco.** Um conserto só no `inbound-turn`
+conserta o screenshot 2 e deixa o 1 exatamente como está.
+
+## A ordem é obrigatória, não estética
+
+`performHumanHandoff` grava `contacts.force_human = true`, e o gate 1 da cadeia
+de envio (`stopGate`, `before-send.ts`) relê `(is_blocked or force_human)` direto
+da fonte a cada tentativa. **Avisar depois é avisar ninguém.** Medido: invertendo
+a ordem, o turno registra `gate: stop → veto → contato_bloqueado`
+(`evidence/handoff-avisa-antes/sabotagem-ordem-invertida.txt`).
+
+## O que foi feito
+
+| Arquivo | O quê |
+|---|---|
+| `lib/escalacao/aviso-ao-lead.ts` (novo) | O TEXTO — puro, um só para os dois mundos. Varia por motivo e por disponibilidade real da equipe; 3 variantes por lead (hash) |
+| `lib/agent-engine/agent/aviso-de-escalacao.ts` (novo) | Envio do lado do MOTOR, atrás de `runBeforeSend` (cadeia completa), `seq: 0` |
+| `lib/ai/handoff/aviso-ao-lead.ts` (novo) | Envio do lado do CRM, por `sendMessageHandler` (não há `pg.Pool` nem job ali) |
+| `lib/agent-engine/agent/inbound-turn.ts` | Avisa nos 3 desvios: pedido explícito, opt-out ambíguo, teto de gasto. Canal hoistado para antes deles |
+| `lib/ai/handoff/orchestrator.ts` | `Step 0` avisa antes do UPDATE; `Step 6` abre item na Central (não abria) |
+| `lib/agent-engine/agent/human-handoff.ts` | `avisoAoLead` vira LINHA no item da Central; retorno da tool deixa de mandar calar |
+| `lib/agent-engine/guardrails/before-send.ts` | `spinningEnforced` — desarme explícito do gate de spinning só para o aviso |
+| `app/api/v1/ai/cases/[id]/reply/route.ts` | Escalação de caso avisa antes |
+
+### Por que o gate de spinning é desarmado (a conta que reprovou a v1)
+
+`decideSpinning` veta candidata idêntica/quase (Jaccard ≥ 0,8) a 2+ das últimas
+20 mensagens DAQUELE NÚMERO — janela que cruza leads. Medido com a função real:
+com 3 variantes, **14 de 20** avisos seguidos eram vetados. Variante não é
+garantia; o desarme é. Congelado em `tests/unit/aviso-ao-lead.test.ts`.
+
+## Provas observadas
+
+- `pnpm test:db tests/invariants/handoff-avisa-o-lead.test.ts` → **8/8**, turno
+  REAL contra Postgres do `baseline.sql`. Log em
+  `evidence/handoff-avisa-antes/ordem-no-turno-real.txt`: 10 gates → `spinning:
+  skipped` → "lead avisado" → **só então** "handoff humano aplicado".
+- Sabotagem (inverter a ordem) → **4 de 8 vermelhos**, incluindo
+  `expected [] to have a length of 1` — o defeito original reproduzido.
+- `tests/unit/aviso-ao-lead.test.ts` 14/14; sabotado (colapsar variantes) → vermelho.
+- `tests/unit/handoff-avisa-o-lead.test.ts` 11/11 (varredura AST dos 2 motores);
+  3 sabotagens distintas → 3 vermelhos.
+- `tests/unit/handoff-por-orcamento.test.ts` 24/24 (3 casos novos).
+- `pnpm typecheck` 0, `pnpm lint:channels` ok.
+
+## O que NÃO foi provado ainda
+
+- Envio real por WhatsApp: só na VPS (próximo passo).
+- E2E de tela: não escrito.

--- a/app/api/v1/ai/cases/[id]/reply/route.ts
+++ b/app/api/v1/ai/cases/[id]/reply/route.ts
@@ -32,6 +32,8 @@ import {
   buildCaseSummary,
 } from "@/lib/agent-engine/agent/human-cases";
 import { performHumanHandoff } from "@/lib/agent-engine/agent/human-handoff";
+import { avisarLeadDoCrm } from "@/lib/ai/handoff/aviso-ao-lead";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { getRequestPool } from "@/lib/agent-engine/db/request-pool";
 import { createLogger } from "@/lib/agent-engine/obs/logger";
 import { enqueueJob } from "@/lib/agent-engine/queue/queue";
@@ -124,6 +126,25 @@ export async function POST(req: NextRequest, { params }: RouteParams): Promise<R
   const { conversation_id: conversationId, contact_id: contactId } = caseRow;
 
   if (action === "escalate") {
+    // AVISA O LEAD ANTES DE SILENCIAR.
+    //
+    // Até aqui o automático estava CONVERSANDO com o cliente — abrir um caso não
+    // silencia ninguém (`CASES_SYSTEM_BLOCK`: "você CONTINUA conversando"). O
+    // `performHumanHandoff` da linha seguinte é que corta, e corta de vez. Sem
+    // esta mensagem, do lado de fora, o atendimento simplesmente para no meio.
+    //
+    // Emissor do lado do CRM (`avisarLeadDoCrm`), e não o do motor: aqui não há
+    // job da fila, e `runBeforeSend` grava o ledger por `(job_id, seq)`. Forjar
+    // um job para mandar uma frase seria pior que perder os gates de pacing —
+    // que, neste caminho, protegem contra um risco que não existe: é UMA
+    // mensagem, disparada por um clique humano, dentro de uma conversa aberta.
+    const aviso = await avisarLeadDoCrm(createAdminClient(), {
+      organizationId: org.orgId,
+      conversationId,
+      contactId,
+      reason: body,
+    });
+
     // O handoff roda ANTES de fechar o caso, e nesta ordem de propósito: ele é
     // idempotente (re-executar é no-op) e recebe um pg.Pool próprio, então não
     // entra na transação abaixo. Se ele falhar, o caso continua `awaiting_human`
@@ -135,6 +156,7 @@ export async function POST(req: NextRequest, { params }: RouteParams): Promise<R
       {
         reason: body,
         conversationSummary: buildCaseSummary(caseRow),
+        avisoAoLead: aviso,
         log: createLogger(),
       },
     );

--- a/docs/architecture/escalacao-ciclo-humano.architecture.json
+++ b/docs/architecture/escalacao-ciclo-humano.architecture.json
@@ -321,6 +321,54 @@
       "type": "service",
       "label": "CONVERSATION_QUEUE_STATUSES",
       "sublabel": "quem está esperando uma pessoa — uma definição, quatro consumidores"
+    },
+    {
+      "id": "avisoTexto",
+      "lane": "regra",
+      "col": 2,
+      "type": "lib",
+      "label": "lib/escalacao/aviso-ao-lead.ts",
+      "sublabel": "O QUE O CLIENTE LÊ — puro, um só para os dois motores"
+    },
+    {
+      "id": "avisoMotor",
+      "lane": "motor",
+      "col": 3,
+      "type": "lib",
+      "label": "aviso-de-escalacao.ts",
+      "sublabel": "envia atrás de runBeforeSend, seq 0, ANTES da trava"
+    },
+    {
+      "id": "avisoCrm",
+      "lane": "regra",
+      "col": 3,
+      "type": "lib",
+      "label": "lib/ai/handoff/aviso-ao-lead.ts",
+      "sublabel": "o mesmo texto pelo sendMessageHandler (mundo supabase-js)"
+    },
+    {
+      "id": "orquestrador",
+      "lane": "motor",
+      "col": 2,
+      "type": "worker",
+      "label": "triggerHandoff (orchestrator)",
+      "sublabel": "o SEGUNDO motor de passagem — sentimento, confiança, etapa, termo jurídico"
+    },
+    {
+      "id": "sentimento",
+      "lane": "motor",
+      "col": 1,
+      "type": "worker",
+      "label": "ai-sentiment-worker",
+      "sublabel": "score < limiar → ai.sentiment_alert → passagem, sem o lead saber"
+    },
+    {
+      "id": "central",
+      "lane": "dados",
+      "col": 4,
+      "type": "table",
+      "label": "agent_inbox_items",
+      "sublabel": "kind='handoff' — quem assume lê aqui se o cliente foi avisado"
     }
   ],
   "edges": [
@@ -617,6 +665,90 @@
       "from": "fila",
       "to": "comando",
       "label": "o estado 'aguardando' do selo sai daqui"
+    },
+    {
+      "id": "e50",
+      "from": "avisoMotor",
+      "to": "avisoTexto",
+      "label": "o texto vem de um lugar só — duas redações envelheceriam separadas"
+    },
+    {
+      "id": "e51",
+      "from": "avisoCrm",
+      "to": "avisoTexto",
+      "label": "o MESMO texto, outro encanamento"
+    },
+    {
+      "id": "e52",
+      "from": "avisoMotor",
+      "to": "conversas",
+      "label": "a mensagem é gravada e sai pelo canal ANTES do silêncio"
+    },
+    {
+      "id": "e53",
+      "from": "guarda",
+      "to": "avisoMotor",
+      "label": "o stopGate lê force_human: por isso o aviso vem primeiro"
+    },
+    {
+      "id": "e54",
+      "from": "avisoMotor",
+      "to": "contacts",
+      "label": "ordem obrigatória — avisar depois de force_human é avisar ninguém"
+    },
+    {
+      "id": "e55",
+      "from": "sentimento",
+      "to": "orquestrador",
+      "label": "ai.sentiment_alert → handoff que o lead nunca soube que aconteceu"
+    },
+    {
+      "id": "e56",
+      "from": "orquestrador",
+      "to": "avisoCrm",
+      "label": "Step 0: avisa antes do UPDATE que silencia"
+    },
+    {
+      "id": "e57",
+      "from": "orquestrador",
+      "to": "conversas",
+      "label": "status='pending' + bot_silenced_until='infinity' (NÃO grava force_human)"
+    },
+    {
+      "id": "e58",
+      "from": "orquestrador",
+      "to": "central",
+      "label": "Step 6: o item que este motor nunca abriu"
+    },
+    {
+      "id": "e59",
+      "from": "avisoMotor",
+      "to": "central",
+      "label": "o desfecho do aviso vira LINHA no item — 'essa pessoa sabe que estou vindo?'"
+    },
+    {
+      "id": "e60",
+      "from": "avisoCrm",
+      "to": "atendentes",
+      "label": "mesma régua de disponibilidade: não prometer contato para o vazio"
+    },
+    {
+      "id": "e61",
+      "from": "avisoTexto",
+      "to": "atendentes",
+      "label": "3 estados da equipe, 3 promessas — nenhuma inventada"
+    },
+    {
+      "id": "e62",
+      "from": "central",
+      "to": "cabecalho",
+      "label": "o atendente abre a conversa sabendo se o cliente foi avisado"
+    },
+    {
+      "id": "e63",
+      "from": "reply",
+      "to": "avisoCrm",
+      "label": "'Assumir eu' também avisa antes de calar o automático"
     }
   ],
   "cards": [

--- a/docs/testing/user-journey-map.md
+++ b/docs/testing/user-journey-map.md
@@ -230,8 +230,37 @@ Evidência: `.superpowers/evidence/ia-360-w3/`.
 | J8.7 | A **ida** aparece na linha do tempo | atividade "Passou para humano" também pelo caminho do harness/casos | FAIL(BUG-05) → PASS |
 | J8.8 | O agente retoma **sabendo** o que a pessoa fez | a abertura do turno (`ritualBlocks`) cita a decisão dela, sem apagar o acumulado anterior | PASS |
 | J8.9 | Status da conversa escalada em português | o cabeçalho mostrava `pending` cru | FAIL → PASS |
+| J8.10 | **O cliente é AVISADO antes de a IA sair de campo** | mensagem ao lead dizendo que uma pessoa vai assumir, ANTES do silêncio | FAIL(BUG-06) → PASS |
+| J8.11 | O aviso respeita o motivo | quem pediu para PARAR recebe confirmação da parada, não oferta de atendente | FAIL(BUG-06) → PASS |
+| J8.12 | O aviso respeita a equipe real | conta sem ninguém configurado não recebe promessa de contato | FAIL(BUG-06) → PASS |
+| J8.13 | A passagem por SENTIMENTO abre item na Central | `triggerHandoff` não abria nenhum — cliente sem resposta E time sem sinal | FAIL(BUG-07) → PASS |
 
-Bugs desta jornada estão detalhados em `HANDOFF-ia-360.md` (BUG-01 a BUG-05).
+Bugs desta jornada estão detalhados em `HANDOFF-ia-360.md` (BUG-01 a BUG-05) e em
+`HANDOFF-handoff-avisa-o-lead.md` (BUG-06, BUG-07).
+
+### BUG-06 — a passagem para humano era MUDA (2026-08-26)
+
+Achado pelo dono do produto, em duas conversas reais na mesma hora, e a medição
+no banco de produção mostrou que **são dois motores, não um**:
+
+```
+status  | bot_silenced_until | last_handoff_reason | force_human
+open    | infinity           | requested_human     | t     <- performHumanHandoff (motor, pg)
+pending | infinity           | low_sentiment       | f     <- triggerHandoff (CRM, supabase-js)
+```
+
+O pior caso não foi o pedido explícito: foi o do sentimento. Às 14:50:32 o agente
+PERGUNTOU o e-mail do cliente; às 14:51:01 o worker de sentimento disparou o
+handoff; às 14:51:27 o e-mail chegou e o turno foi pulado. Ele respondeu uma
+pergunta da própria IA para o vazio.
+
+**A ordem é obrigatória:** `performHumanHandoff` grava `force_human`, e o gate 1
+da cadeia de envio o relê a cada tentativa — avisar depois é avisar ninguém.
+Provado por sabotagem em `evidence/handoff-avisa-antes/sabotagem-ordem-invertida.txt`.
+
+Guardas: `tests/invariants/handoff-avisa-o-lead.test.ts` (turno real contra
+Postgres do baseline), `tests/unit/handoff-avisa-o-lead.test.ts` (varredura AST
+dos dois motores) e `tests/unit/aviso-ao-lead.test.ts` (o texto).
 
 ---
 

--- a/evidence/handoff-avisa-antes/classificacao-falhas-test-unit.txt
+++ b/evidence/handoff-avisa-antes/classificacao-falhas-test-unit.txt
@@ -1,0 +1,18 @@
+CLASSIFICAÇÃO DAS FALHAS DE test:unit (mesma régua nos dois lados)
+SHA da minha branch: 39da60e1  |  base: main @ 7c63e05a
+
+MINHAS (consertadas neste commit):
+  tests/unit/orcamento-caminho-legado.test.ts     — 2 falhas: a régua filtrava agent_inbox_items por TABELA,
+                                                     não por assunto; o item kind='handoff' novo entrava na conta
+  tests/unit/ai-response-worker-sent-via.test.ts  — 1 falha: passaram a existir 2 linhas outbound (aviso + rascunho);
+                                                     o aviso agora nasce marcado em metadata e a régua o exclui
+
+AMBIENTE (idênticas na main, medido):
+  lib/ai/dispatcher/rate-limit.test.ts            — 5 falhas, 15s cada. Aponta para localhost:8079
+                                                     (serverless-redis-http local, contêiner Exited há semanas)
+     prova: rodado no worktree da main COM o mesmo .env.local -> mesmas 5 falhas, mesmos tempos
+
+MINHA, mas de AMBIENTE (já revertida):
+  tests/unit/canal-zernio-vocabulario.test.ts     — 1 falha: eu apaguei supabase/migrations nos experimentos
+                                                     com o supabase CLI. git checkout restaurou os 162 arquivos.
+                                                     Foi o próprio gate que pegou.

--- a/evidence/handoff-avisa-antes/ordem-no-turno-real.txt
+++ b/evidence/handoff-avisa-antes/ordem-no-turno-real.txt
@@ -1,0 +1,22 @@
+18:46:11.616 7a6ec782 | before_send gate avaliado | spinning=skipped/not_applicable
+18:46:11.640 7a6ec782 | lead avisado antes da passagem para humano | 
+18:46:11.652 7a6ec782 | handoff humano aplicado (force_human + silêncio + crons canc | requested_human
+18:46:11.711 03044461 | before_send gate avaliado | spinning=skipped/not_applicable
+18:46:11.716 03044461 | lead avisado antes da passagem para humano | 
+18:46:11.723 03044461 | handoff humano aplicado (force_human + silêncio + crons canc | requested_human
+18:46:11.778 002de54d | before_send gate avaliado | spinning=skipped/not_applicable
+18:46:11.782 002de54d | lead avisado antes da passagem para humano | 
+18:46:11.792 002de54d | handoff humano aplicado (force_human + silêncio + crons canc | requested_human
+18:46:11.867 ff5dcd56 | before_send gate avaliado | spinning=skipped/not_applicable
+18:46:11.874 ff5dcd56 | lead avisado antes da passagem para humano | 
+18:46:11.886 ff5dcd56 | handoff humano aplicado (force_human + silêncio + crons canc | requested_human
+18:46:11.981 9beb21f1 | before_send gate avaliado | spinning=skipped/not_applicable
+18:46:11.989 9beb21f1 | lead avisado antes da passagem para humano | 
+18:46:12.001 9beb21f1 | handoff humano aplicado (force_human + silêncio + crons canc | requested_human
+18:46:12.188 c933c768 | before_send gate avaliado | spinning=skipped/not_applicable
+18:46:12.195 c933c768 | lead avisado antes da passagem para humano | 
+18:46:12.206 c933c768 | handoff humano aplicado (force_human + silêncio + crons canc | requested_human
+18:46:12.223 dfbc22dd | turno pulado — lead em handoff humano (bot silenciado) | 
+18:46:12.287 c2a34f07 | before_send gate avaliado | spinning=skipped/not_applicable
+18:46:12.292 c2a34f07 | lead avisado antes da passagem para humano | 
+18:46:12.303 c2a34f07 | handoff humano aplicado (force_human + silêncio + crons canc | suspected_optout

--- a/evidence/handoff-avisa-antes/producao-2026-08-26.txt
+++ b/evidence/handoff-avisa-antes/producao-2026-08-26.txt
@@ -1,0 +1,10 @@
+14:48:52 | d9e198c1 | tools MCP bloqueadas no turno do engine (envio/handoff são do harness) | 
+14:49:32 | d9e198c1 | tools MCP bloqueadas no turno do engine (envio/handoff são do harness) | 
+14:49:55 | d9e198c1 | turno do agente concluído | 1
+14:50:02 | d9e198c1 | tools MCP bloqueadas no turno do engine (envio/handoff são do harness) | 
+14:50:32 | d9e198c1 | turno do agente concluído | 1
+14:51:27 | d9e198c1 | turno pulado — lead em handoff humano (bot silenciado) | 
+14:54:41 | 4435a78d | tools MCP bloqueadas no turno do engine (envio/handoff são do harness) | 
+14:55:09 | 4435a78d | turno do agente concluído | 1
+14:55:46 | 4435a78d | handoff humano aplicado (force_human + silêncio + crons cancelados + inbox) | requested_human
+14:55:46 | 4435a78d | handoff humano acionado por pedido explícito do lead (detecção determinísti | 

--- a/evidence/handoff-avisa-antes/sabotagem-ordem-invertida.txt
+++ b/evidence/handoff-avisa-antes/sabotagem-ordem-invertida.txt
@@ -1,0 +1,19 @@
+SABOTAGEM: aviso movido para DEPOIS de performHumanHandoff (a inversão que o stopGate mata em silêncio)
+Comando: pnpm test:db tests/invariants/handoff-avisa-o-lead.test.ts
+
+⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯
+ FAIL  tests/invariants/handoff-avisa-o-lead.test.ts > pedido explícito de atendente > o lead RECEBE uma resposta — e ela não é vazia
+AssertionError: o defeito original: pedido explícito de humano e ZERO mensagens ao lead: expected [] to have a length of 1 but got +0
+ FAIL  tests/invariants/handoff-avisa-o-lead.test.ts > pedido explícito de atendente > o aviso saiu ANTES de a trava ser armada
+ FAIL  tests/invariants/handoff-avisa-o-lead.test.ts > pedido explícito de atendente > a Central registra que o cliente FOI avisado
+AssertionError: expected 'Motivo: requested_human. Resumo da co…' to match /JÁ FOI avisado/u
+ FAIL  tests/invariants/handoff-avisa-o-lead.test.ts > pedido explícito de atendente > lead já em handoff não recebe aviso de novo
+AssertionError: expected [] to have a length of 1 but got +0
+      Tests  4 failed | 4 passed (8)
+
+--- o mecanismo, no log do turno sabotado ---
+{"ts":"2026-08-26T18:49:31.708Z","level":"info","msg":"before_send gate avaliado","job_id":"a1b8b60c-18ee-4c20-aa65-5137e3cc7a3c","tenant_id":"eeee0000-0000-4000-8000-000000000001","lead_id":"eeee0000-0000-4000-8000-000000000002","channel_session_id":"eeee0000-0000-4000-8000-000000000003","gate":"stop","verdict":"veto","code":"contato_bloqueado"}
+{"ts":"2026-08-26T18:49:32.272Z","level":"info","msg":"aviso de escalação vetado pela cadeia — a passagem acontece assim mesmo","job_id":"a1b8b60c-18ee-4c20-aa65-5137e3cc7a3c","tenant_id":"eeee0000-0000-4000-8000-000000000001","lead_id":"eeee0000-0000-4000-8000-000000000002","code":"contato_bloqueado"}
+
+--- CONTROLE: mesmo arquivo, código íntegro ---
+      Tests  8 passed (8)

--- a/lib/agent-engine/agent/aviso-de-escalacao.ts
+++ b/lib/agent-engine/agent/aviso-de-escalacao.ts
@@ -1,0 +1,220 @@
+/**
+ * O ENVIO do aviso de que a IA está saindo de campo — lado do MOTOR (`pg`).
+ *
+ * A frase mora em `lib/escalacao/aviso-ao-lead.ts` (uma só, para os dois mundos).
+ * Aqui só o encanamento: resolver a disponibilidade real da equipe, montar o
+ * corpo e mandá-lo pela MESMA cadeia de guardrails por onde passa tudo que sai
+ * daqui — `runBeforeSend`. Nada sai por baixo dela (CLAUDE.md, princípio 2).
+ *
+ * ## É o irmão de `runDeterministicReentry`
+ *
+ * `lib/agent-engine/agent/followup-turn.ts` já envia texto escrito em CÓDIGO,
+ * sem gastar modelo, atrás da cadeia. Este arquivo é a mesma figura para um
+ * momento diferente: lá é a re-entrada, aqui é a saída.
+ *
+ * ## Duas escolhas de gate que precisam estar escritas
+ *
+ * 1. **`casesEnabled: false` de propósito.** O `casePromiseGate` existe para o
+ *    lead nunca receber promessa-de-humano que o modelo inventou sem abrir caso.
+ *    Este corpo promete um humano — e a promessa é VERDADEIRA por construção: a
+ *    linha seguinte do chamador executa a passagem. Deixar o gate armado aqui o
+ *    faria vetar exatamente a mensagem que ele existe para garantir, e o desfecho
+ *    seria o silêncio que este arquivo veio acabar.
+ * 2. **`seq: 0`.** O contrato do ledger é "posição da mensagem no turno (1..n)"
+ *    (`ChannelSendInput.seq`), e o aviso não é uma mensagem do turno — é a
+ *    despedida dele. `0` nunca colide com o `seq` que a tool `send_message`
+ *    consome, então o replay pós-crash de um job continua deduplicando por
+ *    `(job_id, seq)` sem que um aviso vire `already_sent` de uma fala do modelo
+ *    (ou o contrário).
+ *
+ * ## O que acontece quando a cadeia VETA
+ *
+ * A passagem para humano acontece do mesmo jeito — quem pediu uma pessoa não
+ * pode ficar preso ao automático porque a janela de envio fechou. Mas o desfecho
+ * volta ao chamador para virar linha no aviso da Central: o atendente que abre a
+ * conversa precisa saber se o cliente foi avisado ou está esperando no escuro.
+ * Falhar fechado na AÇÃO, aberto na INFORMAÇÃO.
+ */
+import type pg from 'pg';
+
+import { expectativaDeAtendimento } from '@/lib/escalacao/disponibilidade';
+import { deriveLgpdFromContact } from '../guardrails/lgpd/legal-basis';
+import { textoDoAviso, type MotivoDoAviso } from '@/lib/escalacao/aviso-ao-lead';
+
+import type { ChannelAdapter } from '../channel-adapter';
+import { runBeforeSend } from '../guardrails/before-send';
+import type { LgpdInput } from '../guardrails/lgpd/legal-basis';
+import type { Logger } from '../obs/logger';
+
+/**
+ * `seq` do aviso no ledger de envio. Ver o cabeçalho: o turno usa 1..n.
+ */
+export const SEQ_DO_AVISO = 0;
+
+/** O que aconteceu com o aviso — vai ao log e ao aviso da Central, nunca ao lead. */
+export type DesfechoDoAviso =
+  | { avisado: true }
+  /** A cadeia vetou (janela fechada, contato bloqueado, cap diário…) ou o canal não aceitou. */
+  | { avisado: false; porque: string };
+
+export interface AvisoDeEscalacaoIds {
+  tenantId: string;
+  leadId: string;
+  conversationId: string;
+  channelSessionId: string;
+  jobId: string;
+}
+
+export interface AvisoDeEscalacaoOpts {
+  motivo: MotivoDoAviso;
+  channel: ChannelAdapter;
+  /** `contacts.is_blocked` lido no contexto deste turno (fonte confiável). */
+  optedOutThisTurn: boolean;
+  now: Date;
+  log: Logger;
+  lgpd?: LgpdInput;
+  agentId?: string | null;
+  disclosureMode?: 'inject' | 'veto';
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Avisa o lead de que uma pessoa vai assumir. NUNCA lança: um erro aqui não pode
+ * impedir a passagem que ele antecede — o cliente sem aviso é ruim, o cliente
+ * preso a um automático que já decidiu sair é pior.
+ */
+export async function avisarLeadDaEscalacao(
+  pool: pg.Pool,
+  ids: AvisoDeEscalacaoIds,
+  opts: AvisoDeEscalacaoOpts,
+): Promise<DesfechoDoAviso> {
+  let body: string;
+  try {
+    const { quem } = await expectativaDeAtendimento(pool, ids.tenantId, opts.now);
+    body = textoDoAviso(opts.motivo, quem, ids.leadId);
+  } catch (err) {
+    // `expectativaDeAtendimento` já tem rede própria; se ainda assim quebrar,
+    // a frase conservadora (sem prazo) é a certa — nunca a ausência de frase.
+    opts.log.warn('aviso de escalação: disponibilidade não lida, usando a frase conservadora', {
+      error: err instanceof Error ? err.message.slice(0, 120) : 'erro desconhecido',
+    });
+    body = textoDoAviso(opts.motivo, null, ids.leadId);
+  }
+
+  try {
+    const chain = await runBeforeSend({
+      pool,
+      log: opts.log,
+      tenantId: ids.tenantId,
+      leadId: ids.leadId,
+      jobId: ids.jobId,
+      channelSessionId: ids.channelSessionId,
+      body,
+      optedOutThisTurn: opts.optedOutThisTurn,
+      // Ver `GateContext.spinningEnforced`: com o gate armado, a terceira pessoa
+      // a ser escalada na mesma janela do número receberia silêncio — pelo
+      // guardrail. Este é o ÚNICO chamador que o desarma.
+      enforceSpinning: false,
+      // Mesmo débito declarado no caminho do agente e no da re-entrada: o
+      // daily_message_limit do CRM ainda não é lido no runtime.
+      crmDailyLimit: null,
+      now: opts.now,
+      ...(opts.sleep !== undefined ? { sleep: opts.sleep } : {}),
+      ...(opts.lgpd !== undefined ? { lgpd: opts.lgpd } : {}),
+      ...(opts.agentId !== undefined ? { agentId: opts.agentId } : {}),
+      ...(opts.disclosureMode !== undefined ? { disclosureMode: opts.disclosureMode } : {}),
+      send: (finalBody) =>
+        opts.channel.send({
+          tenantId: ids.tenantId,
+          leadId: ids.leadId,
+          jobId: ids.jobId,
+          seq: SEQ_DO_AVISO,
+          conversationId: ids.conversationId,
+          body: finalBody,
+        }),
+    });
+
+    if (chain.status === 'vetoed') {
+      opts.log.info('aviso de escalação vetado pela cadeia — a passagem acontece assim mesmo', {
+        code: chain.code,
+      });
+      return { avisado: false, porque: chain.code };
+    }
+
+    const outcome = chain.outcome;
+    switch (outcome.kind) {
+      case 'sent':
+      case 'already_sent':
+      case 'queued':
+        // 'queued' = o canal aceitou e segura (sessão fora do ar) — está sob
+        // custódia do CRM, então o cliente FOI avisado do ponto de vista de quem
+        // decide; a entrega é problema do canal, com dono e watchdog próprios.
+        opts.log.info('lead avisado antes da passagem para humano', { kind: outcome.kind });
+        return { avisado: true };
+      case 'blocked':
+        return { avisado: false, porque: 'contato_bloqueado' };
+      case 'failed':
+        return { avisado: false, porque: 'canal_falhou' };
+      case 'unavailable':
+        return { avisado: false, porque: 'canal_indisponivel' };
+    }
+  } catch (err) {
+    opts.log.warn('aviso de escalação falhou — a passagem acontece assim mesmo', {
+      error: err instanceof Error ? err.message.slice(0, 200) : 'erro desconhecido',
+    });
+    return { avisado: false, porque: 'erro_no_envio' };
+  }
+}
+
+
+/**
+ * A mesma coisa, para quem NÃO tem o contexto do turno na mão.
+ *
+ * A escolta do orçamento (`comHandoffSeOrcamentoAcabar`) envolve o turno INTEIRO
+ * — inclusive a leitura do contexto —, então quando ela precisa avisar, o
+ * `getLeadContext` pode nem ter rodado. Em vez de deixar esse caminho sem os
+ * insumos dos gates (o de LGPD viraria no-op, e um contato anonimizado receberia
+ * mensagem), ele lê a linha do contato direto do banco. É UMA query, e só no
+ * caminho de erro — o caminho feliz não paga nada por ela.
+ */
+export async function avisarLeadLendoOContato(
+  pool: pg.Pool,
+  ids: AvisoDeEscalacaoIds,
+  opts: Omit<AvisoDeEscalacaoOpts, 'optedOutThisTurn' | 'lgpd'>,
+): Promise<DesfechoDoAviso> {
+  let optedOutThisTurn = false;
+  let lgpd: LgpdInput | undefined;
+  try {
+    const { rows } = await pool.query<{
+      is_blocked: boolean;
+      is_anonymized: boolean;
+      source: string | null;
+      consent: Record<string, unknown> | null;
+    }>(
+      'select is_blocked, is_anonymized, source, consent from contacts where organization_id = $1 and id = $2',
+      [ids.tenantId, ids.leadId],
+    );
+    const c = rows[0];
+    if (c !== undefined) {
+      optedOutThisTurn = c.is_blocked === true;
+      // isProspecting=false: isto responde a alguém que JÁ está numa conversa —
+      // mesma leitura de `get-lead-context.ts`.
+      lgpd = deriveLgpdFromContact(
+        { source: c.source, consent: c.consent, is_anonymized: c.is_anonymized },
+        false,
+      );
+    }
+  } catch (err) {
+    // Sem a leitura, o `stopGate` ainda lê as travas DIRETO da fonte sob o lock
+    // (`readStopFlags`) — o que se perde é só o gate de LGPD, e perder o aviso
+    // inteiro por causa disso seria trocar um risco pequeno por um dano certo.
+    opts.log.warn('aviso de escalação: contato não lido, seguindo com o que a cadeia lê sozinha', {
+      error: err instanceof Error ? err.message.slice(0, 120) : 'erro desconhecido',
+    });
+  }
+  return avisarLeadDaEscalacao(pool, ids, {
+    ...opts,
+    optedOutThisTurn,
+    ...(lgpd !== undefined ? { lgpd } : {}),
+  });
+}

--- a/lib/agent-engine/agent/human-handoff.ts
+++ b/lib/agent-engine/agent/human-handoff.ts
@@ -3,8 +3,9 @@
  * clara e imediata é EXIGÊNCIA fiscalizada da Meta, não fallback). Dois gatilhos, uma
  * ação idempotente:
  *   1. DETERMINÍSTICO — regex PT-BR na última mensagem do lead ("falar com atendente",
- *      "quero falar com uma pessoa"…). Roda no runtime ANTES do modelo: o turno vira
- *      NO-OP (o bot silencia, não gasta LLM nem envia).
+ *      "quero falar com uma pessoa"…). Roda no runtime ANTES do modelo: o turno não gasta
+ *      LLM. Ele AVISA o lead (texto de código, `avisarLeadDaEscalacao`) e só então silencia
+ *      — nesta ordem, porque `force_human` arma o `stopGate` e mata todo envio posterior.
  *   2. TOOL request_human_handoff — o modelo aciona quando percebe o limite da automação.
  *
  * A ação (performHumanHandoff), idempotente e at-least-once — TUDO no mesmo banco agora
@@ -116,7 +117,24 @@ export interface HandoffIds {
 export async function performHumanHandoff(
   db: pg.Pool,
   ids: HandoffIds,
-  opts: { reason: string; conversationSummary: string; inboxTitle?: string; log: Logger },
+  opts: {
+    reason: string;
+    conversationSummary: string;
+    inboxTitle?: string;
+    /**
+     * O desfecho do aviso que o chamador mandou ao lead ANTES desta passagem
+     * (`avisarLeadDaEscalacao`). Opcional porque nem todo chamador é o motor de
+     * conversa — o "Assumir eu" de um caso é acionado por uma pessoa que já está
+     * na conversa e fala por si.
+     *
+     * Quando presente, ele vira LINHA no aviso da Central. A pergunta que o
+     * atendente faz ao abrir a conversa é "essa pessoa sabe que estou vindo?", e
+     * a resposta muda a primeira frase que ele digita. Falhar fechado na ação,
+     * aberto na informação.
+     */
+    avisoAoLead?: { avisado: boolean; porque?: string };
+    log: Logger;
+  },
 ): Promise<void> {
   // (a) FONTE DA VERDADE: force_human no contato — irrevogável pelo agente (regra dura 2).
   await db.query(`update contacts set force_human = true where organization_id = $1 and id = $2`, [
@@ -158,7 +176,7 @@ export async function performHumanHandoff(
     [
       ids.tenantId,
       opts.inboxTitle ?? 'Handoff humano solicitado — assumir a conversa',
-      `Motivo: ${opts.reason}. Resumo da conversa até aqui:\n${opts.conversationSummary}`,
+      `Motivo: ${opts.reason}. ${linhaDoAviso(opts.avisoAoLead)}Resumo da conversa até aqui:\n${opts.conversationSummary}`,
       ids.leadId,
     ],
   );
@@ -200,6 +218,19 @@ export async function performHumanHandoff(
   });
 }
 
+/**
+ * A linha do aviso da Central que responde "essa pessoa sabe que estou vindo?".
+ *
+ * Ausente = o chamador não mandou aviso nenhum (caminho acionado por uma pessoa),
+ * e aí o silêncio é honesto: nada a afirmar. Presente e falso = o cliente está
+ * esperando SEM SABER, e o atendente precisa abrir a conversa se apresentando.
+ */
+function linhaDoAviso(aviso: { avisado: boolean; porque?: string } | undefined): string {
+  if (aviso === undefined) return '';
+  if (aviso.avisado) return 'O cliente JÁ FOI avisado de que uma pessoa vai assumir. ';
+  return `⚠️ O cliente NÃO foi avisado (${aviso.porque ?? 'motivo desconhecido'}) — ele está esperando sem saber. `;
+}
+
 /** Whitelist EXATA do payload da tool (mesmo padrão .strict() da F2-10/F3-02). */
 export const requestHumanHandoffInputSchema = z.strictObject({
   reason: z.string().min(1).max(500).optional(),
@@ -221,7 +252,12 @@ export type RequestHumanHandoffResult =
 export async function applyRequestHumanHandoff(
   db: pg.Pool,
   ids: HandoffIds,
-  opts: { conversationSummary: string; log: Logger },
+  opts: {
+    conversationSummary: string;
+    /** Ver `performHumanHandoff` — o desfecho do aviso vira linha no aviso da Central. */
+    avisoAoLead?: { avisado: boolean; porque?: string };
+    log: Logger;
+  },
   rawInput: unknown,
 ): Promise<RequestHumanHandoffResult> {
   const forbidden = findForbiddenKey(rawInput);
@@ -236,6 +272,7 @@ export async function applyRequestHumanHandoff(
   await performHumanHandoff(db, ids, {
     reason: parsed.data.reason ?? 'requested_human',
     conversationSummary: opts.conversationSummary,
+    ...(opts.avisoAoLead !== undefined ? { avisoAoLead: opts.avisoAoLead } : {}),
     log: opts.log,
   });
 
@@ -245,12 +282,24 @@ export async function applyRequestHumanHandoff(
   // carrega o estado real da equipe, e o modelo não precisa lembrar de perguntar.
   const { frase } = await expectativaDeAtendimento(db, ids.tenantId, new Date());
 
+  // ⚠️ A frase anterior era "encerre o turno AGORA, sem enviar mais mensagens ao
+  // lead além do aviso" — e prometia uma saída que a PRIMEIRA linha de
+  // `performHumanHandoff` acabou de fechar: `force_human = true` arma o
+  // `stopGate`, que veta todo envio seguinte. O modelo que obedecesse ao "além
+  // do aviso" mandaria uma mensagem que morre no gate, e o lead ficaria mudo.
+  // Agora a mensagem AFIRMA o que é verdade: o aviso ou já foi dele, antes da
+  // chamada, ou foi do sistema — em nenhum dos casos há uma fala a mais.
+  const jaAvisado =
+    opts.avisoAoLead === undefined || opts.avisoAoLead.avisado
+      ? 'O lead JÁ foi avisado de que uma pessoa vai assumir.'
+      : 'ATENÇÃO: não foi possível avisar o lead (o canal recusou a mensagem); a equipe foi alertada disso.';
+
   return {
     ok: true,
     status: 'handoff_solicitado',
     message:
-      `Handoff humano acionado; a conversa saiu do atendimento automático. ${frase} ` +
-      'Encerre o turno AGORA, sem enviar mais mensagens ao lead além do aviso.',
+      `Handoff humano acionado; a conversa saiu do atendimento automático. ${jaAvisado} ${frase} ` +
+      'Encerre o turno AGORA — você não consegue mais enviar mensagens a este lead.',
   };
 }
 

--- a/lib/agent-engine/agent/inbound-turn.ts
+++ b/lib/agent-engine/agent/inbound-turn.ts
@@ -58,6 +58,11 @@ import { applyLeadStateUpdate, getLeadState, type LeadStage, type LeadStateRow }
 import { applySaveLeadNote, buildNotesIndexBlock, getLeadNoteBody } from './lead-notes';
 import { applyScheduleFollowup, type FollowupWindowKnobs } from './schedule-followup';
 import {
+  avisarLeadDaEscalacao,
+  avisarLeadLendoOContato,
+  type DesfechoDoAviso,
+} from './aviso-de-escalacao';
+import {
   applyRequestHumanHandoff,
   buildHandoffSummary,
   detectAmbiguousOptOut,
@@ -218,8 +223,10 @@ export const AGENT_TOOL_DEFS = {
     description:
       'Passa a conversa para um ATENDENTE HUMANO imediatamente. Use quando o lead pedir para falar com ' +
       'uma pessoa, quando a situação exigir alguém humano (reclamação séria, questão jurídica/financeira ' +
-      'sensível) ou quando você atingir o limite do que pode resolver. Depois de acionar, o bot silencia ' +
-      'para este lead — encerre o turno sem enviar mais mensagens.',
+      'sensível) ou quando você atingir o limite do que pode resolver. ' +
+      'AVISE O LEAD ANTES: mande uma mensagem dizendo que você vai chamar alguém da equipe e SÓ ENTÃO ' +
+      'chame esta ferramenta — depois dela você não consegue mais falar com ele. Se você não avisar, ' +
+      'o sistema manda um aviso padrão no seu lugar. Acionada a ferramenta, encerre o turno.',
     // Schema LARGO para o SDK (o modelo vê o campo); a validação REAL é a whitelist .strict()
     // + guard de prototype pollution dentro de applyRequestHumanHandoff — campo extra/forjado
     // vira erro de ENSINO ao modelo, nunca exceção do SDK nem strip silencioso.
@@ -466,6 +473,15 @@ export async function comHandoffSeOrcamentoAcabar<T>(
      * — do checkpoint durável, zero LLM.
      */
     resumoDoCheckpoint: () => Promise<string>;
+    /**
+     * Avisa o lead de que uma pessoa vai assumir, ANTES do handoff.
+     *
+     * Também resolvido só no caminho de erro, e pela mesma razão do resumo: o
+     * caminho feliz não deve pagar por nada disto. O aviso é texto de CÓDIGO,
+     * então não gasta um token — o que aqui não é detalhe, é o único jeito de
+     * ele existir: o motivo do desvio é justamente não haver mais orçamento.
+     */
+    avisarLead: () => Promise<DesfechoDoAviso>;
     log: Logger;
   },
   chamada: () => Promise<T>,
@@ -475,6 +491,25 @@ export async function comHandoffSeOrcamentoAcabar<T>(
   } catch (err) {
     if (!(err instanceof LlmBudgetExceededError)) throw err;
     const resumo = await ctx.resumoDoCheckpoint();
+    // AVISA antes de silenciar — ver a nota de ORDEM no gatilho determinístico:
+    // `performHumanHandoff` arma a trava que o gate de envio lê, então a única
+    // janela em que o aviso passa é ANTES dela.
+    //
+    // O try/catch NÃO é defesa contra o emissor de hoje (`avisarLeadLendoOContato`
+    // já promete não lançar) — é contra a dependência que a ordem cria. Sem ele,
+    // um canal fora do ar faria o cliente perder o aviso E o atendente, quando o
+    // pior dos dois já teria acontecido no primeiro. Medido por
+    // `tests/unit/handoff-por-orcamento.test.ts` ("aviso que falha NÃO impede a
+    // passagem"), que reprovava a versão anterior desta linha.
+    let aviso: DesfechoDoAviso;
+    try {
+      aviso = await ctx.avisarLead();
+    } catch (erroDoAviso) {
+      ctx.log.warn('aviso ao lead falhou antes da passagem por orçamento', {
+        error: erroDoAviso instanceof Error ? erroDoAviso.message.slice(0, 200) : 'erro desconhecido',
+      });
+      aviso = { avisado: false, porque: 'erro_no_envio' };
+    }
     await performHumanHandoff(
       ctx.pool,
       { tenantId: ctx.tenantId, leadId: ctx.leadId, conversationId: ctx.conversationId },
@@ -482,10 +517,13 @@ export async function comHandoffSeOrcamentoAcabar<T>(
         reason: HANDOFF_REASON_ORCAMENTO,
         conversationSummary: `${RESUMO_DO_HANDOFF_POR_ORCAMENTO}\n\n${resumo}`,
         inboxTitle: TITULO_DO_HANDOFF_POR_ORCAMENTO,
+        avisoAoLead: aviso,
         log: ctx.log,
       },
     );
-    ctx.log.warn('turno interrompido pelo teto de gasto — conversa devolvida à fila humana');
+    ctx.log.warn('turno interrompido pelo teto de gasto — conversa devolvida à fila humana', {
+      lead_avisado: aviso.avisado,
+    });
     throw err;
   }
 }
@@ -993,6 +1031,29 @@ export async function runAgentTurn(
       conversationId: input.conversationId,
       resumoDoCheckpoint: () =>
         resumoDoCheckpointDuravel(pool, job.organization_id, leadIdDoJob, logDaEscolta),
+      // O canal nasce DENTRO da closure: instanciá-lo aqui faria todo turno feliz
+      // pagar por um adapter que só o caminho de erro usa. Sem `agentActorId` de
+      // propósito — quando o teto estoura antes da primeira chamada, não houve
+      // agente resolvido para creditar.
+      avisarLead: () =>
+        avisarLeadLendoOContato(
+          pool,
+          {
+            tenantId: job.organization_id,
+            leadId: leadIdDoJob,
+            conversationId: input.conversationId,
+            channelSessionId: input.channelSessionId,
+            jobId: job.id,
+          },
+          {
+            motivo: 'orcamento_de_ia',
+            channel: (deps.channel ?? ((p: pg.Pool) => new WahaChannelAdapter(p, deps.crmCfg)))(pool),
+            now: deps.clock?.() ?? new Date(),
+            log: logDaEscolta,
+            ...(deps.knobs.disclosureMode !== undefined ? { disclosureMode: deps.knobs.disclosureMode } : {}),
+            ...(deps.sleep !== undefined ? { sleep: deps.sleep } : {}),
+          },
+        ),
       log: logDaEscolta,
     },
     () => executarTurnoDoAgente(deps, job, pool, ctx, input),
@@ -1293,24 +1354,82 @@ async function executarTurnoDoAgente(
     throw new Error(`abertura do turno falhou em get_lead_context (${openingContext.error.code})`);
   }
 
+  // Seam de canal (F2-25): o envio vai SÓ pela interface ChannelAdapter — o
+  // default WAHA-via-CRM envolve o sink F2-06. Instanciado por job (o pool é
+  // per-job neste codebase); trocar o adapter não muda nada abaixo.
+  // Fase 2B: o envio carrega o ai_agents.id REAL como ator (audit/metadata do
+  // CRM apontam o agente publicado, não um id genérico).
+  //
+  // ⚠️ Ele nasce AQUI, e não depois da compactação como antes, porque os dois
+  // desvios determinísticos logo abaixo — pedido de humano e suspeita de
+  // opt-out — passaram a FALAR com o lead antes de silenciar. Eles rodam antes
+  // de qualquer chamada de modelo; o canal precisa existir antes deles.
+  const turnCrmCfg =
+    agentConfig !== null ? { ...deps.crmCfg, agentActorId: agentConfig.agentId } : deps.crmCfg;
+  const channel = (deps.channel ?? ((p: pg.Pool) => new WahaChannelAdapter(p, turnCrmCfg)))(pool);
+  // STOP lido no turno (fonte: CRM via get_lead_context) — combinado com o cache
+  // durável leads.is_opted_out no gate 1 da cadeia (F2-13).
+  const optedOutThisTurn = openingContext.context.contact.is_blocked;
+  // LGPD (F4-09): base legal/anonimização do CRM lidas na abertura do turno (fonte confiável,
+  // regra dura nº 1) — o gate LGPD da cadeia veta anonimizado (sempre) e 1º toque de prospecção
+  // sem base legal. Resposta a inbound (isProspecting=false) não dispara o veto de base legal.
+  const lgpd = openingContext.lgpd;
+
+  /** Argumentos fixos do aviso ao lead — os dois desvios abaixo só trocam o motivo. */
+  const avisoDaEscalacao = {
+    ids: {
+      tenantId,
+      leadId,
+      conversationId: input.conversationId,
+      channelSessionId: input.channelSessionId,
+      jobId: job.id,
+    },
+    base: {
+      channel,
+      optedOutThisTurn,
+      now: clock(),
+      log: runLog,
+      lgpd,
+      agentId: agentConfig?.agentId ?? null,
+      ...(deps.knobs.disclosureMode !== undefined ? { disclosureMode: deps.knobs.disclosureMode } : {}),
+      ...(deps.sleep !== undefined ? { sleep: deps.sleep } : {}),
+    },
+  };
+
   // F4-06 (acceptance 1): detecção DETERMINÍSTICA (regex PT-BR, sem LLM) de pedido explícito
   // de atendimento humano na última mensagem do lead. Handoff é cidadão de 1ª classe (exigência
-  // Meta fiscalizada, blueprint 5.5) — dispara ANTES do modelo: o bot silencia sem gastar LLM,
-  // sem enviar. A ação (CRM force_human + cache + cancela crons + inbox) é idempotente.
+  // Meta fiscalizada, blueprint 5.5) — dispara ANTES do modelo: o bot não gasta LLM.
+  // A ação (CRM force_human + cache + cancela crons + inbox) é idempotente.
+  //
+  // ⚠️ ORDEM: AVISA e SÓ ENTÃO silencia. Não é preferência de redação — é a única
+  // ordem que funciona. `performHumanHandoff` grava `contacts.force_human = true`,
+  // e o gate 1 da cadeia (`stopGate`) lê `(is_blocked or force_human)` DIRETO da
+  // fonte, sob o lock, a cada tentativa de envio. Avisar depois seria avisar
+  // ninguém: a própria trava que a passagem acabou de armar veta a mensagem.
   const inboundSignal = latestInboundSignal(openingContext.context.messages);
   if (
     detectHumanHandoffRequest(inboundSignal) ||
     (agentConfig !== null && matchesHandoffKeyword(inboundSignal, agentConfig.handoffKeywords))
   ) {
+    const aviso = await avisarLeadDaEscalacao(pool, avisoDaEscalacao.ids, {
+      ...avisoDaEscalacao.base,
+      motivo: 'pediu_humano',
+    });
     await performHumanHandoff(
       pool,
       { tenantId, leadId, conversationId: input.conversationId },
-      { reason: 'requested_human', conversationSummary: buildHandoffSummary(previous), log: runLog },
+      {
+        reason: 'requested_human',
+        conversationSummary: buildHandoffSummary(previous),
+        avisoAoLead: aviso,
+        log: runLog,
+      },
     );
     runLog.info('handoff humano acionado por pedido explícito do lead (detecção determinística)', {
       kind: job.kind,
+      lead_avisado: aviso.avisado,
     });
-    return; // bot silencia: sem modelo, sem envio neste turno
+    return; // bot silencia: o aviso já saiu, e nada mais sai neste turno
   }
 
   // F4-07: STOP AMBÍGUO ("para de me mandar isso", "não quero mais receber", "me tira da
@@ -1320,6 +1439,15 @@ async function executarTurnoDoAgente(
   // is_opted_out) e escala à inbox para o humano confirmar o opt-out real (is_blocked) no
   // CRM. Cancela os follow-ups agendados de tabela. Nada disso reverte (regra dura nº 2).
   if (detectAmbiguousOptOut(latestInboundSignal(openingContext.context.messages))) {
+    // O aviso daqui NÃO fala em atendente — quem pediu para parar não quer ouvir
+    // sobre atendimento (`textoDoAviso`, motivo `suspeita_de_opt_out`). Ele
+    // CONFIRMA a parada, que é o padrão de mensageria para um opt-out, e diz que
+    // uma pessoa vai conferir. Sair calado deixaria a pessoa sem saber se o
+    // pedido dela foi ouvido — e ela pediu justamente para ser ouvida.
+    const aviso = await avisarLeadDaEscalacao(pool, avisoDaEscalacao.ids, {
+      ...avisoDaEscalacao.base,
+      motivo: 'suspeita_de_opt_out',
+    });
     await performHumanHandoff(
       pool,
       { tenantId, leadId, conversationId: input.conversationId },
@@ -1327,13 +1455,15 @@ async function executarTurnoDoAgente(
         reason: 'suspected_optout',
         conversationSummary: buildHandoffSummary(previous),
         inboxTitle: 'Suspeita de opt-out — confirmar bloqueio do contato no CRM',
+        avisoAoLead: aviso,
         log: runLog,
       },
     );
     runLog.info('possível opt-out detectado no inbound — bot silenciado e escalado ao humano', {
       kind: job.kind,
+      lead_avisado: aviso.avisado,
     });
-    return; // bot silencia: sem modelo, sem envio neste turno
+    return; // bot silencia: a confirmação já saiu, e nada mais sai neste turno
   }
 
   // F3-07: compaction + flush pré-compaction. Quando o histórico cresce além do limiar,
@@ -1410,21 +1540,6 @@ async function executarTurnoDoAgente(
     });
   }
 
-  // Seam de canal (F2-25): o envio vai SÓ pela interface ChannelAdapter — o
-  // default WAHA-via-CRM envolve o sink F2-06. Instanciado por job (o pool é
-  // per-job neste codebase); trocar o adapter não muda nada abaixo.
-  // Fase 2B: o envio carrega o ai_agents.id REAL como ator (audit/metadata do
-  // CRM apontam o agente publicado, não um id genérico).
-  const turnCrmCfg =
-    agentConfig !== null ? { ...deps.crmCfg, agentActorId: agentConfig.agentId } : deps.crmCfg;
-  const channel = (deps.channel ?? ((p: pg.Pool) => new WahaChannelAdapter(p, turnCrmCfg)))(pool);
-  // STOP lido no turno (fonte: CRM via get_lead_context) — combinado com o cache
-  // durável leads.is_opted_out no gate 1 da cadeia (F2-13).
-  const optedOutThisTurn = openingContext.context.contact.is_blocked;
-  // LGPD (F4-09): base legal/anonimização do CRM lidas na abertura do turno (fonte confiável,
-  // regra dura nº 1) — o gate LGPD da cadeia veta anonimizado (sempre) e 1º toque de prospecção
-  // sem base legal. Resposta a inbound (isProspecting=false) não dispara o veto de base legal.
-  const lgpd = openingContext.lgpd;
 
   // F4-07: STOP no CRM detectado no turno → cancela TODOS os follow-ups agendados do lead
   // (não só o job atual). O stopGate já veta ESTE turno; o cancel garante que nenhum cron
@@ -2089,10 +2204,35 @@ async function executarTurnoDoAgente(
       ...AGENT_TOOL_DEFS.request_human_handoff,
       execute: async (raw) => {
         try {
+          // ═══ O PISO: se o modelo não falou, o sistema fala ═══
+          //
+          // A descrição da tool manda avisar o lead ANTES de chamá-la, e a
+          // mensagem de retorno repete. Mas capacidade que depende de o modelo
+          // LEMBRAR é capacidade que não existe metade das vezes — a mesma
+          // conclusão que fez `expectativaDeAtendimento` parar de esperar que
+          // ele consultasse a disponibilidade sozinho.
+          //
+          // `seq` é o contador de mensagens FÍSICAS já enviadas neste turno. Zero
+          // significa: o modelo decidiu passar a conversa sem dizer nada a
+          // ninguém — e depois desta tool ele não consegue mais falar, porque
+          // `force_human` arma o `stopGate`. Então o aviso determinístico sai
+          // AGORA, antes do handoff.
+          //
+          // `seq > 0` significa que ele JÁ falou neste turno; mandar o aviso ali
+          // em cima seria o robô dizendo duas vezes a mesma coisa, com palavras
+          // diferentes. Confiamos na fala dele e registramos que o piso não foi
+          // preciso.
+          const aviso =
+            seq === 0
+              ? await avisarLeadDaEscalacao(pool, avisoDaEscalacao.ids, {
+                  ...avisoDaEscalacao.base,
+                  motivo: 'pediu_humano',
+                })
+              : ({ avisado: true } as const);
           const res = await applyRequestHumanHandoff(
             pool,
             { tenantId, leadId, conversationId: input.conversationId },
-            { conversationSummary: buildHandoffSummary(previous), log: runLog },
+            { conversationSummary: buildHandoffSummary(previous), avisoAoLead: aviso, log: runLog },
             raw,
           );
           if (!res.ok) return res; // erro de ensino (payload fora da whitelist)

--- a/lib/agent-engine/guardrails/before-send.ts
+++ b/lib/agent-engine/guardrails/before-send.ts
@@ -196,6 +196,31 @@ export interface GateContext {
    * fiação nos dois sentidos: presente no `send_message`, ausente no follow-up.
    */
   internalVocabularyEnforced?: boolean;
+  /**
+   * Arma o `spinningGate`. **Ausente = ARMADO** — a direção segura aqui é a
+   * oposta do `internalVocabularyEnforced` logo acima, e a assimetria é
+   * deliberada: aquele protege o CLIENTE de uma palavra feia, este protege o
+   * NÚMERO de um banimento. Um default desarmado desligaria a proteção
+   * anti-ban em todo chamador que não conhece este campo.
+   *
+   * O único que o desarma é o AVISO DE ESCALAÇÃO
+   * (`lib/agent-engine/agent/aviso-de-escalacao.ts`), e a razão é aritmética,
+   * não preferência. `decideSpinning` conta as candidatas idênticas ou
+   * quase-idênticas (Jaccard ≥ 0,8) nas últimas `windowSize` (20) mensagens do
+   * NÚMERO — janela que cruza leads — e veta a partir da terceira
+   * (`repetitionThreshold: 2`). O aviso é texto de código: por mais variantes
+   * que tenha, a terceira pessoa a pedir um atendente na mesma janela cairia no
+   * veto, e veto ali é DROP SILENCIOSO — exatamente o silêncio que o aviso
+   * existe para acabar, produzido pelo guardrail. Medido antes de escrever esta
+   * linha: com 3 variantes, 14 de 20 avisos seguidos eram vetados
+   * (`tests/unit/aviso-ao-lead.test.ts` congela a conta).
+   *
+   * O risco de ban que isto abre é coberto do outro lado: as variantes seguem
+   * existindo (o número não repete UMA frase), o aviso é UM por escalação e
+   * responde a quem acabou de escrever — o oposto do blast de template que este
+   * gate persegue —, e ele continua contando no cap diário (`recordSend`).
+   */
+  spinningEnforced?: boolean;
 }
 
 /**
@@ -483,6 +508,10 @@ export const messagingWindowGate: Gate = {
 const spinningGate: Gate = {
   name: 'spinning',
   evaluate: (ctx) => {
+    // Desarmado explicitamente: `skipped`, nunca `pass` silencioso — a diferença
+    // entre "não vetou" e "nem chegou a olhar" é esta linha no trace (a mesma
+    // disciplina do `messagingWindowGate` com canal sem janela).
+    if (ctx.spinningEnforced === false) return { pass: true, skipped: 'not_applicable' };
     const decision = decideSpinning({
       candidate: ctx.body,
       window: ctx.spinning.window,
@@ -644,6 +673,16 @@ export interface RunBeforeSendArgs {
    */
   enforceInternalVocabulary?: boolean;
   /**
+   * Desarma o `spinningGate` para ESTA tentativa. Ausente = armado (ver
+   * `GateContext.spinningEnforced` para a razão da assimetria e para a conta que
+   * obriga o único chamador que o desarma).
+   *
+   * Desarmar também tira a candidata da JANELA: um corpo que a cadeia não julga
+   * pelo histórico não pode entrar no histórico que julga os outros. O cap
+   * diário (`recordSend`) continua valendo — o aviso é uma mensagem de verdade.
+   */
+  enforceSpinning?: boolean;
+  /**
    * Enviado SÓ se TODOS os gates passarem — ChannelAdapter (própria tx/idempotência). Recebe o
    * corpo FINAL (o disclosureGate F4-05 pode emendá-lo via `amendBody`): quem monta o send DEVE
    * enviar este `body`, não o corpo original capturado antes da cadeia.
@@ -708,6 +747,7 @@ export async function runBeforeSend(args: RunBeforeSendArgs): Promise<BeforeSend
       messagingWindow: { lastInboundAt, ...(args.isTemplate === true ? { isTemplate: true } : {}) },
       pacing: { knobs: pacingCfg.knobs, state: pacingState, crmDailyLimit: args.crmDailyLimit, rng: args.rng },
       spinning: { knobs: spinningKnobs, window },
+      ...(args.enforceSpinning === false ? { spinningEnforced: false as const } : {}),
       promise: { table: promise?.table ?? null, ...(promise?.versionId !== undefined ? { versionId: promise.versionId } : {}) },
       semanticPromise,
       disclosure: {
@@ -820,7 +860,11 @@ export async function runBeforeSend(args: RunBeforeSendArgs): Promise<BeforeSend
     // repetições curto-circuitarem, então re-registrar aqui inflaria o cap.
     if (outcome.kind === 'sent') {
       await recordSend(client, args.tenantId, args.channelSessionId, args.now);
-      await recordCopy(client, args.tenantId, args.channelSessionId, ctx.body, args.now);
+      // Simetria com o gate desarmado: quem não é julgado pela janela não entra
+      // nela. Ver `GateContext.spinningEnforced`.
+      if (args.enforceSpinning !== false) {
+        await recordCopy(client, args.tenantId, args.channelSessionId, ctx.body, args.now);
+      }
     }
     await client.query('commit');
     return { status: 'sent', outcome, trace };

--- a/lib/ai/handoff/aviso-ao-lead.ts
+++ b/lib/ai/handoff/aviso-ao-lead.ts
@@ -81,7 +81,17 @@ export async function avisarLeadDoCrm(
         actor: { type: "ai_agent", id: ATOR_DO_AVISO, role: "manager" },
         requestId: `handoff-aviso-${input.conversationId}`,
       },
-      { conversation_id: input.conversationId, type: "text", body },
+      {
+        conversation_id: input.conversationId,
+        type: "text",
+        body,
+        // A linha se DECLARA. Sem isto, no banco e na tela, este aviso é
+        // indistinguível de uma fala do agente — e ele não é: é texto de
+        // sistema, escrito em código, que sai no instante em que a IA se
+        // retira. Quem audita a conversa depois precisa saber a diferença, e
+        // quem escreve teste sobre este caminho também.
+        metadata: { aviso_de_escalacao: true, handoff_reason: input.reason },
+      },
     );
     return { avisado: true };
   } catch (err) {

--- a/lib/ai/handoff/aviso-ao-lead.ts
+++ b/lib/ai/handoff/aviso-ao-lead.ts
@@ -1,0 +1,128 @@
+/**
+ * O ENVIO do aviso de escalação — lado do CRM (`supabase-js`).
+ *
+ * ## Por que existe um segundo emissor
+ *
+ * O repo tem DOIS motores de passagem para humano, e eles não se falam:
+ *
+ *   - `performHumanHandoff` (`lib/agent-engine/agent/human-handoff.ts`) roda no
+ *     motor de conversa, sobre `pg.Pool`, dentro de um turno com job e canal;
+ *   - `triggerHandoff` (`./orchestrator.ts`) roda no mundo do CRM, sobre
+ *     `supabase-js`, disparado por evento (sentimento) ou por tool MCP — sem
+ *     job, sem `pg.Pool`, às vezes dentro de uma requisição Next.
+ *
+ * Consertar só o primeiro conserta metade do defeito. A conversa `b934ba2d`
+ * medida em produção em 2026-08-26 — a que ficou muda depois que a IA PERGUNTOU
+ * o e-mail do cliente — foi silenciada por ESTE lado, com
+ * `last_handoff_reason='low_sentiment'`.
+ *
+ * ## Por que o texto é o mesmo e o encanamento não
+ *
+ * O texto é `lib/escalacao/aviso-ao-lead.ts`, compartilhado — duas redações
+ * envelheceriam separadas. O encanamento não pode ser: `runBeforeSend` exige
+ * `pg.Pool` e um `job_id` para o ledger, e aqui não há nem um nem outro. Abrir
+ * um pool dentro de uma rota Next para mandar uma frase seria pagar caro por
+ * simetria de fachada.
+ *
+ * O que se perde sem a cadeia, dito com todas as letras: janela/throttle
+ * anti-ban, spinning, disclosure e o gate de LGPD. O que NÃO se perde é o que
+ * mais importa aqui — `sendMessageHandler` recusa contato `is_blocked` com 403
+ * (`app/api/v1/messages/_handler.ts`), que é a trava irrevogável (regra dura
+ * nº 2). E o aviso do lado do motor, esse sim, passa pela cadeia inteira.
+ *
+ * ## Ordem
+ *
+ * Chamado ANTES do UPDATE que silencia. Do lado do motor a ordem é obrigatória
+ * (o `force_human` que ele grava arma o `stopGate` e mata o envio seguinte);
+ * deste lado ela é apenas honesta — `triggerHandoff` não grava `force_human`, e
+ * o silêncio que ele grava não é lido pelo caminho de envio. Mantê-la igual nos
+ * dois evita que alguém "otimize" um deles sem perceber que no outro isso apaga
+ * a mensagem.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { sendMessageHandler } from "@/app/api/v1/messages/_handler";
+import { motivoDoAviso, textoDoAviso } from "@/lib/escalacao/aviso-ao-lead";
+import { carregarRosterDeAtendimento, podeAssumirAgora } from "@/lib/escalacao/atendentes";
+import type { QuemPodeAssumir } from "@/lib/escalacao/disponibilidade";
+import { logger } from "@/lib/logger";
+
+/** Ator do envio — é o automático falando, não uma pessoa. */
+const ATOR_DO_AVISO = "handoff-orchestrator";
+
+export interface AvisoDoCrmInput {
+  organizationId: string;
+  conversationId: string;
+  /** `contacts.id` — semente da variante do texto (nada dele aparece na frase). */
+  contactId: string;
+  /** `conversations.last_handoff_reason` que está sendo gravado agora. */
+  reason: string;
+}
+
+/**
+ * Avisa o lead. NUNCA lança: o orquestrador inteiro é fire-and-forget por
+ * contrato ("nunca propaga exceção pro caller"), e um erro aqui não pode impedir
+ * a passagem que ele antecede.
+ */
+export async function avisarLeadDoCrm(
+  admin: SupabaseClient,
+  input: AvisoDoCrmInput,
+): Promise<{ avisado: boolean; porque?: string }> {
+  try {
+    const body = textoDoAviso(
+      motivoDoAviso(input.reason),
+      await quemPodeAssumir(admin, input.organizationId),
+      input.contactId,
+    );
+    await sendMessageHandler(
+      admin,
+      {
+        organization_id: input.organizationId,
+        actor: { type: "ai_agent", id: ATOR_DO_AVISO, role: "manager" },
+        requestId: `handoff-aviso-${input.conversationId}`,
+      },
+      { conversation_id: input.conversationId, type: "text", body },
+    );
+    return { avisado: true };
+  } catch (err) {
+    // PII fora do log: só o motivo da falha.
+    const porque = err instanceof Error ? err.name : "erro_desconhecido";
+    logger.warn("[handoff-orchestrator] aviso ao lead não saiu", {
+      conversation_id: input.conversationId,
+      error: err instanceof Error ? err.message.slice(0, 200) : String(err),
+    });
+    return { avisado: false, porque };
+  }
+}
+
+
+/**
+ * Quantos podem assumir agora, no vocabulário que o texto espera.
+ *
+ * Reusa `carregarRosterDeAtendimento` + `podeAssumirAgora` — o par supabase-js
+ * que a rota do painel e a capacidade do agente já usam. Não é um terceiro
+ * leitor: é o MESMO predicado (`isAttendantEligible`) que o motor lê por `pg` em
+ * `quemPodeAssumirAgora`. Duas portas, uma régua.
+ *
+ * `null` quando a leitura falha — e `textoDoAviso` lê `null` como "não prometa
+ * prazo", que é a direção certa do erro.
+ */
+async function quemPodeAssumir(
+  admin: SupabaseClient,
+  organizationId: string,
+): Promise<QuemPodeAssumir | null> {
+  try {
+    const roster = await carregarRosterDeAtendimento(admin, organizationId);
+    const agora = new Date();
+    return {
+      total: roster.length,
+      disponiveis: roster.filter((a) => podeAssumirAgora(a, agora)).length,
+    };
+  } catch (err) {
+    logger.warn("[handoff-orchestrator] disponibilidade não lida — aviso sem prazo", {
+      organization_id: organizationId,
+      error: err instanceof Error ? err.message.slice(0, 200) : String(err),
+    });
+    return null;
+  }
+}

--- a/lib/ai/handoff/orchestrator.ts
+++ b/lib/ai/handoff/orchestrator.ts
@@ -24,6 +24,8 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
 
+import { avisarLeadDoCrm } from "./aviso-ao-lead";
+
 export type HandoffReason =
   | "requested_human"
   | "low_sentiment"
@@ -70,7 +72,7 @@ export async function triggerHandoff(
     // paralelo. Skip silenciosamente.
     const { data: convNow } = await admin
       .from("conversations")
-      .select("id, organization_id, last_handoff_at, last_handoff_reason")
+      .select("id, organization_id, contact_id, last_handoff_at, last_handoff_reason")
       .eq("id", input.conversationId)
       .eq("organization_id", input.organizationId)
       .maybeSingle();
@@ -95,6 +97,27 @@ export async function triggerHandoff(
     }
 
     const nowIso = new Date().toISOString();
+
+    // Step 0 — AVISA O LEAD. Antes de tudo, e este é o passo que faltava.
+    //
+    // Medido em produção (conversa `b934ba2d`, 2026-08-26): o agente PERGUNTOU o
+    // e-mail do cliente, o worker de sentimento disparou este caminho entre a
+    // pergunta e a resposta, e o cliente respondeu para o vazio. A passagem
+    // funcionava; a pessoa do outro lado é que não existia para o código.
+    //
+    // Precisa do `contact_id` — é a semente da variante do texto. Sem ele
+    // (conversa órfã, que a UI não mostra) seguimos sem avisar: o handoff é mais
+    // importante que o aviso, e a falta vira linha no item da Central abaixo.
+    const contactId = (convNow as unknown as { contact_id?: string | null }).contact_id ?? null;
+    const aviso =
+      contactId === null
+        ? { avisado: false, porque: "conversa_sem_contato" }
+        : await avisarLeadDoCrm(admin, {
+            organizationId: input.organizationId,
+            conversationId: input.conversationId,
+            contactId,
+            reason: input.reason,
+          });
 
     // Step 1 — flip conversation to pending + silence bot indefinitely.
     // We use 'infinity' (Postgres timestamp special) so any later comparison
@@ -208,6 +231,65 @@ export async function triggerHandoff(
         conversation_id: input.conversationId,
         error: auditErr.message,
       });
+    }
+
+    // Step 6 — o aviso na CENTRAL, para uma pessoa de verdade puxar a conversa.
+    //
+    // Faltava, e a falta era grave: este motor devolvia a conversa à fila
+    // (`status='pending'`) e silenciava a IA, mas não abria item nenhum em
+    // `agent_inbox_items` — só `performHumanHandoff` abria. O resultado é o
+    // invariante 4 do Sistema Vivo quebrado nos dois sentidos ao mesmo tempo: o
+    // cliente sem resposta E o time sem sinal de que havia alguém esperando.
+    //
+    // Dedup por episódio ABERTO, o mesmo padrão do irmão do motor: dois
+    // gatilhos disparando na mesma conversa (sentimento + termo jurídico, por
+    // exemplo) rendem UM item, não dois.
+    //
+    // A chave do dedup é a MESMA de `performHumanHandoff`
+    // (`kind='handoff'`, `ref_kind='contact'`, `ref_id=<contato>`, `status='open'`),
+    // de propósito: assim os DOIS motores deduplicam um contra o outro, e uma
+    // conversa escalada por sentimento e depois por pedido explícito não vira
+    // dois avisos para a mesma pessoa.
+    if (contactId !== null) {
+      try {
+        const { data: aberto } = await admin
+          .from("agent_inbox_items")
+          .select("id")
+          .eq("organization_id", input.organizationId)
+          .eq("kind", "handoff")
+          .eq("ref_kind", "contact")
+          .eq("ref_id", contactId)
+          .eq("status", "open")
+          .limit(1)
+          .maybeSingle();
+        if (!aberto) {
+          const { error: inboxErr } = await admin.from("agent_inbox_items").insert({
+            organization_id: input.organizationId,
+            kind: "handoff",
+            severity: "critical",
+            title: "Atendimento automático parou — assumir a conversa",
+            body:
+              `Motivo: ${input.reason}. ` +
+              (aviso.avisado
+                ? "O cliente JÁ FOI avisado de que uma pessoa vai assumir."
+                : `⚠️ O cliente NÃO foi avisado (${aviso.porque ?? "motivo desconhecido"}) — ele está esperando sem saber.`),
+            ref_kind: "contact",
+            ref_id: contactId,
+          });
+          if (inboxErr) {
+            logger.warn("[handoff-orchestrator] inbox item insert failed", {
+              conversation_id: input.conversationId,
+              error: inboxErr.message,
+            });
+          }
+        }
+      } catch (err) {
+        // Fire-and-forget como os passos 2..5: o aviso é o alerta, não a ação.
+        logger.warn("[handoff-orchestrator] inbox item skipped", {
+          conversation_id: input.conversationId,
+          error: err instanceof Error ? err.message.slice(0, 200) : String(err),
+        });
+      }
     }
 
     return { triggered: true, reason: input.reason };

--- a/lib/escalacao/aviso-ao-lead.ts
+++ b/lib/escalacao/aviso-ao-lead.ts
@@ -1,0 +1,207 @@
+/**
+ * A FRASE QUE O CLIENTE LÊ QUANDO A IA SAI DE CAMPO.
+ *
+ * ## O defeito que este arquivo existe para consertar
+ *
+ * O sistema tem duas passagens para humano, escritas por times diferentes e em
+ * mundos diferentes — `performHumanHandoff` (motor, `pg`) e `triggerHandoff`
+ * (CRM, `supabase-js`). As duas fazem a mesma coisa bem: silenciam o automático,
+ * devolvem a conversa à fila e abrem o aviso na Central. E as duas fazem a mesma
+ * coisa errada: **não dizem nada a quem está do outro lado**.
+ *
+ * Medido em produção em 2026-08-26, duas conversas reais na mesma hora:
+ *
+ *   - conversa `b934ba2d` — o cliente disse que não conseguia acessar um curso; o
+ *     agente respondeu e PERGUNTOU o e-mail dele. Entre a pergunta e a resposta,
+ *     o worker de sentimento disparou `triggerHandoff('low_sentiment')`. O cliente
+ *     mandou o e-mail às 14:51:2x e o turno foi pulado ("lead em handoff humano").
+ *     Ele respondeu uma pergunta da própria IA para o vazio.
+ *   - conversa `cdd9cbd8` — o cliente escreveu "preciso de falar com atendente".
+ *     A detecção determinística casou, `performHumanHandoff` rodou e o turno deu
+ *     `return` com o comentário "bot silencia: sem modelo, sem envio neste turno".
+ *     Silêncio absoluto.
+ *
+ * Do lado de fora as duas são a mesma coisa: a pessoa falou e ninguém respondeu.
+ * O invariante 4 da doutrina do Sistema Vivo — nenhuma demanda sem próximo passo —
+ * vale para o SISTEMA e valia; o que faltava era ele valer para a PESSOA.
+ *
+ * ## Por que o texto mora aqui, e sozinho
+ *
+ * Porque são dois emissores e um texto. Deixar cada mundo escrever a própria
+ * frase é como as sete leituras de "quem manda na conversa" divergiram
+ * (`lib/inbox/comando-da-conversa.ts`): dois lugares, duas redações, e a segunda
+ * envelhece calada. Aqui a função é PURA — comparar frase é barato, comparar
+ * linha de banco é caro — e cada mundo só a chama.
+ *
+ * ## Por que o texto muda com o MOTIVO
+ *
+ * "Vou chamar um atendente" está certo para quem pediu atendente e está ERRADO
+ * para quem pediu para parar de receber mensagem. O motivo já viaja até aqui
+ * (`conversations.last_handoff_reason`), então a frase o respeita em vez de
+ * escolher um genérico que serve mal aos dois.
+ *
+ * ## Por que o texto muda com a DISPONIBILIDADE
+ *
+ * Mesma razão de `fraseDeExpectativa` em `./disponibilidade.ts`, e a mesma
+ * fonte: prometer "alguém já vai te atender" para uma conta que não tem NINGUÉM
+ * configurado é a pior primeira impressão possível num produto self-host, e é o
+ * estado real de toda instalação recém-feita. A diferença é o destinatário —
+ * lá a frase é INSTRUÇÃO ao modelo, aqui é FALA ao cliente.
+ */
+
+import { createHash } from "node:crypto";
+
+import type { QuemPodeAssumir } from "./disponibilidade";
+
+/**
+ * Por que a IA está saindo de campo. É o mesmo vocabulário de
+ * `conversations.last_handoff_reason` — `HandoffReason` do orquestrador do CRM e
+ * o `reason` que o motor grava —, reduzido ao que MUDA A FRASE.
+ *
+ * `outro` não é preguiça: os motivos são vocabulário aberto (o atendente escreve
+ * texto livre ao escalar um caso), e um mapa exaustivo obrigaria este arquivo a
+ * conhecer cada motivo novo para não quebrar. O default é a frase honesta e
+ * genérica — nunca o silêncio.
+ */
+export type MotivoDoAviso =
+  /** O cliente pediu uma pessoa, com todas as letras. */
+  | "pediu_humano"
+  /** Suspeita de que o cliente pediu para parar de receber mensagens. */
+  | "suspeita_de_opt_out"
+  /** O teto de gasto com IA parou o atendimento automático. */
+  | "orcamento_de_ia"
+  /** O sistema decidiu escalar (sentimento, baixa confiança, etapa, termo jurídico…). */
+  | "outro";
+
+/**
+ * Traduz o `last_handoff_reason` gravado no banco para o motivo que muda a frase.
+ * Aceita `string` porque a coluna é vocabulário ABERTO — ver `MotivoDoAviso`.
+ */
+export function motivoDoAviso(reason: string): MotivoDoAviso {
+  if (reason === "requested_human") return "pediu_humano";
+  if (reason === "suspected_optout") return "suspeita_de_opt_out";
+  if (reason === "orcamento_de_ia") return "orcamento_de_ia";
+  return "outro";
+}
+
+/**
+ * ═══ POR QUE HÁ VARIANTES, E POR QUE ELAS SÃO SORTEADAS PELO LEAD ═══
+ *
+ * Porque um texto FIXO se veta sozinho. O `spinningGate` da cadeia de envio
+ * (`lib/agent-engine/spinning/engine.ts`) conta quantas das últimas 20 mensagens
+ * DAQUELE NÚMERO são idênticas ou quase (Jaccard ≥ 0,8) à candidata, e veta a
+ * partir da terceira (`SPINNING_DEFAULTS.repetitionThreshold = 2`). A janela é
+ * por `(organization_id, channel_session_id)` — ou seja, CRUZA leads. Numa
+ * central com movimento, o terceiro cliente a pedir um atendente receberia
+ * exatamente o silêncio que este arquivo existe para acabar, e pelo guardrail
+ * que existe para proteger o número.
+ *
+ * A saída é a mesma que a re-entrada determinística já usa
+ * (`pickReentryVariant`): variante escolhida por hash do lead. Mesmo lead ⇒
+ * sempre a mesma frase (nada de o cliente ver a redação mudar entre tentativas
+ * do mesmo job); leads diferentes ⇒ frases diferentes. Sem estado, sem relógio.
+ *
+ * As variantes NÃO são a mesma frase com sinônimos: um "spin" superficial não
+ * baixa o Jaccard, e o gate o pega igual. `tests/unit/aviso-ao-lead.test.ts`
+ * mede a similaridade entre TODOS os pares com a função REAL do gate — é ela
+ * que diz se as variantes são de verdade, não a nossa impressão ao lê-las.
+ */
+
+/** Aberturas por motivo. O índice sai do hash do lead — ver o bloco acima. */
+const ABERTURAS: Record<MotivoDoAviso, readonly string[]> = {
+  // Quem pediu para parar não quer ouvir sobre atendente. Confirma o que ele
+  // pediu, diz que uma pessoa vai conferir, e para. Responder ao pedido de
+  // parada é padrão de mensageria (a confirmação de opt-out), não insistência.
+  suspeita_de_opt_out: [
+    "Entendi. Vou parar de te enviar mensagens automáticas por aqui.",
+    "Certo, anotado: não mando mais nada automático para este número.",
+    "Ok! Encerro os envios automáticos deste canal agora mesmo.",
+  ],
+  pediu_humano: [
+    "Claro! Já estou chamando alguém da equipe para falar com você.",
+    "Sem problema — acabei de acionar uma pessoa do time para continuar daqui.",
+    "Perfeito. Passei sua conversa para um atendente humano agora.",
+  ],
+  orcamento_de_ia: [
+    "Vou passar seu atendimento para uma pessoa da equipe.",
+    "A partir daqui quem continua com você é alguém do time.",
+    "Estou transferindo esta conversa para um atendente humano.",
+  ],
+  outro: [
+    "Esse caso é melhor resolvido por uma pessoa. Já acionei o time.",
+    "Prefiro não arriscar aqui: passei seu pedido para um atendente humano.",
+    "Vou pedir ajuda de alguém da equipe para cuidar disso com você.",
+  ],
+};
+
+/** Fechos por estado da equipe. Mesmo sorteio, mesma razão. */
+const FECHOS = {
+  /** Ninguém configurado, ou leitura falhou: NADA de prazo. */
+  sem_equipe: [
+    "Seu pedido ficou registrado e a equipe responde assim que possível.",
+    "Deixei tudo anotado; retornamos para você assim que der.",
+    "Já registrei aqui, e alguém te responde na primeira oportunidade.",
+  ],
+  /** Tem equipe, ninguém elegível agora: nada de prazo curto. */
+  fora_de_expediente: [
+    "No momento ninguém está disponível, mas seu pedido ficou registrado.",
+    "Agora não tem ninguém livre; deixei sua solicitação anotada para o time.",
+    "Não há atendente disponível neste instante — sua conversa entrou na fila.",
+  ],
+  /** Há gente elegível: pode convidar a aguardar. */
+  com_equipe: [
+    "É só aguardar um instante aqui na conversa.",
+    "Fica por aqui que já te respondem.",
+    "Aguarde só um momento nesta conversa, por favor.",
+  ],
+} as const;
+
+/**
+ * Variante DETERMINÍSTICA por lead: sha256(lead_id) → uint32 → módulo.
+ *
+ * É a MESMA regra de `pickReentryVariant` (`lib/agent-engine/agent/reentry-template.ts`),
+ * reescrita aqui em vez de importada porque aquela vive no motor (`agent-engine`)
+ * e este módulo é dos DOIS mundos — o do CRM não pode importar do motor sem
+ * arrastar `pg` para dentro de uma rota Next.
+ */
+function variante<T>(leadId: string, opcoes: readonly T[]): T {
+  const digest = createHash("sha256").update(leadId).digest();
+  return opcoes[digest.readUInt32BE(0) % opcoes.length]!;
+}
+
+/**
+ * O que o cliente lê. Uma frase, sem jargão, sem prometer o que não se cumpre.
+ *
+ * `quem` é `null` quando a leitura de disponibilidade falhou — e aí a frase é a
+ * conservadora, pelo mesmo motivo de `expectativaDeAtendimento`: errar para o
+ * lado de prometer menos é recuperável; prometer o que não se cumpre, não.
+ *
+ * `leadId` entra SÓ como semente do sorteio — nada dele aparece no texto. O nome
+ * do contato também não: o aviso sai por um caminho determinístico, sem modelo, e
+ * uma saudação montada em código ("Oi, {nome}!") em cima de uma conversa já em
+ * andamento soa a robô — que é exatamente o que ele é, mas não precisa parecer
+ * duas vezes.
+ */
+export function textoDoAviso(
+  motivo: MotivoDoAviso,
+  quem: QuemPodeAssumir | null,
+  leadId: string,
+): string {
+  const abertura = variante(leadId, ABERTURAS[motivo]);
+
+  if (motivo === "suspeita_de_opt_out") {
+    // Sem fecho de expediente: quem pediu para parar não está esperando
+    // atendimento, então "aguarde um instante" seria a resposta errada à
+    // pergunta que ele fez.
+    return `${abertura} Encaminhei seu pedido para uma pessoa da equipe confirmar.`;
+  }
+
+  const fecho =
+    quem === null || quem.total === 0
+      ? variante(leadId, FECHOS.sem_equipe)
+      : quem.disponiveis === 0
+        ? variante(leadId, FECHOS.fora_de_expediente)
+        : variante(leadId, FECHOS.com_equipe);
+
+  return `${abertura} ${fecho}`;
+}

--- a/tests/invariants/handoff-avisa-o-lead.test.ts
+++ b/tests/invariants/handoff-avisa-o-lead.test.ts
@@ -1,0 +1,347 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import pg from "pg";
+
+import type * as InboundTurn from "@/lib/agent-engine/agent/inbound-turn";
+import type * as Providers from "@/lib/agent-engine/edge/llm/providers";
+import type * as Queue from "@/lib/agent-engine/queue/queue";
+import type * as ObsLogger from "@/lib/agent-engine/obs/logger";
+
+/**
+ * O TURNO INTEIRO, CONTRA POSTGRES DE VERDADE: quem pede um atendente RECEBE UMA
+ * RESPOSTA — e ela sai ANTES de a trava ser armada.
+ *
+ * ## O defeito, medido em produção (2026-08-26, conversa `cdd9cbd8`)
+ *
+ * O cliente escreveu "preciso de falar com atendente". A detecção determinística
+ * casou, `performHumanHandoff` rodou, e o turno deu `return` com o comentário
+ * *"bot silencia: sem modelo, sem envio neste turno"*. Do lado de fora, no
+ * WhatsApp: silêncio absoluto sobre um pedido explícito.
+ *
+ * ## Por que isto precisa de banco de verdade, e não do guarda estático
+ *
+ * `tests/unit/handoff-avisa-o-lead.test.ts` varre o AST e prova que nenhum sítio
+ * de passagem existe sem um emissor de aviso ao lado. Ele NÃO prova que a
+ * mensagem sai: um emissor cujo corpo fosse `return {avisado:false}` o
+ * satisfaria. E, principalmente, ele não prova a ORDEM contra o estado real —
+ * que é onde o conserto vive ou morre.
+ *
+ * A ordem não é preferência de redação. `performHumanHandoff` grava
+ * `contacts.force_human = true`, e o gate 1 da cadeia (`stopGate`) relê
+ * `(is_blocked or force_human)` DIRETO da fonte, sob o advisory lock, a cada
+ * tentativa de envio. **Avisar depois da passagem é avisar ninguém.** O caso
+ * "avisou ANTES de a trava existir" abaixo é o que impede alguém de "consertar"
+ * invertendo a ordem e ficando verde.
+ *
+ * ## Harness
+ *
+ * Copiado de `limite-de-envios-por-turno.test.ts`: `createInboundTurnHandler`
+ * real, canal que CAPTURA em vez de enviar, `createFakeRegistry` para o modelo,
+ * relógio fixo dentro da janela anti-ban (sem ele o `pacing` veta e a medição é
+ * do motivo errado) e `sleep` no-op.
+ *
+ * O modelo fake aqui é um CONTROLE, não um ator: se ele for chamado num turno de
+ * pedido explícito, o desvio determinístico deixou de ser determinístico.
+ */
+
+const container = process.env.TEST_DB_CONTAINER;
+if (!container) {
+  throw new Error("TEST_DB_CONTAINER not set — rode via `pnpm test:db` (scripts/test-db.sh)");
+}
+
+process.env.NEXT_PUBLIC_SUPABASE_URL ??= "https://placeholder.supabase.co";
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "placeholder-anon";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "placeholder-service";
+
+const PORT = Number(process.env.TEST_DB_PORT ?? 54329);
+const pool = new pg.Pool({
+  connectionString: `postgresql://postgres:postgres@127.0.0.1:${PORT}/postgres`,
+  max: 2,
+});
+
+const ORG = "eeee0000-0000-4000-8000-000000000001";
+const CONTACT = "eeee0000-0000-4000-8000-000000000002";
+const SESSION = "eeee0000-0000-4000-8000-000000000003";
+const CONV = "eeee0000-0000-4000-8000-000000000004";
+
+interface EnvioCapturado {
+  body: string;
+  /** `contacts.force_human` NO INSTANTE do envio — a prova da ordem. */
+  forceHumanNoEnvio: boolean;
+}
+
+type Modules = {
+  createInboundTurnHandler: typeof InboundTurn.createInboundTurnHandler;
+  queue: typeof Queue;
+  createLogger: typeof ObsLogger.createLogger;
+  createFakeRegistry: typeof Providers.createFakeRegistry;
+};
+let m: Modules;
+
+let enviados: EnvioCapturado[] = [];
+let modeloChamado = 0;
+
+const USO = {
+  inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 1, text: 1, reasoning: 0 },
+};
+
+/**
+ * Modelo de CONTROLE: encerra o turno com um checkpoint válido e conta quantas
+ * vezes foi chamado. Num turno de pedido explícito ele tem de ficar em ZERO.
+ */
+function modeloDeControle() {
+  return async () => {
+    modeloChamado += 1;
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            commitments: [],
+            objections: [],
+            next_action: null,
+            rolling_summary: "turno de teste",
+          }),
+        },
+      ],
+      finishReason: { unified: "stop" as const, raw: undefined },
+      usage: USO,
+      warnings: [],
+    };
+  };
+}
+
+function montaHandler() {
+  return m.createInboundTurnHandler({
+    crmCfg: { supabase: {} as never },
+    llmCfg: { anthropicApiKey: "fake" } as never,
+    knobs: {
+      historyLimit: 10,
+      maxContextTokens: 1000,
+      notesIndexMaxTokens: 500,
+      maxSteps: 12,
+      queuedRetryDelayMs: 1000,
+      breaker: {
+        exactFailureWarn: 2,
+        exactFailureBlock: 5,
+        sameToolFailureWarn: 3,
+        sameToolFailureHalt: 8,
+        noProgressWarn: 3,
+        noProgressBlock: 5,
+      },
+    },
+    log: m.createLogger(),
+    registry: m.createFakeRegistry(modeloDeControle() as never),
+    channel: () =>
+      ({
+        channel: "captura",
+        send: async (i: { body: string }) => {
+          // A leitura acontece DENTRO do envio, contra o banco: é o instante
+          // exato em que a pergunta "a trava já está armada?" tem resposta.
+          const { rows } = await pool.query<{ force_human: boolean }>(
+            "select force_human from contacts where id = $1",
+            [CONTACT],
+          );
+          enviados.push({ body: i.body, forceHumanNoEnvio: rows[0]?.force_human === true });
+          return {
+            kind: "sent" as const,
+            idempotencyKey: `k${enviados.length}`,
+            messageId: `m${enviados.length}`,
+          };
+        },
+        sessionHealth: async () => ({ healthy: true, status: "WORKING" }),
+        capabilities: () => ({ freeform: true, media: true, audio: true }),
+        costPerMessage: () => ({ currency: "BRL", cents: 0 }),
+      }) as never,
+    // Terça, 15h BRT: dentro da janela anti-ban (7h-22h). Sem isto o gate
+    // `pacing` vetaria por horário e o arquivo mediria o motivo errado — o
+    // mesmo cuidado de `limite-de-envios-por-turno.test.ts`.
+    clock: () => new Date("2026-07-28T18:00:00Z"),
+    sleep: async () => {},
+  });
+}
+
+/** Grava um inbound e roda UM turno completo por cima dele. */
+async function rodaTurnoCom(texto: string): Promise<void> {
+  const msgId = crypto.randomUUID();
+  await pool.query(
+    `insert into messages (id, organization_id, conversation_id, channel_session_id, contact_id,
+       type, direction, status, body, sent_via, sent_at)
+     values ($1,$2,$3,$4,$5,'text','inbound','delivered',$6,'external_device', now())`,
+    [msgId, ORG, CONV, SESSION, CONTACT, texto],
+  );
+  await pool.query("update job_queue set status = 'done' where status = 'pending'");
+  const { job } = await m.queue.enqueueJob(pool, ORG, {
+    kind: "inbound_turn",
+    leadId: CONTACT,
+    payload: {
+      conversation_id: CONV,
+      contact_id: CONTACT,
+      channel_session_id: SESSION,
+      inbound_message_id: msgId,
+      crm_event_id: crypto.randomUUID(),
+    },
+    maxAttempts: 1,
+  });
+  const [claimed] = await m.queue.claimJobs(pool, { workerId: "aviso", maxConcurrency: 1 });
+  expect(claimed?.id).toBe(job.id);
+  try {
+    await montaHandler()(claimed!, pool, { workerId: "aviso" });
+    await m.queue.completeJob(pool, claimed!.id, "aviso");
+  } catch (err) {
+    await m.queue.failJob(pool, claimed!.id, "aviso", err);
+    throw err;
+  }
+}
+
+beforeAll(async () => {
+  m = {
+    createInboundTurnHandler: (await import("@/lib/agent-engine/agent/inbound-turn"))
+      .createInboundTurnHandler,
+    queue: await import("@/lib/agent-engine/queue/queue"),
+    createLogger: (await import("@/lib/agent-engine/obs/logger")).createLogger,
+    createFakeRegistry: (await import("@/lib/agent-engine/edge/llm/providers")).createFakeRegistry,
+  };
+
+  await pool.query(
+    `insert into organizations (id, slug, legal_name, display_name)
+     values ($1,'handoff-avisa','Handoff Avisa','Handoff Avisa') on conflict (id) do nothing`,
+    [ORG],
+  );
+  await pool.query(
+    `insert into channel_sessions (id, organization_id, waha_session_name, status, webhook_secret_encrypted)
+     values ($1,$2,'handoff-avisa-session','WORKING','\\x00'::bytea) on conflict (id) do nothing`,
+    [SESSION, ORG],
+  );
+  // Camada `platform` do playbook: o ritual de abertura recusa o turno sem ela
+  // ("publique uma versão platform e aponte antes do primeiro run"). Mesma
+  // semente de `limite-de-envios-por-turno.test.ts`.
+  await pool.query(
+    `with v as (
+       insert into playbook_versions (organization_id, layer, content)
+       select null, 'platform', E'## Identidade\nAssistente de teste.'
+       where not exists (select 1 from playbook_pointers where organization_id is null and layer = 'platform')
+       returning id)
+     insert into playbook_pointers (organization_id, layer, version_id)
+     select null, 'platform', id from v`,
+  );
+});
+
+beforeEach(async () => {
+  enviados = [];
+  modeloChamado = 0;
+  // Estado limpo a cada caso: `force_human` é IRREVOGÁVEL em produção, então um
+  // caso herdando a trava do anterior mediria o turno pulado, não o desvio.
+  await pool.query("delete from messages where organization_id = $1", [ORG]);
+  await pool.query("delete from send_ledger where organization_id = $1", [ORG]);
+  await pool.query("delete from outbound_copies where organization_id = $1", [ORG]);
+  await pool.query("delete from agent_inbox_items where organization_id = $1", [ORG]);
+  await pool.query("delete from conversations where organization_id = $1", [ORG]);
+  await pool.query("delete from contacts where organization_id = $1", [ORG]);
+  await pool.query(
+    `insert into contacts (id, organization_id, name, phone_number, force_human)
+     values ($1,$2,'Lead que pede humano','+5511900000777', false)`,
+    [CONTACT, ORG],
+  );
+  await pool.query(
+    `insert into conversations (id, organization_id, contact_id, channel_session_id, status, is_group)
+     values ($1,$2,$3,$4,'ai_handling',false)`,
+    [CONV, ORG, CONTACT, SESSION],
+  );
+});
+
+describe("pedido explícito de atendente", () => {
+  it("o lead RECEBE uma resposta — e ela não é vazia", async () => {
+    await rodaTurnoCom("preciso de falar com atendente");
+    expect(
+      enviados.map((e) => e.body),
+      "o defeito original: pedido explícito de humano e ZERO mensagens ao lead",
+    ).toHaveLength(1);
+    expect(enviados[0]!.body.length).toBeGreaterThan(20);
+  });
+
+  it("o aviso saiu ANTES de a trava ser armada", async () => {
+    // A asserção que impede o conserto de ser invertido. Com `force_human` já
+    // gravado, o `stopGate` vetaria este mesmo envio — e o veto é mudo.
+    await rodaTurnoCom("preciso de falar com atendente");
+    expect(enviados[0]!.forceHumanNoEnvio, "avisou depois de armar a trava que veta o aviso").toBe(
+      false,
+    );
+    const { rows } = await pool.query<{ force_human: boolean }>(
+      "select force_human from contacts where id = $1",
+      [CONTACT],
+    );
+    expect(rows[0]!.force_human, "a passagem não aconteceu — o teste mediu outra coisa").toBe(true);
+  });
+
+  it("nenhum token gasto: o desvio segue determinístico", async () => {
+    await rodaTurnoCom("preciso de falar com atendente");
+    expect(modeloChamado, "o desvio passou a chamar o modelo — custo por pedido de humano").toBe(0);
+  });
+
+  it("a conversa é devolvida à fila humana e silenciada", async () => {
+    await rodaTurnoCom("preciso de falar com atendente");
+    const { rows } = await pool.query<{ status: string; silencio: string | null; motivo: string | null }>(
+      `select status, bot_silenced_until::text as silencio, last_handoff_reason as motivo
+         from conversations where id = $1`,
+      [CONV],
+    );
+    expect(rows[0]!.status).toBe("pending");
+    expect(rows[0]!.silencio).toBe("infinity");
+    expect(rows[0]!.motivo).toBe("requested_human");
+  });
+
+  it("a Central registra que o cliente FOI avisado", async () => {
+    // O que muda a primeira frase que o atendente digita ao abrir a conversa.
+    await rodaTurnoCom("preciso de falar com atendente");
+    const { rows } = await pool.query<{ body: string }>(
+      "select body from agent_inbox_items where organization_id = $1 and kind = 'handoff'",
+      [ORG],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.body).toMatch(/JÁ FOI avisado/u);
+  });
+
+  /**
+   * GUARDA DE VACUIDADE. Sem ela, "exatamente 1 envio" poderia ser verdade por o
+   * harness nunca ter chegado ao desvio — e o arquivo inteiro estaria medindo o
+   * nada com cinco asserções verdes.
+   */
+  it("controle: inbound NEUTRO não dispara passagem nenhuma", async () => {
+    await rodaTurnoCom("bom dia, qual o horário de vocês?");
+    const { rows } = await pool.query<{ force_human: boolean }>(
+      "select force_human from contacts where id = $1",
+      [CONTACT],
+    );
+    expect(rows[0]!.force_human, "mensagem comum virou passagem para humano").toBe(false);
+    expect(modeloChamado, "turno normal não chamou o modelo — o harness não rodou").toBeGreaterThan(0);
+  });
+
+  /**
+   * O SEGUNDO turno do mesmo lead: já em handoff, o turno é NO-OP e não pode
+   * mandar um segundo aviso. Sem este caso, um lead que insistisse receberia o
+   * mesmo texto a cada mensagem.
+   */
+  it("lead já em handoff não recebe aviso de novo", async () => {
+    await rodaTurnoCom("preciso de falar com atendente");
+    expect(enviados).toHaveLength(1);
+    enviados = [];
+    await rodaTurnoCom("e aí, alguém aí?");
+    expect(enviados, "o aviso repetiu a cada mensagem do lead já escalado").toHaveLength(0);
+  });
+});
+
+describe("suspeita de opt-out", () => {
+  it("recebe confirmação da parada, e ela não oferece atendente", async () => {
+    await rodaTurnoCom("não quero mais receber mensagens de vocês");
+    expect(enviados).toHaveLength(1);
+    expect(enviados[0]!.body).toMatch(/parar|encerro|não mando/iu);
+    expect(enviados[0]!.body).not.toMatch(/atendente/iu);
+    expect(enviados[0]!.forceHumanNoEnvio, "confirmou depois de armar a trava").toBe(false);
+    const { rows } = await pool.query<{ motivo: string | null }>(
+      "select last_handoff_reason as motivo from conversations where id = $1",
+      [CONV],
+    );
+    expect(rows[0]!.motivo).toBe("suspected_optout");
+  });
+});

--- a/tests/unit/ai-response-worker-sent-via.test.ts
+++ b/tests/unit/ai-response-worker-sent-via.test.ts
@@ -234,7 +234,16 @@ function prepararWorker(confidenceThreshold: number): LinhaInserida[] {
 
 function mensagemOutbound(inserted: LinhaInserida[]): Record<string, unknown> {
   const linhas = inserted.filter(
-    (i) => i.table === "messages" && i.row["direction"] === "outbound",
+    (i) =>
+      i.table === "messages" &&
+      i.row["direction"] === "outbound" &&
+      // O AVISO DE ESCALAÇÃO não é rascunho do bot: é texto de sistema que
+      // `triggerHandoff` manda ao lead ao tirar a IA de campo, e ele nasce
+      // marcado (`metadata.aviso_de_escalacao`). Sem este corte, o caso de
+      // handoff G3 passa a ver DUAS linhas outbound e a guarda anti-vacuidade
+      // abaixo reprova por um motivo que não é o deste arquivo — que é o
+      // `sent_via` do RASCUNHO caber na constraint do banco.
+      (i.row["metadata"] as Record<string, unknown> | null)?.["aviso_de_escalacao"] !== true,
   );
   // Anti-vacuidade: se o pipeline desviou antes do insert, não há o que
   // asseverar e o teste passaria à toa.

--- a/tests/unit/aviso-ao-lead.test.ts
+++ b/tests/unit/aviso-ao-lead.test.ts
@@ -1,0 +1,203 @@
+/**
+ * A FRASE QUE O CLIENTE LÊ QUANDO A IA SAI DE CAMPO — e a conta que a mantém viva.
+ *
+ * O defeito que este arquivo prende foi MEDIDO em produção, não deduzido
+ * (2026-08-26, duas conversas na mesma hora): as duas passagens para humano do
+ * repo silenciavam o automático sem dizer nada a quem estava do outro lado. Numa
+ * delas o agente tinha acabado de PERGUNTAR o e-mail do cliente; ele respondeu
+ * para o vazio.
+ *
+ * Há três coisas a prender aqui, e só a primeira é óbvia:
+ *
+ *   1. o texto certo para cada motivo e cada estado da equipe;
+ *   2. que quem pediu para PARAR não recebe oferta de atendente;
+ *   3. **a conta do spinning** — a que reprovou a primeira versão do conserto.
+ *      `decideSpinning` veta a candidata quando ela é idêntica ou quase (Jaccard
+ *      ≥ 0,8) a 2+ das últimas 20 mensagens DAQUELE NÚMERO, janela que cruza
+ *      leads. Com texto fixo, o terceiro cliente a pedir um atendente na mesma
+ *      janela receberia silêncio — pelo guardrail. O caso `pior caso real`
+ *      abaixo mede isso com a função REAL do gate, e é ele que justifica o
+ *      `enforceSpinning: false` em `aviso-de-escalacao.ts`.
+ */
+import { createHash, randomUUID } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  motivoDoAviso,
+  textoDoAviso,
+  type MotivoDoAviso,
+} from "@/lib/escalacao/aviso-ao-lead";
+import type { QuemPodeAssumir } from "@/lib/escalacao/disponibilidade";
+import {
+  decideSpinning,
+  hashNormalized,
+  normalizeCopy,
+} from "@/lib/agent-engine/spinning/engine";
+import { SPINNING_DEFAULTS } from "@/lib/agent-engine/spinning/defaults";
+
+/** Lead fixo — o sorteio de variante é por hash, então o texto é reprodutível. */
+const LEAD = "11111111-1111-4111-8111-111111111111";
+
+const MOTIVOS: MotivoDoAviso[] = [
+  "pediu_humano",
+  "suspeita_de_opt_out",
+  "orcamento_de_ia",
+  "outro",
+];
+const ESTADOS: Array<{ rotulo: string; quem: QuemPodeAssumir | null }> = [
+  { rotulo: "leitura falhou", quem: null },
+  { rotulo: "instalação fresca", quem: { disponiveis: 0, total: 0 } },
+  { rotulo: "fora de expediente", quem: { disponiveis: 0, total: 3 } },
+  { rotulo: "com gente livre", quem: { disponiveis: 2, total: 3 } },
+];
+
+describe("motivoDoAviso traduz o que o banco grava", () => {
+  it("mapeia os motivos que mudam a frase", () => {
+    expect(motivoDoAviso("requested_human")).toBe("pediu_humano");
+    expect(motivoDoAviso("suspected_optout")).toBe("suspeita_de_opt_out");
+    expect(motivoDoAviso("orcamento_de_ia")).toBe("orcamento_de_ia");
+  });
+
+  it("vocabulário ABERTO cai em 'outro', nunca em erro", () => {
+    // `last_handoff_reason` recebe texto livre do atendente ao escalar um caso.
+    // Um mapa exaustivo obrigaria este módulo a conhecer cada motivo novo para
+    // não quebrar — e o desfecho de "não conheço" tem de ser a frase honesta.
+    expect(motivoDoAviso("low_sentiment")).toBe("outro");
+    expect(motivoDoAviso("legal_mention")).toBe("outro");
+    expect(motivoDoAviso("preciso que o financeiro veja isso")).toBe("outro");
+    expect(motivoDoAviso("")).toBe("outro");
+  });
+});
+
+describe("o texto respeita o estado REAL da equipe", () => {
+  it("instalação sem ninguém configurado: registra, não promete prazo", () => {
+    const t = textoDoAviso("pediu_humano", { disponiveis: 0, total: 0 }, LEAD);
+    expect(t).toMatch(/registr|anotad|primeira oportunidade/i);
+    expect(t).not.toMatch(/aguard/i);
+  });
+
+  it("leitura falhou é tratado como 'não sei' — mesma cautela", () => {
+    const semLeitura = textoDoAviso("pediu_humano", null, LEAD);
+    const semEquipe = textoDoAviso("pediu_humano", { disponiveis: 0, total: 0 }, LEAD);
+    expect(semLeitura).toBe(semEquipe);
+  });
+
+  it("equipe existe mas ninguém livre: não convida a aguardar", () => {
+    const t = textoDoAviso("pediu_humano", { disponiveis: 0, total: 3 }, LEAD);
+    expect(t).toMatch(/ninguém|não há atendente/i);
+    expect(t).not.toMatch(/aguarde só um momento|é só aguardar/i);
+  });
+
+  it("com gente livre: convida a aguardar na conversa", () => {
+    const t = textoDoAviso("pediu_humano", { disponiveis: 2, total: 3 }, LEAD);
+    expect(t).toMatch(/aguard|fica por aqui/i);
+  });
+
+  it("os três estados produzem fechos DIFERENTES", () => {
+    // Sem este caso, três ramos colapsados num texto só passariam calados.
+    const fechos = new Set(
+      ESTADOS.filter((e) => e.rotulo !== "leitura falhou").map((e) =>
+        textoDoAviso("pediu_humano", e.quem, LEAD),
+      ),
+    );
+    expect(fechos.size).toBe(3);
+  });
+});
+
+describe("quem pediu para PARAR não recebe oferta de atendimento", () => {
+  it("confirma a parada e não fala em atendente, fila nem espera", () => {
+    for (const estado of ESTADOS) {
+      const t = textoDoAviso("suspeita_de_opt_out", estado.quem, LEAD);
+      expect(t, estado.rotulo).toMatch(/parar|encerro|não mando/i);
+      expect(t, estado.rotulo).not.toMatch(/atendente/i);
+      expect(t, estado.rotulo).not.toMatch(/aguard|fila/i);
+    }
+  });
+
+  it("o estado da equipe NÃO muda a frase de opt-out", () => {
+    // Ela responde ao pedido da pessoa, não ao expediente do time. Se um fecho
+    // de disponibilidade vazasse para cá, o texto viraria "não te mando mais
+    // nada… aguarde um instante", que é contraditório.
+    const textos = new Set(ESTADOS.map((e) => textoDoAviso("suspeita_de_opt_out", e.quem, LEAD)));
+    expect(textos.size).toBe(1);
+  });
+});
+
+describe("o aviso é determinístico por lead e variado entre leads", () => {
+  it("mesmo lead, mesma frase — sempre", () => {
+    const a = textoDoAviso("pediu_humano", { disponiveis: 1, total: 1 }, LEAD);
+    const b = textoDoAviso("pediu_humano", { disponiveis: 1, total: 1 }, LEAD);
+    expect(a).toBe(b);
+  });
+
+  /**
+   * ⚠️ A primeira versão deste caso pedia `> 1` texto distinto só em
+   * `pediu_humano` com equipe livre — e passava VERDE com as variantes de
+   * abertura apagadas, porque o FECHO variava sozinho. Sabotagem medida: removi
+   * as três aberturas e o arquivo seguiu 14/14.
+   *
+   * A propriedade que importa não é "o array tem N itens", é **o número não
+   * repete UMA frase para todo mundo** — e ela vale para TODO par
+   * (motivo, estado), inclusive o de opt-out, cujo fecho é fixo por desenho e
+   * portanto só varia se a abertura variar. É este `every` que fecha o buraco.
+   */
+  it("todo motivo, em todo estado, produz ao menos 3 redações entre leads", () => {
+    for (const motivo of MOTIVOS) {
+      for (const estado of ESTADOS) {
+        const textos = new Set(
+          Array.from({ length: 60 }, () => textoDoAviso(motivo, estado.quem, randomUUID())),
+        );
+        expect(textos.size, `${motivo} / ${estado.rotulo}`).toBeGreaterThanOrEqual(3);
+      }
+    }
+  });
+
+  it("nada do id do lead aparece no texto", () => {
+    const id = "abc12345-dead-4beef-8888-000000000001";
+    const t = textoDoAviso("outro", null, id);
+    expect(t).not.toContain(id);
+    expect(t).not.toContain(createHash("sha256").update(id).digest("hex").slice(0, 8));
+  });
+});
+
+describe("a conta do spinning — por que o gate é desarmado para o aviso", () => {
+  /**
+   * Simula N escalações seguidas no MESMO número, leads diferentes, e conta
+   * quantos avisos o `spinningGate` vetaria se estivesse armado. É a função
+   * real do gate, com os knobs default de produção.
+   */
+  function vetadosComOGateArmado(motivo: MotivoDoAviso, quem: QuemPodeAssumir | null, n: number) {
+    const janela: Array<{ normalizedText: string; normalizedHash: string }> = [];
+    let vetados = 0;
+    for (let i = 0; i < n; i++) {
+      const body = textoDoAviso(motivo, quem, `lead-${i}-${LEAD}`);
+      if (!decideSpinning({ candidate: body, window: janela, knobs: SPINNING_DEFAULTS }).allow) {
+        vetados += 1;
+      }
+      const norm = normalizeCopy(body);
+      janela.unshift({ normalizedText: norm, normalizedHash: hashNormalized(norm) });
+    }
+    return vetados;
+  }
+
+  it("o aviso NÃO é curto o bastante para a isenção automática do gate", () => {
+    // `isAllowlisted` isenta corpo com até `allowlistMaxLength` caracteres. Se o
+    // aviso coubesse ali, o desarme explícito seria supérfluo — e alguém o
+    // removeria. Ele não cabe, e é esta linha que prova.
+    for (const m of MOTIVOS) {
+      const t = normalizeCopy(textoDoAviso(m, null, LEAD));
+      expect(t.length, m).toBeGreaterThan(SPINNING_DEFAULTS.allowlistMaxLength);
+    }
+  });
+
+  it("com o gate ARMADO, a maioria dos avisos seguidos morreria calada", () => {
+    // ISTO é o motivo de `enforceSpinning: false`. Não é hipótese: a primeira
+    // versão do conserto tinha só as variantes, e esta conta a reprovou.
+    // Se um dia a contagem cair a zero (mais variantes, outros knobs), o
+    // desarme pode ser reavaliado — e este teste vermelhecendo é o convite.
+    for (const m of MOTIVOS) {
+      expect(vetadosComOGateArmado(m, null, 20), m).toBeGreaterThan(5);
+    }
+  });
+});

--- a/tests/unit/handoff-avisa-o-lead.test.ts
+++ b/tests/unit/handoff-avisa-o-lead.test.ts
@@ -1,0 +1,347 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+/**
+ * NENHUMA PASSAGEM PARA HUMANO SAI CALADA.
+ *
+ * ─── O defeito, medido em produção (2026-08-26) ─────────────────────────────
+ *
+ * Duas conversas reais, na mesma hora, nos DOIS motores de passagem do repo:
+ *
+ *   `cdd9cbd8` — o cliente escreveu "preciso de falar com atendente". A detecção
+ *     determinística casou, `performHumanHandoff` rodou e o turno deu `return`
+ *     com o comentário "bot silencia: sem modelo, sem envio neste turno".
+ *   `b934ba2d` — o agente PERGUNTOU o e-mail do cliente; entre a pergunta e a
+ *     resposta, o worker de sentimento disparou `triggerHandoff('low_sentiment')`.
+ *     O cliente respondeu para o vazio.
+ *
+ * Do lado de fora as duas são a mesma coisa: a pessoa falou e ninguém respondeu.
+ *
+ * ─── Por que a guarda é ESTÁTICA, e por que ela varre DOIS mundos ───────────
+ *
+ * Porque o defeito é de CLASSE. Consertar os dois sítios que apareceram nos
+ * screenshots deixaria o terceiro (teto de gasto), o quarto (escalação de caso)
+ * e o quinto — o que alguém acrescentar amanhã — nascendo mudos, e o modo de
+ * falha é o pior que existe: nada quebra, ninguém vê, o cliente some.
+ *
+ * A varredura cobre os DOIS emissores de silêncio, que vivem em mundos de banco
+ * diferentes e por isso nunca se encontram numa busca só:
+ *   - `performHumanHandoff` — motor de conversa, `pg.Pool`;
+ *   - `triggerHandoff`      — CRM, `supabase-js`.
+ *
+ * AST, nunca regex: a prosa deste repositório cita esses dois nomes o tempo
+ * todo — este próprio cabeçalho é a prova — e um regex acusaria o arquivo por
+ * ele falar de si mesmo.
+ *
+ * ─── O que a guarda NÃO prova ──────────────────────────────────────────────
+ *
+ * Que o aviso CHEGA. Isso é comportamento sobre banco e canal, e mora em
+ * `tests/invariants/handoff-avisa-o-lead.test.ts`. Aqui se prova só que nenhum
+ * sítio de passagem existe sem um emissor de aviso ao lado — o que é
+ * exatamente a classe que o conserto por instância deixa escapar.
+ */
+
+const RAIZ = join(__dirname, "..", "..");
+
+/**
+ * O motor cujo aviso mora no CHAMADOR — e por que ele mora lá.
+ *
+ * `performHumanHandoff` recebe `pg.Pool` e ids, e mais nada: não conhece canal,
+ * job nem sessão, que é justamente o que enviar exige. Pôr o envio dentro dele
+ * obrigaria todos os seus chamadores — inclusive os testes de invariante e o
+ * seed de e2e, que o chamam com pool e logger — a montar um canal só para
+ * silenciar uma conversa. O aviso é do chamador, e é esta guarda que o cobra.
+ *
+ * O outro motor, `triggerHandoff`, faz o contrário: o aviso mora DENTRO dele
+ * (`Step 0`), porque ele monta o próprio client e seus quatro chamadores não
+ * têm contexto nenhum a oferecer. Ver a asserção dedicada mais abaixo.
+ */
+const PASSAGENS = ["performHumanHandoff"] as const;
+
+/** Os emissores de aviso — um por mundo de acesso a banco. */
+const AVISOS = ["avisarLeadDaEscalacao", "avisarLeadLendoOContato", "avisarLeadDoCrm"] as const;
+
+/**
+ * Arquivos que EXECUTAM uma passagem. Não é a lista de quem a menciona: é a de
+ * quem a chama. Um arquivo novo que chame e não esteja aqui é pego pelo caso
+ * "o universo não encolheu" no fim.
+ */
+const FONTES = [
+  "lib/agent-engine/agent/inbound-turn.ts",
+  "lib/agent-engine/agent/human-handoff.ts",
+  "lib/ai/handoff/orchestrator.ts",
+  "app/api/v1/ai/cases/[id]/reply/route.ts",
+] as const;
+
+/**
+ * Sítios de passagem SEM aviso, no fonte dado.
+ *
+ * A regra: uma chamada a `performHumanHandoff`/`triggerHandoff` está coberta
+ * quando um emissor de aviso é chamado ANTES dela **no mesmo corpo de função**.
+ * "Antes" é por posição no fonte — a ordem textual dentro de um bloco `async` é
+ * a ordem de execução, e é justamente ela que o conserto precisa garantir
+ * (avisar depois do handoff é avisar ninguém: `force_human` já armou o gate).
+ *
+ * `applyRequestHumanHandoff` é o wrapper da tool: ele CHAMA `performHumanHandoff`
+ * e recebe o desfecho do aviso pelo parâmetro `avisoAoLead`, que quem o chama
+ * preencheu. Um sítio cujo objeto de opções carrega `avisoAoLead` está, por
+ * construção, avisado — então ele também conta como coberto.
+ */
+export function passagensSemAviso(fonte: string, nomeDoArquivo: string): number[] {
+  const arquivo = ts.createSourceFile(nomeDoArquivo, fonte, ts.ScriptTarget.Latest, true);
+  const linhaDe = (pos: number) => arquivo.getLineAndCharacterOfPosition(pos).line + 1;
+
+  const nomeDaChamada = (no: ts.Node): string | null => {
+    if (!ts.isCallExpression(no)) return null;
+    if (ts.isIdentifier(no.expression)) return no.expression.text;
+    if (ts.isPropertyAccessExpression(no.expression)) return no.expression.name.text;
+    return null;
+  };
+
+  /** O corpo de função que contém o nó — a fronteira do "mesmo bloco". */
+  const corpoQueContem = (no: ts.Node): ts.Node => {
+    let atual: ts.Node | undefined = no.parent;
+    while (atual !== undefined) {
+      if (
+        ts.isFunctionDeclaration(atual) ||
+        ts.isFunctionExpression(atual) ||
+        ts.isArrowFunction(atual) ||
+        ts.isMethodDeclaration(atual)
+      ) {
+        return atual;
+      }
+      atual = atual.parent;
+    }
+    return arquivo;
+  };
+
+  /**
+   * O objeto de opções desta chamada carrega `avisoAoLead`?
+   *
+   * A busca é na SUBÁRVORE do argumento, não nas propriedades diretas: o
+   * wrapper da tool repassa o desfecho por spread condicional
+   * (`...(opts.avisoAoLead !== undefined ? { avisoAoLead } : {})`), e uma
+   * checagem só de propriedade direta o acusaria de mudo — sendo que ele é
+   * exatamente o caminho que carrega o desfecho de quem o chamou.
+   */
+  const declaraDesfecho = (no: ts.CallExpression): boolean =>
+    no.arguments.some((arg) => {
+      let achou = false;
+      const olhar = (n: ts.Node): void => {
+        if (ts.isIdentifier(n) && n.text === "avisoAoLead") achou = true;
+        ts.forEachChild(n, olhar);
+      };
+      olhar(arg);
+      return achou;
+    });
+
+  const avisos: Array<{ corpo: ts.Node; pos: number }> = [];
+  const passagens: Array<{ corpo: ts.Node; pos: number; no: ts.CallExpression }> = [];
+
+  const visitar = (no: ts.Node): void => {
+    const nome = nomeDaChamada(no);
+    if (nome !== null && ts.isCallExpression(no)) {
+      if ((AVISOS as readonly string[]).includes(nome)) {
+        avisos.push({ corpo: corpoQueContem(no), pos: no.getStart(arquivo) });
+      } else if ((PASSAGENS as readonly string[]).includes(nome)) {
+        passagens.push({ corpo: corpoQueContem(no), pos: no.getStart(arquivo), no });
+      }
+    }
+    ts.forEachChild(no, visitar);
+  };
+  visitar(arquivo);
+
+  return passagens
+    .filter((p) => {
+      if (declaraDesfecho(p.no)) return false;
+      return !avisos.some((a) => a.corpo === p.corpo && a.pos < p.pos);
+    })
+    .map((p) => linhaDe(p.pos));
+}
+
+function ler(rel: string): string {
+  return readFileSync(join(RAIZ, rel), "utf8");
+}
+
+describe("toda passagem para humano avisa o lead antes", () => {
+  for (const rel of FONTES) {
+    it(`${rel}: nenhuma passagem sem aviso`, () => {
+      expect(passagensSemAviso(ler(rel), rel)).toEqual([]);
+    });
+  }
+
+  /**
+   * Controle POSITIVO. Sem ele, um bug no localizador (nome trocado, AST mal
+   * percorrido) devolveria `[]` para tudo e o arquivo inteiro ficaria verde
+   * medindo nada — o modo de falha nº 1 de guarda por varredura.
+   */
+  it("controle positivo: o instrumento ENXERGA os sítios que existem", () => {
+    const arquivo = ts.createSourceFile(
+      "controle.ts",
+      ler("lib/agent-engine/agent/inbound-turn.ts"),
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    let vistos = 0;
+    const visitar = (no: ts.Node): void => {
+      if (
+        ts.isCallExpression(no) &&
+        ts.isIdentifier(no.expression) &&
+        (PASSAGENS as readonly string[]).includes(no.expression.text)
+      ) {
+        vistos += 1;
+      }
+      ts.forEachChild(no, visitar);
+    };
+    visitar(arquivo);
+    // Hoje são 3 (dois determinísticos + a escolta do orçamento). O piso é 2 para
+    // não virar contagem a manter; zero seria o instrumento cego.
+    expect(vistos).toBeGreaterThanOrEqual(2);
+  });
+
+  /** Controle NEGATIVO: fonte sabotado tem de acusar. */
+  it("controle negativo: passagem sem aviso é acusada", () => {
+    const sabotado = `
+      async function escalar(pool: unknown, ids: unknown) {
+        await performHumanHandoff(pool, ids, { reason: 'x', conversationSummary: '', log: null });
+      }
+    `;
+    expect(passagensSemAviso(sabotado, "sabotado.ts")).toEqual([3]);
+  });
+
+  /** Controle NEGATIVO 2: avisar DEPOIS não vale — é avisar ninguém. */
+  /**
+   * O OUTRO motor: `triggerHandoff` avisa por dentro, então a guarda tem de
+   * checar a ORDEM lá dentro. Se alguém mover o `avisarLeadDoCrm` para depois
+   * do UPDATE que silencia, este caso vermelha — e é o único que o pega, porque
+   * os quatro chamadores de `triggerHandoff` continuariam limpos.
+   */
+  it("triggerHandoff avisa ANTES de silenciar a conversa", () => {
+    const fonte = ler("lib/ai/handoff/orchestrator.ts");
+    const posAviso = fonte.indexOf("avisarLeadDoCrm(");
+    const posSilencio = fonte.indexOf("bot_silenced_until: SILENCE_INFINITY");
+    expect(posAviso, "avisarLeadDoCrm sumiu do orquestrador").toBeGreaterThan(0);
+    expect(posSilencio, "o UPDATE de silêncio sumiu do orquestrador").toBeGreaterThan(0);
+    expect(posAviso).toBeLessThan(posSilencio);
+  });
+
+  /**
+   * E que o aviso dele alcança TODOS os seus chamadores: se `triggerHandoff`
+   * ganhar um irmão exportado de outro arquivo, o `Step 0` deixa de valer para
+   * ele e ninguém percebe.
+   */
+  it("triggerHandoff é definido num lugar só", () => {
+    const definidores = ARQUIVOS_QUE_DEFINEM_TRIGGER_HANDOFF;
+    expect(definidores).toEqual(["lib/ai/handoff/orchestrator.ts"]);
+  });
+
+  it("controle negativo: aviso DEPOIS da passagem é acusado", () => {
+    const invertido = `
+      async function escalar(pool: unknown, ids: unknown) {
+        await performHumanHandoff(pool, ids, { reason: 'x', conversationSummary: '', log: null });
+        await avisarLeadDaEscalacao(pool, ids, { motivo: 'pediu_humano' });
+      }
+    `;
+    expect(passagensSemAviso(invertido, "invertido.ts")).toEqual([3]);
+  });
+
+  /** Controle do CONTROLE: prosa citando os nomes não pode acusar nada. */
+  it("controle do controle: menção em comentário e string não é chamada", () => {
+    const prosa = `
+      // Este comentário fala de performHumanHandoff( e de triggerHandoff( à vontade.
+      const doc = "performHumanHandoff(pool, ids, opts) e triggerHandoff({...})";
+      export const x = doc;
+    `;
+    expect(passagensSemAviso(prosa, "prosa.ts")).toEqual([]);
+  });
+
+  /**
+   * O universo não pode encolher em silêncio. Se alguém mover uma passagem para
+   * um arquivo fora de FONTES, a lista acima segue verde medindo o lugar errado
+   * — este caso é o que obriga a atualizá-la.
+   */
+  it("FONTES cobre todo arquivo que executa uma passagem", () => {
+    const cobertos = new Set<string>(FONTES);
+    const naoCobertos = ARQUIVOS_QUE_CHAMAM.filter((f) => !cobertos.has(f));
+    expect(naoCobertos).toEqual([]);
+  });
+});
+
+/**
+ * Todo arquivo de produção que CHAMA uma passagem, descoberto por varredura —
+ * não por lista escrita à mão. `git ls-files` é a fonte: arquivo untracked não
+ * existe para o CI, e por isso não pode existir para o guarda.
+ */
+const ARQUIVOS_QUE_CHAMAM: string[] = (() => {
+  const saida = execFileSync("git", ["ls-files", "lib", "app", "workers"], {
+    cwd: RAIZ,
+    encoding: "utf8",
+  });
+  return saida
+    .split("\n")
+    .filter((f) => (f.endsWith(".ts") || f.endsWith(".tsx")) && !f.includes(".test."))
+    .filter((f) => {
+      let fonte: string;
+      try {
+        fonte = readFileSync(join(RAIZ, f), "utf8");
+      } catch {
+        return false;
+      }
+      if (!PASSAGENS.some((p) => fonte.includes(p))) return false;
+      const arquivo = ts.createSourceFile(f, fonte, ts.ScriptTarget.Latest, true);
+      let chama = false;
+      const visitar = (no: ts.Node): void => {
+        if (
+          ts.isCallExpression(no) &&
+          ts.isIdentifier(no.expression) &&
+          (PASSAGENS as readonly string[]).includes(no.expression.text)
+        ) {
+          chama = true;
+        }
+        ts.forEachChild(no, visitar);
+      };
+      visitar(arquivo);
+      return chama;
+    })
+    .sort();
+})();
+
+
+/** Onde `triggerHandoff` é DECLARADO (não chamado) — ver a asserção de ordem. */
+const ARQUIVOS_QUE_DEFINEM_TRIGGER_HANDOFF: string[] = (() => {
+  const saida = execFileSync("git", ["ls-files", "lib", "app", "workers"], {
+    cwd: RAIZ,
+    encoding: "utf8",
+  });
+  return saida
+    .split("\n")
+    .filter((f) => f.endsWith(".ts") && !f.includes(".test."))
+    .filter((f) => {
+      let fonte: string;
+      try {
+        fonte = readFileSync(join(RAIZ, f), "utf8");
+      } catch {
+        return false;
+      }
+      if (!fonte.includes("triggerHandoff")) return false;
+      const arquivo = ts.createSourceFile(f, fonte, ts.ScriptTarget.Latest, true);
+      let define = false;
+      const visitar = (no: ts.Node): void => {
+        if (
+          ts.isFunctionDeclaration(no) &&
+          no.name !== undefined &&
+          no.name.text === "triggerHandoff"
+        ) {
+          define = true;
+        }
+        ts.forEachChild(no, visitar);
+      };
+      visitar(arquivo);
+      return define;
+    })
+    .sort();
+})();

--- a/tests/unit/handoff-por-orcamento.test.ts
+++ b/tests/unit/handoff-por-orcamento.test.ts
@@ -39,6 +39,7 @@ import {
   RESUMO_DO_HANDOFF_POR_ORCAMENTO,
   TITULO_DO_HANDOFF_POR_ORCAMENTO,
 } from "@/lib/agent-engine/agent/inbound-turn";
+import type { DesfechoDoAviso } from "@/lib/agent-engine/agent/aviso-de-escalacao";
 import { corpoDoBloqueio } from "@/lib/agent-engine/edge/llm/orcamento";
 import { LlmBudgetExceededError } from "@/lib/agent-engine/edge/llm/run-model-call";
 
@@ -68,7 +69,20 @@ function logFalso() {
   return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
 }
 
-function contexto(pool: unknown, log: unknown) {
+/**
+ * O AVISO AO LEAD entra como FUNÇÃO, pelo mesmo motivo do resumo: só é
+ * resolvido no caminho de erro — o caminho feliz não paga por ele.
+ *
+ * `avisoEspiao()` devolve o dublê para quem quiser medir SE e QUANDO ele foi
+ * chamado. O TEXTO do aviso não se mede aqui: tem arquivo próprio
+ * (`tests/unit/aviso-ao-lead.test.ts`), e misturá-los faria este reprovar por
+ * mudança de redação.
+ */
+function avisoEspiao() {
+  return vi.fn(async (): Promise<DesfechoDoAviso> => ({ avisado: true }));
+}
+
+function contexto(pool: unknown, log: unknown, avisarLead = avisoEspiao()) {
   return {
     pool: pool as never,
     tenantId: ORG,
@@ -78,6 +92,7 @@ function contexto(pool: unknown, log: unknown) {
     // checkpoint ter sido lido. Resolver o resumo no caminho feliz seria uma
     // query a mais por turno para um texto que quase nunca é usado.
     resumoDoCheckpoint: async () => RESUMO_DO_CHECKPOINT,
+    avisarLead,
     log: log as never,
   };
 }
@@ -176,6 +191,78 @@ describe("a escolta do orçamento", () => {
       RESUMO_DO_HANDOFF_POR_ORCAMENTO,
       "o resumo precisa dizer que o lead NÃO pediu humano — senão quem assume responde a um pedido que não houve",
     ).toMatch(/não pediu atendimento humano/iu);
+  });
+
+  it("o lead é AVISADO, e antes de a trava ser armada", async () => {
+    // O defeito que este caso fecha: a escolta devolvia a conversa à fila humana
+    // e silenciava a IA sem dizer nada a quem estava do outro lado. Do lado de
+    // fora, no WhatsApp, é a mesma coisa que não ter escolta nenhuma.
+    //
+    // A ORDEM é o que se mede, não só a chamada. `performHumanHandoff` grava
+    // `force_human = true`, e o gate 1 da cadeia de envio lê essa flag DIRETO da
+    // fonte a cada tentativa: avisar depois é avisar ninguém. Um conserto que
+    // invertesse a ordem ficaria verde num teste que só contasse a chamada.
+    const { pool, chamadas } = poolFalso();
+    const avisar = avisoEspiao();
+    let avisadoNaChamada = -1;
+    avisar.mockImplementation(async () => {
+      avisadoNaChamada = chamadas.length;
+      return { avisado: true };
+    });
+
+    await expect(
+      comHandoffSeOrcamentoAcabar(contexto(pool, logFalso(), avisar), async () => {
+        throw new LlmBudgetExceededError();
+      }),
+    ).rejects.toThrow();
+
+    expect(avisar, "escolta que silencia sem avisar é o defeito original").toHaveBeenCalledTimes(1);
+
+    const iForceHuman = chamadas.findIndex((c) => c.sql.includes("set force_human = true"));
+    expect(iForceHuman, "sem force_human não há passagem para medir a ordem contra").toBeGreaterThanOrEqual(0);
+    expect(
+      avisadoNaChamada,
+      "o aviso saiu DEPOIS de force_human — a trava que ele acabou de armar veta o envio",
+    ).toBeLessThanOrEqual(iForceHuman);
+  });
+
+  it("aviso que não chegou vira LINHA no item da Central", async () => {
+    // Falhar fechado na AÇÃO, aberto na INFORMAÇÃO: a passagem acontece de todo
+    // jeito, mas quem for assumir precisa saber que o cliente está esperando sem
+    // ter sido avisado — é o que muda a primeira frase que o atendente digita.
+    const { pool, chamadas } = poolFalso();
+    const avisar = vi.fn(async (): Promise<DesfechoDoAviso> => ({ avisado: false, porque: "outside_window" }));
+
+    await expect(
+      comHandoffSeOrcamentoAcabar(contexto(pool, logFalso(), avisar), async () => {
+        throw new LlmBudgetExceededError();
+      }),
+    ).rejects.toThrow();
+
+    const inbox = chamadas.find((c) => c.sql.includes("insert into agent_inbox_items"));
+    const corpo = String(inbox?.params?.[2] ?? "");
+    expect(corpo).toMatch(/NÃO foi avisado/u);
+    expect(corpo).toContain("outside_window");
+  });
+
+  it("aviso que falha NÃO impede a passagem", async () => {
+    // A ordem certa não pode virar dependência: se o canal cair, o cliente perde
+    // o aviso — mas não pode perder também o atendente.
+    const { pool, chamadas } = poolFalso();
+    const avisar = vi.fn(async () => {
+      throw new Error("canal fora");
+    });
+
+    await expect(
+      comHandoffSeOrcamentoAcabar(contexto(pool, logFalso(), avisar as never), async () => {
+        throw new LlmBudgetExceededError();
+      }),
+    ).rejects.toThrow();
+
+    expect(
+      chamadas.some((c) => c.sql.includes("set force_human = true")),
+      "o aviso derrubou a passagem que ele deveria só anteceder",
+    ).toBe(true);
   });
 
   it("handoff que falha deixa SUBIR o erro dele, não o de orçamento", async () => {

--- a/tests/unit/orcamento-caminho-legado.test.ts
+++ b/tests/unit/orcamento-caminho-legado.test.ts
@@ -242,8 +242,24 @@ function montar(
   return { operacoes, tabelasConsultadas };
 }
 
+/**
+ * Os itens da Central que são DESTE assunto.
+ *
+ * ⚠️ A versão anterior filtrava só por TABELA, e o nome mentia: qualquer item de
+ * qualquer assunto entrava na conta. O defeito ficou visível quando
+ * `triggerHandoff` passou a abrir o seu próprio item (`kind='handoff'`) — três
+ * casos deste arquivo vermelharam sem que nada de orçamento tivesse mudado.
+ * Régua que mede o vizinho reprova por motivo alheio.
+ *
+ * O `kind` só existe no INSERT (o UPDATE do retrato carrega `{status}` e a
+ * identidade está no filtro, não na linha), então o corte é: item da Central que
+ * NÃO declara um kind de outro assunto.
+ */
+const KINDS_DE_OUTROS_ASSUNTOS = new Set(["handoff", "qr_rescan", "job_dead", "event_dead"]);
 const itensDeOrcamento = (operacoes: Operacao[]) =>
-  operacoes.filter((o) => o.table === "agent_inbox_items");
+  operacoes.filter(
+    (o) => o.table === "agent_inbox_items" && !KINDS_DE_OUTROS_ASSUNTOS.has(String(o.row.kind)),
+  );
 
 beforeEach(() => {
   vi.clearAllMocks();


### PR DESCRIPTION
## O defeito

O agente faz o handoff certo — e sai de campo **sem dizer nada** a quem está do outro lado. A pessoa fala, e ninguém responde.

Medido no banco de produção, e **são dois defeitos em dois motores**, não um:

```
status  | bot_silenced_until | last_handoff_reason | force_human
open    | infinity           | requested_human     | t     <- performHumanHandoff (motor, pg)
pending | infinity           | low_sentiment       | f     <- triggerHandoff (CRM, supabase-js)
```

- **conversa `cdd9cbd8`** — o cliente escreveu *"preciso de falar com atendente"*. A detecção determinística casou, `performHumanHandoff` rodou, e o turno deu `return` com o comentário *"bot silencia: sem modelo, sem envio neste turno"*.
- **conversa `b934ba2d`** — o pior caso, e não é o do pedido explícito. Às 14:50:32 o agente **perguntou o e-mail do cliente**; às 14:51:01 o worker de sentimento chamou `triggerHandoff('low_sentiment')`; às 14:51:27 o e-mail chegou e o turno foi pulado. Ele respondeu uma pergunta da própria IA para o vazio.

Um conserto só no motor de conversa arruma o primeiro e deixa o segundo exatamente como está: eles vivem em mundos de banco diferentes e nunca se encontram numa busca só.

## A ordem é obrigatória, não estética

`performHumanHandoff` grava `contacts.force_human = true`, e o gate 1 da cadeia de envio relê `(is_blocked or force_human)` direto da fonte a cada tentativa. **Avisar depois é avisar ninguém.**

Não é dedução — é medição. Movendo o aviso para depois da passagem, o turno registra:

```
gate: stop | verdict: veto | code: contato_bloqueado
aviso de escalação vetado pela cadeia — a passagem acontece assim mesmo
```

e o invariante vermelhece com `expected [] to have a length of 1` — o silêncio original, reproduzido.

## O conserto

| Arquivo | O quê |
|---|---|
| `lib/escalacao/aviso-ao-lead.ts` **(novo)** | O TEXTO — puro, um só para os dois mundos. Muda com o motivo e com a disponibilidade real da equipe |
| `lib/agent-engine/agent/aviso-de-escalacao.ts` **(novo)** | Envio do lado do motor, atrás de `runBeforeSend` (cadeia completa), `seq: 0` |
| `lib/ai/handoff/aviso-ao-lead.ts` **(novo)** | O mesmo texto pelo `sendMessageHandler` — não há `pg.Pool` nem job no mundo do CRM |
| `inbound-turn.ts` | Avisa nos três desvios: pedido explícito, opt-out ambíguo e teto de gasto |
| `orchestrator.ts` | `Step 0` avisa antes do UPDATE; `Step 6` abre o item na Central que este motor **nunca abriu** |
| `human-handoff.ts` | O desfecho do aviso vira LINHA no item da Central; o retorno da tool deixa de mandar o modelo calar |
| `before-send.ts` | `spinningEnforced` — desarme explícito, só para o aviso |
| `cases/[id]/reply/route.ts` | "Assumir eu" também avisa antes de calar |

**Quem pediu para PARAR não recebe oferta de atendente.** O texto do opt-out confirma a parada e diz que uma pessoa vai conferir — responder ao pedido é o padrão de mensageria, oferecer atendimento a quem pediu silêncio não é.

**Instalação sem ninguém configurado não recebe promessa de contato.** A mesma régua (`isAttendantEligible`) que o roteamento usa decide a frase.

### Por que o gate de spinning é desarmado (a conta que reprovou a v1)

`decideSpinning` veta candidata idêntica ou quase (Jaccard ≥ 0,8) a 2+ das últimas 20 mensagens **daquele número** — janela que **cruza leads**. A primeira versão do conserto tinha só variantes por lead, e a medição com a função real do gate reprovou: **14 de 20** avisos seguidos eram vetados. A terceira pessoa a pedir um atendente receberia exatamente o silêncio que este PR existe para acabar — pelo guardrail.

Variante não é garantia; o desarme é. As variantes ficam para o número não repetir uma frase só. A conta está congelada em `tests/unit/aviso-ao-lead.test.ts`: se um dia cair a zero, o teste vermelhece e o desarme pode ser reavaliado.

## Provas observadas

| Gate | Resultado |
|---|---|
| `pnpm typecheck` | 0 |
| `pnpm lint` | 0 erros |
| `pnpm lint:channels` | ok (nenhuma dívida nova) |
| `pnpm test:unit` | 5521/5527 — as 6 restantes são o `rate-limit.test.ts`, que aponta para o `serverless-redis-http` local (contêiner parado). **Medido na `main` com o mesmo `.env.local`: as mesmas 5 falhas, mesmos tempos** |
| `pnpm test:db` | **117/117 arquivos, 885 testes** |
| `pnpm test:shell` | todos os validadores passaram |

**A prova que importa** — `tests/invariants/handoff-avisa-o-lead.test.ts`, turno REAL contra o Postgres do `baseline.sql`, 8/8. O log mostra a sequência inteira:

```
10 gates avaliados → spinning: skipped/not_applicable
lead avisado antes da passagem para humano
handoff humano aplicado (force_human + silêncio + crons cancelados + inbox)
```

**Sabotagens** (cada guarda foi quebrada de propósito para ver se vermelhece):

- inverter a ordem → **4 de 8** vermelhos, incluindo o silêncio original
- apagar o aviso do gatilho determinístico → varredura AST acusa
- mover o aviso do `triggerHandoff` para depois do silêncio → acusa
- apagar o aviso da rota de casos → acusa
- colapsar as variantes do texto → acusa

Evidência em `evidence/handoff-avisa-antes/`. Handoff doc em `HANDOFF-handoff-avisa-o-lead.md`.

## O que este PR NÃO prova

- **Envio real por WhatsApp.** Só a VPS prova isso, e é o próximo passo depois do merge.
- **E2E de tela.** Não escrito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwEbGHSkcSyEnN3KtUuF6t
