### PR TITLE
docs(release): o fragmento da Agenda para o corte de 1.7.0

### DIFF
--- a/.changes/agenda-modulo-de-calendario.md
+++ b/.changes/agenda-modulo-de-calendario.md
@@ -1,0 +1,19 @@
+---
+impacto: capacidade_nova
+secao: adicionado
+titulo: Agenda: marcar, remarcar e cancelar compromissos pela tela
+---
+
+O sistema ganhou uma Agenda. Dá para ver a grade da semana, marcar um horário e
+remarcar ou cancelar pela própria tela, com o motivo do cancelamento registrado
+para quem for atender depois. A IA também consulta os horários livres e marca
+durante o atendimento, sem ninguém sair da conversa.
+
+Em Configurações você define os tipos de compromisso do seu negócio — consulta,
+retorno, visita, orçamento e outros — com a duração de cada um, onde acontece e
+quem atende. É isso que a tela de marcar e a IA passam a oferecer ao cliente.
+
+Quem usa Google Agenda pode conectar a conta pelo botão que aparece na própria
+Agenda, e os compromissos passam a aparecer nos dois lados. É opcional: sem
+conectar, a Agenda funciona igual, e quem não mexer em nada não precisa fazer
+coisa alguma depois de atualizar.


### PR DESCRIPTION
Um arquivo: `.changes/agenda-modulo-de-calendario.md`, para o corte de versão do @Maestro (2).

`pnpm release:conferir` → **`1.6.0 + minor = 1.7.0 (3 fragmentos)`**, com a linha da Agenda listada.

## Uma correção de fato no texto original

O rascunho dizia que se conecta o Google **em Configurações**. O botão está na **própria Agenda** (`app/app/agenda/_components/CartaoDaConexaoGoogle.tsx`); o que mora em Configurações são os **tipos** de compromisso.

Mandar o cliente ao lugar errado num texto que ele lê logo depois de atualizar é o tipo de erro que ninguém volta para conferir. Acrescentei também o parágrafo dos tipos — é capacidade nova e não estava no fragmento.

## Conferido antes de escrever

- O parser corta no **primeiro** `:` (`lib/release/fragmento.ts:108`), então o título com dois-pontos passa. Num YAML de verdade ele seria ambíguo — vale saber, porque o próximo título com `:` só funciona por causa disso.
- Os cinco checks obrigatórios do PR #358 fecharam verdes, e ele **já está na main** (merge `3f0ffaac`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THCeiPxospLw1pr3dJG1z7