### PR TITLE
O caso de rolagem da agenda escolhia HOJE, e hoje encolhe com o relógio

### DIFF
--- a/tests/e2e/agenda-painel-cabe-na-tela.spec.ts
+++ b/tests/e2e/agenda-painel-cabe-na-tela.spec.ts
@@ -110,15 +110,73 @@ async function abrirPainelComDiaEscolhido(page: Page, nomeDoTipo: string): Promi
   await expect(page.getByTestId("tipos-de-agendamento")).toBeVisible({ timeout: 15_000 });
   await page.getByRole("button", { name: new RegExp(`^${nomeDoTipo}`) }).click();
 
-  // O primeiro dia CLICÁVEL. `data-disponivel` é o que a tela usa para decidir
-  // o clique, então usá-lo aqui mede o mesmo estado que o usuário enxerga.
-  const dia = page.locator('[data-testid^="dia-"][data-disponivel="true"]').first();
+  // ⚠️ UM DIA INTEIRO, e NÃO o primeiro clicável — que é HOJE, já meio gasto.
+  //
+  // Era `[data-disponivel="true"]`.first(), e o primeiro clicável é hoje: os dias
+  // passados não têm slot nenhum. Só que a jornada do seed é 09:00–18:00 e o tipo
+  // exige 60min de antecedência, então o que HOJE ainda oferece é o RESTO do dia —
+  // um número que é função do relógio de parede, não do seed:
+  //
+  //     run 33183384573, main, 15:27 UTC → 9 horários — "Received: 450"
+  //     run 33189014104, main, 16:37 UTC → 7 horários — "Received: 350"
+  //
+  // Mesmo commit, mesmo seed, contagens diferentes: a variável é a hora. Antes das
+  // ~15:00 UTC sobram 10+ horários e a pré-condição de suficiência passa; depois
+  // dela o caso reprova por FALTA DE CENÁRIO — a lista cabe na tela e, como a
+  // própria mensagem diz, o verde ali não seria evidência. A main ficou vermelha
+  // ao meio-dia sem ninguém ter mexido em nada.
+  //
+  // Um dia FUTURO oferece a janela inteira: 09:00–17:30 de 30 em 30 = 18 horários,
+  // 900px de lista, independentes de que horas são. O cenário deixa de depender do
+  // relógio sem que asserção nenhuma afrouxe — a pré-condição continua exatamente
+  // onde estava, e continua reprovando uma lista que não precise rolar.
+  const chavesCheias = async (): Promise<string[]> => {
+    const hoje = await page.evaluate(() => {
+      // Calculado DENTRO do browser de propósito: é o mesmo relógio e o mesmo fuso
+      // que formatam o `data-testid` de cada dia. Comparar com a data do processo
+      // do Node erraria por um dia sempre que os dois discordassem.
+      const d = new Date();
+      const dd = (n: number) => String(n).padStart(2, "0");
+      return `${d.getFullYear()}-${dd(d.getMonth() + 1)}-${dd(d.getDate())}`;
+    });
+    const chaves = await page
+      .locator('[data-testid^="dia-"][data-disponivel="true"]')
+      .evaluateAll((els) => els.map((el) => el.getAttribute("data-testid")!.slice(4)));
+    // `yyyy-MM-dd` compara como texto na mesma ordem em que compara como data.
+    return chaves.filter((k) => k > hoje).sort();
+  };
+
+  // `data-disponivel` é o que a tela usa para decidir o clique, então esperar por
+  // ele mede o mesmo estado que o usuário enxerga — e é o que dá tempo à consulta
+  // de horários responder: até ela chegar, TODO dia nasce indisponível, e uma
+  // varredura feita antes disso leria "não há dia cheio" onde há.
   await expect(
-    dia,
+    page.locator('[data-testid^="dia-"][data-disponivel="true"]').first(),
     "nenhum dia disponível — o seed da agenda não deixou jornada publicada, e sem " +
       "dia clicável a coluna de horários nunca abre (o defeito ficaria invisível)",
   ).toBeVisible({ timeout: 20_000 });
-  await dia.click();
+
+  let cheios = await chavesCheias();
+  if (cheios.length === 0) {
+    // Hoje é o último dia útil do mês visível: o próximo dia com jornada cai no mês
+    // seguinte, e o mini-calendário só torna clicável o que é `isSameMonth` do mês
+    // em tela. Sem este passo a spec reprovaria nos dias 30/31 — a mesma classe de
+    // vermelho-por-calendário que ela acabou de sair.
+    await page.getByTestId("mes-seguinte").click();
+    await expect(
+      page.locator('[data-testid^="dia-"][data-disponivel="true"]').first(),
+      "nem o mês seguinte oferece dia — a janela de busca da tela é de 30 dias",
+    ).toBeVisible({ timeout: 20_000 });
+    cheios = await chavesCheias();
+  }
+
+  const dia = cheios[0];
+  expect(
+    dia,
+    "nenhum dia FUTURO disponível — sem um dia com a jornada inteira, a contagem de " +
+      "horários volta a depender da hora em que a suíte roda",
+  ).toBeTruthy();
+  await page.getByTestId(`dia-${dia}`).click();
 
   const coluna = page.getByTestId("coluna-de-horarios");
   await expect(coluna).toHaveAttribute("data-aberta", "true", { timeout: 15_000 });
@@ -214,8 +272,11 @@ test("a lista de horários ROLA, e o último horário é alcançável — 1280×
    * também não rola, porque o Sheet é `position: fixed` e transbordo de elemento
    * fixo não estende a área rolável do documento.
    *
-   * Viewport 700px de altura de propósito: é onde a lista estoura com a
-   * quantidade de horários que o seed produz.
+   * Viewport 700px de altura de propósito: é onde a lista estoura com os 18
+   * horários de um dia inteiro da jornada semeada (09:00–17:30, de 30 em 30).
+   * "De um dia inteiro" é a parte que este caso já pagou caro: enquanto ele
+   * clicava em HOJE, a contagem era o resto do dia e mudava com a hora do run —
+   * ver o comentário de `abrirPainelComDiaEscolhido`.
    */
   await page.setViewportSize({ width: 1280, height: 700 });
   const creds = lerCreds();
@@ -228,9 +289,14 @@ test("a lista de horários ROLA, e o último horário é alcançável — 1280×
   const n = await horarios.count();
 
   // ── PRÉ-CONDIÇÃO DE SUFICIÊNCIA ──────────────────────────────────────────
-  // Sem isto o caso fica VERDE POR VACUIDADE no dia em que o seed produzir
+  // Sem isto o caso fica VERDE POR VACUIDADE no dia em que o cenário produzir
   // poucos slots: uma lista que cabe na tela não precisa rolar, e "não rolou"
   // passaria a ser lido como "está consertado".
+  //
+  // Ela JÁ COBROU, e cobrou certo: com o dia sendo hoje, reprovou a `main` com 9
+  // e depois com 7 horários — recusando-se a passar por um cenário que não
+  // exercitava rolagem nenhuma. O conserto foi dar-lhe o cenário (um dia com a
+  // jornada inteira), nunca baixar a régua.
   //
   // ⚠️ A RÉGUA É O ESPAÇO QUE SOBRA PARA A LISTA, e não a altura da janela — e
   // eu escrevi errado da primeira vez. Comparar `n * 50` com os 700px da


### PR DESCRIPTION
## O que quebrou

A `main` ficou vermelha ao meio-dia sem ninguém ter mexido em nada. O caso
`a lista de horários ROLA, e o último horário é alcançável — 1280×700` reprovou
na sua **pré-condição de suficiência** — a linha que se recusa a ficar verde por
vacuidade quando a lista cabe inteira na tela.

## O diagnóstico

Duas reprovações, mesmo commit, mesmo seed, contagens diferentes:

| run | horário | horários | `Received` |
|---|---|---|---|
| [33183384573](https://github.com/melgarafael/DeskcommCRM/actions/runs/33183384573) (main) | 15:27 UTC | 9 | 450 |
| [33189014104](https://github.com/melgarafael/DeskcommCRM/actions/runs/33189014104) (main) | 16:37 UTC | 7 | 350 |

Duas contagens para o mesmo cenário só têm uma variável possível, e é **a hora**.

`abrirPainelComDiaEscolhido` clicava no primeiro dia CLICÁVEL, que é **hoje** —
os dias passados não oferecem slot nenhum. A jornada semeada é 09:00–18:00 com
60 min de antecedência mínima, então o que hoje ainda oferece é **o resto do
dia**: 18 horários de manhã, 9 ao meio-dia, 7 à tarde, zero depois das 17:30.
Acima de ~10 a lista estoura os ~497px que sobram abaixo do seu topo e o caso
passa; abaixo disso ele reprova — dizendo com razão que aquele verde não seria
evidência de rolagem nenhuma.

Ou seja: **o teste estava certo e o cenário é que era insuficiente**. Ele não
falhou por regressão do produto; falhou por se recusar a mentir.

## O conserto

Dar-lhe o cenário, **sem tocar em asserção nenhuma**: o painel passa a abrir no
primeiro dia **futuro** disponível, que oferece a jornada inteira — 09:00 às
17:30 de 30 em 30, 18 horários, 900px de lista, independentes de que horas são.

A pré-condição continua exatamente onde estava, com a mesma régua, e continua
reprovando uma lista que não precise rolar. As réguas 1 a 6 estão intactas.

Inclui o passo para o mês seguinte: quando hoje é o último dia útil do mês
visível, o próximo dia com jornada cai fora da grade em tela — a mesma classe de
vermelho-por-calendário, adiada para o dia 30.

## O que NÃO foi tocado

- **O seed** (`scripts/seed-e2e-agenda.ts`) — ele é infra compartilhada com
  `agente-marca-consulta` e `agenda-marcar-pela-tela`; mexer na jornada dele
  mudaria o cenário das duas sem necessidade. E não resolveria: alargar a janela
  só empurra a hora em que a contagem volta a ficar curta.
- **O produto.** Nenhum arquivo de `app/`, `lib/` ou `components/` no diff.
- **`.changes/`** — nada aqui é visível a quem opera uma VPS; o único arquivo
  tocado é uma spec.

## Prova nos dois sentidos

- **A lista que não rola continua reprovando:** é literalmente o estado da `main`
  hoje, medido duas vezes (tabela acima). Reverter esta mudança é reproduzir o
  vermelho.
- **O caso continua pegando o defeito real:** as réguas 4 (`scrollHeight >
  clientHeight`), 5 (o último horário alcançável) e 6 (o Sheet segue `fixed`)
  não foram tocadas — com 18 horários em vez de 9 elas ficam mais exigentes, não
  menos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F37LqMkUyGYaVYgYemsY3x