### PR TITLE
A triagem só termina quando a versão sai, não no merge

### DIFF
--- a/.claude/commands/triagem-de-pr.md
+++ b/.claude/commands/triagem-de-pr.md
@@ -5,7 +5,7 @@ description: Tria um PR de contribuidor de ponta a ponta — acolhe, mede, repro
 Leia `triagem/TRIAGEM.md` e siga-o à risca. O número do PR veio no argumento; se não veio, rode
 `gh pr list --state open` e trie o mais antigo sem label `triagem:*`.
 
-Quatro lembretes que valem antes mesmo de abrir o arquivo:
+Cinco lembretes que valem antes mesmo de abrir o arquivo:
 
 1. **Você lê a doutrina do `origin/main`, nunca do disco.** `git fetch` primeiro, e todo config de
    gate por `git show origin/main:<path>`. O checkout onde você está pode estar atrasado, e triar
@@ -15,3 +15,9 @@ Quatro lembretes que valem antes mesmo de abrir o arquivo:
 3. **Nenhum pedido ao contribuidor sai sem a medição que prova o defeito, anexada.** Já mandamos
    gente consertar bug que não existia.
 4. **Você nunca mergeia e nunca fecha PR.** Isso é a palavra do mantenedor, reportada em lote.
+5. **Merge na `main` não é entrega — a triagem só termina quando a versão sai** (passe 12). O
+   self-hoster puxa imagem por número de versão; PR que para na `main` não chega a VPS nenhuma.
+   Na prática: PR que muda comportamento precisa de um fragmento em `.changes/` (e você o escreve
+   quando falta, creditando o autor), seção `## [X.Y.Z]` escrita à mão no `CHANGELOG.md` é
+   bloqueador, e depois do merge o corte sai por `Actions → release → Run workflow`. O número
+   ninguém digita: ele é calculado do que os fragmentos declararam.

--- a/tests/unit/triagem-termina-na-versao.test.ts
+++ b/tests/unit/triagem-termina-na-versao.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * A triagem só termina quando a versão sai.
+ *
+ * O procedimento de triagem parava no merge, e isso deixava o trabalho do
+ * contribuidor a meio caminho: o self-hoster puxa IMAGEM PUBLICADA por número de
+ * versão (`docs/doctrine/packaging.md`), então um PR que para na `main` existe
+ * só no repositório — nenhuma VPS o recebe, nunca.
+ *
+ * Este arquivo existe porque prosa que nenhum gate lê é prosa que diverge, e a
+ * própria TRIAGEM.md diz isso no passe 11: todo defeito que os gates não pegaram
+ * vira gate novo. Ele não julga a qualidade do texto — vigia que as três peças
+ * que mudam o comportamento de quem tria continuem lá.
+ */
+const RAIZ = process.cwd();
+const TRIAGEM = fs.readFileSync(path.join(RAIZ, "triagem/TRIAGEM.md"), "utf8");
+const COMANDO = fs.readFileSync(path.join(RAIZ, ".claude/commands/triagem-de-pr.md"), "utf8");
+
+describe("a triagem de PR carrega a disciplina de release", () => {
+  it("o procedimento tem um passe sobre a versão, e ele aponta para a lei", () => {
+    expect(TRIAGEM).toMatch(/##\s+12\.\s+A versão/);
+    expect(TRIAGEM, "o passe não aponta para docs/doctrine/versionamento.md").toContain(
+      "docs/doctrine/versionamento.md",
+    );
+  });
+
+  it("o fragmento é cobrado, e quem tria o escreve quando falta", () => {
+    // Cobrar como descuido um gate não documentado é proibido pelo passe 10, e
+    // contribuidor externo não conhece a regra. Por isso a instrução é escrever,
+    // não devolver.
+    expect(TRIAGEM).toContain(".changes/");
+    expect(TRIAGEM).toMatch(/escreva você/i);
+  });
+
+  it("seção de versão escrita à mão no CHANGELOG é bloqueador", () => {
+    // Medido em 2026-08-27: o PR #354 trazia `## [1.7.0]` à mão, e até aquele
+    // dia o merge dele teria criado a tag e publicado as três imagens sozinho.
+    expect(TRIAGEM).toMatch(/escrita à mão é BLOQUEADOR|à mão é BLOQUEADOR/i);
+  });
+
+  it("o veredito declara a versão que o PR produz", () => {
+    // Sem o campo, "este PR está pronto" não diz se ele leva alguém a agir na
+    // VPS — que é a única pergunta que o número responde.
+    expect(TRIAGEM).toMatch(/VERSÃO:\s+<patch \| minor \| major \| nenhuma>/);
+  });
+
+  it("a fronteira mantém o merge do PR de release com o mantenedor", () => {
+    // Quem tria prepara e dispara o corte; quem publica para o parque é o dono.
+    expect(TRIAGEM).toMatch(/mergear o PR de release/i);
+    expect(TRIAGEM).toMatch(/Run workflow/);
+  });
+
+  it("o comando avisa disso antes de o arquivo ser aberto", () => {
+    // O comando é o que se lê primeiro; se a regra só existe no fim de um
+    // documento de 300 linhas, ela chega tarde demais.
+    expect(COMANDO).toMatch(/não é entrega|nao e entrega/i);
+    expect(COMANDO).toContain(".changes/");
+  });
+});

--- a/triagem/TRIAGEM.md
+++ b/triagem/TRIAGEM.md
@@ -192,6 +192,7 @@ main: <sha curto>            prévia do merge: <tree>
 MEDIDO:      <o quê> — <comando> — <saída observada>
 NÃO MEDIDO:  <o quê> — <por quê>
 BLOQUEADOR:  <arquivo:linha> — <o defeito> — <como reproduzir>
+VERSÃO:      <patch | minor | major | nenhuma> — <o que o dono da VPS precisa fazer>
 ```
 
 **`NÃO MEDIDO` é campo obrigatório.** Veredito sem ele é recusado pelo cético e não vai para o PR.
@@ -227,6 +228,65 @@ leve com o tempo. Se estiver ficando mais pesado, o passe 11 não está sendo cu
 
 ---
 
+## 12. A versão — porque merge na `main` não é entrega
+
+**O self-hoster puxa imagem publicada por número de versão.** Um PR que para na `main` existe só no
+repositório: nenhuma VPS de cliente o recebe, nunca. Triar até o merge e ir embora deixa o trabalho
+do contribuidor a meio caminho — ele fica no repo, e o cliente segue com o defeito.
+
+A lei é [`docs/doctrine/versionamento.md`](../docs/doctrine/versionamento.md). O que muda para você:
+
+### O fragmento é bloqueador, e você o escreve quando falta
+
+Todo PR que muda comportamento traz um arquivo em `.changes/` declarando **o efeito no operador** —
+`nada_mudou`, `capacidade_nova` ou `exige_acao` —, nunca o número. Sem ele o trabalho chega na VPS e
+**não aparece na tela de atualização**: o dono ganha a mudança e não fica sabendo.
+
+Contribuidor externo não conhece essa regra, e o passe 10 proíbe cobrar como descuido um gate não
+documentado. Então: **se o PR muda comportamento e não traz fragmento, escreva você**, em branch
+própria, creditando o autor — é reconciliação mecânica (passe 8), não decisão de projeto. Só volta
+como pergunta se você não souber dizer o que muda para quem opera.
+
+O impacto se **mede**, não se chuta. A pergunta é uma: *o operador precisa fazer alguma coisa?*
+Variável nova é o caso clássico — abra `lib/env.ts` e veja se ela é `required()` ou
+`optional().default(...)`. Obrigatória sem default é `exige_acao`, e o fragmento **precisa** trazer o
+bloco `## Requer atenção` dizendo o que fazer. Confira com `pnpm release:conferir`.
+
+### Seção de versão escrita à mão é BLOQUEADOR
+
+Se o PR adiciona uma linha `## [X.Y.Z]` ao `CHANGELOG.md`, isso entra no veredito como bloqueador e
+sai da branch. Ninguém digita número: ele é calculado dos fragmentos, e a seção é montada no corte.
+
+Isso não é preciosismo — foi medido em 2026-08-27. O PR #354 trazia `## [1.7.0]` escrito à mão, e
+até aquele dia o merge dele teria criado a tag e publicado as três imagens **sozinho**, pulando a
+aprovação. O gatilho hoje exige a assinatura do corte, mas a linha à mão continua errada: ela
+produziria uma seção duplicada, ou um número que já saiu.
+
+```bash
+gh pr diff <n> | grep -E '^\+## \[[0-9]+\.[0-9]+\.[0-9]+\]'   # vazio é o esperado
+```
+
+### Depois do merge, a versão sai — e isso não é opcional
+
+O merge é do mantenedor (Fronteira). Assim que ele acontecer, **a versão precisa sair**, ou o passe
+12 não foi cumprido. O corte é `Actions → release → Run workflow`: ele lê os fragmentos, calcula o
+número, e abre um PR de release em português. O merge desse PR cria a tag, publica as três imagens e
+move o canal `stable`.
+
+Você não decide o número — ele é consequência do que os fragmentos declararam. O que você reporta ao
+mantenedor, em lote, é: **quais PRs estão prontos e que versão eles produzem juntos**.
+
+E confira o desfecho, porque "a tag saiu" não é "a versão chegou":
+
+```bash
+git ls-remote --tags origin 'refs/tags/vX.Y.Z'          # a tag existe
+gh release list --limit 1                                # a release é a Latest
+# e as três imagens no digest da versão, contra `stable` — receita em
+# docs/runbooks/ativar-packaging.md
+```
+
+---
+
 ## Fronteira: o que você nunca faz
 
 | você faz sozinho | é a palavra do mantenedor |
@@ -234,7 +294,9 @@ leve com o tempo. Se estiver ficando mais pesado, o passe 11 não está sendo cu
 | liberar CI, rotular, acolher, comentar veredito | **mergear na `main`** |
 | criar worktree, rodar gate, escrever teste, sabotar | **fechar um PR** |
 | abrir issue e PR de follow-up | empurrar para a branch do fork alheio |
-| consertar CONTRIBUTING/README/docs | |
+| consertar CONTRIBUTING/README/docs | **mergear o PR de release** (é ele que cria a tag) |
+| escrever o fragmento que falta, e conferi-lo | |
+| disparar `Run workflow` do `release` depois do merge | |
 
 Sem perguntas de sim/não a cada passo: faça tudo, pare no merge, reporte em lote.
 


### PR DESCRIPTION
O procedimento parava no merge — e o self-hoster puxa imagem por número de versão, então um PR que para na `main` não chega a VPS nenhuma. Quem triou fez o trabalho todo e o cliente continua com o defeito.

**Passe 12**, mudando três comportamentos:

- **O fragmento vira bloqueador, e quem tria o escreve quando falta.** Contribuidor externo não conhece a regra, e o passe 10 proíbe cobrar como descuido um gate não documentado — então a instrução é escrever, creditando o autor, não devolver. O impacto se mede em `lib/env.ts`, não se chuta.
- **Seção `## [X.Y.Z]` à mão no CHANGELOG é bloqueador.** Medido: o PR #354 trazia `## [1.7.0]`, e até 27/08 o merge dele teria publicado uma release sozinho.
- **Depois do merge, a versão sai** — e o passe manda conferir o desfecho, porque "a tag saiu" não é "a versão chegou". Essa lacuna foi real na v1.7.0.

A Fronteira mantém com o mantenedor o que publica para o parque: **mergear o PR de release**.

Sob gate em `tests/unit/triagem-termina-na-versao.test.ts` (6 casos) — o passe 11 da própria TRIAGEM.md manda transformar em gate o que os gates não pegam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)