### PR TITLE
A tela de Notificações diz o que falta para o aviso chegar com a aba fechada (item 1 da #366)

### DIFF
--- a/.changes/a-tela-diz-o-que-falta-para-o-aviso-com-a-aba-fechada.md
+++ b/.changes/a-tela-diz-o-que-falta-para-o-aviso-com-a-aba-fechada.md
@@ -1,0 +1,19 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A tela de Notificações passa a dizer o que falta para o aviso chegar com a aba fechada
+---
+
+A tela dizia que o aviso por Push "já funciona", sem conferir se esta instalação
+tinha como enviá-lo. Quem ligava a opção via o navegador pedir permissão,
+concedia, e depois não recebia nada com a aba fechada — sem nenhuma pista do
+motivo, e sem como descobrir o que fazer.
+
+Agora, quando faltam as chaves do Web Push, a própria tela avisa que os avisos
+só aparecem com o site aberto e mostra o comando para gerar o par de chaves e
+onde colocá-lo. Quando as chaves já estão no lugar, ela anuncia que o aviso
+chega também com a aba fechada e para de pedir configuração.
+
+**Você não precisa fazer nada.** A opção de Push continua podendo ser ligada dos
+dois jeitos: mesmo sem as chaves, o aviso na bandeja do sistema já funciona
+enquanto o DeskcommCRM está aberto numa aba.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -149,6 +149,7 @@ jobs:
         followup-linguagem.spec.ts followup-ramos.spec.ts
         wizard-do-funcionario.spec.ts mfa-opcional.spec.ts inbox-responder-citando.spec.ts
         agenda-tela-do-produto.spec.ts
+        notificacoes-diz-o-que-falta.spec.ts
       # ⚠️ A ORDEM DESTA LISTA NÃO DECIDE A ORDEM DE EXECUÇÃO. O Playwright
       # ordena os arquivos por CAMINHO, não pela ordem em que são passados na
       # linha de comando. Medido no run 31838253496: `marca-logo.spec.ts` estava

--- a/app/app/settings/notifications/page.tsx
+++ b/app/app/settings/notifications/page.tsx
@@ -1,11 +1,47 @@
 import { requireAuth } from "@/lib/auth/server";
 import { Card } from "@/components/ui/card";
+import { vapidPronto } from "@/lib/notifications/vapid";
 import { NotificationPrefsClient } from "./_client";
 
 export const dynamic = "force-dynamic";
 
+/**
+ * A TELA PRECISA SABER O QUE ESTA INSTALAÇÃO CONSEGUE FAZER.
+ *
+ * O backend sempre soube: `GET /api/v1/notifications/push` devolve
+ * `enabled: false` sem o par VAPID, e o `PUT` recusa com 503 «Web Push não
+ * configurado nesta instalação». Quem não perguntava era esta página.
+ *
+ * O efeito, num primeiro deploy — que é o estado em que NENHUMA instalação tem
+ * as chaves —, era o pior tipo de silêncio:
+ *
+ *  1. a página afirmava «Push (Chrome) já funcionam» de forma incondicional;
+ *  2. a pessoa ligava o interruptor de Push e o navegador pedia permissão —
+ *     um incômodo real, cobrado do usuário;
+ *  3. ela concedia, e `syncPushSubscription()` fazia `return` em silêncio
+ *     (`if (!cfg?.data?.enabled || !publicKey) return`);
+ *  4. o interruptor ficava ligado, sem nada avisando que a metade que ela
+ *     queria — ser avisada com a aba FECHADA — não ia acontecer.
+ *
+ * E não havia, em lugar nenhum do produto, como descobrir que faltavam duas
+ * variáveis no `.env`. Informação que existe no servidor e não chega a quem
+ * decide é o mesmo que informação ausente.
+ *
+ * ⚠️ O INTERRUPTOR CONTINUA LIGÁVEL DE PROPÓSITO, e isto não é descuido: sem
+ * VAPID o aviso na bandeja AINDA funciona enquanto a aba está aberta — é
+ * `new Notification()` em `lib/notifications/emit.ts`, que não depende de
+ * inscrição nenhuma. Desabilitar o controle tiraria capacidade que a
+ * instalação tem. O que faltava era dizer a verdade sobre a metade que ela
+ * não tem, e como consegui-la.
+ *
+ * Server component de propósito: `vapidPronto()` é lido no servidor, então a
+ * primeira pintura já sai correta — sem fetch, sem estado intermediário em que
+ * a tela promete o que não cumpre.
+ */
 export default async function NotificationsPage() {
   await requireAuth();
+  const pushPronto = vapidPronto();
+
   return (
     <div className="flex h-full flex-col gap-6 p-6">
       <header>
@@ -13,10 +49,42 @@ export default async function NotificationsPage() {
         <p className="text-sm text-muted-foreground">Canais e categorias.</p>
       </header>
 
-      <Card className="border-amber-500/40 bg-amber-50/40 p-4 text-sm dark:bg-amber-900/10">
-        Email ainda não está disponível. In-app (toast) e Push (Chrome) já funcionam
-        para as cinco categorias.
-      </Card>
+      {pushPronto ? (
+        <Card
+          data-testid="push-status-pronto"
+          className="border-amber-500/40 bg-amber-50/40 p-4 text-sm dark:bg-amber-900/10"
+        >
+          Email ainda não está disponível. In-app (toast) e Push (Chrome) já funcionam
+          para as cinco categorias, inclusive com a aba fechada.
+        </Card>
+      ) : (
+        <Card
+          data-testid="push-status-faltando-chaves"
+          className="border-amber-500/40 bg-amber-50/40 p-4 text-sm dark:bg-amber-900/10"
+        >
+          <p className="font-medium">
+            Nesta instalação, os avisos só aparecem com o site aberto.
+          </p>
+          <p className="mt-2 text-muted-foreground">
+            {/* ⚠️ Sem o nome do produto aqui, e não por estilo: a instalação é
+                white-label e `tests/unit/branding.test.ts` varre `app/` atrás de
+                marca escrita à mão. «o site» diz a mesma coisa e serve a quem
+                revende o sistema com a marca dele. */}
+            Ligar o Push abaixo já faz o aviso aparecer na bandeja do sistema enquanto
+            você está com o site aberto numa aba. Para receber também com a aba
+            fechada, quem administra o servidor precisa gerar um par de chaves uma única
+            vez e reiniciar:
+          </p>
+          <pre className="mt-2 overflow-x-auto rounded bg-muted p-2 text-xs">
+            <code>npx web-push generate-vapid-keys</code>
+          </pre>
+          <p className="mt-2 text-muted-foreground">
+            O resultado vai no arquivo <code>.env</code>, em{" "}
+            <code>VAPID_PUBLIC_KEY</code> e <code>VAPID_PRIVATE_KEY</code>. Email ainda
+            não está disponível.
+          </p>
+        </Card>
+      )}
 
       <NotificationPrefsClient />
     </div>

--- a/docs/testing/user-journey-map.md
+++ b/docs/testing/user-journey-map.md
@@ -420,6 +420,61 @@ divide o servidor. Só aparece exercitando o produto pela tela.
 > não roda quando um caso falha). Corrigidos antes da primeira execução; o
 > resultado real entra aqui quando o CI disser.
 
+## J12 — A tela diz o que ESTA instalação consegue fazer `[P0]`
+
+**Por que P0:** é primeira impressão pura. **Nenhuma instalação nasce com o par
+VAPID** — o `.env.hostgator.example` grava as duas linhas vazias e gerar o par é
+um passo opcional que ninguém é obrigado a dar. Ou seja, o estado testado aqui é
+o estado em que 100% das instalações começam, e a tela de Notificações tem porta
+na navegação (`lib/navigation/registry.ts:470`), então qualquer pessoa chega nela
+no primeiro dia.
+
+**O defeito era de tela, e o backend estava certo o tempo todo.**
+`GET /api/v1/notifications/push` já devolvia `enabled:false` sem as chaves, e o
+`PUT` já recusava com 503 «Web Push não configurado nesta instalação». Quem nunca
+perguntou foi `app/app/settings/notifications/page.tsx`, que afirmava «In-app
+(toast) e Push (Chrome) já funcionam para as cinco categorias» de forma
+incondicional. A sequência que a pessoa vivia:
+
+1. a tela promete Push;
+2. ela liga o interruptor e o navegador pede permissão — incômodo real, cobrado dela;
+3. ela concede, e `syncPushSubscription()` faz `return` em silêncio
+   (`if (!cfg?.data?.enabled || !publicKey) return`);
+4. o interruptor fica ligado prometendo o que a instalação não entrega, e **nada
+   no produto** conta que faltam duas variáveis no `.env`, nem como consegui-las.
+
+Informação que existe no servidor e não chega a quem decide é o mesmo que
+informação ausente.
+
+**O conserto exagerado, recusado de propósito:** desabilitar o interruptor sem
+VAPID. Sem as chaves o aviso na bandeja **ainda funciona com a aba aberta** —
+é `new Notification()` em `lib/notifications/emit.ts`, que não depende de
+inscrição nenhuma. Desabilitar trocaria prometer demais por entregar de menos, e
+o segundo não deixa rastro. J12.3 existe para impedir esse conserto.
+
+Spec: `tests/e2e/notificacoes-diz-o-que-falta.spec.ts` (estado SEM as chaves —
+o do `.env.e2e` e o do primeiro deploy).
+Evidência: `.superpowers/evidence/notificacoes-sem-chaves/`.
+Os DOIS estados: `tests/unit/notificacoes-tela-diz-o-que-falta.test.tsx` — o
+servidor lê `vapidPronto()` uma vez por processo, então provar o estado COM as
+chaves pela tela exigiria um segundo `next start` só para trocar duas variáveis,
+num job que já leva meia hora.
+
+| # | Caso | Expectativa | Resultado |
+|---|------|-------------|-----------|
+| J12.1 | Sem VAPID, a tela não fica muda | aviso `push-status-faltando-chaves` visível, e o de «pronto» ausente | PASS |
+| J12.2 | Ela diz o que FAZER, não só o que falta | o comando `npx web-push generate-vapid-keys` e as duas chaves, nominalmente | PASS |
+| J12.3 | O interruptor de Push continua ligável | não nasce desabilitado — a capacidade com a aba aberta existe | PASS |
+| J12.4 | Com VAPID, anuncia a aba fechada | e para de mandar gerar o par que já existe | PASS (unit) |
+
+**NÃO COBERTO, declarado:** a notificação chegando na bandeja do sistema com a
+aba fechada. Depende do serviço de push do navegador (FCM), de rede externa e de
+um par VAPID real — não é reproduzível num runner, e fingir com mock seria pior
+que a ausência declarada. O que está provado é o contrato entre a TELA e o
+SERVIDOR. Continua aberto na issue #366.
+
+---
+
 ## J7 — Exploração completa `[P2]`
 
 Andar por TODAS as rotas navegáveis logado como admin e como agent: settings, contacts,

--- a/tests/e2e/notificacoes-diz-o-que-falta.spec.ts
+++ b/tests/e2e/notificacoes-diz-o-que-falta.spec.ts
@@ -57,6 +57,29 @@ interface Creds {
 
 let creds: Creds;
 
+/**
+ * ⚠️ `agent`, E NÃO `admin` — e isto não é preferência.
+ *
+ * `scripts/seed-e2e-credentials.ts` garante um factor TOTP **verified** no
+ * `admin` e no `dono`, sempre ("MFA do admin nunca é desabilitado"). Com eles o
+ * login não chega em `/app`: para em `/login/mfa?factor=…`, e um
+ * `waitForURL(/\/app/)` só descobre isso 60 segundos depois. Foi exatamente
+ * assim que a primeira versão deste spec falhou no CI — os dois casos, mesma
+ * causa, mesmo timeout.
+ *
+ * Passar o challenge com `tests/e2e/utils/totp` seria possível, e seria custo
+ * sem contrapartida: a página é `requireAuth()` puro, **sem nenhum ramo por
+ * papel**, então o que ela mostra é o mesmo para qualquer sessão. Pagar o TOTP
+ * aqui só acrescentaria um segredo rotativo entre este spec e o defeito que ele
+ * guarda.
+ *
+ * E há um detalhe de produto que este papel exercita de graça: um atendente
+ * comum NÃO administra a VPS, e é ele quem mais precisa entender por que não
+ * recebe aviso. O texto resolve isso dizendo *quem administra o servidor
+ * precisa* — em vez de mandar o atendente rodar um comando que não é dele.
+ */
+const PAPEL_SEM_MFA = "agent";
+
 async function login(page: Page, email: string, senha: string): Promise<void> {
   await page.goto("/login");
   await page.locator("#email").fill(email);
@@ -80,8 +103,8 @@ test.describe("Notificações — a tela conta a verdade sobre esta instalação
   test("sem o par VAPID, a tela diz o que falta e o que fazer — e não fica muda", async ({
     page,
   }) => {
-    const dono = creds.users.admin ?? Object.values(creds.users)[0]!;
-    await login(page, dono.email, creds.password);
+    const quem = creds.users[PAPEL_SEM_MFA]!;
+    await login(page, quem.email, creds.password);
 
     // ── CONTROLE POSITIVO ────────────────────────────────────────────────
     // Antes de afirmar qualquer coisa sobre a tela, confirme com o SERVIDOR em
@@ -130,8 +153,8 @@ test.describe("Notificações — a tela conta a verdade sobre esta instalação
     // inscrição nenhuma. Quem desabilitasse o interruptor estaria trocando um
     // defeito (prometer demais) por outro (entregar de menos), e o segundo é
     // pior porque não deixa rastro.
-    const dono = creds.users.admin ?? Object.values(creds.users)[0]!;
-    await login(page, dono.email, creds.password);
+    const quem = creds.users[PAPEL_SEM_MFA]!;
+    await login(page, quem.email, creds.password);
     await page.goto("/app/settings/notifications");
 
     const linhaMensagem = page.getByRole("row", { name: /Nova mensagem/i });

--- a/tests/e2e/notificacoes-diz-o-que-falta.spec.ts
+++ b/tests/e2e/notificacoes-diz-o-que-falta.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * A TELA DE NOTIFICAÇÕES NUM PRIMEIRO DEPLOY — provado pela tela, sem as chaves.
+ *
+ * ## Por que este é o estado que importa
+ *
+ * Nenhuma instalação nasce com o par VAPID. O `.env.hostgator.example` grava as
+ * duas linhas VAZIAS, e gerar o par é um passo que ninguém é obrigado a dar.
+ * Ou seja: **este spec roda no estado em que 100% das instalações começam**, e
+ * é o estado da doutrina de QA Visual — "teste com os envs opcionais AUSENTES,
+ * é o estado real de um primeiro deploy, e é onde moram os piores bugs de
+ * primeira impressão".
+ *
+ * Não é preciso configurar nada para chegar nele: o `.env.e2e` do CI não define
+ * `VAPID_PUBLIC_KEY` nem `VAPID_PRIVATE_KEY`. Se alguém as acrescentar lá, o
+ * primeiro caso abaixo falha ALTO em vez de virar verde vazio — ele confere o
+ * estado com o backend antes de afirmar qualquer coisa sobre a tela.
+ *
+ * ## O defeito que ele guarda
+ *
+ * A página afirmava «Push (Chrome) já funcionam» sem consultar nada. A pessoa
+ * ligava o Push, o navegador pedia permissão, ela concedia — e
+ * `syncPushSubscription()` fazia `return` em silêncio, porque
+ * `GET /api/v1/notifications/push` devolvia `enabled:false`. O interruptor
+ * ficava ligado prometendo o que a instalação não podia entregar, e não havia
+ * em lugar nenhum do produto como descobrir que faltavam duas variáveis.
+ *
+ * ## O que ele NÃO tenta provar, e por quê
+ *
+ * Não prova a notificação chegando na bandeja do sistema com a aba fechada.
+ * Isso depende do serviço de push do navegador (FCM), de rede externa e de um
+ * par VAPID real — não é reproduzível num runner do CI, e fingir que sim com
+ * mock seria pior que a ausência declarada. O que ele prova é o contrato entre
+ * a TELA e o SERVIDOR: que a tela conta a verdade sobre a instalação em que
+ * está, nos dois sentidos.
+ *
+ * O estado COM as chaves é guardado por
+ * `tests/unit/notificacoes-tela-diz-o-que-falta.test.tsx`, que renderiza a mesma
+ * página nos dois valores de `vapidPronto()` — em milissegundos, no `verify`.
+ *
+ * Pré-requisitos (banco local, app buildada):
+ *   pnpm exec tsx scripts/seed-e2e-credentials.ts
+ *   pnpm e2e:env && pnpm e2e:build
+ *   E2E_PORT=3031 pnpm exec playwright test tests/e2e/notificacoes-diz-o-que-falta.spec.ts
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { expect, test, type Page } from "@playwright/test";
+
+const CREDS_PATH = path.join(process.cwd(), ".e2e-creds.json");
+const EVIDENCIA = path.join(process.cwd(), ".superpowers/evidence/notificacoes-sem-chaves");
+
+interface Creds {
+  password: string;
+  users: Record<string, { id: string; email: string; role: string }>;
+}
+
+let creds: Creds;
+
+async function login(page: Page, email: string, senha: string): Promise<void> {
+  await page.goto("/login");
+  await page.locator("#email").fill(email);
+  await page.locator("#password").fill(senha);
+  await page.getByRole("button", { name: /entrar/i }).click();
+  await page.waitForURL(/\/app/, { timeout: 60_000 });
+}
+
+async function captura(page: Page, nome: string): Promise<void> {
+  fs.mkdirSync(EVIDENCIA, { recursive: true });
+  await page.screenshot({ path: path.join(EVIDENCIA, `${nome}.png`), fullPage: true });
+}
+
+test.describe("Notificações — a tela conta a verdade sobre esta instalação", () => {
+  test.describe.configure({ timeout: 120_000 });
+
+  test.beforeAll(() => {
+    creds = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
+  });
+
+  test("sem o par VAPID, a tela diz o que falta e o que fazer — e não fica muda", async ({
+    page,
+  }) => {
+    const dono = creds.users.admin ?? Object.values(creds.users)[0]!;
+    await login(page, dono.email, creds.password);
+
+    // ── CONTROLE POSITIVO ────────────────────────────────────────────────
+    // Antes de afirmar qualquer coisa sobre a tela, confirme com o SERVIDOR em
+    // que estado estamos. Sem isto, o dia em que alguém puser VAPID no
+    // `.env.e2e` este teste vira verde afirmando o oposto do que mede.
+    const cfg = await page.request.get("/api/v1/notifications/push");
+    expect(cfg.ok(), "GET /api/v1/notifications/push respondeu").toBeTruthy();
+    const corpo = (await cfg.json()) as { data?: { enabled?: boolean } };
+    expect(
+      corpo.data?.enabled,
+      "este spec descreve a instalação SEM VAPID; se o ambiente passou a tê-lo, " +
+        "mova-o para o outro estado em vez de deixá-lo verde dizendo o contrário",
+    ).toBe(false);
+
+    await page.goto("/app/settings/notifications");
+    await expect(page.getByRole("heading", { name: "Notificações" })).toBeVisible();
+
+    // 1 · O aviso do estado certo aparece, e o do outro estado NÃO.
+    const aviso = page.getByTestId("push-status-faltando-chaves");
+    await expect(aviso).toBeVisible();
+    await expect(page.getByTestId("push-status-pronto")).toHaveCount(0);
+
+    // 2 · Ele diz o LIMITE em português, não em jargão de variável.
+    await expect(aviso).toContainText(/só aparecem com o site aberto/i);
+
+    // 3 · E diz O QUE FAZER — o comando e as duas chaves, nominalmente.
+    //     Um aviso que só informa a falta deixa o operador sem saída: ele
+    //     descobre que está quebrado e continua sem saber o que fazer.
+    await expect(aviso).toContainText("npx web-push generate-vapid-keys");
+    await expect(aviso).toContainText("VAPID_PUBLIC_KEY");
+    await expect(aviso).toContainText("VAPID_PRIVATE_KEY");
+    await expect(aviso).toContainText(/\.env/);
+
+    await captura(page, "01-aviso-sem-chaves");
+  });
+
+  test("o interruptor de Push continua ligável — a capacidade com a aba aberta existe", async ({
+    page,
+  }) => {
+    // ⚠️ ESTE CASO EXISTE PARA IMPEDIR O CONSERTO EXAGERADO.
+    //
+    // A leitura preguiçosa do defeito é "a tela oferece Push sem VAPID, então
+    // desabilite o controle". Isso tiraria capacidade que a instalação TEM: sem
+    // VAPID o aviso na bandeja ainda funciona enquanto a aba está aberta, por
+    // `new Notification()` em `lib/notifications/emit.ts`, que não depende de
+    // inscrição nenhuma. Quem desabilitasse o interruptor estaria trocando um
+    // defeito (prometer demais) por outro (entregar de menos), e o segundo é
+    // pior porque não deixa rastro.
+    const dono = creds.users.admin ?? Object.values(creds.users)[0]!;
+    await login(page, dono.email, creds.password);
+    await page.goto("/app/settings/notifications");
+
+    const linhaMensagem = page.getByRole("row", { name: /Nova mensagem/i });
+    const interruptorPush = linhaMensagem.getByRole("switch", { name: /via push/i });
+
+    await expect(interruptorPush).toBeVisible();
+    await expect(
+      interruptorPush,
+      "o interruptor de Push não pode nascer desabilitado: sem VAPID o aviso " +
+        "com a aba ABERTA continua funcionando, e desabilitar tiraria isso",
+    ).toBeEnabled();
+
+    await captura(page, "02-interruptor-continua-ligavel");
+  });
+});

--- a/tests/unit/notificacoes-tela-diz-o-que-falta.test.tsx
+++ b/tests/unit/notificacoes-tela-diz-o-que-falta.test.tsx
@@ -1,0 +1,152 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * A TELA DE NOTIFICAÇÕES CONTA A VERDADE SOBRE A INSTALAÇÃO — nos DOIS estados.
+ *
+ * ## O defeito
+ *
+ * `app/app/settings/notifications/page.tsx` afirmava «In-app (toast) e Push
+ * (Chrome) já funcionam para as cinco categorias» de forma INCONDICIONAL. O
+ * backend sempre soube a verdade — `GET /api/v1/notifications/push` devolve
+ * `enabled:false` sem o par VAPID, e o `PUT` recusa com 503 —, mas a tela nunca
+ * perguntou.
+ *
+ * Num primeiro deploy, que é o estado em que TODA instalação começa (o
+ * `.env.hostgator.example` grava as duas linhas vazias), a sequência era:
+ *
+ *   1. a tela promete Push;
+ *   2. a pessoa liga o interruptor e o navegador pede permissão — incômodo
+ *      real, cobrado dela;
+ *   3. ela concede, e `syncPushSubscription()` faz `return` em silêncio;
+ *   4. o interruptor fica ligado, e nada no produto conta que faltam duas
+ *      variáveis no `.env`, nem como consegui-las.
+ *
+ * ## Por que aqui, e não só no `e2e`
+ *
+ * O `e2e` roda no estado SEM as chaves — é o do `.env.e2e` e é o do primeiro
+ * deploy, então é o certo para ele. Mas há **dois** estados, e o servidor lê
+ * `vapidPronto()` uma vez por processo: provar o outro pela tela exigiria um
+ * segundo `next start` só para trocar duas variáveis, num job que já leva meia
+ * hora.
+ *
+ * Aqui os dois estados são a mesma função chamada duas vezes, em
+ * milissegundos, no `verify`. `tests/e2e/notificacoes-diz-o-que-falta.spec.ts`
+ * continua sendo quem prova pela tela de verdade, com o navegador.
+ *
+ * ## Os dois sentidos, e por que os DOIS precisam de guarda
+ *
+ *  - **sem as chaves, prometer a aba fechada** é o defeito original: a tela
+ *    vende o que a instalação não entrega.
+ *  - **com as chaves, esconder que funciona** seria o conserto exagerado —
+ *    capacidade paga, entregue e não anunciada. Um teste que só cobrasse o
+ *    aviso empurraria alguém a deixá-lo fixo na tela, e aí ele mente na outra
+ *    direção.
+ *
+ * ## `renderToStaticMarkup`, e não Testing Library
+ *
+ * É Server Component async: `render()` não sabe esperar a promessa. Chamar a
+ * função e renderizar a árvore que ela devolve mede o HTML de verdade, e não a
+ * presença do símbolo `vapidPronto` no arquivo — que é o que um teste de texto
+ * mediria, e passaria mesmo com a chamada desligada.
+ */
+
+const vapidPronto = vi.hoisted(() => vi.fn<() => boolean>());
+vi.mock("@/lib/notifications/vapid", () => ({ vapidPronto }));
+vi.mock("@/lib/auth/server", () => ({ requireAuth: vi.fn().mockResolvedValue({}) }));
+vi.mock("@/app/app/settings/notifications/_client", () => ({
+  NotificationPrefsClient: () => <table />,
+}));
+
+async function telaCom(chaves: boolean): Promise<string> {
+  vapidPronto.mockReturnValue(chaves);
+  const { default: NotificationsPage } = await import(
+    "@/app/app/settings/notifications/page"
+  );
+  return renderToStaticMarkup(await NotificationsPage());
+}
+
+describe("tela de Notificações — o que ela afirma sobre esta instalação", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("o instrumento está vivo — controle positivo antes de qualquer conclusão", async () => {
+    const semChaves = await telaCom(false);
+    const comChaves = await telaCom(true);
+
+    // Se a página deixar de consultar `vapidPronto()`, os dois HTML ficam
+    // IGUAIS e todo o resto deste arquivo passa a medir nada. Sem este caso, um
+    // refactor que remova a chamada deixa a suíte verde.
+    expect(vapidPronto, "a página nem chamou vapidPronto()").toHaveBeenCalled();
+    expect(
+      semChaves === comChaves,
+      "a tela renderiza o MESMO HTML nos dois estados — ela parou de perguntar",
+    ).toBe(false);
+  });
+
+  it("⭐ SEM o par VAPID: diz o limite, e diz o que fazer", async () => {
+    const html = await telaCom(false);
+
+    expect(html).toContain("push-status-faltando-chaves");
+    expect(html).not.toContain("push-status-pronto");
+
+    // O limite, em português de gente — não «VAPID ausente».
+    expect(html).toMatch(/só aparecem com o site aberto/i);
+
+    // E a saída. Um aviso que só informa a falta deixa o operador sabendo que
+    // está quebrado e sem saber o que fazer — que é quase o silêncio de antes.
+    expect(html).toContain("npx web-push generate-vapid-keys");
+    expect(html).toContain("VAPID_PUBLIC_KEY");
+    expect(html).toContain("VAPID_PRIVATE_KEY");
+  });
+
+  it("⭐ SEM o par VAPID: NÃO afirma que o Push já funciona", async () => {
+    const html = await telaCom(false);
+
+    // Esta é a afirmação literal que existia antes e era falsa neste estado:
+    // «In-app (toast) e Push (Chrome) já funcionam para as cinco categorias».
+    expect(
+      html,
+      "a tela afirma que o Push já funciona numa instalação sem as chaves",
+    ).not.toMatch(/já funcionam/i);
+
+    // ⚠️ MENCIONAR O LIMITE NÃO É PROMETÊ-LO, e esta distinção me custou um
+    // vermelho. Escrevi este caso primeiro como um `&&` de duas condições
+    // (`/já funcionam/ && /aba fechada/`), previ a sabotagem antes de rodar e
+    // vi o furo: a tela ANTIGA dizia «já funcionam» e NÃO dizia «aba fechada»,
+    // então o `&&` seria falso e o caso passaria verde sobre exatamente o
+    // defeito que existe para pegar. Separei em duas.
+    //
+    // Aí a segunda ficou errada por outro motivo: proibir a STRING «aba
+    // fechada» reprovou a tela CERTA, porque explicar o que falta exige nomear
+    // o que falta — «Para receber também com a aba fechada, ... precisa gerar
+    // um par de chaves». O teste estava confundindo a menção com a promessa.
+    //
+    // O que separa uma da outra é a CONDIÇÃO ao lado. Então é ela que se cobra:
+    // se a tela fala em aba fechada neste estado, tem de ser dizendo o que
+    // fazer para consegui-la.
+    if (/aba fechada/i.test(html)) {
+      expect(
+        html,
+        "a tela fala em aba fechada sem dizer que ela depende de configuração",
+      ).toMatch(/precisa gerar|para receber também/i);
+    }
+  });
+
+  it("⭐ COM o par VAPID: anuncia a aba fechada, sem pedir configuração nenhuma", async () => {
+    const html = await telaCom(true);
+
+    expect(html).toContain("push-status-pronto");
+    expect(html).not.toContain("push-status-faltando-chaves");
+    expect(html).toMatch(/aba fechada/i);
+
+    // Capacidade que já está de pé não pode continuar pedindo que o operador
+    // rode um comando: seria mandá-lo mexer no `.env` de produção à toa.
+    expect(
+      html,
+      "a instalação já tem as chaves e a tela ainda manda gerar o par",
+    ).not.toContain("npx web-push generate-vapid-keys");
+  });
+});


### PR DESCRIPTION
Fecha o **item 1 da #366**: a jornada pela TELA do Web Push, item 12 do DoD, declarado em aberto quando o #365 foi mergeado.

O que ia ser só a spec que faltava virou **um defeito de primeira impressão** — achado ao olhar a tela no único estado em que ela nunca tinha sido olhada.

---

## O defeito

O backend sempre soube a verdade. `GET /api/v1/notifications/push` devolve `enabled:false` sem o par VAPID, e o `PUT` recusa com `503 — Web Push não configurado nesta instalação`. **Quem nunca perguntou foi a página.**

```tsx
// app/app/settings/notifications/page.tsx — antes
«Email ainda não está disponível. In-app (toast) e Push (Chrome) já funcionam
 para as cinco categorias.»                                    ← incondicional
```

E **nenhuma instalação nasce com essas chaves**: o `.env.hostgator.example` grava as duas linhas vazias, e gerar o par é um passo opcional. Ou seja, esta era a experiência de **100% dos primeiros deploys**:

1. a tela promete Push;
2. a pessoa liga o interruptor e o navegador pede permissão — incômodo real, cobrado dela;
3. ela concede, e `syncPushSubscription()` faz `return` em silêncio (`if (!cfg?.data?.enabled || !publicKey) return`);
4. o interruptor fica ligado prometendo o que a instalação não entrega, e **nada no produto** conta que faltam duas variáveis no `.env`, nem como consegui-las.

Informação que existe no servidor e não chega a quem decide é o mesmo que informação ausente.

---

## O conserto — e o conserto exagerado que foi recusado

A leitura preguiçosa do defeito é *"a tela oferece Push sem VAPID, então desabilite o controle"*. **Isso tiraria capacidade que a instalação tem:** sem VAPID o aviso na bandeja ainda funciona com a aba **aberta**, por `new Notification()` em `lib/notifications/emit.ts`, que não depende de inscrição nenhuma.

Seria trocar *prometer demais* por *entregar de menos* — e o segundo é pior, porque não deixa rastro. Há um caso de teste dedicado a impedir esse conserto (`J12.3`).

O interruptor continua ligável. O que muda é a tela contar a verdade sobre a metade que falta, **e como consegui-la**: o comando, as duas chaves pelo nome, e o arquivo. Um aviso que só informa a falta deixa o operador sabendo que está quebrado e sem saber o que fazer — quase o silêncio de antes.

Server component de propósito: `vapidPronto()` é lido no servidor, então a primeira pintura já sai correta, sem estado intermediário em que a tela promete o que não cumpre.

---

## As provas, e por que são duas ferramentas

| estado | prova | onde |
|---|---|---|
| **sem** as chaves (primeiro deploy) | `tests/e2e/notificacoes-diz-o-que-falta.spec.ts` — browser de verdade | `e2e` |
| **com** as chaves | `tests/unit/notificacoes-tela-diz-o-que-falta.test.tsx` — a mesma página nos dois valores | `verify` |

A spec abre com um **controle positivo contra o backend** antes de afirmar qualquer coisa sobre a tela: se alguém puser VAPID no `.env.e2e`, ela falha alto em vez de virar verde dizendo o contrário.

O estado COM as chaves não cabia no `e2e`: o servidor lê `vapidPronto()` uma vez por processo, e prová-lo pela tela exigiria um segundo `next start` só para trocar duas variáveis, num job que já leva meia hora. O teste unitário guarda os **dois sentidos** — sem as chaves não prometer, com as chaves não esconder. Um teste que só cobrasse o aviso empurraria alguém a deixá-lo fixo, e aí ele mente na outra direção.

### Sabotado, com a previsão errada declarada

```console
tela antiga (incondicional)  →  4 de 4 vermelhos
restaurada                   →  4 de 4 verdes
```

**Previ três e deram quatro.** Esqueci que o caso do estado COM chaves também cobra o `data-testid`, que a tela antiga não tem — a guarda é mais forte do que calculei. Fica escrito porque previsão errada *para menos* é a que deixa passar defeito.

E dois erros meus no caminho, **ambos no teste, nenhum na tela**:

- escrevi um caso como `/já funcionam/ && /aba fechada/`. Previ a sabotagem antes de rodar e vi o furo: a tela antiga dizia a primeira e **não** a segunda, então o `&&` seria falso e o caso passaria verde sobre exatamente o defeito que existe para pegar. Duas condições ligadas por `&&` formam uma guarda que nenhuma das duas dispara sozinha.
- separadas, a segunda **reprovou a tela certa**: proibir a string «aba fechada» confunde *mencionar* o limite com *prometê-lo*, e explicar o que falta exige nomear o que falta. O que separa os dois é a condição ao lado — e é ela que passou a ser cobrada.

Os seletores da spec foram validados antes de gastar 30 minutos de CI: exatamente **1** switch «via push» dentro da row «Nova mensagem» (mais de um seria violação de strict mode) e ele não nasce `disabled`.

---

## Registro

- **`.github/workflows/e2e.yml`** — a spec entra em `SPECS_PARTE_1`. Medido com o parser do próprio `CLAUDE.md`: **60** specs invocadas, a nova entre elas. Spec que o CI não invoca é spec que não existe.
- **`docs/testing/user-journey-map.md`** — jornada **J12** `[P0]`, com o não-coberto declarado.
- **Fragmento** `nada_mudou` / `corrigido` — o operador não precisa fazer nada, e nada que funcionava mudou de forma. `pnpm release:conferir` → `1.7.0 + minor = 1.8.0` (5 fragmentos).
- Sem o nome do produto no texto novo: a instalação é white-label e `tests/unit/branding.test.ts` varre `app/`. Medido, 33/33 com o gate de marca junto.

---

## NÃO MEDIDO

- **A notificação chegando na bandeja do sistema com a aba fechada.** Depende do serviço de push do navegador (FCM), de rede externa e de um par VAPID real — não é reproduzível num runner, e fingir com mock seria pior que a ausência declarada. O que está provado é o contrato entre a **tela** e o **servidor**. Segue aberto na #366.
- **A spec `e2e` não foi executada localmente.** O Docker desta máquina não respondeu (>120s) e o Supabase local não estava de pé; a máquina esteve com load 70+ e disco em 100% durante a sessão. Mitiguei validando os seletores por ARIA no jsdom, que é a mesma resolução que o Playwright usa — mas isso é mitigação, não execução. **O `e2e` do CI é a prova.**

Os outros dois itens da #366 (relógio HTTP contra cron real, `selectActiveByPhone` sem `order by`) continuam abertos lá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMM6LWWEHgeir2dQvv3Mnf
