### PR TITLE
release(1.6.0): a passagem para humano deixa de ser muda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Se você roda o DeskcommCRM numa VPS, **leia a seção da versão para a qual es
 
 ## [Não lançado]
 
+## [1.6.0] — 2026-08-26
+
 ### Adicionado
 
 - **Formulários do Respondi entram como lead, com as respostas na ficha.** Antes, quem ligava


### PR DESCRIPTION
Corte da **v1.6.0** — MINOR, porque muda comportamento visível ao cliente final.

Sem esta versão, o conserto do #350 existe só no repositório: o self-hoster puxa **imagem publicada por número de versão**, e é a tag que a produz. Merge na `main` não atualiza VPS nenhuma.

### Checklist de release (`docs/doctrine/packaging.md`)

| # | Item | Estado |
|---|---|---|
| 1 | Seção no CHANGELOG com o que muda para quem já instalou | ✅ três entradas, na voz de quem opera |
| 2 | Nenhuma variável nova obrigatória sem default | ✅ `git diff -- .env.example` vazio |
| 3 | O número nunca foi publicado | ✅ tag local vazia; `ghcr_status deskcommcrm 1.6.0` → **404**, com controle positivo (`1.5.0` → 200) e negativo (`9.9.9` → 404) |
| 4 | Pins upstream revisitados | ✅ **decidido: ficam.** `waha:latest-2026.7.2`, `redis:7-alpine`, `caddy:2-alpine`, `srh` por digest. Esta versão existe para tirar o cliente do silêncio; misturar bump de infra num conserto de comportamento troca um risco conhecido por dois desconhecidos |
| 5–11 | Tag, publicação, digest do `stable` | ⬜ depois deste merge |
| 12 | Ensaio de `update.sh` numa instalação real | ⬜ é o item que responde "o cliente consegue atualizar?" |

### O que a versão entrega

O agente fazia o handoff certo e **saía de campo calado** — a pessoa falava e ninguém respondia. Eram dois defeitos em dois motores diferentes; o pior era o silencioso, em que a IA tinha acabado de perguntar o e-mail do cliente e o sistema desligou o automático antes de a resposta chegar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwEbGHSkcSyEnN3KtUuF6t