### PR TITLE
Qual grafia do telefone vence deixa de ser decisão do banco (item 3 da #366)

### DIFF
--- a/.changes/mesmo-celular-vai-sempre-para-o-mesmo-cadastro.md
+++ b/.changes/mesmo-celular-vai-sempre-para-o-mesmo-cadastro.md
@@ -1,0 +1,14 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O mesmo celular escrito das duas formas passa a cair sempre no mesmo cadastro
+---
+
+Quando um celular ainda existia gravado nas duas formas — com e sem o nono
+dígito —, o sistema podia escolher qualquer uma das duas ao reencontrar a
+pessoa. Na prática isso aparecia no pior momento: a resposta do cliente entrava
+no cadastro errado, o follow-up não a reconhecia como resposta, e a mesma
+pergunta era enviada de novo.
+
+Agora a escolha é sempre a mesma e é sempre a forma com o nono dígito, que é a
+que o CRM guarda e mostra. Você não precisa fazer nada.

--- a/app/api/v1/webhooks/in/[token]/route.ts
+++ b/app/api/v1/webhooks/in/[token]/route.ts
@@ -19,7 +19,7 @@ import { emitLeadActivity } from "@/lib/leads/activity-emitter";
 import { classificarLeadInicial, type ResultadoClassificacaoInicial } from "@/lib/leads/classificacao-inicial";
 import type { CreateLeadInput } from "@/lib/schemas";
 import { mapInboundPayload, verifyInboundSignature, type FieldMap } from "@/lib/webhooks/inbound";
-import { phoneLookupVariants } from "@/lib/channels/phone-variants";
+import { encontrarContatoPorTelefoneComNome } from "@/lib/channels/contato-por-telefone";
 import {
   buildContactConsentGrant,
   buildContactConsentDenial,
@@ -323,23 +323,30 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<NextRespons
   // a reconciliação abaixo existe só para quem JÁ era contato.
   let contatoNasceuAqui = false;
   if (mapped.phone) {
-    const variantes = phoneLookupVariants(mapped.phone);
-    const selectActiveByPhone = () =>
-      admin
-        .from("contacts")
-        .select("id, name")
-        .eq("organization_id", source.organization_id)
-        .in("phone_number", variantes)
-        .is("is_merged_into", null)
-        .limit(1)
-        .maybeSingle();
+    /** O que os dois caminhos (telefone e e-mail) devolvem — um tipo só. */
+    type ContatoAchado = { data: { id: string; name: string | null } | null };
+
+    // ⚠️ QUAL GRAFIA VENCE é decidido por `escolherContatoCanonico`, e não pelo
+    // banco. Isto era `.in(variantes).limit(1)` SEM `order by`: com as duas
+    // grafias do mesmo celular ainda vivas — estado que a migration `0198`
+    // admite ao chamar o próprio passo 3 de "piso de segurança para o unique" —
+    // o Postgres devolvia qualquer uma das duas. A resposta do cliente entrava
+    // no cadastro errado, o follow-up não a reconhecia, e a mesma pergunta saía
+    // de novo.
+    const selectActiveByPhone = async (): Promise<ContatoAchado> => ({
+      data: await encontrarContatoPorTelefoneComNome(
+        admin,
+        source.organization_id,
+        mapped.phone!,
+      ),
+    });
 
     // uniq_contacts_org_email (baseline.sql) é um SEGUNDO índice único parcial,
     // independente de uniq_contacts_org_phone — um INSERT pode colidir nele
     // mesmo com telefone inédito (mesma pessoa manda e-mail repetido, telefone
     // novo). email_normalized é coluna GERADA (`lower(trim(email))`), então a
     // comparação replica exatamente essa normalização — não `email` bruto.
-    const selectActiveByEmail = (): ReturnType<typeof selectActiveByPhone> | null => {
+    const selectActiveByEmail = (): PromiseLike<ContatoAchado> | null => {
       if (!mapped.email) return null;
       return admin
         .from("contacts")

--- a/lib/channels/contato-por-telefone.ts
+++ b/lib/channels/contato-por-telefone.ts
@@ -4,24 +4,107 @@
  */
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-import { phoneLookupVariants } from "./phone-variants";
+import { canonicalPhoneBR, phoneLookupVariants } from "./phone-variants";
+
+/** O que toda busca por telefone precisa saber para escolher, e mais nada. */
+export interface ContatoCandidato {
+  id: string;
+  phone_number: string | null;
+}
+
+/**
+ * QUAL DAS GRAFIAS VENCE — a regra, separada da consulta de propósito.
+ *
+ * ## O defeito que ela fecha
+ *
+ * A busca era `.in("phone_number", variantes).limit(1)`, **sem `order by`**.
+ * `+55 32 8479-3302` e `+55 32 98479-3302` são a mesma pessoa e são DUAS linhas
+ * enquanto a fusão da migration `0198` não passou por elas — e sem ordenação o
+ * Postgres devolve qualquer uma das duas. Não é hipótese de laboratório: a
+ * própria `0198` chama o passo que trata o resto de "piso de segurança para o
+ * unique", ou seja, ela já admite que pode sobrar par.
+ *
+ * O estrago, quando a linha errada volta: a resposta do cliente entra no
+ * cadastro errado, o follow-up não a reconhece como resposta, e a mesma
+ * pergunta é enviada de novo — exatamente o sintoma que a `0198` existe para
+ * acabar.
+ *
+ * ## Por que a canônica, e por que ela sempre existe no par
+ *
+ * `canonicalPhoneBR` já define a forma que o CRM grava e mostra: celular BR
+ * **com** o nono dígito. Para um par de grafias, `phoneLookupVariants` devolve
+ * no máximo duas formas e **uma delas é sempre a canônica** — então preferi-la
+ * decide o par inteiro, sem depender de ordenação nenhuma.
+ *
+ * Fixo e número estrangeiro têm variante única, e o índice parcial
+ * `uniq_contacts_org_phone` garante no máximo uma linha ativa: ali não há o que
+ * desempatar.
+ *
+ * ## O desempate final é arbitrário DE PROPÓSITO
+ *
+ * Se nenhuma candidata for a canônica — estado que não deveria existir —, vence
+ * o menor `id`. Não é uma escolha com significado: é uma escolha **estável**.
+ * Devolver "qualquer uma" é o defeito; devolver sempre a mesma é o conserto,
+ * mesmo quando a regra de negócio não tem preferência.
+ */
+export function escolherContatoCanonico<T extends ContatoCandidato>(
+  candidatos: readonly T[],
+  rawPhone: string,
+): T | null {
+  if (candidatos.length === 0) return null;
+  const canonica = canonicalPhoneBR(rawPhone);
+  const exata = candidatos.filter((c) => c.phone_number === canonica);
+  const pool = exata.length > 0 ? exata : candidatos;
+  return [...pool].sort((a, b) => a.id.localeCompare(b.id))[0]!;
+}
+
+/**
+ * Busca por todas as grafias e devolve UMA, sempre a mesma.
+ *
+ * `limit(4)` e não `limit(1)`: com `limit(1)` a escolha é do banco, e é ela que
+ * era não-determinística. Quatro é folga sobre as duas grafias possíveis — se
+ * aparecerem mais, é dado corrompido, e ainda assim a saída é estável.
+ */
+async function buscarPorVariantes(
+  admin: SupabaseClient,
+  orgId: string,
+  rawPhone: string,
+  colunas: string,
+): Promise<Record<string, unknown> | null> {
+  const variantes = phoneLookupVariants(rawPhone);
+  if (variantes.length === 0) return null;
+  const { data } = await admin
+    .from("contacts")
+    .select(colunas)
+    .eq("organization_id", orgId)
+    .in("phone_number", variantes)
+    // Contato FUNDIDO não é alvo: ele aponta para o vencedor da fusão, e
+    // escrever nele é escrever num cadastro que ninguém mais lê. Dois dos
+    // quatro chamadores desta busca não filtravam isto — ver o cabeçalho do
+    // conserto.
+    .is("is_merged_into", null)
+    .limit(4);
+  const linhas = (data ?? []) as unknown as ContatoCandidato[];
+  return (escolherContatoCanonico(linhas, rawPhone) as Record<string, unknown> | null) ?? null;
+}
 
 export async function encontrarContatoPorTelefone(
   admin: SupabaseClient,
   orgId: string,
   rawPhone: string,
 ): Promise<{ id: string; phone_number: string } | null> {
-  const variantes = phoneLookupVariants(rawPhone);
-  if (variantes.length === 0) return null;
-  const { data } = await admin
-    .from("contacts")
-    .select("id, phone_number")
-    .eq("organization_id", orgId)
-    .in("phone_number", variantes)
-    .is("is_merged_into", null)
-    .limit(1)
-    .maybeSingle();
-  return (data as { id: string; phone_number: string } | null) ?? null;
+  const linha = await buscarPorVariantes(admin, orgId, rawPhone, "id, phone_number");
+  return (linha as { id: string; phone_number: string } | null) ?? null;
+}
+
+/** Como `encontrarContatoPorTelefone`, mas trazendo o nome de quem já existia. */
+export async function encontrarContatoPorTelefoneComNome(
+  admin: SupabaseClient,
+  orgId: string,
+  rawPhone: string,
+): Promise<{ id: string; phone_number: string | null; name: string | null } | null> {
+  const linha = await buscarPorVariantes(admin, orgId, rawPhone, "id, phone_number, name");
+  return (linha as { id: string; phone_number: string | null; name: string | null } | null) ?? null;
 }
 
 /** O contato da mensagem e os gêmeos gravados com a outra grafia do número. */
@@ -41,6 +124,8 @@ export async function idsDoContatoEGemeos(
   if (!phone) return [...ids];
   const variantes = phoneLookupVariants(phone);
   if (variantes.length === 0) return [...ids];
+  // Aqui NÃO se escolhe uma: o objetivo é o conjunto inteiro dos gêmeos, e
+  // `limit` nenhum entra. Esta busca nunca teve o defeito das outras.
   const { data: gemeos } = await admin
     .from("contacts")
     .select("id")

--- a/lib/channels/meta/ingest.ts
+++ b/lib/channels/meta/ingest.ts
@@ -25,6 +25,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 
 import { ARCHIVED_AT, queryTolerantToMissingArchived } from "../archived";
 import { aplicarEfeitosPosEntrada } from "../pos-entrada";
+import { encontrarContatoPorTelefone } from "../contato-por-telefone";
 import { canonicalPhoneBR, phoneLookupVariants } from "../phone-variants";
 import type { ChannelTenantScope } from "../types";
 import type { InboundMessageEvent } from "./webhook";
@@ -89,21 +90,19 @@ async function sessionByPhoneNumberId(
  * Contato já existente sob QUALQUER variante do número. Só depois de não achar é que
  * deixamos o upsert criar — assim o cadastro nasce uma vez só.
  */
+/**
+ * Delega para `encontrarContatoPorTelefone`, que decide QUAL grafia vence.
+ *
+ * Era uma cópia local com `.in(variantes).limit(1)` — sem `order by`, e sem o
+ * filtro de contato fundido. Três funções idênticas viviam assim no repo; a
+ * regra agora mora num lugar só.
+ */
 async function findContactByVariants(
   admin: Admin,
   orgId: string,
   waId: string,
 ): Promise<{ id: string; phone_number: string } | null> {
-  const variantes = phoneLookupVariants(waId);
-  if (variantes.length === 0) return null;
-  const { data } = await admin
-    .from("contacts")
-    .select("id, phone_number")
-    .eq("organization_id", orgId)
-    .in("phone_number", variantes)
-    .limit(1)
-    .maybeSingle();
-  return data ?? null;
+  return encontrarContatoPorTelefone(admin as never, orgId, waId);
 }
 
 /** Prévia curta para a lista de conversas. Mídia vira rótulo, nunca URL. */

--- a/lib/messaging/open-shared-contact-conversation.ts
+++ b/lib/messaging/open-shared-contact-conversation.ts
@@ -5,6 +5,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 import { ensureConversation, sessaoProntaParaEnvio } from "@/lib/automation/start-conversation";
+import { encontrarContatoPorTelefone } from "@/lib/channels/contato-por-telefone";
 import { phoneLookupVariants, canonicalPhoneBR } from "@/lib/channels/phone-variants";
 import { parseDialablePhone } from "@/lib/messaging/contact-card";
 
@@ -22,21 +23,16 @@ export interface OpenSharedContactResult {
   contact_id: string;
 }
 
+/**
+ * Delega para `encontrarContatoPorTelefone` — ver o cabeçalho de
+ * `escolherContatoCanonico`. Era cópia local com `.limit(1)` e sem `order by`.
+ */
 async function findContactByPhoneVariants(
   admin: Admin,
   orgId: string,
   rawPhone: string,
 ): Promise<{ id: string; phone_number: string } | null> {
-  const variantes = phoneLookupVariants(rawPhone);
-  if (variantes.length === 0) return null;
-  const { data } = await admin
-    .from("contacts")
-    .select("id, phone_number")
-    .eq("organization_id", orgId)
-    .in("phone_number", variantes)
-    .limit(1)
-    .maybeSingle();
-  return data ?? null;
+  return encontrarContatoPorTelefone(admin as never, orgId, rawPhone);
 }
 
 async function resolveContactId(

--- a/tests/unit/qual-grafia-do-telefone-vence.test.ts
+++ b/tests/unit/qual-grafia-do-telefone-vence.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  escolherContatoCanonico,
+  type ContatoCandidato,
+} from "@/lib/channels/contato-por-telefone";
+import { canonicalPhoneBR, phoneLookupVariants } from "@/lib/channels/phone-variants";
+
+/**
+ * QUAL GRAFIA DO TELEFONE VENCE — e por que o teste alimenta as DUAS ordens.
+ *
+ * ## O defeito
+ *
+ * Quatro sítios do repo buscavam o contato com
+ * `.in("phone_number", variantes).limit(1)`, **sem `order by`**:
+ *
+ *   app/api/v1/webhooks/in/[token]/route.ts   (o que a issue #366 nomeia)
+ *   lib/channels/contato-por-telefone.ts
+ *   lib/channels/meta/ingest.ts
+ *   lib/messaging/open-shared-contact-conversation.ts
+ *
+ * `+553284793302` e `+5532984793302` são a mesma pessoa e são DUAS linhas
+ * enquanto a fusão da migration `0198` não passou por elas — estado que a
+ * própria `0198` admite, ao chamar o seu passo 3 de "piso de segurança para o
+ * unique". Sem ordenação, qual das duas volta é decisão do Postgres.
+ *
+ * O estrago: a resposta do cliente entra no cadastro errado, o follow-up não a
+ * reconhece como resposta, e a mesma pergunta é enviada de novo — exatamente o
+ * sintoma que a `0198` existe para acabar.
+ *
+ * ## Por que ALIMENTAR AS DUAS ORDENS é o teste, e não um capricho
+ *
+ * O defeito não é "devolve a linha X". É **"a saída depende da ordem em que as
+ * linhas chegaram"**. Um teste que passasse uma ordem só mediria qual linha
+ * volta naquela ordem — e passaria verde sobre o defeito, porque o código
+ * antigo também devolveria algo. A propriedade só aparece comparando as duas
+ * chamadas: mesma resposta, venha o par na ordem que vier.
+ *
+ * ## O que este arquivo NÃO cobre, declarado
+ *
+ * Mede a REGRA, que é pura. Não prova que o PostgREST devolve as duas linhas
+ * (isso é `.in()` com `limit(4)`, e depende do banco), nem que a `0198` funde
+ * os pares no backfill. O que ele garante é que, chegando o par, a escolha é
+ * sempre a mesma e é a canônica.
+ */
+
+const SEM_NONO = "+553284793302";
+const COM_NONO = "+5532984793302";
+
+const linha = (id: string, phone: string | null): ContatoCandidato => ({
+  id,
+  phone_number: phone,
+});
+
+describe("a premissa: o par existe e uma das grafias é a canônica", () => {
+  it("controle positivo — as duas grafias são variantes uma da outra", () => {
+    // Sem isto, todo caso abaixo poderia estar medindo dois números que o
+    // produto nem considera o mesmo contato.
+    expect(phoneLookupVariants(SEM_NONO)).toContain(COM_NONO);
+    expect(phoneLookupVariants(COM_NONO)).toContain(SEM_NONO);
+  });
+
+  it("a canônica é a COM o nono dígito, pelas duas entradas", () => {
+    expect(canonicalPhoneBR(SEM_NONO)).toBe(COM_NONO);
+    expect(canonicalPhoneBR(COM_NONO)).toBe(COM_NONO);
+  });
+});
+
+describe("escolherContatoCanonico", () => {
+  it("⭐ a ordem de chegada NÃO muda a resposta — é o defeito, em uma linha", () => {
+    const a = linha("aaaa-1111", SEM_NONO);
+    const b = linha("bbbb-2222", COM_NONO);
+
+    const numaOrdem = escolherContatoCanonico([a, b], SEM_NONO);
+    const naOutra = escolherContatoCanonico([b, a], SEM_NONO);
+
+    expect(
+      numaOrdem?.id,
+      "a escolha mudou com a ordem das linhas — é exatamente o `.limit(1)` sem `order by`",
+    ).toBe(naOutra?.id);
+  });
+
+  it("⭐ vence a grafia canônica, e não a que chegou primeiro", () => {
+    const semNono = linha("aaaa-1111", SEM_NONO);
+    const comNono = linha("bbbb-2222", COM_NONO);
+
+    // O `id` do sem-nono ordena ANTES: se a regra fosse só "o menor id", este
+    // caso passaria pelo motivo errado. É a canônica que tem de vencer.
+    expect(escolherContatoCanonico([semNono, comNono], SEM_NONO)?.id).toBe("bbbb-2222");
+    expect(escolherContatoCanonico([comNono, semNono], COM_NONO)?.id).toBe("bbbb-2222");
+  });
+
+  it("uma linha só é devolvida como está — inclusive a não-canônica", () => {
+    // Quem tem só a grafia antiga continua sendo encontrado. Um conserto que
+    // exigisse a canônica devolveria `null` aqui e perderia o contato.
+    expect(escolherContatoCanonico([linha("x", SEM_NONO)], SEM_NONO)?.id).toBe("x");
+  });
+
+  it("sem candidatos, devolve null", () => {
+    expect(escolherContatoCanonico([], SEM_NONO)).toBeNull();
+  });
+
+  it("nenhuma candidata canônica: a escolha é ARBITRÁRIA mas ESTÁVEL", () => {
+    // Estado que não deveria existir. Devolver "qualquer uma" é o defeito;
+    // devolver sempre a mesma é o conserto, mesmo sem preferência de negócio.
+    const p = linha("zzzz-9999", null);
+    const q = linha("mmmm-5555", null);
+    expect(escolherContatoCanonico([p, q], SEM_NONO)?.id).toBe("mmmm-5555");
+    expect(escolherContatoCanonico([q, p], SEM_NONO)?.id).toBe("mmmm-5555");
+  });
+
+  it("fixo e estrangeiro não têm par — e passam intactos", () => {
+    const fixo = "+553132345678";
+    expect(phoneLookupVariants(fixo)).toHaveLength(1);
+    expect(escolherContatoCanonico([linha("f1", fixo)], fixo)?.id).toBe("f1");
+
+    const gringo = "+14155550123";
+    expect(phoneLookupVariants(gringo)).toHaveLength(1);
+    expect(escolherContatoCanonico([linha("g1", gringo)], gringo)?.id).toBe("g1");
+  });
+});


### PR DESCRIPTION
Fecha o **item 3 da #366**: *"`selectActiveByPhone` virou `.in(...).limit(1)` sem `order by`"*.

## A issue nomeia um sítio. São quatro.

A mesma consulta, copiada, com o mesmo defeito:

| arquivo | |
|---|---|
| `app/api/v1/webhooks/in/[token]/route.ts` | o que a issue viu no diff |
| `lib/channels/contato-por-telefone.ts` | |
| `lib/channels/meta/ingest.ts` | |
| `lib/messaging/open-shared-contact-conversation.ts` | |

Todos faziam `.in("phone_number", variantes).limit(1)` **sem `order by`**. Achei os outros três procurando a *classe* em vez de consertar a instância citada.

## O defeito não é hipotético — medido contra o banco real

`+553284793302` e `+5532984793302` são a mesma pessoa e são **duas linhas** enquanto a fusão da `0198` não passou por elas. Sem ordenação, qual volta é decisão do Postgres. E o estado não é teórico: a própria `0198` chama o seu passo 3 de *"piso de segurança para o unique"* — ela já admite que pode sobrar par.

Plantado no Postgres/PostgREST do ambiente e2e, com o de **12 dígitos inserido primeiro**:

```console
CONTROLE POSITIVO — linhas que o banco devolve: 2
buscando por +553284793302  -> +5532984793302  OK (canônica)
buscando por +5532984793302 -> +5532984793302  OK (canônica)
```

O controle positivo é o que dá sentido ao resto: sem as duas linhas vivas, o cenário não existiria e a prova não mediria nada.

**O estrago quando volta a linha errada:** a resposta do cliente entra no cadastro errado, o follow-up não a reconhece como resposta, e a mesma pergunta é enviada de novo — exatamente o sintoma que a `0198` existe para acabar.

## O conserto

A regra sai do banco e vira `escolherContatoCanonico`, **pura**: vence a grafia que `canonicalPhoneBR` define — celular BR **com** o nono dígito. Para um par, `phoneLookupVariants` devolve no máximo duas formas e **uma delas é sempre a canônica**, então preferi-la decide o par inteiro sem depender de ordenação nenhuma.

`.limit(4)` no lugar de `.limit(1)`: com `limit(1)` a escolha é do banco, e era ela que não era determinística.

**De brinde:** dois dos quatro sítios não filtravam `is_merged_into is null` — podiam devolver um contato já fundido, cujo cadastro ninguém mais lê. A função central filtra.

## Por que o teste alimenta as DUAS ordens

O defeito não é *"devolve a linha X"*. É **"a saída depende da ordem em que as linhas chegaram"**. Um teste com uma ordem só mediria qual linha volta naquela ordem — e passaria verde sobre o defeito, porque o código antigo também devolveria *algo*. A propriedade só aparece comparando as duas chamadas.

### Sabotado, com a previsão declarada antes de rodar

```console
A: "a primeira que chegou" (o defeito antigo)   →  3 de 8 vermelhos
B: ordena por id, SEM preferir a canônica       →  1 de 8 vermelho
restaurado                                      →  8 de 8
```

**A sabotagem B é a que vale:** ela é *determinística* e ainda assim errada. Sem o caso "vence a grafia canônica", o conserto quase-certo passaria — e a diferença entre "sempre a mesma" e "sempre a certa" desaparece. Por isso aquele caso usa um `id` que ordena **antes** para a linha errada: se a regra fosse só "menor id", ele passaria pelo motivo errado.

O desempate final (menor `id`, quando nenhuma é canônica) é arbitrário **de propósito**, e está escrito assim no código: devolver *"qualquer uma"* é o defeito; devolver *sempre a mesma* é o conserto, mesmo sem preferência de negócio.

## Medido

```console
$ pnpm typecheck                                     exit 0
$ pnpm lint                                          exit 0 (0 erros)
$ pnpm test:unit    # o script INTEIRO, sem caminho  exit 0
    Test Files  570 passed (570)
    Tests  6379 passed | 1 expected fail (6380)
    controle rodapé × grep FAIL: 0 failed | 0
```

Branch atualizada com a `main` de agora (`d2d42747`), e o gate `numero-de-jornada-e-unico` revalidado depois do merge.

## NÃO MEDIDO

- **Que a `0198` funde todos os pares no backfill.** Este conserto torna a escolha correta *com o par vivo*, que é a garantia que faltava — ele não substitui a fusão, e não fui verificar o backfill.

Com este, os três itens da #366 estão fechados (o 1 pelo #367, o 2 pelo #385).

Refs #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMM6LWWEHgeir2dQvv3Mnf
