### PR TITLE
A J15 sai da allowlist, porque a colisão dela foi paga

### DIFF
--- a/tests/unit/numero-de-jornada-e-unico.test.ts
+++ b/tests/unit/numero-de-jornada-e-unico.test.ts
@@ -55,10 +55,6 @@ const COLISOES_CONGELADAS: Record<string, string> = {
   J10:
     "anterior a este gate (2026-08-28): 'Marca própria: o revendedor põe a cara dele no sistema' " +
     "e 'Instalação fresca com a marca do revendedor'. Mesmo custo de renumeração.",
-  J15:
-    "nasceu em 2026-08-28, de dois trabalhos paralelos: 'A grade da Agenda como agenda de " +
-    "verdade' (#382) e 'Trocar de organização, incluindo a que não foi configurada' (#389). " +
-    "A segunda já virou J17 na branch do #387; quando aquele PR entrar, ESTA ENTRADA SAI.",
 };
 
 interface Jornada {


### PR DESCRIPTION
O gate de jornadas nasceu vermelho na `main` — e pelo motivo **certo**. A catraca funcionou no primeiro minuto de vida:

```
estes números não colidem mais — tire-os de COLISOES_CONGELADAS, porque
allowlist que não encolhe deixa de descrever a dívida e passa a autorizar
a próxima
```

O próprio comentário da entrada previa: *"quando aquele PR entrar, esta entrada sai"*. O #387 entrou às 14h.

Isso é o oposto de um gate frouxo: a maioria das allowlists só cobra que a lista **contenha** a dívida — e aí ela cresce para sempre e vira autorização. Esta cobra também que ela **não contenha** o que já foi pago.

Ficam as duas anteriores ao gate (J8 e J10), com motivo escrito.

Sabotado: reintroduzir uma colisão dá 1 vermelho, como previsto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)