### PR TITLE
fix(auth): fecha bypass de MFA em 14 rotas administrativas

### DIFF
--- a/app/api/v1/ai/guardrail-layers/route.ts
+++ b/app/api/v1/ai/guardrail-layers/route.ts
@@ -29,8 +29,8 @@ import { z } from "zod";
 
 import { fail, ok } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
-import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
-import { ROLE_RANK } from "@/lib/auth/types";
+import { requireRole } from "@/lib/auth/require-role";
+import { roleAtLeast } from "@/lib/auth/types";
 import { CAMADAS_SEMANTICAS } from "@/lib/agent-engine/guardrails/camadas-da-org";
 import { createClient } from "@/lib/supabase/server";
 
@@ -53,12 +53,9 @@ function padraoDoAmbiente(): Record<string, boolean> {
 }
 
 export async function GET(): Promise<Response> {
-  const user = await requireAuth();
-  const org = await resolveActiveOrg(user);
-  if (!org) return fail("no_active_org", "nenhuma organização ativa", 400);
-  if (ROLE_RANK[org.role] < ROLE_RANK.manager) {
-    return fail("forbidden", "requer papel de gerente ou superior", 403);
-  }
+  const authz = await requireRole("manager", { resource: "ai_guardrail_layers" });
+  if (!authz.ok) return authz.response;
+  const { org } = authz;
 
   const db = await createClient();
   const { data, error } = await db
@@ -79,7 +76,7 @@ export async function GET(): Promise<Response> {
       padraoDoAmbiente: padrao[layer] ?? false,
       efetivo: escolhido.get(layer) ?? padrao[layer] ?? false,
     })),
-    podeEditar: ROLE_RANK[org.role] >= ROLE_RANK.admin,
+    podeEditar: roleAtLeast(org.role, "admin"),
   });
 }
 
@@ -91,12 +88,9 @@ const corpoDoPut = z.object({
 });
 
 export async function PUT(req: NextRequest): Promise<Response> {
-  const user = await requireAuth();
-  const org = await resolveActiveOrg(user);
-  if (!org) return fail("no_active_org", "nenhuma organização ativa", 400);
-  if (ROLE_RANK[org.role] < ROLE_RANK.admin) {
-    return fail("forbidden", "requer papel de administrador", 403);
-  }
+  const authz = await requireRole("admin", { resource: "ai_guardrail_layers" });
+  if (!authz.ok) return authz.response;
+  const { user, org } = authz;
 
   const parsed = corpoDoPut.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {

--- a/app/api/v1/ai/operator-metrics/route.ts
+++ b/app/api/v1/ai/operator-metrics/route.ts
@@ -28,8 +28,7 @@
  * pertencer a mais de uma organização — a RLS deixaria passar as duas.
  */
 import { fail, ok } from "@/lib/api/wrappers";
-import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
-import { ROLE_RANK } from "@/lib/auth/types";
+import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -38,12 +37,9 @@ export const dynamic = "force-dynamic";
 const DIAS = 30;
 
 export async function GET(): Promise<Response> {
-  const user = await requireAuth();
-  const org = await resolveActiveOrg(user);
-  if (!org) return fail("no_active_org", "nenhuma organização ativa", 400);
-  if (ROLE_RANK[org.role] < ROLE_RANK.manager) {
-    return fail("forbidden", "requer papel de gerente ou superior", 403);
-  }
+  const authz = await requireRole("manager", { resource: "ai_operator_metrics" });
+  if (!authz.ok) return authz.response;
+  const { org } = authz;
 
   const db = await createClient();
   const desde = new Date(Date.now() - DIAS * 24 * 60 * 60 * 1000).toISOString();

--- a/app/api/v1/ai/providers/route.ts
+++ b/app/api/v1/ai/providers/route.ts
@@ -16,8 +16,8 @@ import { z } from "zod";
 
 import { fail, ok } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
-import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
-import { ROLE_RANK } from "@/lib/auth/types";
+import { requireRole } from "@/lib/auth/require-role";
+import { roleAtLeast } from "@/lib/auth/types";
 import {
   decidirBinding,
   EXPLICACAO_DA_ORIGEM,
@@ -44,12 +44,9 @@ interface ModeloDoCatalogo {
 }
 
 export async function GET(): Promise<Response> {
-  const user = await requireAuth();
-  const org = await resolveActiveOrg(user);
-  if (!org) return fail("no_active_org", "nenhuma organização ativa", 400);
-  if (ROLE_RANK[org.role] < ROLE_RANK.manager) {
-    return fail("forbidden", "requer papel de gerente ou superior", 403);
-  }
+  const authz = await requireRole("manager", { resource: "ai_providers" });
+  if (!authz.ok) return authz.response;
+  const { org } = authz;
 
   const db = await createClient();
 
@@ -178,7 +175,7 @@ export async function GET(): Promise<Response> {
     provedores: PROVEDORES,
     credenciais: credsRes.data ?? [],
     modelos,
-    podeEditar: ROLE_RANK[org.role] >= ROLE_RANK.admin,
+    podeEditar: roleAtLeast(org.role, "admin"),
   });
 }
 
@@ -204,12 +201,9 @@ const corpoDoPut = z.object({
 });
 
 export async function PUT(req: NextRequest): Promise<Response> {
-  const user = await requireAuth();
-  const org = await resolveActiveOrg(user);
-  if (!org) return fail("no_active_org", "nenhuma organização ativa", 400);
-  if (ROLE_RANK[org.role] < ROLE_RANK.admin) {
-    return fail("forbidden", "requer papel de administrador", 403);
-  }
+  const authz = await requireRole("admin", { resource: "ai_providers" });
+  if (!authz.ok) return authz.response;
+  const { user, org } = authz;
 
   const parsed = corpoDoPut.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {

--- a/app/api/v1/ai/runs/route.ts
+++ b/app/api/v1/ai/runs/route.ts
@@ -12,8 +12,7 @@ import { z } from "zod";
 import type { NextRequest } from "next/server";
 
 import { fail, ok } from "@/lib/api/wrappers";
-import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
-import { ROLE_RANK } from "@/lib/auth/types";
+import { requireRole } from "@/lib/auth/require-role";
 import { PONTO_POR_ID } from "@/lib/ai/pontos/registro";
 import { EXPLICACAO_DA_ORIGEM, type OrigemDaEscolha } from "@/lib/ai/pontos/resolver";
 import { createClient } from "@/lib/supabase/server";
@@ -73,12 +72,9 @@ const filtrosDaQuery = z.object({
 });
 
 export async function GET(req: NextRequest): Promise<Response> {
-  const user = await requireAuth();
-  const org = await resolveActiveOrg(user);
-  if (!org) return fail("no_active_org", "nenhuma organização ativa", 400);
-  if (ROLE_RANK[org.role] < ROLE_RANK.manager) {
-    return fail("forbidden", "requer papel de gerente ou superior", 403);
-  }
+  const authz = await requireRole("manager", { resource: "ai_runs" });
+  if (!authz.ok) return authz.response;
+  const { org } = authz;
 
   // Zod na query string, como a rota irmã de uso já faz. `Math.min(Number(…))`
   // não valida nada: `?limit=abc` virava `NaN` e `?limit=-5` passava direto,

--- a/app/api/v1/attendants/availability/[user_id]/route.ts
+++ b/app/api/v1/attendants/availability/[user_id]/route.ts
@@ -20,7 +20,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { ApiError } from "@/lib/api/types";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
-import { ROLE_RANK } from "@/lib/auth/types";
+import { roleAtLeast } from "@/lib/auth/types";
 import { availabilityPatchSchema, validateRequest } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
 
@@ -41,7 +41,7 @@ export async function PATCH(
   const { user: authUser, org: activeOrg } = authz;
 
   const isSelf = targetUserId === authUser.id;
-  const isManager = ROLE_RANK[activeOrg.role] >= ROLE_RANK.manager;
+  const isManager = roleAtLeast(activeOrg.role, "manager");
   if (!isSelf && !isManager) {
     return fail(
       "forbidden_role",

--- a/app/api/v1/channels/official/route.ts
+++ b/app/api/v1/channels/official/route.ts
@@ -25,8 +25,7 @@ import type { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
 import { fail, ok } from "@/lib/api/wrappers";
-import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
-import { ROLE_RANK } from "@/lib/auth/types";
+import { requireRole } from "@/lib/auth/require-role";
 import { ARCHIVED_AT, queryTolerantToMissingArchived } from "@/lib/channels/archived";
 import { CHANNEL_PROVIDER_META } from "@/lib/channels/capabilities";
 import { validateMetaCredentials } from "@/lib/channels/meta/validate-credentials";
@@ -43,17 +42,6 @@ const conectarSchema = z.object({
   waba_id: z.string().min(5),
   token: z.string().min(20),
 });
-
-type Gate = { ok: true; orgId: string; userId: string } | { ok: false; resposta: NextResponse };
-
-async function adminGate(requestId: string): Promise<Gate> {
-  const user = await requireAuth();
-  const org = await resolveActiveOrg(user);
-  if (!org || ROLE_RANK[org.role] < ROLE_RANK.admin) {
-    return { ok: false, resposta: fail("forbidden", "admin_required", 403, { requestId }) };
-  }
-  return { ok: true, orgId: org.orgId, userId: user.id };
-}
 
 /**
  * Base pública desta instalação — é o que o operador cola no dashboard da Meta.
@@ -74,8 +62,9 @@ function publicBase(req: NextRequest): string {
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const requestId = randomUUID();
-  const g = await adminGate(requestId);
-  if (!g.ok) return g.resposta;
+  const authz = await requireRole("admin", { requestId, resource: "channels_official" });
+  if (!authz.ok) return authz.response;
+  const orgId = authz.org.orgId;
 
   const admin = createAdminClient();
   // Canal ARQUIVADO não conta como conectado. A linha sobrevive à exclusão como
@@ -88,7 +77,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     admin
       .from("channel_sessions")
       .select("id, meta_phone_number_id, meta_waba_id, meta_token_encrypted, phone_number, display_name, webhook_path_token, status")
-      .eq("organization_id", g.orgId)
+      .eq("organization_id", orgId)
       .eq("provider", CHANNEL_PROVIDER_META);
   const { data } = await queryTolerantToMissingArchived(
     () => consultar().is(ARCHIVED_AT, null).maybeSingle(),
@@ -119,8 +108,10 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const requestId = randomUUID();
-  const g = await adminGate(requestId);
-  if (!g.ok) return g.resposta;
+  const authz = await requireRole("admin", { requestId, resource: "channels_official" });
+  if (!authz.ok) return authz.response;
+  const orgId = authz.org.orgId;
+  const userId = authz.user.id;
 
   const parsed = conectarSchema.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
@@ -158,7 +149,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     admin
       .from("channel_sessions")
       .select(colunas)
-      .eq("organization_id", g.orgId)
+      .eq("organization_id", orgId)
       .eq("provider", CHANNEL_PROVIDER_META)
       .maybeSingle();
   const { data: existenteRaw } = await queryTolerantToMissingArchived(
@@ -168,7 +159,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const existente = existenteRaw as { id: string; archived_at?: string | null } | null;
 
   const linha = {
-    organization_id: g.orgId,
+    organization_id: orgId,
     provider: CHANNEL_PROVIDER_META,
     meta_phone_number_id: phone_number_id,
     meta_waba_id: waba_id,
@@ -195,13 +186,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     ? await reactivateChannelSession(
         admin,
         {
-          organizationId: g.orgId,
+          organizationId: orgId,
           channelSessionId: existente.id,
           archivedAt: existente.archived_at ?? null,
         },
         linha,
         {
-          userId: g.userId,
+          userId: userId,
           requestId,
           metadata: { provider: CHANNEL_PROVIDER_META, phone_number: linha.phone_number },
         },

--- a/app/api/v1/channels/partner/route.ts
+++ b/app/api/v1/channels/partner/route.ts
@@ -21,8 +21,7 @@ import type { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
 import { fail, ok } from "@/lib/api/wrappers";
-import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
-import { ROLE_RANK } from "@/lib/auth/types";
+import { requireRole } from "@/lib/auth/require-role";
 import {
   PARTNER_CHANNEL_LABEL,
   findPartnerSession,
@@ -40,19 +39,6 @@ const conectarSchema = z.object({
   account_id: z.string().trim().min(1).max(200),
   api_key: z.string().trim().min(8).max(500),
 });
-
-type Gate = { ok: true; orgId: string } | { ok: false; resposta: NextResponse };
-
-async function adminGate(requestId: string): Promise<Gate> {
-  const user = await requireAuth();
-  const org = await resolveActiveOrg(user);
-  // Conectar um canal move dinheiro e expõe a conta da empresa: é decisão de
-  // dono, não de quem atende.
-  if (!org || ROLE_RANK[org.role] < ROLE_RANK.admin) {
-    return { ok: false, resposta: fail("forbidden", "admin_required", 403, { requestId }) };
-  }
-  return { ok: true, orgId: org.orgId };
-}
 
 /**
  * Endereço público desta instalação — é o que o operador cola no provedor.
@@ -81,10 +67,13 @@ function urlDoWebhook(req: NextRequest, token: string): string {
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const requestId = randomUUID();
-  const g = await adminGate(requestId);
-  if (!g.ok) return g.resposta;
+  // Conectar um canal move dinheiro e expõe a conta da empresa: é decisão de
+  // dono, não de quem atende.
+  const authz = await requireRole("admin", { requestId, resource: "channels_partner" });
+  if (!authz.ok) return authz.response;
+  const orgId = authz.org.orgId;
 
-  const sessao = await findPartnerSession(createAdminClient(), g.orgId);
+  const sessao = await findPartnerSession(createAdminClient(), orgId);
   const conectado = !!sessao && !sessao.archivedAt;
 
   return ok(
@@ -106,8 +95,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   const requestId = randomUUID();
-  const g = await adminGate(requestId);
-  if (!g.ok) return g.resposta;
+  // Conectar um canal move dinheiro e expõe a conta da empresa: é decisão de
+  // dono, não de quem atende.
+  const authz = await requireRole("admin", { requestId, resource: "channels_partner" });
+  if (!authz.ok) return authz.response;
+  const orgId = authz.org.orgId;
 
   const parsed = conectarSchema.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
@@ -139,13 +131,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const existente = await findPartnerSession(admin, g.orgId);
+  const existente = await findPartnerSession(admin, orgId);
   // Reconectar por cima de um canal excluído RESSUSCITA a linha, e o token de
   // webhook é preservado para não invalidar o que já está colado do outro lado.
   const token = existente?.webhookPathToken ?? randomBytes(16).toString("hex");
 
   const { error } = await savePartnerSession(admin, {
-    organizationId: g.orgId,
+    organizationId: orgId,
     existingId: existente?.id ?? null,
     accountId: parsed.data.account_id.trim(),
     apiKeyEncrypted: chaveCifrada,

--- a/app/api/v1/channels/templates/route.ts
+++ b/app/api/v1/channels/templates/route.ts
@@ -13,8 +13,7 @@ import { randomUUID } from "node:crypto";
 import type { NextRequest, NextResponse } from "next/server";
 
 import { fail, ok } from "@/lib/api/wrappers";
-import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
-import { ROLE_RANK } from "@/lib/auth/types";
+import { requireRole } from "@/lib/auth/require-role";
 import { metaSessionForOrg } from "@/lib/channels/meta/session";
 import { normalizeRejectedReason } from "@/lib/channels/meta/webhook";
 import { deriveTemplateContract, describeAddress } from "@/lib/channels/meta/template-contract";
@@ -77,15 +76,9 @@ type OrgGate =
   | { autorizado: false; resposta: NextResponse };
 
 async function orgOrFail(requestId: string): Promise<OrgGate> {
-  const user = await requireAuth();
-  const activeOrg = await resolveActiveOrg(user);
-  if (!activeOrg || ROLE_RANK[activeOrg.role] < ROLE_RANK.admin) {
-    return {
-      autorizado: false,
-      resposta: fail("forbidden", "admin_required", 403, { requestId }),
-    };
-  }
-  return { autorizado: true, orgId: activeOrg.orgId };
+  const authz = await requireRole("admin", { requestId, resource: "channels_templates" });
+  if (!authz.ok) return { autorizado: false, resposta: authz.response };
+  return { autorizado: true, orgId: authz.org.orgId };
 }
 
 export async function GET(): Promise<NextResponse> {

--- a/app/api/v1/contacts/_handler.ts
+++ b/app/api/v1/contacts/_handler.ts
@@ -11,6 +11,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { ApiError } from "@/lib/api/types";
 import type { Actor, HandlerCtx } from "@/lib/api/handlers/types";
 import { audit } from "@/lib/audit";
+import { roleAtLeast } from "@/lib/auth/types";
 import { canonicalPhoneBR, phoneLookupVariants } from "@/lib/channels/phone-variants";
 import { hashCpf, encryptCpfSql } from "@/lib/contacts/cpf";
 import type { Contact } from "@/lib/types/contacts";
@@ -27,13 +28,6 @@ type SB = SupabaseClient;
 
 const SELECT_COLS =
   "id, organization_id, name, display_name, email, email_normalized, phone_number, cpf_hash, birthdate, is_blocked, blocked_reason, is_anonymized, anonymized_at, is_merged_into, merged_at, consent, tags, source, source_metadata, created_at, updated_at, last_activity_at";
-
-const ROLE_RANK: Record<string, number> = {
-  viewer: 1,
-  agent: 2,
-  manager: 3,
-  admin: 4,
-};
 
 interface CursorPayload {
   sort: string | null;
@@ -285,8 +279,7 @@ export async function getContactHandler(
       .maybeSingle();
 
     const role = membership?.role as string | undefined;
-    const rank = role ? (ROLE_RANK[role] ?? 0) : 0;
-    if (rank < ROLE_RANK.manager!) {
+    if (!roleAtLeast(role, "manager")) {
       cpfDecryptDenied = true;
     } else {
       const { data: dec, error: decErr } = await supabase.rpc("decrypt_cpf", {

--- a/app/api/v1/conversations/[id]/notes/[noteId]/route.ts
+++ b/app/api/v1/conversations/[id]/notes/[noteId]/route.ts
@@ -8,7 +8,7 @@ import { type NextRequest } from "next/server";
 import { audit } from "@/lib/audit";
 import { fail, noContent } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
-import { ROLE_RANK } from "@/lib/auth/types";
+import { roleAtLeast } from "@/lib/auth/types";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -37,7 +37,7 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams): Promis
     .maybeSingle();
   if (!note) return fail("not_found", "Nota não encontrada.", 404, { requestId });
 
-  if (note.created_by_user_id !== user.id && ROLE_RANK[org.role] < ROLE_RANK.manager) {
+  if (note.created_by_user_id !== user.id && !roleAtLeast(org.role, "manager")) {
     return fail("forbidden", "Só o autor ou manager+ pode apagar esta nota.", 403, { requestId });
   }
 

--- a/app/api/v1/marca/logo/route.ts
+++ b/app/api/v1/marca/logo/route.ts
@@ -57,7 +57,7 @@ import { z } from "zod";
 import { fail, ok } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { loadAuthUser, mfaEmDivida, resolveActiveOrg } from "@/lib/auth/server";
-import { ROLE_RANK } from "@/lib/auth/types";
+import { roleAtLeast } from "@/lib/auth/types";
 import { checkRateLimit } from "@/lib/ai/dispatcher/rate-limit";
 import { invalidarMarcaDaInstalacao } from "@/lib/branding/instalacao";
 import {
@@ -160,7 +160,7 @@ async function abrirContexto(escopo: Escopo): Promise<{ ctx: Contexto } | { recu
       recusa: { codigo: "forbidden_tenant", mensagem: "Sem organização ativa.", status: 403 },
     };
   }
-  if (!user.is_platform_admin && ROLE_RANK[org.role] < ROLE_RANK.admin) {
+  if (!user.is_platform_admin && !roleAtLeast(org.role, "admin")) {
     return {
       recusa: {
         codigo: "forbidden_role",

--- a/app/api/v1/message-templates/route.ts
+++ b/app/api/v1/message-templates/route.ts
@@ -11,7 +11,7 @@ import { type NextRequest } from "next/server";
 import { audit } from "@/lib/audit";
 import { fail, ok } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
-import { ROLE_RANK } from "@/lib/auth/types";
+import { roleAtLeast } from "@/lib/auth/types";
 import { createTemplateSchema } from "@/lib/schemas/templates";
 import { createClient } from "@/lib/supabase/server";
 
@@ -53,7 +53,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   // Compartilhado exige manager+. requireRole já resolveu o role efetivo do
   // banco em org.role — reusar em vez de uma 2ª chamada/RPC. A RLS with_check
   // barra de qualquer forma; isto só dá um erro claro antes do insert.
-  if (shared && ROLE_RANK[org.role] < ROLE_RANK.manager) {
+  if (shared && !roleAtLeast(org.role, "manager")) {
     return fail("forbidden", "Só manager+ cria template compartilhado.", 403, { requestId });
   }
   const supabase = await createClient();

--- a/app/api/v1/system/instalacao/route.ts
+++ b/app/api/v1/system/instalacao/route.ts
@@ -17,8 +17,7 @@
 import type { NextRequest } from "next/server";
 
 import { fail, ok } from "@/lib/api/wrappers";
-import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
-import { ROLE_RANK } from "@/lib/auth/types";
+import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { listSelectableChannels } from "@/lib/channels/selectable";
@@ -47,12 +46,9 @@ export async function contarCanaisDaOrg(orgId: string) {
 }
 
 export async function GET(req: NextRequest) {
-  const user = await requireAuth();
-  const org = await resolveActiveOrg(user);
-  if (!org) return fail("no_active_org", "nenhuma organização ativa", 400);
-  if (ROLE_RANK[org.role] < ROLE_RANK.manager) {
-    return fail("forbidden", "requer papel de gerente ou superior", 403);
-  }
+  const authz = await requireRole("manager", { resource: "system_instalacao" });
+  if (!authz.ok) return authz.response;
+  const { org } = authz;
 
   const supabase = await createClient();
   const retrato = await lerRetratoDaInstalacao({
@@ -65,10 +61,11 @@ export async function GET(req: NextRequest) {
   if (!querProvar) return ok(retrato);
 
   // A partir daqui custa dinheiro: uma geração real de um token. Nunca sai de
-  // graça num GET que a tela chama sozinha.
-  if (ROLE_RANK[org.role] < ROLE_RANK.admin) {
-    return fail("forbidden", "provar a chave requer papel de administrador", 403);
-  }
+  // graça num GET que a tela chama sozinha. 2ª chamada a requireRole de
+  // propósito: é o mesmo mecanismo, com o mínimo mais alto — inclui o gate de
+  // MFA para quem só tinha rank de manager mas está prestes a exercer admin.
+  const authzProva = await requireRole("admin", { resource: "system_instalacao_provar" });
+  if (!authzProva.ok) return authzProva.response;
 
   const { origemDaChave, modeloCurado, provedor, chaveEmVerificacao } = retrato.inteligencia;
   if (origemDaChave === "nenhuma" || !modeloCurado) {

--- a/app/api/v1/system/relogio/tick/route.ts
+++ b/app/api/v1/system/relogio/tick/route.ts
@@ -8,8 +8,8 @@ import type { NextRequest } from "next/server";
 
 import { fail, ok } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
-import { loadAuthUser, resolveActiveOrg } from "@/lib/auth/server";
-import { ROLE_RANK } from "@/lib/auth/types";
+import { loadAuthUser } from "@/lib/auth/server";
+import { requireRole } from "@/lib/auth/require-role";
 import { env } from "@/lib/env";
 import { executarTickDoRelogio } from "@/lib/relogio/executar";
 
@@ -42,18 +42,25 @@ function bearerValido(req: NextRequest): boolean {
   });
 }
 
-async function sessaoAdmin(): Promise<boolean> {
-  const user = await loadAuthUser();
-  if (!user) return false;
-  if (user.is_platform_admin) return true;
-  const org = await resolveActiveOrg(user);
-  return Boolean(org && ROLE_RANK[org.role] >= ROLE_RANK.admin);
+/**
+ * Via `requireRole`, e não a comparação manual de antes: ganha o gate de MFA
+ * de graça — uma sessão admin `aal1` não deve conseguir disparar manualmente
+ * um tick de produção só porque tem o rank. `allowPlatformAdmin` replica o
+ * bypass que já existia aqui.
+ */
+async function sessaoAdmin(requestId: string): Promise<boolean> {
+  const authz = await requireRole("admin", {
+    requestId,
+    resource: "system_relogio_tick",
+    allowPlatformAdmin: true,
+  });
+  return authz.ok;
 }
 
 export async function POST(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const porSegredo = bearerValido(req);
-  if (!porSegredo && !(await sessaoAdmin())) {
+  if (!porSegredo && !(await sessaoAdmin(requestId))) {
     return fail("forbidden", "Cron secret missing or invalid.", 403, { requestId });
   }
 

--- a/lib/auth/types.ts
+++ b/lib/auth/types.ts
@@ -26,6 +26,21 @@ export const ROLE_RANK: Record<Role, number> = {
   admin: 5,
 };
 
+/**
+ * Compara um role (possivelmente vindo solto de uma consulta, não tipado)
+ * contra um mínimo. NÃO é gate de rota — isso é `requireRole()`
+ * (`lib/auth/require-role.ts`), o único lugar que decide 403 e aplica o gate
+ * de MFA. Este helper existe para os usos legítimos que sobram depois de uma
+ * rota já ter passado por `requireRole()`: computar um campo informativo no
+ * payload (ex.: `podeEditar`) ou uma regra de escopo adicional sobre o MESMO
+ * role já resolvido (ex.: "autor OU manager+"). Em ambos a decisão de ACESSO
+ * À ROTA já foi tomada; isto só lê o rank — nunca decide 401/403 sozinho.
+ */
+export function roleAtLeast(role: string | null | undefined, min: Role): boolean {
+  const rank = role ? (ROLE_RANK[role as Role] ?? 0) : 0;
+  return rank >= ROLE_RANK[min];
+}
+
 /** Papéis que uma PESSOA pode ter. Espelha `user_organizations_role_check`. */
 export const PAPEIS_HUMANOS: ReadonlyArray<Role> = ["viewer", "agent", "manager", "admin"];
 

--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
     "test:shell": "bash tests/shell/update-guard.test.sh && bash tests/shell/dono-do-projeto.test.sh && bash tests/shell/scheduler-entrypoint.test.sh && bash hostgator-setup-kit/test-validators.sh",
     "test:invariants": "bash scripts/test-db.sh",
     "lint:channels": "tsx scripts/lint-channels.ts",
+    "lint:role-rank": "tsx scripts/lint-role-rank.ts",
     "release:conferir": "tsx scripts/cortar-release.ts",
     "release:cortar": "tsx scripts/cortar-release.ts --escrever",
-    "gov:verify": "pnpm typecheck && pnpm lint && pnpm lint:channels && pnpm test:unit",
+    "gov:verify": "pnpm typecheck && pnpm lint && pnpm lint:channels && pnpm lint:role-rank && pnpm test:unit",
     "worker": "tsx --env-file=.env --env-file=.env.local workers/agent-worker/main.ts",
     "dev:crons": "tsx --env-file=.env --env-file=.env.local scripts/dev-crons.ts",
     "flywheel:judge": "tsx --env-file=.env --env-file=.env.local scripts/flywheel-judge-live.ts"

--- a/scripts/lint-role-rank.ts
+++ b/scripts/lint-role-rank.ts
@@ -1,0 +1,83 @@
+/**
+ * Invariante do `lib/auth/require-role.ts`: "nenhuma rota deve reimplementar a
+ * checagem [de papel] na mão" (comparação com `ROLE_RANK` direto numa rota é o
+ * anti-pattern "matriz advisória"). Rodado pelo `gov:verify`.
+ *
+ * Por que ROTA importa: o gate de MFA (`mfaEmDivida`) só existe DENTRO de
+ * `requireRole()`. Uma comparação manual de `ROLE_RANK` decide 403 sem nunca
+ * passar por ali — e uma sessão `aal1` de admin com TOTP cadastrado atravessa
+ * uma rota "protegida" sem nunca provar o segundo fator nesta sessão. Foi
+ * exatamente esse buraco que motivou `requireRole()` existir.
+ *
+ * ─── Por que o escopo é `app/api`, não o repo inteiro ───────────────────────
+ *
+ * O docstring de `require-role.ts` fala em "rotas /api/v1" (spec 13 §4 —
+ * G2-01), não em toda leitura de papel do sistema. Fora de `app/api` o
+ * `ROLE_RANK` tem usos legítimos e não relacionados a decidir 401/403 de uma
+ * rota — ex.: `.tsx` de `app/app/**` escondendo item de menu (a segurança real
+ * é a RLS + esta mesma rota), `lib/mcp/auth.ts` (outro mecanismo de auth
+ * inteiro, bearer token sem `cookies()`, onde `requireRole()` não se aplica) e
+ * `lib/escalacao/*.ts` (elegibilidade de roteamento, não autorização). Variar
+ * o escopo pra cobrir esses casos trocaria um allowlist "pequeno e explícito"
+ * por uma lista de dezenas de arquivos que nada tem a ver com o incidente.
+ *
+ * Arquivo `*.test.ts(x)` fica de fora pelo mesmo motivo: teste que referencia
+ * `ROLE_RANK` (a constante exportada, fonte única) pra montar um fixture não é
+ * uma rota decidindo 403 na mão — é leitura do mesmo valor que o produto usa.
+ *
+ * ─── Sem allowlist ────────────────────────────────────────────────────────
+ *
+ * Ao migrar as rotas encontradas com este padrão (2026-08), os dois casos que
+ * pareciam precisar de exceção — `contacts/_handler.ts` (handler
+ * compartilhado com MCP tools, onde `requireRole()` não se aplica porque não
+ * há `cookies()` fora de uma rota Next) e `marca/logo/route.ts` (gate de duas
+ * camadas que `requireRole()` não modela: platform admin SEM org nenhuma) —
+ * não precisaram de raw `ROLE_RANK[`: os dois usam `roleAtLeast()` (fonte
+ * única do rank, `lib/auth/types.ts`) para a leitura que sobra depois da
+ * decisão de acesso. Se surgir um caso legítimo que só dê pra resolver com
+ * `ROLE_RANK[` cru, documente-o aqui como um allowlist explícito — pelo
+ * mesmo padrão de `KNOWN_DEBT` em `lint-channels.ts` — em vez de calar o
+ * lint.
+ *
+ * ─── Por que não é `fs.globSync` ─────────────────────────────────────────────
+ *
+ * Walk recursivo manual, como `lint-channels.ts`: `globSync` só existe em
+ * node 22+, e walk custa 8 linhas e nenhuma dependência.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = "app/api";
+
+function walk(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) return e.name === "node_modules" ? [] : walk(p);
+    return /\.tsx?$/.test(e.name) ? [p] : [];
+  });
+}
+
+const arquivos = walk(ROOT)
+  .map((f) => f.replace(/\\/g, "/"))
+  .filter((f) => !/\.test\.tsx?$/.test(f));
+
+const offenders = arquivos
+  .filter((f) => readFileSync(f, "utf8").includes("ROLE_RANK["))
+  .sort();
+
+if (offenders.length) {
+  console.error(
+    "ROLE_RANK[ comparado na mão fora de lib/auth/ (require-role.ts, invariante G2-01):",
+  );
+  for (const f of offenders) console.error(`  ${f}`);
+  console.error(
+    "\nUse requireRole(min, { requestId, resource }) — é o único lugar que aplica o\n" +
+      "gate de MFA. Para uma leitura de rank que NÃO decide 401/403 sozinha (ex.:\n" +
+      "campo informativo, regra de escopo sobre um role já resolvido), use\n" +
+      "roleAtLeast(role, min) de lib/auth/types.ts. Se nenhum dos dois servir,\n" +
+      "documente a exceção aqui como um allowlist explícito, com a razão escrita.",
+  );
+  process.exit(1);
+}
+
+console.info("lint-role-rank: ok (nenhum ROLE_RANK[ fora de lib/auth/ em app/api)");


### PR DESCRIPTION
## Problema (achado crítico)

`lib/auth/require-role.ts` documenta que comparar `ROLE_RANK[...]` direto numa rota, sem passar por `requireRole()`, é o anti-padrão banido "matriz advisória" — porque o gate de MFA (`mfaEmDivida()`) só existe dentro de `requireRole()`, depois de um incidente real de sessões `aal1` sem segundo fator comprovado acessando rotas administrativas.

O padrão banido seguia ativo em 14 pontos, incluindo rotas que conectam credencial oficial/parceira do WhatsApp, trocam credencial de provedor de IA e alteram guardrails de segurança do agente — exatamente a classe de ataque que o gate foi criado pra impedir.

## Solução

- Migra as 14 rotas (+ 2 achadas durante a migração, fora da lista original: `ai/operator-metrics` e `marca/logo`) para `requireRole()`, preservando o role mínimo original de cada uma.
- Duas rotas ficam de fora de `requireRole()` por razão estrutural, documentada no código: `contacts/_handler.ts` (compartilhado com MCP tools, sem `cookies()` disponível) e `marca/logo/route.ts` (gate de duas camadas — platform admin sem org nenhuma — que `requireRole()` não modela). Ambas trocam o `ROLE_RANK[]` cru por `roleAtLeast()`, novo helper em `lib/auth/types.ts` para leitura de rank que **não** decide 401/403 sozinha.
- Adiciona `scripts/lint-role-rank.ts` (rodado via `gov:verify`) que reprova qualquer `ROLE_RANK[` novo fora de `lib/auth/` em `app/api`, fechando a porta pra reincidência. Testado manualmente que o ratchet pega regressão.

## Teste

- `pnpm typecheck`: limpo.
- `pnpm lint`: 0 erros (287 warnings pré-existentes, nenhum nos arquivos tocados).
- `pnpm lint:role-rank` (novo): verde.
- `pnpm test:unit`: 109/109 testes de auth relevantes passam (`require-role.test.ts`, `require-role-mfa.test.ts`, `rbac-matrix.test.ts`, etc). As 19 falhas remanescentes na suíte completa são pré-existentes e não relacionadas — confirmado comparando com `git stash` da baseline sem estas mudanças.