### PR TITLE
O fragmento da Agenda, para ela aparecer na tela de quem atualizar

### DIFF
--- a/.changes/agenda-modulo-de-calendario.md
+++ b/.changes/agenda-modulo-de-calendario.md
@@ -1,0 +1,15 @@
+---
+impacto: capacidade_nova
+secao: adicionado
+titulo: Agenda: marcar, remarcar e cancelar compromissos pela tela
+---
+
+O sistema ganhou uma Agenda. Dá para criar tipos de compromisso, ver a grade da
+semana, marcar um horário e remarcar ou cancelar pela própria tela, com o motivo
+registrado. A IA também consegue consultar os horários livres e marcar durante o
+atendimento, sem ninguém sair da conversa.
+
+Quem usa Google Agenda pode conectar a sua conta em Configurações, e os
+compromissos passam a aparecer nos dois lados. Isso é opcional: sem conectar, a
+Agenda funciona igual, e quem não mexer em nada não precisa fazer coisa alguma
+depois de atualizar.


### PR DESCRIPTION
O #358 entrou sem fragmento. Sem ele a Agenda chega na VPS e não aparece na tela de atualização — o dono ganha um módulo inteiro e não fica sabendo.

Impacto `capacidade_nova` e não `exige_acao`, medido: as duas variáveis novas são `optional().default("")` em `lib/env.ts:293-294` e o kit as grava vazias.

`pnpm release:conferir` → **1.6.0 + minor = 1.7.0** (3 fragmentos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)