### PR TITLE
Testes do kit derivam o namespace das imagens de IMG_NS, em vez de repeti-lo

### DIFF
--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -1494,7 +1494,7 @@ STUB
   tag_app="${img_app##*:}"
   for par in "WORKER_IMAGE:deskcomm-worker" "SCHEDULER_IMAGE:deskcomm-scheduler"; do
     chave="${par%%:*}"; repo="${par##*:}"
-    if [ "$(valor_no_env "$VPS_PROJ/.env" "$chave")" != "ghcr.io/melgarafael/${repo}:${tag_app}" ]; then
+    if [ "$(valor_no_env "$VPS_PROJ/.env" "$chave")" != "${IMG_NS}/${repo}:${tag_app}" ]; then
       printf '  ✗ %s não acompanha a versão do app (%s): %s\n' "$chave" "$tag_app" \
         "$(grep -E "^${chave}=" "$VPS_PROJ/.env" || echo '(ausente)')"
       printf '     app numa versão e worker em outra é a matriz que ninguém testou.\n'; exit 1
@@ -1653,7 +1653,7 @@ STUB
 
   for par in "APP_IMAGE:deskcommcrm" "WORKER_IMAGE:deskcomm-worker" "SCHEDULER_IMAGE:deskcomm-scheduler"; do
     chave="${par%%:*}"; repo="${par##*:}"
-    if [ "$(valor_no_env "$VPS_PROJ/.env" "$chave")" != "ghcr.io/melgarafael/${repo}:1.10.0" ]; then
+    if [ "$(valor_no_env "$VPS_PROJ/.env" "$chave")" != "${IMG_NS}/${repo}:1.10.0" ]; then
       printf '  ✗ %s não foi pinado na versão resolvida (1.10.0): %s\n' "$chave" \
         "$(grep -E "^${chave}=" "$VPS_PROJ/.env" || echo '(ausente)')"
       printf '     instalação de cliente NUNCA nasce em tag móvel — docs/doctrine/packaging.md, invariante 3.\n'

--- a/tests/shell/update-guard.test.sh
+++ b/tests/shell/update-guard.test.sh
@@ -24,6 +24,15 @@
 #      isolam cada uma, provado por sabotagem cirúrgica de cada linha.
 set -uo pipefail
 
+# O namespace das imagens publicadas, lido da FONTE (hostgator-setup-kit/_common.sh)
+# em vez de repetido aqui. Este arquivo tinha o literal em 29 lugares — fixtures e
+# asserções —, o que amarrava a suíte a UM publicador: um fork que publica as
+# próprias imagens fica vermelho sem ter quebrado nada. O que estes casos provam é
+# que as três imagens andam na MESMA versão, e isso independe de quem publica.
+NS="$(sed -n 's/^IMG_NS="\(.*\)"$/\1/p' "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../hostgator-setup-kit" && pwd)/_common.sh" | head -1)"
+[ -n "$NS" ] || { echo "não consegui ler IMG_NS de _common.sh"; exit 1; }
+
+
 # Capturado ANTES de qualquer `cd`: o script muda de diretório várias vezes, e
 # `${BASH_SOURCE[0]}` é relativo ao cwd de quem invocou. Resolvê-lo lá embaixo
 # devolvia string vazia, e o `.` virava `/_common.sh`.
@@ -132,7 +141,7 @@ STUB
 printf 'services:\n  app:\n    image: \${APP_IMAGE:-x}\n' > "$PROJ/docker-compose.prod.yml"
 printf 'select 1;\n' > "$PROJ/supabase/baseline.sql"
 cat > "$PROJ/.env" <<ENV
-APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:latest
+APP_IMAGE=${NS}/deskcommcrm:latest
 APP_PULL_POLICY=always
 SUPABASE_DB_URL=postgresql://x/y
 NEXT_PUBLIC_APP_URL=https://crm.exemplo.com.br
@@ -185,7 +194,7 @@ echo nova > nova.txt; git add -A; git commit --quiet -m "v1.1.0"; git tag v1.1.0
 git checkout --quiet v0.9.0
 run_update --to v1.1.0
 check "a atualização termina com sucesso" test "$RC" -eq 0
-check ".env aponta para a imagem da versão instalada" grep -q '^APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:1.1.0$' .env
+check ".env aponta para a imagem da versão instalada" grep -q "^APP_IMAGE=${NS}/deskcommcrm:1.1.0$" .env
 check "a chave APP_IMAGE não duplicou" test "$(grep -c '^APP_IMAGE=' .env)" -eq 1
 run_update --to v1.1.0 --force
 check "segunda execução também não duplica" test "$(grep -c '^APP_IMAGE=' .env)" -eq 1
@@ -215,9 +224,9 @@ echo "── 4b. As três imagens sobem juntas, na mesma versão"
 # runtime do agente de IA — ficava congelado no código do dia da instalação.
 # Se estas três linhas voltarem a divergir, o defeito voltou.
 check "o worker é pinado na MESMA versão do app" \
-  grep -q '^WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:1.1.0$' .env
+  grep -q "^WORKER_IMAGE=${NS}/deskcomm-worker:1.1.0$" .env
 check "o scheduler é pinado na MESMA versão do app" \
-  grep -q '^SCHEDULER_IMAGE=ghcr.io/melgarafael/deskcomm-scheduler:1.1.0$' .env
+  grep -q "^SCHEDULER_IMAGE=${NS}/deskcomm-scheduler:1.1.0$" .env
 check "o worker herda a política da tag imutável" \
   grep -q '^WORKER_PULL_POLICY=missing$' .env
 check "o scheduler herda a política da tag imutável" \
@@ -246,7 +255,7 @@ echo topo > topo.txt; git add -A; git commit --quiet -m "main, depois da release
 clona_raso() {  # clona_raso <destino> — igual ao install.sh: --depth 1
   git clone --depth 1 --quiet "file://$SRC" "$1"
   cat > "$1/.env" <<ENV
-APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:latest
+APP_IMAGE=${NS}/deskcommcrm:latest
 APP_PULL_POLICY=always
 SUPABASE_DB_URL=postgresql://x/y
 NEXT_PUBLIC_APP_URL=https://crm.exemplo.com.br
@@ -268,7 +277,7 @@ check "aborta com o código de recusa (3), não com falha genérica" test "$RC" 
 check "explica em português que é retrocesso" grep -q "ANTERIOR à que já está instalada" "$OUTFILE"
 check "não chegou a rodar o backup" test ! -f "$BACKUP_MARK"
 check "NÃO rebobinou: o HEAD é o mesmo de antes" test "$(git rev-parse HEAD)" = "$HEAD_ANTES"
-check "a imagem do .env continua intacta" grep -q '^APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:latest$' .env
+check "a imagem do .env continua intacta" grep -q "^APP_IMAGE=${NS}/deskcommcrm:latest$" .env
 check "completou a história para poder decidir (deixou de ser raso)" \
   test "$(git rev-parse --is-shallow-repository)" = "false"
 
@@ -297,7 +306,7 @@ bash hostgator-setup-kit/agent.sh > "$WORK/agente.out" 2>&1
 check "o agente chegou a executar o update (o app de mentira pediu)" \
   grep -q '"kind":"run_progress"\|"kind":"run_result"' "$CURL_LOG"
 check "NÃO reiniciou o container" test -z "$(grep -F 'up -d app' "$DOCKER_LOG" || true)"
-check "NÃO reescreveu a imagem do .env" grep -q '^APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:latest$' .env
+check "NÃO reescreveu a imagem do .env" grep -q "^APP_IMAGE=${NS}/deskcommcrm:latest$" .env
 check "reportou 'failed', não 'failed_rolled_back'" \
   test -n "$(grep -F '"status":"failed"' "$CURL_LOG" || true)"
 check "não reportou rollback nenhum" test -z "$(grep -F 'failed_rolled_back' "$CURL_LOG" || true)"
@@ -368,21 +377,21 @@ pin_caso() {  # pin_caso <descrição> <conteúdo do .env> <esperado>
   check "$d" test "$r" = "$esperado"
 }
 pin_caso "app pinado + worker/scheduler AUSENTES → acusa os dois" \
-  "APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:1.3.0" "worker scheduler"
+  "APP_IMAGE=${NS}/deskcommcrm:1.3.0" "worker scheduler"
 pin_caso "app pinado + worker em canal móvel → acusa" \
-  "APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:1.3.0
-WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:stable
-SCHEDULER_IMAGE=ghcr.io/melgarafael/deskcomm-scheduler:1.3.0" "worker"
+  "APP_IMAGE=${NS}/deskcommcrm:1.3.0
+WORKER_IMAGE=${NS}/deskcomm-worker:stable
+SCHEDULER_IMAGE=${NS}/deskcomm-scheduler:1.3.0" "worker"
 pin_caso "as três na mesma versão → silêncio" \
-  "APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:1.3.0
-WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:1.3.0
-SCHEDULER_IMAGE=ghcr.io/melgarafael/deskcomm-scheduler:1.3.0" ""
+  "APP_IMAGE=${NS}/deskcommcrm:1.3.0
+WORKER_IMAGE=${NS}/deskcomm-worker:1.3.0
+SCHEDULER_IMAGE=${NS}/deskcomm-scheduler:1.3.0" ""
 pin_caso "app num canal deliberado (:latest) → não é 'metade', silêncio" \
-  "APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:latest" ""
+  "APP_IMAGE=${NS}/deskcommcrm:latest" ""
 pin_caso "valores entre aspas, como o install grava → silêncio" \
-  "APP_IMAGE='ghcr.io/melgarafael/deskcommcrm:1.3.0'
-WORKER_IMAGE='ghcr.io/melgarafael/deskcomm-worker:1.3.0'
-SCHEDULER_IMAGE='ghcr.io/melgarafael/deskcomm-scheduler:1.3.0'" ""
+  "APP_IMAGE="${NS}/deskcommcrm:1.3.0"
+WORKER_IMAGE="${NS}/deskcomm-worker:1.3.0"
+SCHEDULER_IMAGE="${NS}/deskcomm-scheduler:1.3.0"" ""
 rm -f "$PROJ/.env.pin"
 
 
@@ -401,7 +410,7 @@ cat > "$PIN_DIR/bin/docker" <<'STUBDOCKER'
 #!/usr/bin/env bash
 # inspect de contêiner → devolve o nome da imagem; de imagem → devolve a versão
 case "$*" in
-  *"Config.Image"*)  printf 'ghcr.io/melgarafael/deskcomm-worker:stable
+  *"Config.Image"*)  printf '${NS}/deskcomm-worker:stable
 ' ;;
   *"image.version"*) printf '%s
 ' "${DUBLE_VERSION:-1.3.0}" ;;
@@ -417,10 +426,10 @@ autopin() {  # autopin <conteúdo do .env> → ecoa o que a função corrigiu
       ". '$KIT_DIR_TESTE/_common.sh'; completar_pin_ausente .env" 2>/dev/null ) || true
 }
 
-R="$(autopin "APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:1.3.0")"
+R="$(autopin "APP_IMAGE=${NS}/deskcommcrm:1.3.0")"
 check "chave AUSENTE → preenche os dois" test "$R" = "worker scheduler"
 check "  e grava a versão da imagem em execução, não um canal" \
-  grep -q "^WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:1.3.0$" "$PIN_DIR/.env"
+  grep -q "^WORKER_IMAGE=${NS}/deskcomm-worker:1.3.0$" "$PIN_DIR/.env"
 check "  com pull_policy de tag imutável" \
   grep -q "^WORKER_PULL_POLICY=missing$" "$PIN_DIR/.env"
 
@@ -432,21 +441,21 @@ check "  e não altera um byte do .env" test "$ANTES_MD5" = "$(md5sum "$PIN_DIR/
 
 # A REGRA QUE PROTEGE O OPERADOR. Se esta cair, o cron passa a sobrescrever
 # escolha explícita — e a decisão de implementar a autocorreção deixa de valer.
-R="$(autopin "APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:1.3.0
-WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:stable
-SCHEDULER_IMAGE=ghcr.io/melgarafael/deskcomm-scheduler:stable")"
+R="$(autopin "APP_IMAGE=${NS}/deskcommcrm:1.3.0
+WORKER_IMAGE=${NS}/deskcomm-worker:stable
+SCHEDULER_IMAGE=${NS}/deskcomm-scheduler:stable")"
 check "canal móvel EXPLÍCITO → não toca (é decisão de quem opera)" test -z "$R"
 check "  o :stable escolhido continua lá, intacto" \
-  grep -q "^WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:stable$" "$PIN_DIR/.env"
+  grep -q "^WORKER_IMAGE=${NS}/deskcomm-worker:stable$" "$PIN_DIR/.env"
 
-R="$(autopin "APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:1.3.0
-WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:1.3.0
-SCHEDULER_IMAGE=ghcr.io/melgarafael/deskcomm-scheduler:1.3.0")"
+R="$(autopin "APP_IMAGE=${NS}/deskcommcrm:1.3.0
+WORKER_IMAGE=${NS}/deskcomm-worker:1.3.0
+SCHEDULER_IMAGE=${NS}/deskcomm-scheduler:1.3.0")"
 check "já pinada → silêncio" test -z "$R"
 
 # Imagem sem o label (build local): não há versão para gravar, e inventar uma
 # seria pior que não fazer nada.
-R="$( printf 'APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:1.3.0\n' > "$PIN_DIR/.env"
+R="$( printf "APP_IMAGE=${NS}/deskcommcrm:1.3.0\n" > "$PIN_DIR/.env"
       cd "$PIN_DIR" && PATH="$PIN_DIR/bin:$PATH" DUBLE_VERSION="<no value>" bash -c \
         ". '$KIT_DIR_TESTE/_common.sh'; completar_pin_ausente .env" 2>/dev/null || true )"
 check "imagem sem label de versão → não inventa pin" test -z "$R"


### PR DESCRIPTION
## O problema

`tests/shell/update-guard.test.sh` (**29 lugares**) e `hostgator-setup-kit/test-validators.sh` (**2**) escreviam `ghcr.io/melgarafael` à mão — em fixtures **e** em asserções.

Isso amarra a suíte a **um** publicador. Qualquer fork que publique as próprias imagens — o caminho natural de quem precisa rodar código próprio numa instalação, já que o `update.sh` reescreve `APP_IMAGE` a partir de `IMG_NS` — fica vermelho em 4 casos sem ter quebrado nada.

E a mensagem de falha aponta para o valor **certo**:

```
✗ WORKER_IMAGE não acompanha a versão do app (1.9.0): WORKER_IMAGE="ghcr.io/<fork>/deskcomm-worker:1.9.0"
```

Quem investiga vai procurar defeito onde não há.

## A correção

O invariante que esses casos existem para provar é *"as três imagens saem na MESMA referência e com o `pull_policy` que combina com ela"*. Isso **não depende de quem publica**.

O valor passa a vir da fonte única — `IMG_NS`, em `_common.sh`.

## Contraprova

Trocando `IMG_NS` para outro namespace, a suíte **segue verde**. Antes reprovava em 4 casos.

**Nada muda para este repositório:** `IMG_NS` continua `ghcr.io/melgarafael` e o mesmo conjunto de casos passa.

## Uma armadilha registrada no commit

O regex `'[^']*ghcr[^']*'` que trocaria aspas simples por duplas **atravessa quebra de linha**, e casou de uma aspa até outra oito linhas abaixo, destruindo uma função no meio. `[^'\n]*` é a forma correta.

## Validação

`pnpm test:shell` passa. Resta apenas a falha do apóstrofo em `envq` (`Sant'Ana`), **pré-existente nesta base**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)