### PR TITLE
fix: pin *.sql para LF, corrige self-check de md5 quebrado em clone Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,3 +27,17 @@ supabase/migrations/MANIFEST.md merge=union
 #
 # O conserto certo para o baseline é de processo, não de atributo: apêndice
 # idempotente por migration, como a doutrina de migrations do CLAUDE.md manda.
+
+# ─── Fim de linha fixo em LF pra todo .sql ───────────────────────────────────
+#
+# supabase/baseline.sql tem blocos que se autoconferem por md5(body) contra uma
+# constante `v_md5` gravada no próprio arquivo (ex.: migration 0191, playbook
+# `agendamento`). Sem esta regra, um clone com `core.autocrlf=true` (padrão do
+# instalador git pra Windows) faz checkout do arquivo com CRLF — o hash
+# declarado foi calculado sobre o blob LF do git, então o corpo inserido no
+# banco (lido do disco, já CRLF) diverge do declarado e o self-check do
+# `do $pub$ ... end $pub$;` derruba `pnpm test:db` antes de qualquer teste
+# rodar. CI passa porque `ubuntu-latest` não converte por padrão — só quem
+# clona no Windows vê a falha. `eol=lf` fixa LF no checkout independente do
+# `core.autocrlf` de quem clonou.
+*.sql text eol=lf


### PR DESCRIPTION
## Problema

`pnpm test:db` falhava na aplicação do baseline num clone Windows limpo: o self-check da migration 0191 compara `md5(body)` contra uma constante `v_md5` computada sobre o conteúdo LF do blob git, mas `core.autocrlf=true` (padrão do Git no Windows) faz o checkout converter para CRLF — o hash nunca bate. O CI ficava verde porque `ubuntu-latest` não converte final de linha.

Achado durante o trabalho no PR #388 (N+1 do Inbox), sinalizado como fora de escopo e corrigido separadamente aqui.

## Solução

`.gitattributes` fixando `*.sql` como LF, independente da config local de `autocrlf`. Nenhum conteúdo SQL mudou — `baseline.sql` e as migrations foram re-checked-out sob o novo atributo e são byte-idênticos aos blobs do git.

## Teste

`pnpm test:db` verde num clone Windows limpo após o fix.