### PR TITLE
A versão deixa de ser escolhida e passa a ser calculada

### DIFF
--- a/.changes/tela-mostra-a-faixa-inteira.md
+++ b/.changes/tela-mostra-a-faixa-inteira.md
@@ -1,0 +1,11 @@
+---
+impacto: capacidade_nova
+secao: corrigido
+titulo: A tela de atualização mostra tudo o que mudou desde a sua versão
+---
+
+Antes ela mostrava só o texto da versão mais nova. Quem pulava versões — por
+exemplo, quem estava na 1.4.0 e atualizava direto para a 1.6.0 — nunca via o que
+tinha mudado no meio do caminho, e isso incluía os avisos de coisas que exigiam
+a sua ação. Agora a tela lista todas as versões entre a sua e a nova, com os
+avisos reunidos no topo e cada um dizendo de que versão veio.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+# Merge entre sessões paralelas.
+#
+# O conflito que mais custa neste repo não é o do CHANGELOG (o git auto-mescla
+# aquele: medido entre os PRs #354 e #349, `git merge-file` sai com 0). É o dos
+# dois arquivos append-only que TODA migration toca — e neles os dois lados
+# estão sempre certos: cada sessão acrescentou a sua linha no fim.
+
+# `union` = fica com os dois lados, sem marcador. Para uma tabela de registro,
+# é a resolução que um humano faria à mão em 100% dos casos.
+supabase/migrations/MANIFEST.md merge=union
+
+# ─── E por que `supabase/baseline.sql` NÃO está aqui ────────────────────────
+#
+# Porque `union` nele é pior que o conflito. Medido num merge real seguido de
+# aplicação num Postgres 17: o merge sai LIMPO (exit 0, "Merge made by the
+# 'ort' strategy", zero marcadores) e o SQL resultante intercala duas funções —
+# uma declarada e nunca definida, a outra com o corpo da primeira. Aí:
+#
+#   - no `install.sh` (banco novo, ON_ERROR_STOP=1) morre com syntax error;
+#   - no `update.sh` do CLIENTE (sem ON_ERROR_STOP) sai com codigo 0, deixando
+#     zero funções criadas e engolindo o resto do arquivo em silêncio.
+#
+# O marcador de conflito, aqui, é FEATURE: ele é a única coisa que obriga
+# alguém a olhar antes de o arquivo chegar à VPS de um cliente. `merge=binary`
+# tem o mesmo defeito pelo outro lado (fica com "ours" e um `git add` descarta
+# o outro lado sem ninguém ver).
+#
+# O conserto certo para o baseline é de processo, não de atributo: apêndice
+# idempotente por migration, como a doutrina de migrations do CLAUDE.md manda.

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -50,7 +50,52 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+  # Nenhuma tag publica sem estar CONTIDA na `main`.
+  #
+  # `on: push: tags: ["v*"]` reage a tag de QUALQUER ramo, e nenhuma das três
+  # condições do canal `stable` (mais abaixo) olha procedência — nem o
+  # `type=semver`, que publica `X.Y.Z` do mesmo jeito. A branch protection não
+  # cobre isto: ela vale para a branch `main`, não para refs de tag.
+  #
+  # E o alcance disso é o parque inteiro: `hostgator-setup-kit/agent.sh` oferece
+  # a MAIOR tag `v*` a toda VPS instalada, sem olhar de onde ela veio. Este repo
+  # já teve na árvore local uma tag `v1.4.0` de um FORK — ela existe hoje
+  # renomeada para `jmpo/v1.4.0` justamente para não colidir com a numeração
+  # daqui.
+  a-tag-veio-da-main:
+    runs-on: ubuntu-latest
+    # Sem o bloco, o token herda o default do REPOSITÓRIO — configuração que vive
+    # fora do repo. Mesma razão do `permissions: {}` de `imagens-ok`.
+    permissions:
+      contents: read
+    steps:
+      - name: A tag está contida na main?
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Sem `if:` no job, de propósito: job pulado deixa `build-and-push`
+          # pulado também, e `imagens-ok` (que roda com `always()`) lê `skipped`
+          # como reprovação. Em PR e em push de branch este job RODA e sai zero.
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "não é push de tag (${GITHUB_REF_TYPE}) — nada a conferir"
+            exit 0
+          fi
+          estado=$(gh api "repos/${GITHUB_REPOSITORY}/compare/main...${GITHUB_SHA}" --jq .status)
+          echo "compare main...${GITHUB_SHA} → ${estado}"
+          # `identical` = a tag é o topo da main; `behind` = está atrás dela, ou
+          # seja, contida. `ahead` e `diverged` são commit que a main não tem.
+          case "$estado" in
+            identical|behind) echo "ok: o commit da tag está contido na main" ;;
+            *)
+              echo "::error::A tag ${GITHUB_REF_NAME} aponta para um commit que a main NÃO contém (${estado})."
+              echo "::error::Publicar isso entregaria ao parque instalado código que nunca passou pelo CI da main."
+              exit 1
+              ;;
+          esac
+
   build-and-push:
+    needs: [a-tag-veio-da-main]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -165,6 +210,7 @@ jobs:
   # depois disso é esperado (não há Supabase aqui) e não reprova — o que
   # reprova é o processo não chegar a servir.
   imagem-do-app-sobe:
+    needs: [a-tag-veio-da-main]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,177 @@
+name: release
+
+# Os dois atos do ciclo, e nenhum deles cria tag na máquina de ninguém.
+#
+#   1. VOCÊ dispara "Run workflow" → ele lê `.changes/`, calcula o número, monta
+#      a seção do CHANGELOG e abre um PR de release em português dizendo o que
+#      vai sair. Nada é publicado ainda.
+#   2. VOCÊ faz merge desse PR → ele cria a tag `vX.Y.Z`, e é a tag que faz o
+#      `publish-image.yml` publicar as três imagens que a VPS puxa.
+#
+# Quem escreve (branch, PR, tag) é o token de um GitHub App, NUNCA o
+# GITHUB_TOKEN. A razão é uma armadilha documentada pelo próprio GitHub: evento
+# disparado com o GITHUB_TOKEN não cria novo workflow run. Se a tag nascesse
+# dele, o `publish-image.yml` jamais rodaria — a tag existiria, ninguém veria
+# erro, e NENHUMA VPS receberia a atualização. Falha silenciosa, descoberta só
+# quando um cliente tentasse atualizar.
+#
+# Por isso o ato 2 não confia: ele espera a publicação e CONFERE as três imagens
+# no registro, falhando alto se não aparecerem.
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+
+# O GITHUB_TOKEN aqui só clona e lê. Todo escopo de escrita vem do App, o que
+# mantém `tests/unit/workflows-tem-permissions.test.ts` sem entrada nova.
+permissions:
+  contents: read
+
+jobs:
+  abrir-pr-de-release:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          # `fetch-depth: 0` porque o corte compara com as tags, e o checkout
+          # raso padrão não traz nenhuma.
+          fetch-depth: 0
+          token: ${{ steps.token.outputs.token }}
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Calcular o número e montar a seção
+        id: corte
+        run: |
+          set -euo pipefail
+          pnpm exec tsx scripts/cortar-release.ts --escrever | tee /tmp/corte.txt
+          versao=$(pnpm exec tsx scripts/cortar-release.ts --versao-do-changelog)
+          echo "versao=${versao}" >> "$GITHUB_OUTPUT"
+
+      - name: Abrir o PR
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          VERSAO: ${{ steps.corte.outputs.versao }}
+        run: |
+          set -euo pipefail
+          git config user.name  'deskcomm-release[bot]'
+          git config user.email '${{ steps.token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          git checkout -b "release/${VERSAO}"
+          git add CHANGELOG.md .changes
+          git commit -m "release(${VERSAO}): a versão montada a partir dos fragmentos declarados"
+          git push origin "release/${VERSAO}"
+          {
+            echo "Esta versão sai como **${VERSAO}**, e o número foi CALCULADO a partir do que cada PR declarou — ninguém digitou."
+            echo
+            echo '```'
+            cat /tmp/corte.txt
+            echo '```'
+            echo
+            echo "Ao fazer merge deste PR, a tag \`v${VERSAO}\` é criada automaticamente e as três imagens são publicadas."
+            echo "Se algo aqui estiver errado, **feche o PR** em vez de editar o número: corrija o fragmento e dispare o workflow de novo."
+          } > /tmp/corpo.md
+          gh pr create --base main --head "release/${VERSAO}" \
+            --title "Release ${VERSAO}" --body-file /tmp/corpo.md
+
+  cortar-tag:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          token: ${{ steps.token.outputs.token }}
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: A main anuncia uma versão que ainda não tem tag?
+        id: pendente
+        run: |
+          set -euo pipefail
+          versao=$(pnpm exec tsx scripts/cortar-release.ts --versao-do-changelog)
+          if git rev-parse -q --verify "refs/tags/v${versao}" >/dev/null; then
+            echo "v${versao} já existe — nada a cortar (este push não era um merge de release)"
+            echo "cortar=nao" >> "$GITHUB_OUTPUT"
+          else
+            echo "v${versao} ainda não existe — esta main traz uma versão nova"
+            echo "cortar=sim"       >> "$GITHUB_OUTPUT"
+            echo "versao=${versao}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Criar e empurrar a tag
+        if: steps.pendente.outputs.cortar == 'sim'
+        env:
+          VERSAO: ${{ steps.pendente.outputs.versao }}
+        run: |
+          set -euo pipefail
+          git config user.name  'deskcomm-release[bot]'
+          git config user.email '${{ steps.token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          # Tag ANOTADA: guarda autor e data, e é o que `git describe
+          # --exact-match` do agent.sh espera encontrar na VPS.
+          git tag -a "v${VERSAO}" -m "v${VERSAO}"
+          git push origin "v${VERSAO}"
+
+      # A falha desta cadeia é silenciosa por natureza — a tag existe e ninguém
+      # vê erro —, então o workflow prova a CONSEQUÊNCIA em vez de supô-la.
+      - name: As três imagens existem nesta versão?
+        if: steps.pendente.outputs.cortar == 'sim'
+        env:
+          VERSAO: ${{ steps.pendente.outputs.versao }}
+        run: |
+          set -euo pipefail
+          # A mesma sonda do runbook (docs/runbooks/ativar-packaging.md): token
+          # anônimo de pull do próprio registro. Não usa o GITHUB_TOKEN de
+          # propósito — o que interessa provar é que a imagem está alcançável
+          # para QUEM INSTALA, e quem instala não tem credencial nossa.
+          ghcr_status() {
+            local t
+            t=$(curl -s "https://ghcr.io/token?scope=repository:${GITHUB_REPOSITORY_OWNER}/$1:pull&service=ghcr.io" \
+                | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
+            curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $t" \
+              -H 'Accept: application/vnd.oci.image.index.v1+json' \
+              "https://ghcr.io/v2/${GITHUB_REPOSITORY_OWNER}/$1/manifests/$2"
+          }
+          echo "esperando a publicação de v${VERSAO}…"
+          for _ in $(seq 1 60); do
+            faltando=""
+            for img in deskcommcrm deskcomm-worker deskcomm-scheduler; do
+              [ "$(ghcr_status "$img" "${VERSAO}")" = "200" ] || faltando="${faltando} ${img}"
+            done
+            if [ -z "$faltando" ]; then
+              echo "as três imagens respondem em ${VERSAO}"
+              exit 0
+            fi
+            sleep 30
+          done
+          echo "::error::A tag v${VERSAO} foi criada, mas as imagens não apareceram:${faltando}"
+          echo "::error::O parque instalado NÃO consegue atualizar para esta versão."
+          echo "::error::Confira o run de publish-image.yml para a tag v${VERSAO}."
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ evidence/.sonda-score-residuo.json
 
 # sessão reusada pelas jornadas (contém tokens)
 .auth/
+
+# QA em VPS: guarda segredo TOTP da conta de teste (repo e publico)
+.qa-vps/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,19 @@ que a major já não cobrisse — issue #235. Para a versão exata, `package.jso
 
 Runtime: **Node ≥22** (`.nvmrc` = 22; os quatro workflows fixam `node-version: 22` —
 `ci` ×2, `perf`, `e2e`). Gerenciador: **pnpm 9.15.9** (`packageManager`).
-Versão do produto: **1.0.0** (`CHANGELOG.md`, SemVer — mudança que afeta quem roda VPS entra lá).
+Versão do produto: **não está escrita aqui, de propósito.** Esta linha afirmava `1.0.0` até a
+v1.6.0 — seis minors de atraso, e nenhum teste a vigiava. Afirmação de versão envelhece a cada
+release; comando não. A que está publicada agora:
+
+```bash
+git ls-remote --tags --refs origin 'refs/tags/v*' \
+  | sed 's#.*refs/tags/v##' | awk '!/-/' | sort -V | tail -1   # awk, nao grep -v -- '-':
+                                                                # em maquina com ugrep aquele nao roda
+```
+
+O `package.json` **não** é a fonte da versão do produto (segue em `0.1.0`, e é assim de
+propósito). A fonte é a tag `v*` mais a seção do `CHANGELOG.md` — que é tela de produto, lida
+pelo dono da VPS. Como o número é decidido: [`docs/doctrine/versionamento.md`](docs/doctrine/versionamento.md).
 
 ## Estrutura que importa
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,4 +424,14 @@ Antes de declarar uma task pronta:
     Onde a afirmação puder virar **comando**, troque em vez de corrigir: um número corrigido
     envelhece de novo; um `rode isto para saber` não envelhece nunca
 
+17. **Se o PR muda comportamento visível a quem opera uma VPS, ele traz o seu fragmento em
+    `.changes/`** (lei em [`docs/doctrine/versionamento.md`](docs/doctrine/versionamento.md)).
+    O fragmento declara **o efeito no operador** — `nada_mudou` / `capacidade_nova` /
+    `exige_acao` —, nunca o número: o número é calculado a partir do conjunto, e é por isso
+    que duas sessões paralelas não colidem mais. Confira com `pnpm release:conferir`.
+    O CI valida a FORMA de todo fragmento, mas **não** cobra a presença de um — cobrar
+    presença num check obrigatório reprovaria PR de Dependabot, PR de fork, e o próprio PR
+    de release, que consome os fragmentos e deixa o diretório vazio. A presença é cobrada
+    aqui, e por quem revisa.
+
 Um staff engineer aprovaria? Se não, itera.

--- a/app/api/v1/system/version/route.test.ts
+++ b/app/api/v1/system/version/route.test.ts
@@ -54,7 +54,11 @@ beforeEach(() => {
     current_version: "1.0.0",
     latest_version: "1.1.0",
     off_release: false,
-    changelog_raw: "## [1.1.0] — 2026-08-02\n\n**⚠️ Requer atenção**\n\nreconecte o número.\n\n### Adicionado\n\n- botão.\n",
+    // A seção da versão INSTALADA precisa estar aqui: sem ela, todo caso
+    // exercitaria o caminho "faixa incompleta" e o caminho feliz nasceria sem
+    // cobertura nenhuma.
+    changelog_raw:
+      "## [1.1.0] — 2026-08-02\n\n**⚠️ Requer atenção**\n\nreconecte o número.\n\n### Adicionado\n\n- botão.\n\n## [1.0.0] — 2026-08-01\n\n- primeira versão.\n",
     agent_last_seen_at: new Date().toISOString(),
     compare_failed: false,
     update_requested_at: null,
@@ -158,13 +162,86 @@ describe("GET /api/v1/system/version", () => {
     expect(body.data.notes).toBeUndefined();
   });
 
-  it("entrega o estado completo e a seção do CHANGELOG para o dono", async () => {
+  it("entrega o estado completo e a faixa do CHANGELOG para o dono", async () => {
     vi.mocked(loadAuthUser).mockResolvedValue(OWNER as never);
     const { GET } = await import("../version/route");
     const body = await (await GET(get())).json();
     expect(body.data.update_available).toBe(true);
-    expect(body.data.notes.body).toContain("botão");
-    expect(body.data.notes.requires_attention).toContain("reconecte o número");
+    expect(body.data.notes.sections.map((s: { version: string }) => s.version)).toEqual(["1.1.0"]);
+    expect(body.data.notes.sections[0].body).toContain("botão");
+    expect(body.data.notes.requires_attention).toEqual([
+      { version: "1.1.0", texto: expect.stringContaining("reconecte o número") },
+    ]);
+    expect(body.data.notes.complete).toBe(true);
+  });
+
+  it("entrega TODAS as seções entre a instalada e a alvo, com o aviso do meio nomeado", async () => {
+    // O defeito que esta faixa conserta: quem pula versões via só a seção-alvo,
+    // e o aviso de ação manual da versão do meio desaparecia (commit ac9472c5).
+    versionRow.current_version = "1.0.0";
+    versionRow.latest_version = "1.2.0";
+    versionRow.changelog_raw = [
+      "## [1.2.0] — 2026-08-03",
+      "",
+      "### Adicionado",
+      "",
+      "- coisa nova.",
+      "",
+      "## [1.1.0] — 2026-08-02",
+      "",
+      "**⚠️ Requer atenção**",
+      "",
+      "reconecte o número.",
+      "",
+      "## [1.0.0] — 2026-08-01",
+      "",
+      "- primeira versão.",
+      "",
+    ].join("\n");
+    vi.mocked(loadAuthUser).mockResolvedValue(OWNER as never);
+    const { GET } = await import("../version/route");
+    const body = await (await GET(get())).json();
+    expect(body.data.notes.sections.map((s: { version: string }) => s.version)).toEqual([
+      "1.2.0",
+      "1.1.0",
+    ]);
+    expect(body.data.notes.requires_attention.map((a: { version: string }) => a.version)).toEqual([
+      "1.1.0",
+    ]);
+    expect(body.data.notes.complete).toBe(true);
+  });
+
+  it("declara faixa INCOMPLETA quando o texto não alcança a versão que está no ar", async () => {
+    // O agente manda o CHANGELOG cortado em bytes. Um corpo truncado no meio da
+    // frase é indistinguível de um corpo inteiro — sem este sinal, a tela
+    // afirmaria completude que não tem.
+    versionRow.changelog_raw = "## [1.1.0] — 2026-08-02\n\n### Adicionado\n\n- botão.\n";
+    vi.mocked(loadAuthUser).mockResolvedValue(OWNER as never);
+    const { GET } = await import("../version/route");
+    const body = await (await GET(get())).json();
+    expect(body.data.notes.complete).toBe(false);
+  });
+
+  it("depois de um rollback a faixa parte da versão que VOLTOU AO AR, não da que quebrou", async () => {
+    // `current_version` nomeia a versão que quebrou (o `git checkout` deu
+    // certo; quem não subiu foi o container). Usar esse campo deixaria a faixa
+    // vazia justamente para quem mais precisa lê-la.
+    versionRow.current_version = "1.1.0";
+    versionRow.latest_version = "1.1.0";
+    runRow = {
+      id: "run-1",
+      status: "failed_rolled_back",
+      from_version: "1.0.0",
+      to_version: "1.1.0",
+      last_step: null,
+      log_tail: "",
+      dispatched_at: new Date().toISOString(),
+    } as never;
+    vi.mocked(loadAuthUser).mockResolvedValue(OWNER as never);
+    const { GET } = await import("../version/route");
+    const body = await (await GET(get())).json();
+    expect(body.data.current_version).toBe("1.0.0");
+    expect(body.data.notes.sections.map((s: { version: string }) => s.version)).toEqual(["1.1.0"]);
   });
 
   it("entrega compare_failed para a tela poder dizer 'não sei' em vez de 'está em dia'", async () => {

--- a/app/api/v1/system/version/route.ts
+++ b/app/api/v1/system/version/route.ts
@@ -11,7 +11,7 @@ import { fail, ok } from "@/lib/api/wrappers";
 import { loadAuthUser } from "@/lib/auth/server";
 import { logger } from "@/lib/logger";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { extractChangelogSection } from "@/lib/system/changelog";
+import { extractChangelogRange } from "@/lib/system/changelog";
 import { isRunStale, type RunStatus, type RunStep } from "@/lib/system/update-run";
 
 export const dynamic = "force-dynamic";
@@ -80,7 +80,15 @@ export async function GET(_req: NextRequest): Promise<Response> {
   }
 
   const latest = version?.latest_version ?? "";
-  const section = latest ? extractChangelogSection(version?.changelog_raw ?? "", latest) : null;
+  // A faixa INTEIRA entre o que está no ar e o que vai entrar, não só a seção
+  // da versão-alvo. Mostrar só a alvo perdia aviso: quem pulava da 1.4.0 para a
+  // 1.6.0 nunca lia a 1.4.1 nem a 1.5.0 — e a 1.4.1 existia para corrigir uma
+  // instrução invertida que mandava apagar a conexão que estava funcionando.
+  //
+  // O limite inferior é `running`, NUNCA `current`: depois de um rollback,
+  // `current` nomeia a versão que quebrou, e a faixa sairia vazia justamente
+  // para quem mais precisa lê-la.
+  const faixa = latest ? extractChangelogRange(version?.changelog_raw ?? "", latest, running) : null;
 
   return ok({
     current_version: running,
@@ -99,7 +107,23 @@ export async function GET(_req: NextRequest): Promise<Response> {
     // não tocada por nenhum heartbeat, coluna com o default da migration).
     has_known_release: version?.has_known_release ?? true,
     agent_online: !Number.isNaN(lastSeen) && now.getTime() - lastSeen < AGENT_OFFLINE_AFTER_MS,
-    notes: section ? { body: section.body, requires_attention: section.requiresAttention } : null,
+    notes:
+      faixa && faixa.secoes.length > 0
+        ? {
+            // Consolidados no topo, cada um dizendo de que versão veio: numa
+            // faixa de várias versões, "reconecte o número" sem dizer de qual
+            // release não informa o operador — assusta.
+            requires_attention: faixa.secoes
+              .filter((s) => s.requiresAttention)
+              .map((s) => ({ version: s.version, texto: s.requiresAttention ?? "" })),
+            sections: faixa.secoes.map((s) => ({ version: s.version, body: s.body })),
+            // `false` = o texto recebido não alcança a versão que está no ar, e
+            // a última seção da lista pode estar cortada no meio da frase. A
+            // tela precisa DIZER isso — corpo truncado é indistinguível de
+            // corpo inteiro para quem lê.
+            complete: faixa.completa,
+          }
+        : null,
     run: run
       ? {
           id: run.id,

--- a/app/app/settings/atualizacao/_components/UpdatePanel.tsx
+++ b/app/app/settings/atualizacao/_components/UpdatePanel.tsx
@@ -286,23 +286,57 @@ export function UpdatePanel() {
         </p>
       )}
 
-      {data.notes?.requires_attention && (
+      {/* Os avisos de TODAS as versões da faixa, reunidos e sempre à vista.
+          Nenhum deles entra em `<details>`: esconder o que exige ação manual é
+          exatamente o defeito que esta tela passou a consertar. Cada um diz de
+          que versão veio — num salto de várias, "reconecte o número" sem dizer
+          de qual release não informa o operador, assusta. */}
+      {data.notes?.requires_attention.length ? (
         <div className="mb-4 rounded-md border border-warning bg-warning-bg p-3 text-sm text-warning-fg">
           <p className="mb-1 font-medium">⚠️ Requer atenção</p>
-          <p className="whitespace-pre-line">
-            {markdownParaTextoSimples(data.notes.requires_attention)}
-          </p>
+          {data.notes.requires_attention.map((aviso) => (
+            <div key={aviso.version} className="mt-2">
+              <p className="font-medium">Da versão {aviso.version}:</p>
+              <p className="whitespace-pre-line">{markdownParaTextoSimples(aviso.texto)}</p>
+            </div>
+          ))}
         </div>
+      ) : null}
+
+      {data.notes?.complete === false && data.notes.sections.length > 0 && (
+        <p className="mb-4 text-sm text-muted-foreground">
+          Este histórico começa na versão {data.notes.sections.at(-1)?.version} e pode não alcançar
+          a que você tem instalada ({versao}) — a última parte pode estar cortada. O texto completo
+          está no arquivo CHANGELOG.md do projeto.
+        </p>
       )}
 
-      {data.notes?.body && (
+      {data.notes?.sections.length ? (
         <div className="mb-6">
           <p className="mb-2 text-sm font-medium">O que muda</p>
-          <pre className="whitespace-pre-wrap font-sans text-sm text-muted-foreground">
-            {markdownParaTextoSimples(data.notes.body)}
-          </pre>
+          {data.notes.sections.map((secao, i) => (
+            <div key={secao.version} className="mb-3">
+              {/* A versão-alvo fica aberta; as do meio ficam recolhidas, para a
+                  lista não virar um muro de texto num salto de várias versões.
+                  Só o CORPO é recolhido — o aviso delas já está lá em cima. */}
+              {i === 0 ? (
+                <pre className="whitespace-pre-wrap font-sans text-sm text-muted-foreground">
+                  {markdownParaTextoSimples(secao.body)}
+                </pre>
+              ) : (
+                <details>
+                  <summary className="cursor-pointer text-sm font-medium">
+                    Versão {secao.version}
+                  </summary>
+                  <pre className="mt-2 whitespace-pre-wrap font-sans text-sm text-muted-foreground">
+                    {markdownParaTextoSimples(secao.body)}
+                  </pre>
+                </details>
+              )}
+            </div>
+          ))}
         </div>
-      )}
+      ) : null}
 
       <BotaoAtualizar mutate={() => atualizar.mutate()} isPending={atualizar.isPending} erro={erro} />
     </Layout>

--- a/docs/architecture/atualizacao-self-service.architecture.json
+++ b/docs/architecture/atualizacao-self-service.architecture.json
@@ -8,39 +8,181 @@
     "quality_profile": "standard"
   },
   "lanes": [
-    { "id": "host", "label": "VPS (fora do app)" },
-    { "id": "app", "label": "App — rota do agente e da UI" },
-    { "id": "banco", "label": "Banco (instância, sem organization_id)" },
-    { "id": "humano", "label": "O que o dono vê" }
+    {
+      "id": "host",
+      "label": "VPS (fora do app)"
+    },
+    {
+      "id": "app",
+      "label": "App — rota do agente e da UI"
+    },
+    {
+      "id": "banco",
+      "label": "Banco (instância, sem organization_id)"
+    },
+    {
+      "id": "humano",
+      "label": "O que o dono vê"
+    }
   ],
-  "mainPath": ["agentsh", "agentroute", "systemversion", "footer", "painel", "updateroute", "runs"],
+  "mainPath": [
+    "agentsh",
+    "agentroute",
+    "systemversion",
+    "footer",
+    "painel",
+    "updateroute",
+    "runs"
+  ],
   "nodes": [
-    { "id": "agentsh", "lane": "host", "col": 0, "type": "service", "label": "agent.sh", "sublabel": "cron 5min · flock · esc() byte-safe (LC_ALL=C)" },
-    { "id": "updatesh", "lane": "host", "col": 1, "type": "service", "label": "update.sh --to <tag>", "sublabel": "backup → checkout da tag → baseline → imagem → healthcheck" },
-
-    { "id": "agentroute", "lane": "app", "col": 0, "type": "api", "label": "POST /api/v1/system/agent", "sublabel": "bearer INTERNAL_CRON_SECRET · heartbeat/run_progress/run_result" },
-    { "id": "versionroute", "lane": "app", "col": 2, "type": "api", "label": "GET /api/v1/system/version", "sublabel": "só is_platform_admin vê o operacional" },
-    { "id": "updateroute", "lane": "app", "col": 3, "type": "api", "label": "POST /api/v1/system/update", "sublabel": "cria o run — nunca executa nada" },
-
-    { "id": "systemversion", "lane": "banco", "col": 1, "type": "database", "label": "system_version", "sublabel": "singleton id=1 · current/latest/changelog_raw" },
-    { "id": "runs", "lane": "banco", "col": 3, "type": "database", "label": "system_update_runs", "sublabel": "índice único: no máx. 1 'dispatched'" },
-
-    { "id": "footer", "lane": "humano", "col": 2, "type": "frontend", "label": "Rodapé da sidebar", "sublabel": "aviso só se is_owner E update_available" },
-    { "id": "painel", "lane": "humano", "col": 3, "type": "frontend", "label": "/app/settings/atualizacao", "sublabel": "4 estados · atenção ANTES do botão" }
+    {
+      "id": "agentsh",
+      "lane": "host",
+      "col": 0,
+      "type": "service",
+      "label": "agent.sh",
+      "sublabel": "cron 5min · flock · esc() byte-safe (LC_ALL=C)"
+    },
+    {
+      "id": "updatesh",
+      "lane": "host",
+      "col": 1,
+      "type": "service",
+      "label": "update.sh --to <tag>",
+      "sublabel": "backup → checkout da tag → baseline → imagem → healthcheck"
+    },
+    {
+      "id": "agentroute",
+      "lane": "app",
+      "col": 0,
+      "type": "api",
+      "label": "POST /api/v1/system/agent",
+      "sublabel": "bearer INTERNAL_CRON_SECRET · heartbeat/run_progress/run_result"
+    },
+    {
+      "id": "versionroute",
+      "lane": "app",
+      "col": 2,
+      "type": "api",
+      "label": "GET /api/v1/system/version",
+      "sublabel": "só is_platform_admin vê o operacional · entrega a faixa instalada→alvo"
+    },
+    {
+      "id": "updateroute",
+      "lane": "app",
+      "col": 3,
+      "type": "api",
+      "label": "POST /api/v1/system/update",
+      "sublabel": "cria o run — nunca executa nada"
+    },
+    {
+      "id": "systemversion",
+      "lane": "banco",
+      "col": 1,
+      "type": "database",
+      "label": "system_version",
+      "sublabel": "singleton id=1 · current/latest/changelog_raw"
+    },
+    {
+      "id": "runs",
+      "lane": "banco",
+      "col": 3,
+      "type": "database",
+      "label": "system_update_runs",
+      "sublabel": "índice único: no máx. 1 'dispatched'"
+    },
+    {
+      "id": "footer",
+      "lane": "humano",
+      "col": 2,
+      "type": "frontend",
+      "label": "Rodapé da sidebar",
+      "sublabel": "aviso só se is_owner E update_available"
+    },
+    {
+      "id": "painel",
+      "lane": "humano",
+      "col": 3,
+      "type": "frontend",
+      "label": "/app/settings/atualizacao",
+      "sublabel": "4 estados · avisos de TODAS as versões da faixa, antes do botão"
+    }
   ],
   "edges": [
-    { "id": "e1", "from": "agentsh", "to": "agentroute", "label": "heartbeat: versão instalada + changelog cru" },
-    { "id": "e2", "from": "agentroute", "to": "systemversion", "label": "grava current/latest/changelog_raw" },
-    { "id": "e3", "from": "systemversion", "to": "versionroute", "label": "leitura para a tela" },
-    { "id": "e4", "from": "versionroute", "to": "footer", "label": "update_available + is_owner" },
-    { "id": "e5", "from": "footer", "to": "painel", "label": "clique no aviso 'Nova versão'" },
-    { "id": "e6", "from": "painel", "to": "updateroute", "label": "clique em 'Atualizar agora'" },
-    { "id": "e7", "from": "updateroute", "to": "runs", "label": "insert status='dispatched'" },
-    { "id": "e8", "from": "agentroute", "to": "runs", "label": "heartbeat seguinte: update_requested=true" },
-    { "id": "e9", "from": "agentsh", "to": "updatesh", "label": "dispara o script local — nunca um comando vindo do app", "route": "highlight" },
-    { "id": "e10", "from": "updatesh", "to": "agentroute", "label": "report() em 3 pontos: backup/código/banco", "route": "highlight" },
-    { "id": "e11", "from": "agentroute", "to": "runs", "label": "run_result fecha success/failed/failed_rolled_back" },
-    { "id": "e12", "from": "runs", "to": "painel", "label": "polling 5s — progresso e desfecho" }
+    {
+      "id": "e1",
+      "from": "agentsh",
+      "to": "agentroute",
+      "label": "heartbeat: versão instalada + changelog cru"
+    },
+    {
+      "id": "e2",
+      "from": "agentroute",
+      "to": "systemversion",
+      "label": "grava current/latest/changelog_raw"
+    },
+    {
+      "id": "e3",
+      "from": "systemversion",
+      "to": "versionroute",
+      "label": "faixa de seções entre a instalada e a alvo"
+    },
+    {
+      "id": "e4",
+      "from": "versionroute",
+      "to": "footer",
+      "label": "update_available + is_owner"
+    },
+    {
+      "id": "e5",
+      "from": "footer",
+      "to": "painel",
+      "label": "clique no aviso 'Nova versão'"
+    },
+    {
+      "id": "e6",
+      "from": "painel",
+      "to": "updateroute",
+      "label": "clique em 'Atualizar agora'"
+    },
+    {
+      "id": "e7",
+      "from": "updateroute",
+      "to": "runs",
+      "label": "insert status='dispatched'"
+    },
+    {
+      "id": "e8",
+      "from": "agentroute",
+      "to": "runs",
+      "label": "heartbeat seguinte: update_requested=true"
+    },
+    {
+      "id": "e9",
+      "from": "agentsh",
+      "to": "updatesh",
+      "label": "dispara o script local — nunca um comando vindo do app",
+      "route": "highlight"
+    },
+    {
+      "id": "e10",
+      "from": "updatesh",
+      "to": "agentroute",
+      "label": "report() em 3 pontos: backup/código/banco",
+      "route": "highlight"
+    },
+    {
+      "id": "e11",
+      "from": "agentroute",
+      "to": "runs",
+      "label": "run_result fecha success/failed/failed_rolled_back"
+    },
+    {
+      "id": "e12",
+      "from": "runs",
+      "to": "painel",
+      "label": "polling 5s — progresso e desfecho"
+    }
   ],
   "cards": [
     {

--- a/docs/doctrine/versionamento.md
+++ b/docs/doctrine/versionamento.md
@@ -123,12 +123,31 @@ e escreve o texto que o operador vai ler.
 
 ```markdown
 ---
-impacto: patch          # patch | minor | major
-secao: Corrigido        # Adicionado | Alterado | Corrigido
+impacto: nada_mudou     # nada_mudou | capacidade_nova | exige_acao
+secao: corrigido        # adicionado | alterado | corrigido
+titulo: A IA avisa o cliente antes de chamar uma pessoa
 ---
 
-**A IA avisa o cliente antes de chamar uma pessoa.** Quando o atendimento automático
-parava e a conversa ia para a fila humana, o cliente não recebia mensagem nenhuma.
+Quando o atendimento automático parava e a conversa ia para a fila humana, o
+cliente não recebia mensagem nenhuma: ele falava, e ninguém respondia.
+```
+
+**O campo é o efeito, não o número** — e essa escolha é a régua inteira. Pedir
+`impacto: minor` convidaria de volta exatamente o erro que este documento existe para
+corrigir, porque "minor" é a *resposta*, e responder a resposta é o que se faz quando não
+se tem a pergunta. `nada_mudou` não tem como ser respondido errado por quem sabe o que
+fez. O número sai de `BUMP_DO_IMPACTO`, em `lib/release/fragmento.ts`, e a régua está
+presa por valor no teste ao lado — inverter a tabela reprova o CI.
+
+Quando `impacto: exige_acao`, o fragmento traz também um bloco `## Requer atenção` com o
+que o operador precisa fazer; sem ele o fragmento é recusado, e o contrário também
+(aviso com impacto mais brando). Quem emite o `### ⚠️ Requer atenção` que a tela procura é
+o montador, uma vez só.
+
+Para conferir o que os fragmentos de agora produziriam, sem escrever nada:
+
+```bash
+pnpm release:conferir
 ```
 
 Três propriedades, e cada uma resolve um defeito medido:

--- a/docs/doctrine/versionamento.md
+++ b/docs/doctrine/versionamento.md
@@ -1,0 +1,189 @@
+# Doutrina de Versionamento
+
+> Lei sobre o **número**: quem o decide, com que régua, e o que ele promete a quem já
+> instalou. Complementa [`packaging.md`](./packaging.md), que trata de **como** o artefato
+> chega ao disco do cliente — aqui trata-se de **o que o número diz** sobre o que chegou.
+> Amarrada ao Definition of Done (`CLAUDE.md`).
+
+| Se você quer… | Vá para |
+|---|---|
+| decidir se sua mudança é patch, minor ou major | §A régua |
+| saber por que não é você quem escolhe o número | §Ninguém escolhe o número |
+| escrever o fragmento que o seu PR precisa trazer | §O fragmento |
+| saber qual versão está publicada agora | §A versão em vigor |
+
+---
+
+## O princípio-raiz
+
+A pergunta que decide o número **não é** *"o que mudou no código?"*. Tudo muda — essa
+pergunta não separa nada, e uma régua que não separa nada devolve sempre a mesma resposta.
+
+A pergunta é:
+
+> **"O que o dono da VPS precisa fazer?"**
+
+Porque o número não é um rótulo de esforço nem um troféu de tamanho: é uma **promessa
+operacional** para alguém que vai rodar `bash update.sh` sem ler o diff, num servidor onde o
+WhatsApp da empresa dele está atendendo cliente agora.
+
+Quem lê o número é o operador, não o autor. A régua tem que ser escrita da cadeira dele.
+
+---
+
+## A régua
+
+| O que acontece com quem já roda | Número |
+|---|---|
+| Não precisa fazer nada, e **nada que funcionava mudou de forma** | **patch** — `1.6.0` → `1.6.1` |
+| Não precisa fazer nada, mas **ganhou capacidade nova** | **minor** — `1.6.1` → `1.7.0` |
+| **Precisa agir**: editar `.env`, rodar comando, ou algo que existia sumiu / mudou de forma | **major** — `1.7.0` → `2.0.0` |
+
+A linha de baixo não é escolha nossa: ela já é lei em `CLAUDE.md`, na doutrina de packaging
+e no [ADR 0001](../adr/0001-packaging-e-distribuicao.md) — *bump que exige edição manual não
+entra; vira issue com plano de migração e vai para uma major*. Esta doutrina apenas estende
+a mesma lógica para baixo, para a faixa onde **todas** as releases do projeto realmente caem.
+
+### Por que "comportamento visível" NÃO é a régua
+
+Esta é a régua que estava em vigor, e ela é a causa mecânica do problema que originou este
+documento. Escrita em voz alta no commit de release da v1.6.0 (`e9df4bae`):
+
+> *"MINOR porque muda comportamento visível ao cliente final."*
+
+**Um conserto de bug, por definição, muda comportamento visível ao cliente final.** Sob essa
+régua todo conserto é minor, e o número perde a capacidade de distinguir "consertamos o que
+estava quebrado" de "o sistema faz algo novo". Medido no histórico: **seis minors e duas
+patches em trinta dias**, com `v1.4.0` → `v1.6.0` em três dias.
+
+O caso da v1.6.0 é o mais instrutivo, porque o número **estava certo** — aquela versão trazia
+os formulários do Respondi, capacidade nova de verdade. Ele estava certo **pelo motivo
+errado**, justificado pelo conserto e não pela adição. Régua que acerta por acidente erra na
+próxima.
+
+### O teste de uma linha
+
+Antes de escolher, escreva a frase que o operador vai ler na tela de atualização:
+
+- *"Você não precisa fazer nada."* → **patch**
+- *"Você não precisa fazer nada; agora o sistema também faz X."* → **minor**
+- *"Antes de atualizar, você precisa…"* → **major**
+
+Se a terceira frase é verdadeira, o número é major **mesmo que a mudança seja pequena** — o
+custo que ele mede é o do operador, não o do autor.
+
+---
+
+## Ninguém escolhe o número
+
+O número é **calculado** a partir do que os PRs declararam, nunca digitado por quem está
+cortando a release. Isso não é preferência de estilo: é o que torna **impossível** a colisão
+entre duas sessões de trabalho paralelas.
+
+Enquanto a escolha era humana, ela dependia de ler `git tag` e somar um — e duas sessões que
+leem a mesma lista no mesmo dia chegam ao mesmo número. O resultado medido está no commit
+`ac9472c5`, escrito pela sessão que descobriu o estrago por acaso:
+
+> *"A 1.4.1 está no CHANGELOG e NÃO tem tag."*
+
+Uma sessão escreveu a seção da versão e nunca criou a tag. Como a tela de atualização mostra
+**a seção da versão-alvo**, os dois avisos da 1.4.1 — um deles instruindo o operador a apagar
+a conexão que estava funcionando — teriam desaparecido para quem pulasse direto para a 1.5.0.
+
+Com o número derivado, a pergunta *"qual é a próxima versão?"* deixa de ter dono e passa a
+ter **resposta**: é função do conjunto de fragmentos acumulados, e duas sessões que rodem o
+cálculo obtêm o mesmo resultado porque olham para o mesmo conjunto.
+
+### A tag nasce no CI
+
+`git tag` na máquina de alguém é o ponto onde o número deixa de ser revisável. A tag é criada
+pelo CI, a partir de um PR de release, e **só de um commit contido na `main`**.
+
+Três razões medidas, todas com consequência no parque instalado:
+
+1. **A tag é o gatilho de atualização de todo mundo.** `hostgator-setup-kit/agent.sh` faz
+   `git fetch --tags` e `hostgator-setup-kit/update.sh` puxa a imagem **por número**. Tag
+   errada não é erro cosmético de changelog: é o seletor do que cada VPS baixa.
+2. **Uma tag `v*` de qualquer branch move o canal `stable`.** O workflow de publicação não
+   testa se o commit está na `main`.
+3. **Mover uma tag já publicada quebra a VPS e mente sobre o motivo.** O `git fetch --tags`
+   do `update.sh` recusa a tag movida (`would clobber existing tag`) e sai com erro — que o
+   script relata como *"não consegui falar com o GitHub"*. O operador fica no código antigo
+   procurando um problema de rede que não existe.
+
+Daí a regra que a doutrina de packaging já enuncia e esta reforça: **versão publicada é
+imutável**. Corrige-se com `X.Y.Z+1`, nunca republicando o mesmo número.
+
+---
+
+## O fragmento
+
+Todo PR que muda comportamento traz um arquivo em `.changes/`, e é ele que declara o impacto
+e escreve o texto que o operador vai ler.
+
+```markdown
+---
+impacto: patch          # patch | minor | major
+secao: Corrigido        # Adicionado | Alterado | Corrigido
+---
+
+**A IA avisa o cliente antes de chamar uma pessoa.** Quando o atendimento automático
+parava e a conversa ia para a fila humana, o cliente não recebia mensagem nenhuma.
+```
+
+Três propriedades, e cada uma resolve um defeito medido:
+
+- **Um arquivo por PR, nome único.** Dois PRs paralelos criam dois arquivos diferentes, e o
+  conflito de merge deixa de ser possível *por construção*. Medido: **oito merges** com
+  conflito real no `CHANGELOG.md`, todos concentrados em 25–26/08 — a mesma janela dos três
+  minors em três dias.
+- **Escrito por quem fez a mudança, quando fez.** O texto para de ser reconstruído do `git
+  log` dias depois por quem não estava lá. Medido: **13 de 45** commits entre a v1.5.0 e a
+  v1.6.0 não têm eco na seção da versão.
+- **O impacto é declarado, não inferido.** Derivar de mensagem de commit não funcionaria
+  aqui: medido, 94,4% dos commits sem merge seguem Conventional Commits, mas apenas 2,2% dos
+  merges — e há **zero** marcações de breaking change em 2.639 commits, o que tornaria major
+  inderivável.
+
+### Por que não uma ferramenta pronta
+
+`release-please` e `semantic-release` montam o changelog a partir de mensagens de commit.
+Aqui isso não serve, e a razão é do produto, não de gosto: **o `CHANGELOG.md` é tela.**
+`lib/system/changelog.ts` extrai a seção de uma versão e a rota de sistema a entrega ao dono
+da VPS. É prosa longa em português — média de cerca de cem linhas por versão — escrita para
+quem não leu o diff. Nenhum gerador produz isso a partir de `fix(scope): ...`.
+
+O que se adota dessas ferramentas é a **ideia** — fragmento por PR, número derivado, release
+por PR acumulativo —, não o gerador de texto.
+
+---
+
+## A versão em vigor
+
+Não está escrita aqui, e isso é deliberado: afirmação de versão envelhece a cada release, e
+foi assim que `AGENTS.md` passou seis minors dizendo `1.0.0`. Comando não envelhece:
+
+```bash
+git ls-remote --tags --refs origin 'refs/tags/v*' \
+  | sed 's#.*refs/tags/v##' | awk '!/-/' | sort -V | tail -1
+```
+
+O `awk '!/-/'` descarta prerelease e tag de fork — o repositório carrega `v1.1.1-jmpo.1` e
+`jmpo/v1.4.0`, que existem para **não** colidir com a numeração daqui.
+
+E o `package.json` **não** é a fonte: ele segue em `0.1.0`, de propósito. A fonte é a tag
+`v*` mais a seção do `CHANGELOG.md`.
+
+---
+
+## Os invariantes
+
+1. **O número responde ao operador, não ao autor.** A pergunta é sempre o que ele precisa
+   fazer.
+2. **Ninguém digita o número.** Ele é calculado a partir dos fragmentos declarados.
+3. **A tag nasce no CI, de commit contido na `main`.** Nunca da máquina de alguém.
+4. **Versão publicada é imutável.** Conserto é `X.Y.Z+1`; nunca republicar o mesmo número.
+5. **Todo PR que muda comportamento traz seu fragmento.** Sem ele, o texto que chega ao
+   operador é reconstruído por quem não estava lá — ou não chega.
+6. **Bump não pode exigir edição manual de arquivo na VPS.** Se exigir, é major e vem com
+   plano de migração.

--- a/hooks/system/useSystemVersion.ts
+++ b/hooks/system/useSystemVersion.ts
@@ -14,7 +14,14 @@ export interface SystemVersion {
   /** O host já viu ao menos uma tag `v*` publicada neste repositório. */
   has_known_release?: boolean;
   agent_online?: boolean;
-  notes?: { body: string; requires_attention: string | null } | null;
+  notes?: {
+    /** Um por versão da faixa que tem aviso, do mais novo ao mais antigo. */
+    requires_attention: Array<{ version: string; texto: string }>;
+    /** Todas as seções entre a versão no ar e a alvo, da mais nova à mais antiga. */
+    sections: Array<{ version: string; body: string }>;
+    /** `false`: o texto recebido pode não alcançar a versão instalada. */
+    complete: boolean;
+  } | null;
   run?: {
     id: string;
     status: string;

--- a/hostgator-setup-kit/agent.sh
+++ b/hostgator-setup-kit/agent.sh
@@ -157,7 +157,17 @@ if [ -n "$LATEST_TAG" ] && [ "$LATEST_TAG" != "$CURRENT" ]; then
   # HEARTBEAT INTEIRO morreria com 422 — sem short-circuit, isso morre calado.
   # 30000 cru garante ≤60000 escapado mesmo no pior caso (100% do texto
   # escapando 2x), com folga sobre o teto de 64000.
-  CHANGELOG="$(git show "${LATEST_TAG}:CHANGELOG.md" 2>/dev/null | head -c 30000 || true)"
+  # O corte deixou de ser cego. O `awk` para de imprimir AO IMPRIMIR o cabeçalho
+  # da versão instalada — e o cabeçalho entra de propósito: é ele que prova ao
+  # app que a faixa está completa. Isso encolhe o payload no caso comum (uma ou
+  # duas versões de salto) em vez de subir o teto, que mataria o heartbeat
+  # inteiro com 422, calado. O `head -c 30000` continua depois, como teto para o
+  # salto grande. `index()` e não regex: o rótulo tem `[` e `]`, e escapar isso
+  # em awk é onde se erra. Instalação fora de release (CURRENT é um SHA) nunca
+  # casa, cai no arquivo inteiro cortado, e o app declara que não alcançou.
+  # MANTENHA numa linha física só: tests/unit/changelog-cabe-na-tela-da-vps.test.ts
+  # lê o teto daqui por regex de linha única e EXPLODE se ela for quebrada.
+  CHANGELOG="$(git show "${LATEST_TAG}:CHANGELOG.md" 2>/dev/null | awk -v cur="## [${CURRENT#v}]" 'index($0, cur) == 1 { print; exit } { print }' | head -c 30000 || true)"
   # `head -c` corta em byte fixo, e o CHANGELOG tem emoji/acento multi-byte
   # (UTF-8) — um corte no meio de um caractere quebraria o JSON de um jeito
   # difícil de rastrear. `iconv -c` descarta o byte incompleto do final sem

--- a/lib/release/fragmento.test.ts
+++ b/lib/release/fragmento.test.ts
@@ -75,11 +75,25 @@ describe("fragmento — o que o PR declara", () => {
 });
 
 describe("o número é consequência do efeito declarado", () => {
-  // Exercita a FUNÇÃO com cada chave do vocabulário: uma tabela conferida a
-  // olho não pega o dia em que alguém acrescenta um impacto e esquece o mapa.
-  it.each(Impacto.options)("%s tem bump declarado e calculável", (impacto) => {
-    expect(BUMP_DO_IMPACTO[impacto]).toBeDefined();
-    expect(calcularBump([impacto])).toBe(BUMP_DO_IMPACTO[impacto]);
+  // A régua ESCRITA, presa por valor. Comparar `calcularBump(x)` com
+  // `BUMP_DO_IMPACTO[x]` não serve de guarda: as duas pontas derivam da mesma
+  // fonte, então inverter a tabela move as duas juntas e o teste passa —
+  // medido, sabotando `nada_mudou` para `minor` (a régua que causou o
+  // problema): aquele caso ficou VERDE. O que vigia a régua é esta tabela
+  // literal, que é a mesma de `docs/doctrine/versionamento.md`.
+  it.each([
+    ["nada_mudou", "patch"],
+    ["capacidade_nova", "minor"],
+    ["exige_acao", "major"],
+  ] as const)("%s produz %s", (impacto, esperado) => {
+    expect(BUMP_DO_IMPACTO[impacto]).toBe(esperado);
+    expect(calcularBump([impacto])).toBe(esperado);
+  });
+
+  it("todo impacto do vocabulário tem bump — nenhum cai no vazio", () => {
+    for (const impacto of Impacto.options) {
+      expect(BUMP_DO_IMPACTO[impacto], `impacto sem bump: ${impacto}`).toBeDefined();
+    }
   });
 
   it("o conjunto vale pelo mais severo, em qualquer ordem", () => {

--- a/lib/release/fragmento.test.ts
+++ b/lib/release/fragmento.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BUMP_DO_IMPACTO,
+  calcularBump,
+  FragmentoInvalido,
+  Impacto,
+  parseFragmento,
+  proximaVersao,
+} from "./fragmento";
+
+const bom = [
+  "---",
+  "impacto: nada_mudou",
+  "secao: corrigido",
+  "titulo: A IA avisa antes de chamar uma pessoa",
+  "---",
+  "",
+  "Quando o atendimento parava, o cliente não recebia mensagem nenhuma.",
+].join("\n");
+
+describe("fragmento — o que o PR declara", () => {
+  it("lê frontmatter e corpo", () => {
+    const f = parseFragmento("x.md", bom);
+    expect(f.impacto).toBe("nada_mudou");
+    expect(f.secao).toBe("corrigido");
+    expect(f.titulo).toBe("A IA avisa antes de chamar uma pessoa");
+    expect(f.corpo).toContain("não recebia mensagem");
+    expect(f.atencao).toBeNull();
+  });
+
+  it("aceita comentário depois de ` #`, mas não corta um `#` colado no valor", () => {
+    const f = parseFragmento("x.md", bom.replace("impacto: nada_mudou", "impacto: nada_mudou # patch"));
+    expect(f.impacto).toBe("nada_mudou");
+    const t = parseFragmento("x.md", bom.replace("titulo: A IA", "titulo: Conserta o #351 da"));
+    expect(t.titulo).toContain("#351");
+  });
+
+  it.each([
+    ["sem frontmatter", "só o corpo"],
+    ["frontmatter aberto e não fechado", "---\nimpacto: nada_mudou\nsem fim"],
+    ["impacto fora do vocabulário", bom.replace("nada_mudou", "minor")],
+    ["seção fora do vocabulário", bom.replace("secao: corrigido", "secao: removido")],
+    ["título vazio", bom.replace("titulo: A IA avisa antes de chamar uma pessoa", "titulo:   ")],
+    ["corpo vazio", bom.split("\n").slice(0, 5).join("\n")],
+  ])("recusa: %s", (_nome, texto) => {
+    expect(() => parseFragmento("x.md", texto)).toThrow(FragmentoInvalido);
+  });
+
+  // Cada caso abaixo é um defeito que apareceria na TELA do dono da VPS, não no
+  // repositório — por isso a recusa é na entrada, não na revisão.
+  it.each([
+    ["heading no corpo decapita a seção", "## Adicionado à força"],
+    ["um segundo ⚠️ desloca o bloco de atenção", "⚠️ cuidado"],
+    ["referência de link no meio aparece crua", "[a]: https://exemplo.test"],
+    ["`**` que não fecha vaza asterisco para a tela", "isto é **importante"],
+  ])("recusa corpo que quebra o parser da tela: %s", (_nome, linha) => {
+    expect(() => parseFragmento("x.md", `${bom}\n${linha}`)).toThrow(FragmentoInvalido);
+  });
+
+  it("exige_acao sem bloco de aviso é recusado — e o contrário também", () => {
+    const semAviso = bom.replace("impacto: nada_mudou", "impacto: exige_acao");
+    expect(() => parseFragmento("x.md", semAviso)).toThrow(/Requer atenção/);
+
+    const avisoSemAcao = `${bom}\n\n## Requer atenção\n\nEdite o .env antes.`;
+    expect(() => parseFragmento("x.md", avisoSemAcao)).toThrow(/exige_acao/);
+  });
+
+  it("com exige_acao, o aviso sai separado do corpo", () => {
+    const texto = `${bom.replace("impacto: nada_mudou", "impacto: exige_acao")}\n\n## Requer atenção\n\nRode \`bash update.sh\` duas vezes.`;
+    const f = parseFragmento("x.md", texto);
+    expect(f.atencao).toContain("duas vezes");
+    expect(f.corpo).not.toContain("duas vezes");
+  });
+});
+
+describe("o número é consequência do efeito declarado", () => {
+  // Exercita a FUNÇÃO com cada chave do vocabulário: uma tabela conferida a
+  // olho não pega o dia em que alguém acrescenta um impacto e esquece o mapa.
+  it.each(Impacto.options)("%s tem bump declarado e calculável", (impacto) => {
+    expect(BUMP_DO_IMPACTO[impacto]).toBeDefined();
+    expect(calcularBump([impacto])).toBe(BUMP_DO_IMPACTO[impacto]);
+  });
+
+  it("o conjunto vale pelo mais severo, em qualquer ordem", () => {
+    expect(calcularBump(["nada_mudou", "capacidade_nova"])).toBe("minor");
+    expect(calcularBump(["capacidade_nova", "nada_mudou"])).toBe("minor");
+    expect(calcularBump(["exige_acao", "nada_mudou", "capacidade_nova"])).toBe("major");
+    expect(calcularBump(["nada_mudou", "nada_mudou"])).toBe("patch");
+  });
+
+  it("sem fragmento não há release — nunca um patch inventado", () => {
+    expect(() => calcularBump([])).toThrow(FragmentoInvalido);
+  });
+
+  it("o conserto de um bug NÃO sobe a minor — a régua que causou o problema", () => {
+    // v1.6.0 justificou MINOR com "muda comportamento visível ao cliente
+    // final" (commit e9df4bae). Conserto muda comportamento visível por
+    // definição; sob aquela régua todo conserto era minor.
+    expect(proximaVersao("1.6.0", calcularBump(["nada_mudou"]))).toBe("1.6.1");
+  });
+
+  it.each([
+    ["1.6.0", "patch", "1.6.1"],
+    ["1.6.1", "minor", "1.7.0"],
+    ["1.7.0", "major", "2.0.0"],
+    ["v1.6.0", "patch", "1.6.1"],
+  ] as const)("%s + %s = %s", (base, bump, esperado) => {
+    expect(proximaVersao(base, bump)).toBe(esperado);
+  });
+
+  it.each(["1.6", "1.6.0-rc1", "latest", ""])("recusa base que não é X.Y.Z: %s", (base) => {
+    expect(() => proximaVersao(base, "patch")).toThrow(FragmentoInvalido);
+  });
+});

--- a/lib/release/fragmento.ts
+++ b/lib/release/fragmento.ts
@@ -1,0 +1,197 @@
+/**
+ * O fragmento que cada PR traz em `.changes/` — leitura, validação e o cálculo
+ * do número que eles produzem juntos.
+ *
+ * A lei está em `docs/doctrine/versionamento.md`. O que este módulo carrega e a
+ * prosa não consegue carregar é a RECUSA: um fragmento malformado reprova o
+ * `verify` em vez de virar defeito visível na tela do dono da VPS, que é onde a
+ * seção montada termina (`lib/system/changelog.ts` a extrai e a rota de sistema
+ * a entrega).
+ *
+ * Por que o autor declara o EFEITO e não o número: a régua anterior — "mudança
+ * de comportamento visível = minor" — transformava todo conserto em minor,
+ * porque conserto muda comportamento visível por definição. Medido: seis minors
+ * e duas patches em trinta dias. Pedir `impacto: minor` convidaria o mesmo erro
+ * de volta; pedir "o operador precisa fazer alguma coisa?" não tem como ser
+ * respondido errado por quem sabe o que fez.
+ *
+ * Módulo PURO: recebe texto, devolve dado. Quem toca disco é o CLI.
+ */
+import { z } from "zod";
+
+/**
+ * O que acontece com quem JÁ roda o sistema numa VPS. Os nomes são a pergunta,
+ * não a resposta — o número é consequência, e vem de `BUMP_DO_IMPACTO`.
+ */
+export const Impacto = z.enum(["nada_mudou", "capacidade_nova", "exige_acao"]);
+export type Impacto = z.infer<typeof Impacto>;
+
+/** As três de Keep a Changelog que este produto usa de fato. */
+export const Secao = z.enum(["adicionado", "alterado", "corrigido"]);
+export type Secao = z.infer<typeof Secao>;
+
+export type Bump = "patch" | "minor" | "major";
+
+/**
+ * Fonte ÚNICA da tradução efeito → número. `calcularBump` deriva daqui em vez
+ * de repetir as strings: uma segunda lista com um nome digitado errado devolve
+ * `patch` em silêncio para uma mudança que exigia ação do operador, e o
+ * typecheck não pega string literal comparada com string literal.
+ */
+export const BUMP_DO_IMPACTO = {
+  nada_mudou: "patch",
+  capacidade_nova: "minor",
+  exige_acao: "major",
+} as const satisfies Record<Impacto, Bump>;
+
+/** Severidade crescente. `calcularBump` devolve o máximo do conjunto. */
+const SEVERIDADE: Record<Bump, number> = { patch: 0, minor: 1, major: 2 };
+
+export interface Fragmento {
+  /** Nome do arquivo, para a mensagem de erro apontar o culpado. */
+  arquivo: string;
+  impacto: Impacto;
+  secao: Secao;
+  titulo: string;
+  /** Prosa em pt-BR, verbatim — nunca reflua: veja `montar-secao.ts`. */
+  corpo: string;
+  /** Presente só quando `impacto: exige_acao`. */
+  atencao: string | null;
+}
+
+const Frontmatter = z.object({
+  impacto: Impacto,
+  secao: Secao,
+  titulo: z.string().trim().min(1, "titulo vazio"),
+});
+
+/**
+ * Cada regra abaixo é um comportamento MEDIDO do parser da tela
+ * (`lib/system/changelog.ts`), não gosto:
+ *
+ * - `^#` — `VERSION_HEADING` corta a seção inteira em `^##\s+\[`, e
+ *   `findAttentionRange` encerra o bloco de atenção no primeiro `^#{2,4}\s`.
+ *   Um heading no corpo do fragmento decapita a seção de alguém.
+ * - `⚠` — quem emite o heading de atenção é o gerador, uma vez só. Um segundo
+ *   no corpo faz `findAttentionRange` casar na linha errada.
+ * - referência de link — `cleanBody` só a remove no FIM do corpo; no meio, ela
+ *   aparece crua na tela.
+ */
+const PROIBIDO: ReadonlyArray<{ re: RegExp; porque: string }> = [
+  { re: /^#/, porque: "heading no corpo corta a seção na tela (VERSION_HEADING / findAttentionRange)" },
+  { re: /⚠/, porque: "o heading de atenção é do gerador; um segundo aqui desloca o bloco" },
+  { re: /^\s*\[[^\]]+\]:\s+https?:\/\//, porque: "referência de link fora do fim do arquivo aparece crua na tela" },
+];
+
+/** Campos cujo valor é uma palavra de uma lista: só neles ` #` inicia comentário. */
+const VOCABULARIO_FECHADO = new Set(["impacto", "secao"]);
+
+/** `**` precisa fechar na MESMA linha: a regex do renderizador é single-line. */
+function negritoAberto(linha: string): boolean {
+  return ((linha.match(/\*\*/g)?.length ?? 0) % 2) !== 0;
+}
+
+export class FragmentoInvalido extends Error {}
+
+/** Frontmatter à mão: o projeto não tem parser de YAML entre as dependências. */
+function separarFrontmatter(texto: string): { campos: Record<string, string>; corpo: string } {
+  const linhas = texto.replace(/^﻿/, "").split("\n");
+  if ((linhas[0] ?? "").trim() !== "---") {
+    throw new FragmentoInvalido("falta o bloco `---` de abertura na primeira linha");
+  }
+  const fim = linhas.findIndex((l, i) => i > 0 && l.trim() === "---");
+  if (fim === -1) throw new FragmentoInvalido("falta o `---` que fecha o frontmatter");
+
+  const campos: Record<string, string> = {};
+  for (const linha of linhas.slice(1, fim)) {
+    if (!linha.trim() || linha.trim().startsWith("#")) continue;
+    const sep = linha.indexOf(":");
+    if (sep === -1) throw new FragmentoInvalido(`linha de frontmatter sem \`:\` → ${linha.trim()}`);
+    const chave = linha.slice(0, sep).trim();
+    // Comentário à direita só existe em campo de vocabulário FECHADO. Em
+    // `titulo`, que é texto livre, ` #` é conteúdo: metade dos títulos deste
+    // repo cita uma issue (`conserta o #351`), e comer isso silenciosamente
+    // entregaria à tela do dono da VPS um título cortado no meio.
+    const cru = linha.slice(sep + 1);
+    const valor = (VOCABULARIO_FECHADO.has(chave) ? cru.replace(/\s+#.*$/, "") : cru).trim();
+    campos[chave] = valor.replace(/^["']|["']$/g, "");
+  }
+  return { campos, corpo: linhas.slice(fim + 1).join("\n").trim() };
+}
+
+/** O bloco de aviso é opcional e marcado por `## Requer atenção` no fragmento. */
+const MARCA_ATENCAO = /^##\s+Requer atenção\s*$/i;
+
+export function parseFragmento(arquivo: string, texto: string): Fragmento {
+  const { campos, corpo } = separarFrontmatter(texto);
+
+  const parsed = Frontmatter.safeParse(campos);
+  if (!parsed.success) {
+    const detalhe = parsed.error.issues
+      .map((i) => `${i.path.join(".") || "(raiz)"}: ${i.message}`)
+      .join("; ");
+    throw new FragmentoInvalido(`frontmatter inválido → ${detalhe}`);
+  }
+
+  // A marca de atenção é a única exceção à proibição de heading, e some antes
+  // da varredura: quem emite o heading de verdade é o gerador.
+  const linhas = corpo.split("\n");
+  const iAtencao = linhas.findIndex((l) => MARCA_ATENCAO.test(l.trim()));
+  const linhasCorpo = iAtencao === -1 ? linhas : linhas.slice(0, iAtencao);
+  const linhasAtencao = iAtencao === -1 ? [] : linhas.slice(iAtencao + 1);
+
+  for (const [n, linha] of [...linhasCorpo, ...linhasAtencao].entries()) {
+    for (const { re, porque } of PROIBIDO) {
+      if (re.test(linha)) throw new FragmentoInvalido(`linha ${n + 1}: ${porque} → ${linha.trim()}`);
+    }
+    if (negritoAberto(linha)) {
+      throw new FragmentoInvalido(
+        `linha ${n + 1}: \`**\` que não fecha na mesma linha chega à tela com os asteriscos literais`,
+      );
+    }
+  }
+
+  const textoCorpo = linhasCorpo.join("\n").trim();
+  if (!textoCorpo) throw new FragmentoInvalido("corpo vazio: é ele que o dono da VPS lê na tela");
+
+  const atencao = linhasAtencao.join("\n").trim() || null;
+
+  // As duas direções do cruzamento, porque cada uma é um defeito distinto:
+  // aviso sem `exige_acao` some da caixa destacada; `exige_acao` sem aviso põe
+  // o operador para agir sem dizer o quê.
+  if (parsed.data.impacto === "exige_acao" && !atencao) {
+    throw new FragmentoInvalido(
+      "`impacto: exige_acao` sem bloco `## Requer atenção`: o operador precisa saber o que fazer",
+    );
+  }
+  if (atencao && parsed.data.impacto !== "exige_acao") {
+    throw new FragmentoInvalido(
+      `bloco \`## Requer atenção\` com \`impacto: ${parsed.data.impacto}\`: se há ação a fazer, o impacto é \`exige_acao\``,
+    );
+  }
+
+  return { arquivo, ...parsed.data, corpo: textoCorpo, atencao };
+}
+
+/**
+ * O número que o conjunto produz. Sem fragmento não há resposta — e devolver
+ * `patch` no vazio seria inventar uma release que ninguém descreveu.
+ */
+export function calcularBump(impactos: readonly Impacto[]): Bump {
+  if (impactos.length === 0) {
+    throw new FragmentoInvalido("nenhum fragmento em `.changes/`: não há versão a cortar");
+  }
+  return impactos
+    .map((i) => BUMP_DO_IMPACTO[i])
+    .reduce((a, b) => (SEVERIDADE[b] > SEVERIDADE[a] ? b : a));
+}
+
+/** `1.6.0` + `minor` → `1.7.0`. Recusa o que não for `X.Y.Z` de inteiros. */
+export function proximaVersao(atual: string, bump: Bump): string {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(atual.trim().replace(/^v/i, ""));
+  if (!m) throw new FragmentoInvalido(`versão base não é X.Y.Z → ${atual}`);
+  const [maior, menor, correcao] = [Number(m[1]), Number(m[2]), Number(m[3])];
+  if (bump === "major") return `${maior + 1}.0.0`;
+  if (bump === "minor") return `${maior}.${menor + 1}.0`;
+  return `${maior}.${menor}.${correcao + 1}`;
+}

--- a/lib/release/montar-secao.test.ts
+++ b/lib/release/montar-secao.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import { extractChangelogSection, markdownParaTextoSimples } from "../system/changelog";
+import { parseFragmento } from "./fragmento";
+import { aplicarNoChangelog, montarSecao } from "./montar-secao";
+
+/** URL sintética: este arquivo é varrido pela catraca de marca e não nomeia o repo. */
+const comparar = (de: string, para: string) => `https://exemplo.test/compare/${de}...${para}`;
+
+function frag(over: {
+  impacto?: string;
+  secao?: string;
+  titulo?: string;
+  corpo?: string;
+  atencao?: string;
+}) {
+  const texto = [
+    "---",
+    `impacto: ${over.impacto ?? "nada_mudou"}`,
+    `secao: ${over.secao ?? "corrigido"}`,
+    `titulo: ${over.titulo ?? "Um conserto"}`,
+    "---",
+    "",
+    over.corpo ?? "O que estava quebrado voltou a funcionar.",
+    ...(over.atencao ? ["", "## Requer atenção", "", over.atencao] : []),
+  ].join("\n");
+  return parseFragmento("x.md", texto);
+}
+
+const CABECALHO = ["# Changelog", "", "## [Não lançado]", "", "## [1.6.0] — 2026-08-26", "", "### Corrigido", "", "- **Algo antigo** ...", ""].join("\n");
+
+describe("montarSecao — o que a TELA da VPS vai mostrar", () => {
+  it("a seção montada é legível pelo parser que a tela usa", () => {
+    const texto = aplicarNoChangelog(
+      CABECALHO,
+      montarSecao([frag({ titulo: "A IA avisa antes de sair" })], "1.6.1", "2026-08-27"),
+      "1.6.0",
+      comparar,
+    );
+    const s = extractChangelogSection(texto, "1.6.1");
+    expect(s).not.toBeNull();
+    expect(s?.body).toContain("A IA avisa antes de sair");
+  });
+
+  it("todos os avisos caem num único bloco de atenção, e não vazam para o corpo", () => {
+    const secao = montarSecao(
+      [
+        frag({ impacto: "exige_acao", titulo: "Primeiro", atencao: "Edite o arquivo A." }),
+        frag({ impacto: "exige_acao", titulo: "Segundo", atencao: "Rode o comando B." }),
+      ],
+      "2.0.0",
+      "2026-08-27",
+    );
+    const s = extractChangelogSection(aplicarNoChangelog(CABECALHO, secao, "1.6.0", comparar), "2.0.0")!;
+
+    expect(s.requiresAttention).toContain("Edite o arquivo A.");
+    expect(s.requiresAttention).toContain("Rode o comando B.");
+    // Se o aviso também ficasse no corpo, a tela o mostraria duas vezes — e a
+    // segunda sem a distinção entre "aviso" e "changelog geral".
+    expect(s.body).not.toContain("Edite o arquivo A.");
+    expect(s.body).not.toContain("Requer atenção");
+  });
+
+  it("nenhuma marcação sobra depois da conversão que a tela faz", () => {
+    const secao = montarSecao(
+      [frag({ titulo: "Conserto", corpo: "Mexe em `fn_user_org_ids()` e no *fluxo* de envio." })],
+      "1.6.1",
+      "2026-08-27",
+    );
+    const s = extractChangelogSection(aplicarNoChangelog(CABECALHO, secao, "1.6.0", comparar), "1.6.1")!;
+    const naTela = markdownParaTextoSimples(s.body);
+    expect(naTela).not.toMatch(/\*\*/);
+    // O identificador precisa chegar inteiro: a regra de ênfase do renderizador
+    // ignora `_` colado em letra justamente por causa de nomes de função.
+    expect(naTela).toContain("fn_user_org_ids()");
+  });
+
+  it("preserva o corpo verbatim, sem refluir — negrito partido chegaria com asterisco à mostra", () => {
+    const corpo = "Primeira linha do parágrafo,\nsegunda linha que continua a frase.";
+    const secao = montarSecao([frag({ corpo })], "1.6.1", "2026-08-27");
+    expect(secao.texto).toContain("segunda linha que continua a frase.");
+    const s = extractChangelogSection(aplicarNoChangelog(CABECALHO, secao, "1.6.0", comparar), "1.6.1")!;
+    expect(markdownParaTextoSimples(s.body)).toContain("segunda linha que continua a frase.");
+  });
+
+  it("a seção anterior continua inteira e alcançável", () => {
+    const texto = aplicarNoChangelog(CABECALHO, montarSecao([frag({})], "1.6.1", "2026-08-27"), "1.6.0", comparar);
+    expect(extractChangelogSection(texto, "1.6.0")?.body).toContain("Algo antigo");
+  });
+
+  it("`## [Não lançado]` continua existindo e vazio", () => {
+    const texto = aplicarNoChangelog(CABECALHO, montarSecao([frag({})], "1.6.1", "2026-08-27"), "1.6.0", comparar);
+    expect(texto).toContain("## [Não lançado]");
+    expect(extractChangelogSection(texto, "Não lançado")?.body).toBe("");
+  });
+
+  it("prosa com `$&` e crase invertida sai idêntica — `replace` com string a corromperia", () => {
+    const corpo = "O padrão $& e o `$`' do shell aparecem literais aqui.";
+    const texto = aplicarNoChangelog(CABECALHO, montarSecao([frag({ corpo })], "1.6.1", "2026-08-27"), "1.6.0", comparar);
+    expect(texto).toContain("O padrão $& e o");
+    expect(texto).not.toContain("## [Não lançado]## [Não lançado]");
+  });
+
+  it("o rodapé de referências é reescrito — à mão ele apodrece, e apodreceu", () => {
+    const comRodape = `${CABECALHO}\n[Não lançado]: https://exemplo.test/compare/v1.5.0...HEAD\n`;
+    const texto = aplicarNoChangelog(comRodape, montarSecao([frag({})], "1.6.1", "2026-08-27"), "1.6.0", comparar);
+    expect(texto).toContain("[Não lançado]: https://exemplo.test/compare/v1.6.1...HEAD");
+    expect(texto).toContain("[1.6.1]: https://exemplo.test/compare/v1.6.0...v1.6.1");
+    expect(texto).not.toContain("compare/v1.5.0...HEAD");
+  });
+
+  it("recusa CHANGELOG sem a âncora, em vez de inserir em lugar nenhum", () => {
+    expect(() => aplicarNoChangelog("# Changelog\n", montarSecao([frag({})], "1.6.1", "2026-08-27"), "1.6.0", comparar)).toThrow(
+      /Não lançado/,
+    );
+  });
+});

--- a/lib/release/montar-secao.ts
+++ b/lib/release/montar-secao.ts
@@ -1,0 +1,130 @@
+/**
+ * Fragmentos → a seção do CHANGELOG que a tela da VPS mostra.
+ *
+ * O que este módulo protege, e que nenhuma ferramenta pronta protegeria: o
+ * `CHANGELOG.md` deste produto **é tela**. `lib/system/changelog.ts` extrai a
+ * seção de uma versão e a rota de sistema a entrega ao dono do servidor. Por
+ * isso a saída aqui não é "um changelog bonito" — é a entrada de um parser
+ * conhecido, e cada decisão de forma abaixo existe para não quebrá-lo.
+ *
+ * Módulo PURO. Sem disco, sem rede, sem marca: `lib/` é varrido por
+ * `tests/unit/branding.test.ts`, então a URL de comparação entra por parâmetro.
+ */
+import type { Fragmento, Secao } from "./fragmento";
+
+/** Exatamente o que `ATTENTION_HEADING` casa, com o U+26A0 que ela espera. */
+const HEADING_ATENCAO = "### ⚠️ Requer atenção";
+
+/**
+ * O bloco de atenção vem PRIMEIRO, e isso não é estética: o agente do host
+ * corta o CHANGELOG em bytes antes de mandar, e `findAttentionRange` acha o
+ * bloco em qualquer posição. Na frente, o aviso sobrevive mesmo quando o corpo
+ * é decapitado pelo corte.
+ */
+const ORDEM: readonly Secao[] = ["adicionado", "alterado", "corrigido"];
+
+const TITULO_DA_SECAO: Record<Secao, string> = {
+  adicionado: "### Adicionado",
+  alterado: "### Alterado",
+  corrigido: "### Corrigido",
+};
+
+/**
+ * Um item vira `- **titulo** corpo`, com as quebras de linha do fragmento
+ * PRESERVADAS e a continuação indentada em dois espaços.
+ *
+ * Nunca refluir: `markdownParaTextoSimples` converte `**...**` com uma regex
+ * single-line, então um negrito partido entre duas linhas chega à tela com os
+ * asteriscos literais.
+ */
+function item(f: Fragmento): string {
+  const [primeira, ...resto] = f.corpo.split("\n");
+  const continuacao = resto.map((l) => (l.trim() === "" ? "" : `  ${l}`));
+  return [`- **${f.titulo}** ${primeira ?? ""}`.trimEnd(), ...continuacao].join("\n");
+}
+
+export interface SecaoMontada {
+  versao: string;
+  texto: string;
+}
+
+/**
+ * @param data no formato `YYYY-MM-DD` — vem de fora porque o módulo é puro e
+ *   porque um teste que chama `new Date()` mede o relógio, não a montagem.
+ */
+export function montarSecao(
+  fragmentos: readonly Fragmento[],
+  versao: string,
+  data: string,
+): SecaoMontada {
+  if (fragmentos.length === 0) {
+    throw new Error("montarSecao sem fragmento: não há seção a escrever");
+  }
+
+  const partes: string[] = [`## [${versao}] — ${data}`, ""];
+
+  // TODOS os avisos sob UM heading só. Dois headings de atenção fariam
+  // `findAttentionRange` pegar o primeiro e deixar o segundo vazando para
+  // dentro de "O que muda" na tela.
+  const avisos = fragmentos.filter((f) => f.atencao);
+  if (avisos.length > 0) {
+    partes.push(HEADING_ATENCAO, "");
+    for (const f of avisos) {
+      partes.push(`- **${f.titulo}** ${f.atencao?.split("\n")[0] ?? ""}`.trimEnd());
+      const resto = (f.atencao ?? "").split("\n").slice(1);
+      for (const l of resto) partes.push(l.trim() === "" ? "" : `  ${l}`);
+    }
+    partes.push("");
+  }
+
+  for (const secao of ORDEM) {
+    const daSecao = fragmentos.filter((f) => f.secao === secao);
+    if (daSecao.length === 0) continue;
+    partes.push(TITULO_DA_SECAO[secao], "");
+    for (const f of daSecao) {
+      partes.push(item(f), "");
+    }
+  }
+
+  return { versao, texto: partes.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd() };
+}
+
+/** `## [Não lançado]` — a âncora que a seção nova nasce logo abaixo. */
+const ANCORA = /^##\s+\[Não lançado\].*$/m;
+
+/**
+ * Insere a seção montada e atualiza o rodapé de referências de link.
+ *
+ * O rodapé apodrece à mão, e já apodreceu: medido no HEAD b3996c43, o arquivo
+ * não tem linha `[1.6.0]:` e o `[Não lançado]` ainda compara contra `v1.5.0` —
+ * uma versão inteira depois. Quem escreve à mão esquece; quem monta, não.
+ *
+ * @param compararUrl função que devolve a URL de comparação entre duas tags.
+ *   Entra por parâmetro porque este arquivo não pode nomear o repositório.
+ */
+export function aplicarNoChangelog(
+  raw: string,
+  secao: SecaoMontada,
+  anterior: string,
+  compararUrl: (de: string, para: string) => string,
+): string {
+  if (!ANCORA.test(raw)) {
+    throw new Error("CHANGELOG.md sem `## [Não lançado]`: não sei onde inserir a seção");
+  }
+
+  // `replace` com FUNÇÃO, nunca com string: `$&`, `$'` e `` $` `` são
+  // sequências especiais no argumento de substituição, e o texto do fragmento
+  // é prosa escrita à mão que neste repo rotineiramente carrega shell e regex.
+  let saida = raw.replace(ANCORA, (ancora) => `${ancora}\n\n${secao.texto}`);
+
+  const refNova = `[${secao.versao}]: ${compararUrl(`v${anterior}`, `v${secao.versao}`)}`;
+  const refNaoLancado = `[Não lançado]: ${compararUrl(`v${secao.versao}`, "HEAD")}`;
+
+  if (/^\[Não lançado\]:\s+\S+$/m.test(saida)) {
+    saida = saida.replace(/^\[Não lançado\]:\s+\S+$/m, () => `${refNaoLancado}\n${refNova}`);
+  } else {
+    saida = `${saida.trimEnd()}\n\n${refNaoLancado}\n${refNova}\n`;
+  }
+
+  return saida.endsWith("\n") ? saida : `${saida}\n`;
+}

--- a/lib/system/changelog.test.ts
+++ b/lib/system/changelog.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { readFileSync } from "fs";
 import { join } from "path";
 
-import { extractChangelogSection, markdownParaTextoSimples } from "./changelog";
+import { extractChangelogRange, extractChangelogSection, markdownParaTextoSimples } from "./changelog";
 
 const CHANGELOG = `# Changelog
 
@@ -191,5 +191,87 @@ describe("markdownParaTextoSimples", () => {
     expect(markdownParaTextoSimples("isso é _importante_ para todos")).toBe(
       "isso é importante para todos",
     );
+  });
+});
+
+describe("extractChangelogRange — todas as seções entre a instalada e a alvo", () => {
+  const TRES = [
+    "# Changelog",
+    "",
+    "## [Não lançado]",
+    "",
+    "## [1.2.0] — 2026-08-03",
+    "",
+    "### Adicionado",
+    "",
+    "- coisa nova",
+    "",
+    "## [1.1.0] — 2026-08-02",
+    "",
+    "### ⚠️ Requer atenção",
+    "",
+    "- reconecte o número depois de atualizar",
+    "",
+    "### Corrigido",
+    "",
+    "- conserto do meio",
+    "",
+    "## [1.0.0] — 2026-08-01",
+    "",
+    "- primeira",
+    "",
+  ].join("\n");
+
+  it("devolve da mais nova para a mais antiga, sem incluir a instalada", () => {
+    const f = extractChangelogRange(TRES, "1.2.0", "1.0.0");
+    expect(f.secoes.map((s) => s.version)).toEqual(["1.2.0", "1.1.0"]);
+    expect(f.completa).toBe(true);
+  });
+
+  it("o aviso da versão do MEIO sobrevive — é o defeito que esta função existe para corrigir", () => {
+    // Quem pulava versões via só a seção-alvo, e o aviso de ação manual da
+    // versão intermediária desaparecia (commit ac9472c5).
+    const f = extractChangelogRange(TRES, "1.2.0", "1.0.0");
+    const comAviso = f.secoes.filter((s) => s.requiresAttention);
+    expect(comAviso.map((s) => s.version)).toEqual(["1.1.0"]);
+    expect(comAviso[0]?.requiresAttention).toContain("reconecte o número");
+  });
+
+  it("não afirma completude quando a instalada é um SHA (instalação fora de release)", () => {
+    const f = extractChangelogRange(TRES, "1.2.0", "abc1234");
+    expect(f.completa).toBe(false);
+    expect(f.secoes.length).toBeGreaterThan(0);
+  });
+
+  it("não afirma completude quando o texto chegou cortado antes da instalada", () => {
+    const cortado = TRES.slice(0, TRES.indexOf("## [1.0.0]"));
+    expect(extractChangelogRange(cortado, "1.2.0", "1.0.0").completa).toBe(false);
+  });
+
+  it("em dia: nada entre as duas, e isso NÃO é incompletude", () => {
+    expect(extractChangelogRange(TRES, "1.2.0", "1.2.0")).toEqual({ secoes: [], completa: true });
+  });
+
+  it("instalada mais nova que a alvo devolve a seção-alvo, nunca uma lista vazia dizendo-se completa", () => {
+    // Um `slice(iAlvo, iInst)` ingênuo devolveria [] com completa=true aqui: a
+    // tela ficaria sem corpo nenhum afirmando estar inteira.
+    const f = extractChangelogRange(TRES, "1.0.0", "1.2.0");
+    expect(f.secoes.map((s) => s.version)).toEqual(["1.0.0"]);
+    expect(f.secoes[0]?.body).toContain("primeira");
+  });
+
+  it("alvo que não existe no texto devolve vazio e incompleto", () => {
+    expect(extractChangelogRange(TRES, "9.9.9", "1.0.0")).toEqual({ secoes: [], completa: false });
+  });
+
+  it("faixa de uma versão só é igual à seção única — as duas leituras não podem divergir", () => {
+    const pelaFaixa = extractChangelogRange(TRES, "1.2.0", "1.1.0").secoes[0];
+    const pelaSecao = extractChangelogSection(TRES, "1.2.0");
+    expect(pelaFaixa).toEqual(pelaSecao);
+  });
+
+  it("`[Não lançado]` nunca entra na faixa", () => {
+    const f = extractChangelogRange(TRES, "1.2.0", "1.0.0");
+    expect(f.secoes.map((s) => s.version)).not.toContain("Não lançado");
   });
 });

--- a/lib/system/changelog.ts
+++ b/lib/system/changelog.ts
@@ -45,6 +45,16 @@ export function extractChangelogSection(raw: string, version: string): Changelog
 
   if (start === -1) return null;
 
+  return montarSecao(lines, start, end, wanted);
+}
+
+/** O miolo de `extractChangelogSection`, reusado pela faixa. */
+function montarSecao(
+  lines: readonly string[],
+  start: number,
+  end: number,
+  versao: string,
+): ChangelogSection {
   const bodyLines = lines.slice(start, end);
   const attention = findAttentionRange(bodyLines);
 
@@ -62,7 +72,84 @@ export function extractChangelogSection(raw: string, version: string): Changelog
     ? cleanBody(bodyLines.slice(attention.start + 1, attention.end).join("\n").trim()) || null
     : null;
 
-  return { version: wanted, body, requiresAttention };
+  return { version: versao, body, requiresAttention };
+}
+
+export interface ChangelogRange {
+  /** Da mais NOVA para a mais antiga, como o arquivo. */
+  secoes: ChangelogSection[];
+  /**
+   * Achei o cabeçalho da versão instalada no texto recebido?
+   *
+   * `false` significa "este histórico pode não alcançar a sua versão" — e a tela
+   * precisa DIZER isso. O agente da VPS manda o CHANGELOG cortado em bytes, e um
+   * corpo truncado no meio da frase é indistinguível de um corpo inteiro: sem
+   * este sinal, a tela afirmaria completude que não tem.
+   */
+  completa: boolean;
+}
+
+/**
+ * Todas as seções entre a versão-alvo e a instalada.
+ *
+ * Existe porque mostrar só a seção-alvo perde aviso: quem pula da 1.4.0 para a
+ * 1.6.0 nunca lia a 1.4.1 nem a 1.5.0 — e a 1.4.1 existia justamente para
+ * corrigir uma instrução invertida que mandava o operador apagar a conexão que
+ * estava funcionando. O contorno da época foi carregar o aviso órfão para a
+ * versão seguinte, à mão (commit ac9472c5); isto o aposenta.
+ *
+ * A seleção é POSICIONAL, não semver: o arquivo já vem do mais novo para o mais
+ * antigo, e comparar número exigiria um comparador que não existe no projeto —
+ * que tropeçaria em `v1.1.1-jmpo.1`, tag de fork que este repo carrega.
+ */
+export function extractChangelogRange(
+  raw: string,
+  alvo: string,
+  instalada: string,
+): ChangelogRange {
+  const vazio: ChangelogRange = { secoes: [], completa: false };
+  if (!raw || !alvo) return vazio;
+
+  const lines = raw.split("\n");
+  const cabs: Array<{ rotulo: string; i: number }> = [];
+  lines.forEach((linha, i) => {
+    const m = VERSION_HEADING.exec(linha);
+    if (m) cabs.push({ rotulo: normalize(m[1] ?? ""), i });
+  });
+
+  const iAlvo = cabs.findIndex((c) => c.rotulo === normalize(alvo));
+  if (iAlvo === -1) return vazio;
+
+  const iInst = cabs.findIndex((c) => c.rotulo === normalize(instalada));
+
+  // Os quatro casos são escritos um a um de propósito. Um `slice(iAlvo, iInst)`
+  // ingênuo devolve lista VAZIA quando `iInst < iAlvo`, e ainda assim diria
+  // `completa: true` — a tela ficaria sem corpo nenhum afirmando estar inteira.
+  let fim: number;
+  let completa: boolean;
+  if (iInst === -1) {
+    // Instalação fora de release (a versão é um SHA) ou texto cortado antes de
+    // alcançá-la. Mostra o que veio e admite que pode não alcançar.
+    fim = cabs.length;
+    completa = false;
+  } else if (iInst === iAlvo) {
+    return { secoes: [], completa: true }; // está em dia: nada entre as duas
+  } else if (iInst < iAlvo) {
+    // A instalada é MAIS NOVA que a alvo (rollback pendente, canal trocado).
+    // Só a seção-alvo faz sentido aqui.
+    fim = iAlvo + 1;
+    completa = true;
+  } else {
+    fim = iInst;
+    completa = true;
+  }
+
+  const secoes = cabs.slice(iAlvo, fim).map((c, k, arr) => {
+    const proximo = arr[k + 1]?.i ?? cabs[iAlvo + arr.length]?.i ?? lines.length;
+    return montarSecao(lines, c.i + 1, proximo, c.rotulo);
+  });
+
+  return { secoes, completa };
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "test:shell": "bash tests/shell/update-guard.test.sh && bash tests/shell/dono-do-projeto.test.sh && bash tests/shell/scheduler-entrypoint.test.sh && bash hostgator-setup-kit/test-validators.sh",
     "test:invariants": "bash scripts/test-db.sh",
     "lint:channels": "tsx scripts/lint-channels.ts",
+    "release:conferir": "tsx scripts/cortar-release.ts",
+    "release:cortar": "tsx scripts/cortar-release.ts --escrever",
     "gov:verify": "pnpm typecheck && pnpm lint && pnpm lint:channels && pnpm test:unit",
     "worker": "tsx --env-file=.env --env-file=.env.local workers/agent-worker/main.ts",
     "flywheel:judge": "tsx --env-file=.env --env-file=.env.local scripts/flywheel-judge-live.ts"

--- a/scripts/cortar-release.ts
+++ b/scripts/cortar-release.ts
@@ -94,10 +94,20 @@ function hoje(): string {
 
 function main(argv: readonly string[]): number {
   const escrever = argv.includes("--escrever");
-  const desconhecido = argv.find((a) => a !== "--escrever");
+  const soAVersao = argv.includes("--versao-do-changelog");
+  const conhecidos = new Set(["--escrever", "--versao-do-changelog"]);
+  const desconhecido = argv.find((a) => !conhecidos.has(a));
   if (desconhecido) {
     process.stderr.write(`argumento desconhecido: ${desconhecido}\n`);
     return 2;
+  }
+
+  // O workflow de release usa isto para saber se o merge que acabou de entrar
+  // na main trouxe uma versão nova. Imprime só o número, sem mais nada, para
+  // caber num `$(...)`.
+  if (soAVersao) {
+    process.stdout.write(`${versaoBase(fs.readFileSync(CHANGELOG, "utf8"))}\n`);
+    return 0;
   }
 
   const fragmentos = lerFragmentos(DIR_FRAGMENTOS);

--- a/scripts/cortar-release.ts
+++ b/scripts/cortar-release.ts
@@ -1,0 +1,151 @@
+/**
+ * Corta a release: lê os fragmentos de `.changes/`, calcula o número, monta a
+ * seção do CHANGELOG e apaga os fragmentos consumidos.
+ *
+ * Ninguém digita o número. Essa é a propriedade que faz duas sessões de
+ * trabalho paralelas não colidirem: enquanto a escolha era humana, ela dependia
+ * de ler `git tag` e somar um — e duas sessões que leem a mesma lista no mesmo
+ * dia chegam ao mesmo número.
+ *
+ * Casca fina de I/O: a decisão toda mora em `lib/release/`, que é typechecado
+ * (`tsconfig.typecheck.json` exclui `scripts/**`, então lógica aqui chegaria
+ * verde na `main` sem `tsc` nunca a ter olhado).
+ *
+ *   pnpm release:conferir     # não escreve; diz que número sairia
+ *   pnpm release:cortar       # escreve o CHANGELOG e apaga os fragmentos
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { calcularBump, type Fragmento, parseFragmento, proximaVersao } from "../lib/release/fragmento";
+import { aplicarNoChangelog, montarSecao } from "../lib/release/montar-secao";
+
+const RAIZ = path.resolve(__dirname, "..");
+const DIR_FRAGMENTOS = path.join(RAIZ, ".changes");
+const CHANGELOG = path.join(RAIZ, "CHANGELOG.md");
+const REPO = "melgarafael/DeskcommCRM";
+
+const compararUrl = (de: string, para: string) => `https://github.com/${REPO}/compare/${de}...${para}`;
+
+/** `.gitkeep` e qualquer não-`.md` ficam de fora; o diretório guarda só fragmento. */
+export function arquivosDeFragmento(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".md"))
+    .sort();
+}
+
+function lerFragmentos(dir: string): Fragmento[] {
+  const problemas: string[] = [];
+  const lidos: Fragmento[] = [];
+  for (const arquivo of arquivosDeFragmento(dir)) {
+    try {
+      lidos.push(parseFragmento(arquivo, fs.readFileSync(path.join(dir, arquivo), "utf8")));
+    } catch (erro) {
+      problemas.push(`  ${arquivo}: ${erro instanceof Error ? erro.message : String(erro)}`);
+    }
+  }
+  if (problemas.length > 0) {
+    throw new Error(`fragmento(s) inválido(s):\n${problemas.join("\n")}`);
+  }
+  return lidos;
+}
+
+/**
+ * A base é a seção mais nova do CHANGELOG, não a maior tag — o repositório
+ * carrega `v1.1.1-jmpo.1` e `jmpo/v1.4.0`, que existem justamente para não
+ * colidir com a numeração daqui.
+ */
+function versaoBase(changelog: string): string {
+  for (const linha of changelog.split("\n")) {
+    const m = /^##\s+\[(\d+\.\d+\.\d+)\]/.exec(linha);
+    if (m?.[1]) return m[1];
+  }
+  throw new Error("CHANGELOG.md sem nenhuma seção `## [X.Y.Z]`");
+}
+
+/** Só para conferência: um aviso, nunca uma recusa — o CI clona raso e não vê tag. */
+function maiorTagLocal(): string | null {
+  try {
+    const saida = execFileSync("git", ["tag", "--list", "v*.*.*"], { cwd: RAIZ, encoding: "utf8" });
+    const versoes = saida
+      .split("\n")
+      .map((t) => t.trim().replace(/^v/, ""))
+      .filter((t) => /^\d+\.\d+\.\d+$/.test(t))
+      .sort((a, b) => {
+        const [A, B] = [a.split(".").map(Number), b.split(".").map(Number)];
+        return (A[0]! - B[0]!) || (A[1]! - B[1]!) || (A[2]! - B[2]!);
+      });
+    return versoes.at(-1) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function hoje(): string {
+  // Data local, não UTC: a seção é lida por quem opera no Brasil, e `toISOString`
+  // vira o dia anterior a cada release cortada depois das 21h.
+  const d = new Date();
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
+function main(argv: readonly string[]): number {
+  const escrever = argv.includes("--escrever");
+  const desconhecido = argv.find((a) => a !== "--escrever");
+  if (desconhecido) {
+    process.stderr.write(`argumento desconhecido: ${desconhecido}\n`);
+    return 2;
+  }
+
+  const fragmentos = lerFragmentos(DIR_FRAGMENTOS);
+  const changelog = fs.readFileSync(CHANGELOG, "utf8");
+  const base = versaoBase(changelog);
+
+  if (fragmentos.length === 0) {
+    const tag = maiorTagLocal();
+    // Terceiro desfecho, e não uma recusa: depois de `--escrever` o estado
+    // normal da branch de release é exatamente este — `.changes/` vazio e a
+    // seção nova à frente da última tag, porque a tag só nasce no merge.
+    if (tag && tag !== base) {
+      process.stdout.write(`já cortado: ${base} aguarda a tag (última publicada: ${tag})\n`);
+      return 0;
+    }
+    process.stderr.write(
+      "nenhum fragmento em `.changes/`: não há versão a cortar.\n" +
+        "Todo PR que muda comportamento traz o seu — docs/doctrine/versionamento.md.\n",
+    );
+    return 1;
+  }
+
+  const bump = calcularBump(fragmentos.map((f) => f.impacto));
+  const versao = proximaVersao(base, bump);
+  const secao = montarSecao(fragmentos, versao, hoje());
+
+  process.stdout.write(`${base} + ${bump} = ${versao}  (${fragmentos.length} fragmento(s))\n`);
+  for (const f of fragmentos) {
+    process.stdout.write(`  ${f.impacto.padEnd(16)} ${f.secao.padEnd(11)} ${f.titulo}\n`);
+  }
+
+  if (!escrever) {
+    process.stdout.write("\n(conferência: nada foi escrito — use --escrever)\n");
+    return 0;
+  }
+
+  fs.writeFileSync(CHANGELOG, aplicarNoChangelog(changelog, secao, base, compararUrl));
+  for (const f of fragmentos) fs.rmSync(path.join(DIR_FRAGMENTOS, f.arquivo));
+  process.stdout.write(`\nCHANGELOG.md atualizado; ${fragmentos.length} fragmento(s) consumido(s).\n`);
+  process.stdout.write("A tag NÃO é criada aqui — ela nasce no CI, do merge do PR de release.\n");
+  return 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exit(main(process.argv.slice(2)));
+  } catch (erro) {
+    process.stderr.write(`${erro instanceof Error ? erro.message : String(erro)}\n`);
+    process.exit(1);
+  }
+}

--- a/tests/e2e/system-update.spec.ts
+++ b/tests/e2e/system-update.spec.ts
@@ -178,6 +178,71 @@ function resetEstado(): void {
   execFileSync("npx", ["tsx", "scripts/seed-e2e-system-update.ts"], { stdio: "inherit" });
 }
 
+test("quem pula versões vê os avisos de TODAS elas, não só o da mais nova", async ({
+  page,
+  request,
+}) => {
+  // O defeito que este caso guarda: a tela mostrava só a seção da versão-alvo.
+  // Quem estava na 1.0.0 e ia para a 1.2.0 nunca lia a 1.1.0 — e no caso real
+  // (commit ac9472c5) a versão do meio trazia uma instrução para o operador
+  // apagar a conexão que estava funcionando.
+  const changelog = [
+    "## [1.2.0] — 2026-08-03",
+    "",
+    "**⚠️ Requer atenção**",
+    "",
+    "Rode o comando de migração antes.",
+    "",
+    "### Adicionado",
+    "",
+    "- Coisa da versão nova.",
+    "",
+    "## [1.1.0] — 2026-08-02",
+    "",
+    "**⚠️ Requer atenção**",
+    "",
+    "Reconecte o número depois.",
+    "",
+    "### Corrigido",
+    "",
+    "- Conserto da versão do meio.",
+    "",
+    "## [1.0.0] — 2026-08-01",
+    "",
+    "- Primeira versão.",
+    "",
+  ].join("\n");
+
+  await loginWithTotp(page, creds.users.dono!.email, creds.dono_totp!.secret);
+  await heartbeat(request, { latest_version: "1.2.0", current_version: "1.0.0", changelog });
+  await page.goto("/app/settings/atualizacao");
+
+  // Os DOIS avisos visíveis, o da alvo e o da versão do meio, cada um nomeando
+  // de onde veio.
+  await expect(page.getByText(/Rode o comando de migração antes/)).toBeVisible();
+  await expect(page.getByText(/Reconecte o número depois/)).toBeVisible();
+  await expect(page.getByText(/Da versão 1\.1\.0/)).toBeVisible();
+
+  // E os dois ANTES do botão — medido por ferramenta, nunca a olho: aviso que
+  // aparece depois do clique não é aviso.
+  const y = async (rx: RegExp) => (await page.getByText(rx).boundingBox())!.y;
+  const botao = (await page.getByRole("button", { name: /atualizar agora/i }).boundingBox())!.y;
+  expect(await y(/Rode o comando de migração antes/)).toBeLessThan(botao);
+  expect(await y(/Reconecte o número depois/)).toBeLessThan(botao);
+
+  // O corpo da versão-alvo fica aberto; o da intermediária, recolhido. Texto
+  // dentro de um `<details>` FECHADO não é visível para o Playwright, então o
+  // caso abre e prova pelo estado real do elemento — e nunca põe um AVISO ali
+  // dentro, que é o defeito que esta tela existe para consertar.
+  await expect(page.getByText(/Coisa da versão nova/)).toBeVisible();
+  const recolhido = page.locator("details", { hasText: "Versão 1.1.0" });
+  await recolhido.locator("summary").click();
+  await expect(recolhido).toHaveJSProperty("open", true);
+  await expect(page.getByText(/Conserto da versão do meio/)).toBeVisible();
+
+  await page.screenshot({ path: ".superpowers/evidence/faixa-de-versoes.png" });
+});
+
 test("o dono vê a versão nova na sidebar e atualiza pela tela", async ({ page, request }) => {
   const changelog =
     "## [1.1.0] — 2026-08-02\n\n**⚠️ Requer atenção**\n\nReconecte o número depois.\n\n### Adicionado\n\n- Botão de atualizar pela tela.\n";

--- a/tests/unit/changelog-cabe-na-tela-da-vps.test.ts
+++ b/tests/unit/changelog-cabe-na-tela-da-vps.test.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { parseFragmento } from "@/lib/release/fragmento";
+import { montarSecao } from "@/lib/release/montar-secao";
 import { extractChangelogSection } from "@/lib/system/changelog";
 
 /**
@@ -143,6 +145,39 @@ function fimDaSecao(texto: string, versao: string): number {
   throw new Error(`seção [${versao}] não encontrada`);
 }
 
+/**
+ * Os fragmentos de `.changes/`, já validados. Um fragmento malformado é erro de
+ * quem o escreveu e reprova em `fragmentos-de-release.test.ts` — aqui ele é
+ * pulado para a mensagem de falha não trocar "seção grande demais" por um erro
+ * de parse que confundiria o conserto.
+ */
+function fragmentosDeChanges(): ReturnType<typeof parseFragmento>[] {
+  const dir = path.join(RAIZ, ".changes");
+  if (!fs.existsSync(dir)) return [];
+  const lidos = [];
+  for (const arquivo of fs.readdirSync(dir).filter((f) => f.endsWith(".md")).sort()) {
+    try {
+      lidos.push(parseFragmento(arquivo, fs.readFileSync(path.join(dir, arquivo), "utf8")));
+    } catch {
+      continue;
+    }
+  }
+  return lidos;
+}
+
+/** O arquivo como ele ficará na TAG: `[Não lançado]` vazio, a seção nova abaixo. */
+function comSecaoMontada(raw: string, fragmentos: ReturnType<typeof parseFragmento>[]): string {
+  const { cabecalho, secoes } = fatiar(raw);
+  const numeradas = secoes.filter((s) => s.versao !== null);
+  return (
+    cabecalho +
+    "## [Não lançado]\n\n" +
+    montarSecao(fragmentos, "9.9.9", "2099-01-01").texto +
+    "\n\n" +
+    numeradas.map((s) => s.texto).join("")
+  );
+}
+
 const RAW = fs.readFileSync(CHANGELOG, "utf8");
 const TETO = tetoDoAgente();
 
@@ -174,6 +209,24 @@ const CANDIDATAS: Array<{ nome: string; versao: string; texto: string; conserto:
       versao: "9.9.9",
       texto: comoFicaNaTag(RAW, "9.9.9"),
       conserto: "Enxugue os itens de [Não lançado] (veja o cabeçalho deste arquivo).",
+    });
+  }
+
+  // A partir de `docs/doctrine/versionamento.md`, o texto da próxima release
+  // não mora mais em `[Não lançado]` — ele chega em fragmentos, um por PR, e
+  // `[Não lançado]` fica PERMANENTEMENTE vazio. Sem esta candidata, a guarda
+  // acima passaria a nunca ter o que medir antes de uma release: continuaria
+  // verde por vacuidade, que é o modo de falha que o cabeçalho deste arquivo
+  // existe para evitar.
+  const fragmentos = fragmentosDeChanges();
+  if (fragmentos.length > 0) {
+    CANDIDATAS.push({
+      nome: `a seção que os ${fragmentos.length} fragmento(s) de .changes/ vão produzir`,
+      versao: "9.9.9",
+      texto: comSecaoMontada(RAW, fragmentos),
+      conserto:
+        "Enxugue o corpo dos fragmentos em `.changes/` — item de changelog longo costuma ser " +
+        "explicação que só interessa a quem escreveu o código.",
     });
   }
 }

--- a/tests/unit/fragmentos-de-release.test.ts
+++ b/tests/unit/fragmentos-de-release.test.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { calcularBump, FragmentoInvalido, parseFragmento } from "@/lib/release/fragmento";
+
+/**
+ * O gate do fragmento — e o que ele deliberadamente NÃO faz.
+ *
+ * Ele valida a FORMA de todo fragmento em `.changes/`, e não cobra a PRESENÇA
+ * de um. Cobrar presença dentro de um check obrigatório quebraria três coisas
+ * que este repo tem de verdade: os PRs do Dependabot (`.github/dependabot.yml`,
+ * dois ecossistemas), os PRs de fork de quem contribui de fora, e — o mais
+ * absurdo — o próprio PR de release, que por construção CONSOME os fragmentos e
+ * deixa `.changes/` vazio. O gate existiria para produzir esse PR e o reprovaria.
+ *
+ * A presença é cobrada onde não trava robô: no item do Definition of Done
+ * (`CLAUDE.md`) e na régua de `docs/doctrine/versionamento.md`.
+ *
+ * O que ESTE gate impede é o defeito que a revisão humana não pega: um
+ * fragmento malformado chega ao `CHANGELOG.md`, que é TELA — e o dono da VPS lê
+ * um aviso decapitado, ou não lê o aviso nenhum.
+ */
+const DIR = path.join(process.cwd(), ".changes");
+
+function arquivos(): string[] {
+  if (!fs.existsSync(DIR)) return [];
+  return fs.readdirSync(DIR).filter((f) => f.endsWith(".md")).sort();
+}
+
+/** kebab-case: o nome vira parte do diff, e maiúscula/espaço quebram em outro SO. */
+const NOME_VALIDO = /^[a-z0-9][a-z0-9-]*\.md$/;
+
+describe("os fragmentos de .changes/ estão em forma de chegar à tela", () => {
+  it("o diretório existe — sem ele o corte de release não tem de onde ler", () => {
+    expect(fs.existsSync(DIR), ".changes/ sumiu: veja docs/doctrine/versionamento.md").toBe(true);
+  });
+
+  it.each(arquivos())("%s é legível, válido e nomeado em kebab-case", (arquivo) => {
+    expect(arquivo, `nome fora do padrão kebab-case: ${arquivo}`).toMatch(NOME_VALIDO);
+    const texto = fs.readFileSync(path.join(DIR, arquivo), "utf8");
+    expect(() => parseFragmento(arquivo, texto)).not.toThrow();
+  });
+
+  it("o conjunto produz um número, ou não há release a cortar", () => {
+    const impactos = arquivos().map((a) => parseFragmento(a, fs.readFileSync(path.join(DIR, a), "utf8")).impacto);
+    if (impactos.length === 0) {
+      expect(() => calcularBump(impactos)).toThrow(FragmentoInvalido);
+      return;
+    }
+    expect(["patch", "minor", "major"]).toContain(calcularBump(impactos));
+  });
+
+  // Caso SINTÉTICO: não depende de `.changes/` ter conteúdo. Sem ele, com o
+  // diretório vazio esta suíte ficaria verde sem exercitar validação nenhuma —
+  // um gate que só reprova quando alguém já acertou não é gate.
+  it("um fragmento malformado É recusado (a validação está viva, com o diretório vazio ou não)", () => {
+    expect(() => parseFragmento("ruim.md", "sem frontmatter nenhum")).toThrow(FragmentoInvalido);
+    expect(() =>
+      parseFragmento("ruim.md", "---\nimpacto: minor\nsecao: corrigido\ntitulo: x\n---\n\ncorpo"),
+    ).toThrow(FragmentoInvalido);
+  });
+});

--- a/tests/unit/tag-so-nasce-da-main.test.ts
+++ b/tests/unit/tag-so-nasce-da-main.test.ts
@@ -34,13 +34,18 @@ describe("nenhuma tag publica sem estar contida na main", () => {
     },
   );
 
-  it("a trava exige `identical` ou `behind` no compare com a main", () => {
+  it("a trava aceita EXATAMENTE `identical` e `behind`, e nada mais", () => {
     const t = job(publish, "a-tag-veio-da-main");
     expect(t).toContain("compare/main...");
-    // `ahead` e `diverged` são commit que a main não tem. Aceitar qualquer um
-    // dos dois devolveria a porta que este job fecha.
-    expect(t).toMatch(/identical\|behind/);
-    expect(t).not.toMatch(/\bahead\|/);
+
+    // Prende o CONJUNTO aceito, não a ausência de uma string. A primeira versão
+    // deste caso proibia `/\bahead\|/` — e passou verde quando a sabotagem
+    // trocou o ramo por `identical|behind|ahead)`, porque ali `ahead` vem
+    // seguido de `)` e não de `|`. Proibir uma grafia deixa as outras entrarem;
+    // exigir o conjunto não deixa nenhuma.
+    const ramo = /^\s*([a-z|]+)\)\s*echo "ok:/m.exec(t);
+    expect(ramo, "não achei o ramo de aceitação do `case` — a trava mudou de forma").not.toBeNull();
+    expect(ramo?.[1]?.split("|").sort()).toEqual(["behind", "identical"]);
   });
 
   it("a trava NÃO tem `if:` de job — pulada, ela vira `skipped` e o imagens-ok lê isso como reprovação", () => {

--- a/tests/unit/tag-so-nasce-da-main.test.ts
+++ b/tests/unit/tag-so-nasce-da-main.test.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * A tag `vX.Y.Z` é o gatilho de atualização do parque instalado inteiro:
+ * `hostgator-setup-kit/agent.sh` oferece a MAIOR tag `v*` a toda VPS, e o
+ * `update.sh` puxa a imagem por aquele número. Este arquivo vigia as duas
+ * propriedades que impedem que ela vire uma porta aberta.
+ */
+const RAIZ = process.cwd();
+const publish = fs.readFileSync(path.join(RAIZ, ".github/workflows/publish-image.yml"), "utf8");
+const release = fs.readFileSync(path.join(RAIZ, ".github/workflows/release.yml"), "utf8");
+
+/** As linhas de um job, até o próximo job na mesma indentação. */
+function job(yml: string, nome: string): string {
+  const linhas = yml.split("\n");
+  const i = linhas.findIndex((l) => l === `  ${nome}:`);
+  if (i === -1) return "";
+  const fim = linhas.findIndex((l, n) => n > i && /^ {2}[a-z-]+:$/.test(l));
+  return linhas.slice(i, fim === -1 ? undefined : fim).join("\n");
+}
+
+describe("nenhuma tag publica sem estar contida na main", () => {
+  it("o job da trava existe", () => {
+    expect(job(publish, "a-tag-veio-da-main"), "a trava de procedência sumiu de publish-image.yml").not.toBe("");
+  });
+
+  it.each(["build-and-push", "imagem-do-app-sobe"])(
+    "%s depende da trava — senão publica antes de ela responder",
+    (nome) => {
+      expect(job(publish, nome)).toMatch(/needs:\s*\[[^\]]*a-tag-veio-da-main/);
+    },
+  );
+
+  it("a trava exige `identical` ou `behind` no compare com a main", () => {
+    const t = job(publish, "a-tag-veio-da-main");
+    expect(t).toContain("compare/main...");
+    // `ahead` e `diverged` são commit que a main não tem. Aceitar qualquer um
+    // dos dois devolveria a porta que este job fecha.
+    expect(t).toMatch(/identical\|behind/);
+    expect(t).not.toMatch(/\bahead\|/);
+  });
+
+  it("a trava NÃO tem `if:` de job — pulada, ela vira `skipped` e o imagens-ok lê isso como reprovação", () => {
+    const t = job(publish, "a-tag-veio-da-main");
+    // `if:` de STEP é permitido; o que não pode é o `if:` na altura do job
+    // (quatro espaços), que faz o GitHub pular o job inteiro.
+    expect(t.split("\n").filter((l) => /^ {4}if:/.test(l))).toEqual([]);
+  });
+});
+
+describe("a tag nasce no CI, e nunca do GITHUB_TOKEN", () => {
+  it("o release usa o token do GitHub App para escrever", () => {
+    // Evento disparado com o GITHUB_TOKEN não cria novo workflow run (doc do
+    // GitHub). Se a tag nascesse dele, `publish-image.yml` nunca rodaria: a tag
+    // existiria, nenhum erro apareceria, e NENHUMA VPS receberia a atualização.
+    expect(release).toContain("actions/create-github-app-token");
+    expect(release).toContain("secrets.RELEASE_APP_ID");
+    expect(release).toContain("secrets.RELEASE_APP_PRIVATE_KEY");
+  });
+
+  it("nenhum job do release pede escopo de escrita ao GITHUB_TOKEN", () => {
+    const escritas = release
+      .split("\n")
+      .filter((l) => /^\s+(contents|pull-requests|packages):\s*write\s*$/.test(l));
+    expect(escritas, "escrita pelo GITHUB_TOKEN: quem escreve aqui tem que ser o App").toEqual([]);
+  });
+
+  it("o corte da tag prova que as imagens saíram — a falha aqui é silenciosa por natureza", () => {
+    const t = job(release, "cortar-tag");
+    expect(t).toContain("ghcr_status");
+    for (const img of ["deskcommcrm", "deskcomm-worker", "deskcomm-scheduler"]) {
+      expect(t, `a conferência não cobre ${img}`).toContain(img);
+    }
+    expect(t).toMatch(/::error::/);
+  });
+
+  it("a tag só é criada em push na main, nunca num dispatch de branch qualquer", () => {
+    expect(job(release, "cortar-tag")).toMatch(/if:\s*github\.event_name == 'push'/);
+    expect(release).toMatch(/push:\s*\n\s*branches:\s*\[main\]/);
+  });
+});


### PR DESCRIPTION
## O problema, medido

Cada micro-correção subia uma minor, e sessões paralelas chegavam ao mesmo número. Medindo, eram **três** problemas — e um quarto que ninguém tinha citado.

**1. A régua estava escrita, e estava errada.** Não faltava regra. A que estava em vigor dizia *"mudança de comportamento visível = minor"* — e conserto de bug muda comportamento visível **por definição**. O commit de release da v1.6.0 (`e9df4bae`) a escreve em voz alta: *"MINOR porque muda comportamento visível ao cliente final."*

| | commits | intervalo |
|---|---|---|
| v1.4.0 → v1.4.1 | 16 | 1 dia |
| v1.4.1 → v1.5.0 | 47 | horas |
| v1.5.0 → v1.6.0 | 70 | 1 dia |

Seis minors e duas patches em trinta dias.

**2. Nada protegia o número.** `rulesets` do repositório = `[]`; tag protection = 404; o `pre-push` de `loop/hooks` barra só `refs/heads/main|master` — **tag passa**. Uma tag `v*` de qualquer branch move o canal `stable` do parque inteiro. E tag movida faz o `git fetch --tags` do `update.sh` sair com erro que o script relata como *"não consegui falar com o GitHub"*: a VPS fica no código antigo e a mensagem mente sobre o motivo.

**3. O texto se perdia.** Oito merges com conflito real no `CHANGELOG.md`, todos em 25–26/08. Treze de 45 commits entre a v1.5.0 e a v1.6.0 sem eco na seção. E a 1.4.1 esteve no CHANGELOG **sem tag** (`ac9472c5`) — como a tela mostra só a seção da versão-alvo, seus dois avisos sumiriam para quem pulasse; um deles mandava apagar a conexão que estava funcionando.

**4. `AGENTS.md` afirmava `1.0.0`** e mandava conferir no `package.json`, que diz `0.1.0`. A publicada era a v1.6.0: as duas fontes que um agente consultaria estavam erradas, e nenhum teste vigiava a linha. Sobrava `git tag | tail -1` — exatamente o que duas sessões leem ao mesmo tempo.

## O que este PR faz

**A régua pergunta pelo operador, não pelo código.** Nada a fazer e nada mudou de forma → patch. Nada a fazer, mas ganhou capacidade → minor. Precisa agir → major. A linha de baixo já era lei (`CLAUDE.md:252`, ADR 0001); a doutrina só a estende para a faixa onde **todas** as releases caem.

**E ninguém digita o número.** Cada PR traz `.changes/<nome>.md` declarando o **efeito** — `nada_mudou` / `capacidade_nova` / `exige_acao` —, nunca o número. Pedir `impacto: minor` convidaria o mesmo erro de volta, porque "minor" é a resposta e não a pergunta.

```
1 conserto                      →  1.6.0 + patch = 1.6.1
1 conserto + 1 capacidade nova  →  1.6.0 + minor = 1.7.0
```

O primeiro caso é a correção inteira: sob a régua anterior, aquele conserto teria saído 1.7.0.

**Por que não `release-please`:** ele monta o changelog de mensagens de commit. Aqui o `CHANGELOG.md` **é tela** — `lib/system/changelog.ts` extrai a seção e a rota de sistema a entrega ao dono da VPS, em prosa longa em português. E os números não fechariam: 94,4% dos commits sem merge seguem Conventional Commits, mas só 2,2% dos merges, e há **zero** marcações de breaking change em 2.639 commits — major seria inderivável.

## Guardas

- **A montagem é testada contra o parser real da tela**, não contra a string intermediária: prova que o aviso cai num único bloco e não vaza para o corpo, que `fn_user_org_ids()` chega inteiro, e que a prosa sai verbatim (negrito partido entre linhas chegaria com os asteriscos à mostra).
- **A guarda de bytes ia dormir.** `changelog-cabe-na-tela-da-vps.test.ts` media o `[Não lançado]`, que agora fica vazio para sempre — ficaria verde por vacuidade. Passou a medir a seção que os fragmentos **vão** produzir. Provado: fragmento de 40.500 bytes reprova com `A seção termina no byte 41530, além do corte de 30000`.
- **O gate valida forma, e deliberadamente não cobra presença.** Cobrar presença num check obrigatório reprovaria PR de Dependabot, PR de fork e — o mais absurdo — o próprio PR de release, que consome os fragmentos e deixa `.changes/` vazio. A presença é cobrada no DoD 17.
- **`.gitattributes`: `union` no MANIFEST, e não no `baseline.sql`.** Medido num Postgres 17: ali o merge sai limpo, o SQL intercala duas funções, o `install.sh` morre com syntax error e o `update.sh` do **cliente** sai com código 0 sem criar função nenhuma. O marcador de conflito, ali, é feature.

**Sabotagens, com a contagem prevista antes de rodar:** régua invertida → 3 falhas; proibição do símbolo de atenção removida → 1; vazio virando patch → 1. A primeira rodada revelou um ponto cego meu: comparar `calcularBump(x)` com `BUMP_DO_IMPACTO[x]` não vigia nada, porque as duas pontas derivam da mesma fonte e a sabotagem move as duas juntas. A régua está presa por **valor** agora.

## O que NÃO está aqui, e por que a ordem importa

**A tag ainda não nasce no CI.** Ela depende de um **GitHub App**: confirmado na doc oficial que evento disparado com o `GITHUB_TOKEN` padrão não cria novo workflow run — então `publish-image.yml` nunca rodaria e **nenhuma imagem seria publicada**, falha silenciosa que só apareceria quando um cliente tentasse atualizar. As alternativas caem: `repository_dispatch`/`workflow_run` são proibidos por teste existente, `workflow_dispatch` não move `stable`, e PAT expira em silêncio meses depois.

O `pre-push` barrando `refs/tags/v*` e o ruleset de tags entram **depois** desse workflow — antes, barrariam o caminho manual sem o automático existir, e ninguém conseguiria lançar.

Também fica para depois o defeito de produto da tela mostrar só a seção-alvo em vez do intervalo. Tudo registrado em memória de projeto.

## Evidência

```
pnpm typecheck                                              zerado
pnpm lint                                                   0 errors
pnpm lint:channels                                          ok
pnpm vitest run --exclude 'lib/ai/dispatcher/rate-limit.test.ts'
                                                            497 arquivos, 5602 testes, verde
```

A exclusão é defeito de **ambiente** pré-existente, medido nos dois sentidos: na main pura (`b3996c43`) aquele arquivo dá 5 failed **com** `.env.local` no disco e 5 passed **sem** ele.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAtZo5GWZn8ckdmsoUVKts
