### PR TITLE
test(e2e): a troca de organização espera a transição, não o relógio da máquina

### DIFF
--- a/tests/e2e/agenda-escopo-da-organizacao.spec.ts
+++ b/tests/e2e/agenda-escopo-da-organizacao.spec.ts
@@ -94,9 +94,22 @@ async function trocarPara(page: import("@playwright/test").Page, orgId: string, 
   await page.getByTestId("tenant-switcher").click();
   await page.getByTestId(`tenant-switcher-item-${orgId}`).click();
   if (nome) {
-    await expect(page.getByTestId("tenant-switcher"), `a troca para "${nome}" não pegou`).toContainText(nome, {
-      timeout: 20_000,
-    });
+    const seletor = page.getByTestId("tenant-switcher");
+    // ESPERAR A TRANSIÇÃO TERMINAR ANTES DE LER O TEXTO. A troca é uma server
+    // action dentro de `useTransition`, e enquanto ela roda o botão fica
+    // `disabled` mostrando o nome ANTIGO. Ler o texto nesse meio-tempo mede a
+    // velocidade da máquina, não a troca — e reprova com a acusação errada,
+    // "a troca não pegou", quando o certo seria "a troca ainda não terminou".
+    //
+    // Medido no CI: esta parte da suíte levou 16,9 min numa rodada contra 8,6
+    // min em outra, no mesmo repositório. O teto de 20s era do tamanho dessa
+    // variação, então o resultado dependia de quão carregado o runner estava.
+    //
+    // A propriedade medida NÃO afrouxa: depois que o botão volta a ficar
+    // habilitado, o nome TEM de ser o da organização nova. Troca que não
+    // acontece continua reprovando — só deixa de reprovar troca que demora.
+    await expect(seletor, `a troca para "${nome}" não terminou`).toBeEnabled({ timeout: 60_000 });
+    await expect(seletor, `a troca para "${nome}" não pegou`).toContainText(nome, { timeout: 20_000 });
   }
 }
 


### PR DESCRIPTION
## O que este PR conserta

`tests/e2e/agenda-escopo-da-organizacao.spec.ts` reprova de forma intermitente **na `main`**,
e a mensagem de falha acusa a coisa errada:

```
Error: a troca para "E2E Segunda Organização" não pegou
  5 × locator resolved to <button disabled data-testid="tenant-switcher">
      - unexpected value "E2E Test Org"
```

O botão está **`disabled`** durante os 20 s inteiros. `disabled` ali é `isPending` do
`useTransition` em `components/shell/TenantSwitcher.tsx`: a server action de troca **ainda
estava rodando**. O teste lia o texto no meio da transição — media a velocidade da máquina,
não a troca.

**Medido:** esta parte da suíte levou **16,9 min** numa rodada contra **8,6 min** em outra, no
mesmo repositório. O teto de 20 s era do tamanho dessa variação, então o resultado passava a
depender de quão carregado estava o runner. A mesma spec passou num run e falhou no seguinte.

## O conserto

Esperar o botão voltar a ficar **habilitado** — a transição terminar — e só então ler o nome.

**A propriedade medida não afrouxa:** depois de habilitado, o nome **tem** de ser o da
organização nova. Troca que *não acontece* continua reprovando; o que deixa de reprovar é troca
que *demora*.

Só aumentar o timeout consertaria o sintoma e manteria o teste medindo a coisa errada:
dependeria de a máquina caber no número novo, e a mensagem de falha continuaria acusando o
produto por lentidão do runner.

## Por que vem separado

A spec entrou na `main` pelo **#369** (os oito defeitos da Agenda), que foi mergeado com override
administrativo para destravar a **v1.8.0** — o dono do produto estava bloqueado. Este conserto
ficou de fora por poucos minutos, e sem ele a spec reprova sozinha em PR de qualquer pessoa.

Nada de produto muda aqui: **um arquivo, só teste**. Sem fragmento em `.changes/` porque nada
disto é visível a quem opera uma VPS (`docs/doctrine/versionamento.md`).

A spec segue invocada pelo CI — conferido pelo parser das `SPECS_PARTE_*`, não por `grep` no
arquivo, que conta spec citada em variável de exclusão.
