### PR TITLE
A tag exige a assinatura do corte, não só um número novo no CHANGELOG

### DIFF
--- a/.changes/tag-so-do-corte-de-release.md
+++ b/.changes/tag-so-do-corte-de-release.md
@@ -1,0 +1,11 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A versão só é publicada pelo caminho da release
+---
+
+Uma correção no nosso próprio processo de publicação, feita antes de causar
+problema: o sistema que cria a versão decidia apenas por haver um número novo
+escrito no histórico de mudanças. Bastava alguém escrever esse número junto de
+outra alteração para a versão sair sozinha, sem passar pela aprovação. Agora ele
+exige também a marca de que aquilo foi de fato um fechamento de versão.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,16 +112,39 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
-      - name: A main anuncia uma versão que ainda não tem tag?
+      - name: Este push foi um corte de release?
         id: pendente
         run: |
           set -euo pipefail
+
+          # DUAS condições, e a segunda é a que importa. Só a primeira ("o
+          # CHANGELOG anuncia versão que não tem tag") deixaria QUALQUER PR
+          # cortar a release: bastaria escrever `## [1.7.0]` no CHANGELOG à mão
+          # e a tag nasceria no merge dele, pulando o PR de release inteiro —
+          # e com ela as três imagens e o canal `stable`.
+          #
+          # Isso não é hipótese: medido em 2026-08-27, o PR #354 (RAG) já
+          # trazia uma seção de versão escrita à mão no CHANGELOG.
+          #
+          # A segunda condição é a ASSINATURA do corte, e um PR comum não a
+          # produz nem por engano: o commit CONSUMIU fragmentos — havia
+          # `.changes/*.md` antes e não há depois. PR comum ACRESCENTA
+          # fragmento; só o corte esvazia o diretório.
           versao=$(pnpm exec tsx scripts/cortar-release.ts --versao-do-changelog)
+
+          antes=$(git ls-tree -r --name-only HEAD^ -- .changes/ | grep -c '\.md$' || true)
+          depois=$(git ls-tree -r --name-only HEAD  -- .changes/ | grep -c '\.md$' || true)
+          echo "fragmentos em .changes/: antes=${antes} depois=${depois}"
+
           if git rev-parse -q --verify "refs/tags/v${versao}" >/dev/null; then
-            echo "v${versao} já existe — nada a cortar (este push não era um merge de release)"
+            echo "v${versao} já existe — nada a cortar"
+            echo "cortar=nao" >> "$GITHUB_OUTPUT"
+          elif [ "${antes}" -eq 0 ] || [ "${depois}" -ne 0 ]; then
+            echo "::notice::O CHANGELOG anuncia ${versao} sem tag, mas este push NÃO consumiu fragmentos."
+            echo "::notice::Tag não criada. Uma release sai do workflow 'release' (Run workflow), nunca de um merge comum."
             echo "cortar=nao" >> "$GITHUB_OUTPUT"
           else
-            echo "v${versao} ainda não existe — esta main traz uma versão nova"
+            echo "corte de release: ${antes} fragmento(s) consumido(s), v${versao} ainda não existe"
             echo "cortar=sim"       >> "$GITHUB_OUTPUT"
             echo "versao=${versao}" >> "$GITHUB_OUTPUT"
           fi

--- a/tests/unit/tag-so-nasce-da-main.test.ts
+++ b/tests/unit/tag-so-nasce-da-main.test.ts
@@ -82,6 +82,21 @@ describe("a tag nasce no CI, e nunca do GITHUB_TOKEN", () => {
     expect(t).toMatch(/::error::/);
   });
 
+  it("a tag exige que o push tenha CONSUMIDO fragmentos, não só que haja versão nova no CHANGELOG", () => {
+    // Só a condição "o CHANGELOG anuncia versão sem tag" deixaria QUALQUER PR
+    // cortar a release: bastaria escrever `## [1.7.0]` à mão e a tag nasceria
+    // no merge dele, levando junto as três imagens e o canal `stable`.
+    // Medido em 2026-08-27: o PR #354 já trazia uma seção de versão escrita à
+    // mão. A segunda condição é a assinatura do corte — havia `.changes/*.md`
+    // antes e não há depois — e um PR comum não a produz: ele ACRESCENTA
+    // fragmento, nunca esvazia o diretório.
+    const t = job(release, "cortar-tag");
+    expect(t).toMatch(/git ls-tree[^\n]*HEAD\^[^\n]*\.changes\//);
+    expect(t).toMatch(/git ls-tree[^\n]*HEAD[^\n]*\.changes\//);
+    // O ramo que RECUSA precisa existir e cobrir os dois lados da assinatura.
+    expect(t).toMatch(/antes[^\n]*-eq 0[^\n]*depois[^\n]*-ne 0/);
+  });
+
   it("a tag só é criada em push na main, nunca num dispatch de branch qualquer", () => {
     expect(job(release, "cortar-tag")).toMatch(/if:\s*github\.event_name == 'push'/);
     expect(release).toMatch(/push:\s*\n\s*branches:\s*\[main\]/);


### PR DESCRIPTION
Furo no mecanismo instalado ontem pelo #357, achado antes de cobrar preço.

`cortar-tag` roda em todo push na `main` e decidia por **uma** condição: o CHANGELOG anuncia uma versão que ainda não tem tag. Bastava um PR qualquer escrever `## [1.7.0]` no CHANGELOG à mão, e o merge dele criaria a tag — com as três imagens e o canal `stable` — pulando o PR de release inteiro.

**Não é hipótese.** Medido agora, nos cinco PRs abertos:

```
PR #354 (RAG):                    1 seção de versão adicionada ao CHANGELOG
PR #349, #352, #345, #356:        0
```

Mergear o #354 hoje publicaria uma release sozinho.

## O conserto

A segunda condição é a **assinatura do corte**, e um PR comum não a produz nem por engano: o commit **consumiu** fragmentos — havia `.changes/*.md` em `HEAD^` e não há em `HEAD`. PR comum *acrescenta* fragmento; só o corte esvazia o diretório.

```
antes=0 depois=0   PR sem fragmento                 → não corta
antes=0 depois=1   PR que adiciona o 1º fragmento   → não corta
antes=2 depois=3   PR que adiciona a mais           → não corta
antes=3 depois=0   CORTE de release                 → CORTA
```

Provado também com git real sobre o commit da tela de atualização: `antes=0 depois=1` → não corta.

Quando recusa, o job **não fica mudo**: emite um `::notice::` dizendo que o CHANGELOG anuncia versão sem tag mas o push não consumiu fragmento. Silêncio aqui viraria "por que a tag não saiu?" sem resposta.

Guardado por caso novo em `tag-so-nasce-da-main.test.ts`. Sabotado removendo a segunda condição: 1 falha, como previsto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAtZo5GWZn8ckdmsoUVKts