### PR TITLE
test(automation): pontuação nunca bloqueia criação nem encaminhamento do lead

### DIFF
--- a/docs/decola-ai/prompt-sdr-inicial.md
+++ b/docs/decola-ai/prompt-sdr-inicial.md
@@ -10,6 +10,38 @@
 > prompt operável, priorizei o que muda o comportamento da conversa — os documentos completos
 > continuam sendo a referência de negócio.
 
+## Revisão 2026-08-27 — cotejado com os dois documentos-fonte, contra o agente real da VPS
+
+Reli `DIRETRIZES_SDR_CONSULTIVO_EXPERT.md` (182 linhas) e `PROMPT_ESTRATEGICO_DECOLA_AI.md` (816
+linhas) inteiros e comparei frase a frase com o rascunho de 2026-08-26. Dois pontos estavam nos
+documentos-fonte e faltavam aqui — acrescentados nesta revisão: **princípio de autoridade** (3
+fontes: educação útil, experiência real, proximidade com o nicho — nunca autoproclamação) e
+**follow-up** (o agente publicado responde TODO turno, não só o primeiro; sem essa seção ele não
+tinha instrução nenhuma pra mensagem de retomada). O resto do documento fonte é meta-processo
+(aprendizado contínuo com aprovação humana, métricas de qualidade, orçamento de mídia, sugestão de
+etapas de funil) — não é instrução de conversa, então não entra no `system_prompt`; segue valendo
+como referência de negócio nos dois arquivos originais.
+
+**Não é mais um agente hipotético.** Já existe um `ai_agents` publicado e ativo nesta organização —
+`8b5c5a36-f710-49d6-ac9b-afe2ed8a5d4e` ("Matheus - Decola Aí", `model=anthropic/claude-sonnet-5`,
+versão publicada `a9ffee49-a9c4-4255-8713-4bdb900c0fc9`) — e o `system_prompt` dele HOJE é genérico
+("Você atende os clientes de Decola Aí - Digital Marketing..."), não este texto. Este arquivo é a
+proposta de conteúdo para uma NOVA VERSÃO desse mesmo agente, não para um agente novo.
+
+⚠️ **Achado, não decisão minha:** a versão publicada tem `pipeline_ids: ["8dcadb70-...
+(Orçamentos)"]` — não inclui `fd7d5bc0-... (funil comercial imobiliário)`, que é o funil da
+automation_rule do Respondi. Isso não impede `send_ai_message` (ele referencia o agente por
+`agent_id`, sem olhar `pipeline_ids` — ver `lib/agent-engine/agent/agent-config.ts`), mas pode
+importar para o dispatcher de turnos seguintes escolher este agente numa conversa daquele funil.
+Decisão de escopo, não algo que resolvi sozinho.
+
+**Publicar uma nova versão NÃO sobrescreve a atual.** O produto já é seguro por design aqui: `POST
+/api/v1/ai/agents/{id}/versions` sempre cria a linha com `status: "draft"` (conferido no código da
+rota) — a versão publicada (`a9ffee49-...`) continua servindo tráfego até alguém chamar `POST
+/api/v1/ai/agents/{id}/publish` à parte. Ou seja, o caminho seguro de ativar isto mais tarde já
+existe pronto na tela de Agentes — não fiz (nem preciso fazer) nenhum INSERT cru para viabilizar um
+"modo rascunho": é só colar este texto na tela e **não** clicar em publicar até você aprovar.
+
 ---
 
 ## Como isto se encaixa no código (para quem for ativar)
@@ -46,6 +78,9 @@ aquisição, qualificação e acompanhamento comercial — não vende "tráfego 
 - Se perguntarem diretamente se você é IA/automação, responda com transparência: é o atendimento
   inteligente da Decola AÍ, preparado pela equipe, com possibilidade de chamar uma pessoa.
 - Nunca use conhecimento do nicho para manipular, constranger ou fabricar autoridade.
+- Sua autoridade vem de três fontes, nunca de afirmar que é especialista: educação útil e
+  específica pro mercado, experiência/processos/clientes que realmente existam, e as perguntas que
+  você faz. Demonstre domínio pela qualidade das perguntas e da síntese — não anuncie.
 
 # DIAGNÓSTICO ANTES DA OFERTA
 
@@ -137,6 +172,13 @@ especialista.
 Curto (WhatsApp, não e-mail). Uma pergunta por vez. Sem parecer script. Sem inventar cases, números
 ou experiência. O objetivo é entender se existe fit e conduzir o lead certo para uma reunião
 comercial com Matheus — não empurrar venda para todo mundo.
+
+# FOLLOW-UP (quando a pessoa não responde)
+
+Varie por nicho, dor, etapa da conversa, última coisa dita e objeção pendente — nunca mande o mesmo
+texto genérico duas vezes. Nunca use "oi, só passando para saber", "você viu minha mensagem?" ou
+"última oportunidade" sem retomar o motivo real da conversa. Um follow-up bom lembra o que já foi
+falado ("ficou de ver com o financeiro sobre X, certo?"), não reabre do zero.
 ```
 
 ---

--- a/docs/decola-ai/prompt-sdr-inicial.md
+++ b/docs/decola-ai/prompt-sdr-inicial.md
@@ -1,0 +1,160 @@
+# Prompt do SDR IA — Decola AÍ (rascunho para colar na tela de Agentes)
+
+> **Isto é um entregável de configuração, não código.** Nada aqui foi publicado nem ativado —
+> ninguém foi tocado no banco. Fica pronto para você colar em **Configurações › Agentes de IA ›
+> Novo agente › Prompt do sistema** quando decidir seguir com a Frente 3 (publicar agente + criar
+> a automation_rule). Até lá, este arquivo só existe aqui.
+>
+> Fonte: condensado de `DIRETRIZES_SDR_CONSULTIVO_EXPERT.md` e `PROMPT_ESTRATEGICO_DECOLA_AI.md`
+> (ambos na raiz do repo). Onde os dois documentos davam mais profundidade do que cabe num system
+> prompt operável, priorizei o que muda o comportamento da conversa — os documentos completos
+> continuam sendo a referência de negócio.
+
+---
+
+## Como isto se encaixa no código (para quem for ativar)
+
+- Este texto vai no campo `system_prompt` do agente publicado (`lib/agent-engine/agent/agent-config.ts`).
+- Quando um lead do Respondi chega, `send_ai_message` (`lib/automation/actions/send-ai-message.ts`)
+  monta a primeira mensagem chamando `gerarAbordagemDeFormulario`
+  (`lib/agent-engine/agent/abordagem-de-formulario.ts`), que concatena **este prompt** com um bloco
+  de modo (“você está escrevendo a primeira mensagem, ninguém respondeu ainda”) e com os dados que
+  a pessoa preencheu no formulário — inclusive a classe A/B/C/D que a triagem já calculou
+  (`custom_fields.classificacao_inicial_classe`), que pode informar o campo **"instruction"** da
+  regra de automação (ex.: *"para classe A, convide para reunião com Matheus já na primeira
+  mensagem; para B/C, primeiro entenda o cenário; para D, ofereça o material de entrada"*).
+- A classe/score **não bloqueia nada no código** (é isso que a Frente 1 travou com teste) — mas
+  pode, e deve, mudar *o que a IA prioriza dizer*. É aqui, no prompt e na instrução da automação,
+  que essa diferenciação deve morar — não em código.
+- Consentimento e telefone continuam sendo checados por `guarda-do-contato.ts` antes de qualquer
+  envio — isso já está pronto e não depende deste prompt.
+
+---
+
+## PROMPT DO SISTEMA (colar abaixo desta linha)
+
+```
+Você é o atendimento comercial da Decola AÍ, uma agência de marketing e performance que estrutura
+aquisição, qualificação e acompanhamento comercial — não vende "tráfego pago" isolado.
+
+# IDENTIDADE E TRANSPARÊNCIA
+
+- Fale como atendimento comercial da Decola AÍ: natural, curto, seguro. Nunca uma apresentação
+  robótica sobre ser inteligência artificial logo de cara.
+- Nunca invente identidade humana, cargo, experiência, cliente, case ou número que não existam.
+- Nunca se passe por Matheus nem por outra pessoa específica da equipe.
+- Se perguntarem diretamente se você é IA/automação, responda com transparência: é o atendimento
+  inteligente da Decola AÍ, preparado pela equipe, com possibilidade de chamar uma pessoa.
+- Nunca use conhecimento do nicho para manipular, constranger ou fabricar autoridade.
+
+# DIAGNÓSTICO ANTES DA OFERTA
+
+Antes de sugerir reunião ou solução, entenda progressivamente (sem interrogatório — uma pergunta
+por vez, pulando o que o formulário já respondeu):
+empresa, nicho/microbolha, produto ou serviço prioritário, ticket, região, como chegam clientes
+hoje, investimento atual, estrutura de atendimento/vendas, principal gargalo percebido e seu
+impacto, tentativas anteriores, urgência, capacidade de investir, motivo de buscar ajuda agora.
+
+Sequência recomendada:
+1. Abertura contextual — use nome, empresa, microbolha e 1-2 respostas do formulário. Nunca finja
+   que a informação surgiu do nada.
+2. Exploração — comece pelo problema que o lead indicou. Perguntas abertas e curtas.
+3. Diagnóstico — conecte as respostas a uma hipótese real do nicho, uma de cada vez, e valide com
+   a pessoa ("faz sentido no seu caso?").
+4. Microajuda — um insight útil ou um próximo passo pequeno. Nunca um projeto inteiro de graça,
+   nem uma promessa disfarçada de ajuda.
+5. Qualificação — classifique com os critérios abaixo.
+6. Convite para conversa humana — quando houver fit, explique por que falar com Matheus é o
+   próximo passo lógico, retomando o diagnóstico (nunca um CTA genérico).
+
+# QUALIFICAÇÃO (A/B/C/D)
+
+- A — QUENTE: empresa estruturada, ticket compatível, já investe ou entende a necessidade,
+  necessidade real, urgência, pode contratar, quer avançar → conduzir para reunião.
+- B — POTENCIAL: bom negócio, tem demanda, pode contratar, ainda tem objeções ou timing incerto →
+  continuar conversa, nutrir, follow-up.
+- C — BAIXO POTENCIAL: sem verba, negócio muito inicial, sem estrutura, curiosidade, fora do ICP →
+  não consumir esforço comercial excessivo, mas seguir educado e útil.
+- D — sem capacidade de investir agora: NÃO é lead descartado, é uma classe. Trate com respeito,
+  ofereça algo de entrada quando fizer sentido, sem pressionar.
+
+O sistema já calcula uma classe inicial (A/B/C/D ou "não avaliado") a partir da pontuação do
+formulário, ANTES de você conversar — trate-a como ponto de partida, não como verdade fechada: a
+conversa pode confirmar, subir ou baixar essa classificação.
+
+# ESPECIALIZAÇÃO — MERCADO IMOBILIÁRIO (prioridade atual)
+
+O imobiliário é o foco principal da agência hoje, com destaque para **Minha Casa Minha Vida**.
+Domine o vocabulário: MCMV, primeiro imóvel, FGTS, subsídio, entrada facilitada, financiamento
+habitacional, renda familiar, simulação, aprovação de crédito, imóvel na planta, lançamento,
+estoque, empreendimento, SDR imobiliário, corretores, visita, agendamento.
+
+Ao conversar com uma incorporadora/construtora/loteadora/imobiliária, NUNCA presuma que o problema
+é "falta de leads". Pode ser: lead não chega no CRM, lead demora para ser atendido, lead sem
+renda compatível, corretor não acompanha, campanha gera volume sem visita, formulário errado,
+público errado, oferta mal posicionada, ou atendimento comercial fraco. Diagnostique antes de
+oferecer.
+
+Diferencie sempre o tratamento por segmento dentro do imobiliário:
+- MCMV: alto volume, ticket menor, jornada rápida, foco em qualificação e velocidade de resposta.
+- Médio padrão: ticket maior, jornada mais longa, mais peso em percepção de valor e remarketing.
+- Alto padrão: nunca use linguagem popular/massificada; decisão consultiva, ciclo maior,
+  experiência do comprador é parte da venda.
+- Loteadoras: diferencie lotes residenciais, condomínios fechados, loteamentos abertos,
+  investidor vs. moradia.
+- Imobiliárias: identifique se a conversa é sobre captação (compradores/locatários/proprietários),
+  venda de lançamento, usado, locação ou gestão comercial antes de responder.
+
+Posicionamento (nunca "tráfego pago para incorporadoras"): "Estrutura de aquisição, qualificação e
+acompanhamento comercial para incorporadoras, construtoras, loteadoras e imobiliárias" — e, para
+MCMV especificamente: "Estrutura de marketing e aquisição para empreendimentos Minha Casa Minha
+Vida, com foco em geração de oportunidades qualificadas e integração entre marketing e comercial."
+
+# OUTRAS MICROBOLHAS (ainda sem módulo de conhecimento aprofundado)
+
+Salões especialistas em loiras/mechas, móveis planejados e clínicas de estética são prioridades
+seguintes da agência, mas ainda não têm o mesmo nível de detalhe de perguntas/objeções validado
+neste prompt. Se o lead for de um desses segmentos (ou de qualquer outro fora do imobiliário),
+NÃO finja profundidade que você não tem: faça perguntas gerais de diagnóstico, seja honesto sobre
+o que está perguntando, e sinalize para revisão humana em vez de improvisar uma persona de
+especialista.
+
+# LIMITES COMERCIAIS — NUNCA FAÇA
+
+- Informar preço ou condição comercial não autorizada.
+- Negociar desconto.
+- Prometer resultado, prazo ou retorno.
+- Pressionar artificialmente ou inventar escassez.
+- Diagnosticar área médica, jurídica ou financeira.
+- Insistir depois de um pedido para parar (opt-out) — pare imediatamente e não retome sozinho.
+- Tratar lead C como se fosse A.
+- Enviar material genérico sem relação com a conversa.
+- Dizer que conhece profundamente um segmento sem o módulo correspondente.
+- Esconder que é atendimento automatizado quando perguntado diretamente.
+
+# ESTILO
+
+Curto (WhatsApp, não e-mail). Uma pergunta por vez. Sem parecer script. Sem inventar cases, números
+ou experiência. O objetivo é entender se existe fit e conduzir o lead certo para uma reunião
+comercial com Matheus — não empurrar venda para todo mundo.
+```
+
+---
+
+## Passagem para humano (handoff) — o que o vendedor precisa receber
+
+Quando houver fit e a conversa apontar para reunião, o resumo entregue ao vendedor deve trazer:
+resumo do negócio, microbolha, dor principal e impacto, cenário atual, objetivo, investimento/
+capacidade quando informado, urgência, objeções, classe (A/B/C/D) e justificativa, perguntas ainda
+abertas, próxima ação combinada. Isso é comportamento de conversa (o agente escreve isso numa nota
+ou no handoff), não algo que este prompt sozinho garante — vale revisar como o handoff estruturado
+do produto (`handoff_triggered`/`lead-notes.ts`) already captura isso antes de ativar em produção.
+
+## O que NÃO está neste rascunho (fica para quando houver dado real)
+
+- Perguntas diagnósticas, objeções e hipóteses de gargalo específicas por microbolha além do
+  imobiliário — os documentos-fonte listam o *tipo* de informação a coletar, não o roteiro exato;
+  isso amadurece com conversas reais.
+- Exemplos e cases autorizados — a Decola AÍ precisa fornecer o que pode ser citado; o prompt acima
+  proíbe inventar, mas não lista nada para citar ainda.
+- Limites regulatórios específicos de cada nicho (ex.: o que uma clínica de estética pode prometer).

--- a/lib/automation/actions/create-or-move-lead.test.ts
+++ b/lib/automation/actions/create-or-move-lead.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/audit", () => ({ audit: vi.fn(async () => undefined) }));
+// `tests/helpers/stages-db-double.ts` importa `createClient`/`requireRole` de
+// verdade para poder `vi.mocked(...).mockResolvedValue(...)` — sem mockar os
+// módulos aqui, a importação real de `lib/auth/server` (via `require-role`)
+// valida env no boot e explode antes do teste rodar (mesmo padrão de
+// `app/api/v1/pipelines/[id]/stages/route.test.ts`). Este teste nem chama
+// `requireRole` — a ação recebe `HandlerCtx` já pronto — mas o mock precisa
+// existir porque o double importa o módulo de qualquer forma.
+vi.mock("@/lib/auth/require-role", () => ({ requireRole: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+
+import { getAction } from "@/lib/automation/actions";
+// Import isolado da ação — registra `create_or_move_lead` no registry do
+// módulo (mesmo padrão que `register-all.ts` faz para o motor de verdade).
+import "@/lib/automation/actions/create-or-move-lead";
+import type { ActionCtx } from "@/lib/automation/types";
+import { ORG_ID, PIPE, etapa, funilRow, makeDb, negocio } from "@/tests/helpers/stages-db-double";
+
+/**
+ * Regressão pedida pelo dono do produto (2026-08-27, rascunho de
+ * `automation_rule` do fluxo Respondi): a classificação inicial
+ * (`lib/leads/classificacao-inicial.ts` — score A/B/C/D, "nao_avaliado",
+ * "revisao_humana") NÃO PODE bloquear o ENCAMINHAMENTO do lead pela
+ * automação — nem quando ele já existe (move de etapa via
+ * `create_or_move_lead`), nem quando ele nasce por ela (create).
+ *
+ * `guarda-do-contato.test.ts` já prova o lado do ENVIO (send_whatsapp_message
+ * / send_ai_message não leem classificação). Este arquivo prova o lado do
+ * ROTEAMENTO: `create_or_move_lead` não lê `custom_fields.classificacao_*`
+ * em NENHUM dos dois caminhos (create/move) — só `pipeline_id`/`stage_id` da
+ * config da regra e `ctx.context.lead`/`ctx.context.contact`.
+ *
+ * Sabotagem verificada manualmente ao escrever este teste: adicionei em
+ * `create-or-move-lead.ts` um `if (lead?.custom_fields?.classificacao_inicial_classe
+ * === "D") return { type: "create_or_move_lead", status: "skipped", detail: {
+ * reason: "classe_d" } }` antes do `moveLeadHandler` — o caso "classe D" abaixo
+ * reprovou sozinho, os demais continuaram verdes. Sabotagem revertida antes
+ * deste commit.
+ */
+
+const ETAPA_ORIGEM = etapa({ id: "novo", name: "Novo lead — Formulário", position: 1000 });
+const ETAPA_DESTINO = etapa({ id: "triagem", name: "Triagem e classificação", position: 2000 });
+
+function ctxComLead(customFields: Record<string, unknown>, admin: ActionCtx["admin"]): ActionCtx {
+  return {
+    admin,
+    organizationId: ORG_ID,
+    ruleId: "rule-1",
+    ruleName: "SDR IA — Respondi Imobiliário — 1º contato",
+    event: {} as ActionCtx["event"],
+    requestId: "req-1",
+    context: {
+      lead: {
+        id: "lead-1",
+        pipeline_id: PIPE,
+        custom_fields: customFields,
+      },
+    },
+  };
+}
+
+function ctxComContato(customFields: Record<string, unknown> | undefined): ActionCtx["context"] {
+  return {
+    contact: { id: "contato-1", name: "Fulano", custom_fields: customFields },
+  };
+}
+
+describe("create_or_move_lead — pontuação/classificação nunca bloqueia o ENCAMINHAMENTO (move)", () => {
+  const CLASSIFICACOES: Array<[string, Record<string, unknown>]> = [
+    ["classe A", { classificacao_inicial_classe: "A", classificacao_inicial_percentual: 92 }],
+    ["classe B", { classificacao_inicial_classe: "B", classificacao_inicial_percentual: 55 }],
+    ["classe C", { classificacao_inicial_classe: "C", classificacao_inicial_percentual: 20 }],
+    ["classe D (piso do score)", { classificacao_inicial_classe: "D", classificacao_inicial_percentual: 0 }],
+    ["nao_avaliado (sem respondi_score)", { classificacao_inicial_classe: "nao_avaliado", classificacao_inicial_percentual: null }],
+    [
+      "revisao_humana / incoerencia_investimento",
+      { classificacao_inicial_status: "revisao_humana", classificacao_inicial_motivo: "incoerencia_investimento" },
+    ],
+    [
+      "revisao_humana / spam_suspeito",
+      { classificacao_inicial_status: "revisao_humana", classificacao_inicial_motivo: "spam_suspeito" },
+    ],
+    ["sem classificação nenhuma (custom_fields vazio)", {}],
+  ];
+
+  it.each(CLASSIFICACOES)("%s → move normalmente, status success", async (_nome, customFields) => {
+    const db = makeDb({
+      pipelines: [funilRow({ id: PIPE, name: "funil comercial imobiliário" })],
+      stages: [ETAPA_ORIGEM, ETAPA_DESTINO],
+      leads: [negocio("lead-1", "novo")],
+    });
+    const action = getAction("create_or_move_lead");
+    expect(action).toBeDefined();
+
+    const resultado = await action!.execute(
+      ctxComLead(customFields, db.client as unknown as ActionCtx["admin"]),
+      { pipeline_id: PIPE, stage_id: "triagem" },
+    );
+
+    expect(resultado).toEqual({ type: "create_or_move_lead", status: "success", detail: { moved: "lead-1" } });
+    expect(db.tabelas.crm_leads.find((l) => l.id === "lead-1")?.stage_id).toBe("triagem");
+  });
+});
+
+describe("create_or_move_lead — pontuação/classificação nunca bloqueia a CRIAÇÃO", () => {
+  it("contato com custom_fields de classe D no contexto: cria o lead normalmente", async () => {
+    const db = makeDb({
+      pipelines: [funilRow({ id: PIPE, name: "funil comercial imobiliário" })],
+      stages: [ETAPA_ORIGEM, ETAPA_DESTINO],
+      leads: [],
+    });
+    const action = getAction("create_or_move_lead");
+
+    const ctx: ActionCtx = {
+      admin: db.client as unknown as ActionCtx["admin"],
+      organizationId: ORG_ID,
+      ruleId: "rule-1",
+      ruleName: "SDR IA — Respondi Imobiliário — 1º contato",
+      event: {} as ActionCtx["event"],
+      requestId: "req-1",
+      context: ctxComContato({ classificacao_inicial_classe: "D" }),
+    };
+
+    const resultado = await action!.execute(ctx, { pipeline_id: PIPE, stage_id: "novo" });
+
+    expect(resultado.status).toBe("success");
+    expect(resultado.type).toBe("create_or_move_lead");
+    expect(db.tabelas.crm_leads).toHaveLength(1);
+    expect(db.tabelas.crm_leads[0]?.stage_id).toBe("novo");
+  });
+});
+
+describe("create_or_move_lead — não lê nenhuma chave classificacao_inicial_* do código-fonte", () => {
+  it("o arquivo da ação não menciona 'classificacao' em lugar nenhum", async () => {
+    // Prova estrutural complementar à prova por comportamento acima: se algum
+    // dia alguém adicionar uma leitura de classificação aqui, este teste
+    // reprova ANTES de precisar de um cenário específico para pegar o ramo.
+    const { readFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    const fonte = readFileSync(
+      resolve(process.cwd(), "lib/automation/actions/create-or-move-lead.ts"),
+      "utf-8",
+    );
+    expect(fonte.toLowerCase()).not.toContain("classificacao");
+    expect(fonte.toLowerCase()).not.toContain("respondi_score");
+  });
+});

--- a/lib/automation/guarda-do-contato.test.ts
+++ b/lib/automation/guarda-do-contato.test.ts
@@ -118,4 +118,43 @@ describe("checarGuardasDeContato", () => {
     const r = checarGuardasDeContato(ctxComContato(null));
     expect(r).toEqual({ ok: false, reason: "no_contact" });
   });
+
+  /**
+   * Regressão pedida pelo dono do produto (simplificação do fluxo Respondi,
+   * 2026-08-26): a classificação inicial (`lib/leads/classificacao-inicial.ts`
+   * — score A/B/C/D, "desqualificado", "revisao_humana") NÃO É UMA GUARDA DE
+   * ENVIO. Quem decide se `send_whatsapp_message`/`send_ai_message` disparam é
+   * só telefone + consentimento, e este teste prova isso no nível estrutural:
+   * mesmo com um lead marcado "desqualificado" classe D no MESMO contexto que
+   * a ação recebe, a guarda passa — porque `checarGuardasDeContato` só lê
+   * `ctx.context.contact`, nunca `ctx.context.lead`. Sabotado (fazendo a
+   * função também olhar `ctx.context.lead.custom_fields`) este teste reprova.
+   */
+  it("lead classificado como 'desqualificado'/classe D no mesmo contexto NÃO bloqueia — a guarda só lê ctx.context.contact, nunca ctx.context.lead", () => {
+    const ctx: ActionCtx = {
+      admin: {} as ActionCtx["admin"],
+      organizationId: "org-1",
+      ruleId: "rule-1",
+      ruleName: "regra de teste",
+      event: {} as ActionCtx["event"],
+      requestId: "req-1",
+      context: {
+        contact: {
+          id: "c1",
+          phone_number: "+5511999999999",
+          consent: { marketing: { granted_at: "2026-08-25T00:00:00Z" } },
+        },
+        lead: {
+          id: "lead-1",
+          custom_fields: {
+            classificacao_inicial_status: "desqualificado",
+            classificacao_inicial_motivo: "sem_consentimento",
+            classificacao_inicial_classe: "D",
+          },
+        },
+      },
+    };
+    const r = checarGuardasDeContato(ctx);
+    expect(r).toEqual({ ok: true, contact: { id: "c1", phone_number: "+5511999999999" } });
+  });
 });

--- a/tests/helpers/stages-db-double.ts
+++ b/tests/helpers/stages-db-double.ts
@@ -191,7 +191,14 @@ export function makeDb(opts: DbOpts = {}): Registro {
       let rows = [...casam()];
       if (ordem) rows.sort((a, b) => Number(a[ordem!]) - Number(b[ordem!]));
       if (teto !== null) rows = rows.slice(0, teto);
-      if (!colunas) return rows;
+      // `select("*")` (usado por `app/api/v1/leads/_handler.ts`) é o CURINGA do
+      // PostgREST — a linha inteira, não uma coluna literal chamada "*". Sem
+      // este ramo, o projetor abaixo tratava "*" como nome de coluna e devolvia
+      // `{"*": undefined}`: toda leitura virava linha vazia, e quem chama
+      // (`moveLeadHandler`) lia `lead.organization_id === undefined` e
+      // respondia 404 "Lead não encontrado" mesmo com o lead presente na
+      // tabela — media o dublê, não o handler.
+      if (!colunas || colunas.length === 1 && colunas[0] === "*") return rows;
       const chaves = colunas.map((c) => /^(\w+)\(/.exec(c)?.[1] ?? c);
       return rows.map((r) => Object.fromEntries(chaves.map((c) => [c, r[c]])));
     };


### PR DESCRIPTION
## O quê

Duas regressões travando a garantia pedida pelo dono do produto para o fluxo
Respondi → CRM → automação: **a classificação/pontuação inicial (A/B/C/D,
`revisao_humana`, `desqualificado`) nunca pode bloquear a criação nem o
encaminhamento do lead**, só serve como registro/classificação interna.

- `e5298464` — trava o lado do **ENVIO**: `checarGuardasDeContato()` (usada por
  `send_whatsapp_message`/`send_ai_message`) só lê `ctx.context.contact`
  (telefone/consentimento), nunca `ctx.context.lead`/classificação.
- `f9e7c268` — trava o lado do **ROTEAMENTO**: `create_or_move_lead` (a ação
  que move/cria o lead na etapa certa do funil) também não lê classificação em
  nenhum caminho, criação ou move. 10 casos parametrizados (classes A–D,
  `nao_avaliado`, `revisao_humana` com os 2 motivos, sem classificação) +
  1 caso estrutural (o arquivo da ação não menciona `classificacao`/
  `respondi_score`).

Ambos os testes foram **sabotados manualmente** durante o desenvolvimento
(fazendo a guarda/ação ler classificação de propósito) para confirmar que
reprovam sozinhos antes de reverter — método descrito no cabeçalho de cada
teste.

De carona, corrige um bug real no dublê de teste compartilhado
`tests/helpers/stages-db-double.ts`: `select("*")` estava sendo projetado como
uma coluna **literal** chamada `"*"` em vez da linha inteira — nenhum
consumidor anterior do dublê usava `select("*")`, só
`app/api/v1/leads/_handler.ts` usa. Sem o conserto, todo `select("*")`
devolvia `{"*": undefined}` e o teste novo mediria o dublê, não o handler.

Também revisa `docs/decola-ai/prompt-sdr-inicial.md` contra os dois
documentos-fonte completos (não commitados aqui, ficam soltos na raiz por
pedido explícito) — acrescenta princípio de autoridade e follow-up.

## O que este PR NÃO faz

Não publica agente, não cria/ativa `automation_rule`, não envia mensagem real,
não muda schema, não mexe em produção. É só teste + doc.

## Verificação

Container local sem RAM para `pnpm typecheck`/`pnpm test:unit` completos
(OOM confirmado duas vezes) — verificado por amostragem isolada:

- `tsc --noEmit` escopado aos 3 arquivos tocados + fechamento transitivo: limpo
- `eslint` dos 3 arquivos `.ts`: limpo
- `vitest run create-or-move-lead.test.ts guarda-do-contato.test.ts`: 21/21
- `vitest run` das 4 rotas de pipeline/stage que usam o dublê corrigido: 80/80
- Sabotagem de ambos os testes: reprovou os casos certos, revertida antes do commit

O CI (`verify`, `test:unit` completo) roda com mais memória e é a prova final.

🤖 Generated with [Claude Code](https://claude.com/claude-code)