### PR TITLE
O fragmento do conserto de MFA, que eu mergeei sem exigir

### DIFF
--- a/.changes/rotas-de-administracao-exigem-o-segundo-fator.md
+++ b/.changes/rotas-de-administracao-exigem-o-segundo-fator.md
@@ -1,0 +1,15 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Áreas de administração passam a exigir a verificação em duas etapas
+---
+
+Quatorze telas e ações de administração conferiam apenas o papel de quem
+acessava, sem cobrar a verificação em duas etapas de quem a tem ativada. Entre
+elas estavam as que conectam o número oficial do WhatsApp, as que trocam a
+credencial do provedor de inteligência artificial e as que alteram os limites de
+segurança do agente — justamente as que mais importam.
+
+Quem já usa o sistema não precisa fazer nada, e quem não ativou a verificação
+continua entrando como antes. A mudança é que, para quem a tem ativada, ela
+passa a valer também nesses lugares.


### PR DESCRIPTION
Falha minha na revisão do #381: mergeei um conserto de **segurança** sem fragmento. Sem ele, ele entra na versão e não aparece na tela de atualização de ninguém — e este é o pior caso possível, porque quem opera uma VPS tem o direito de saber que rotas administrativas passaram a exigir o segundo fator.

O PR veio de fork e o contribuidor não conhecia a regra. A doutrina de triagem que entrou hoje diz explicitamente que nesse caso **quem tria escreve o fragmento** em vez de devolver. Não apliquei minha própria regra na hora do merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)