### PR TITLE
Elegância E proteção: os testes derivam o namespace, e um ponto — um só — o ancora

### DIFF
--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -426,6 +426,13 @@ psql_run() { docker run --rm -i postgres:17-alpine psql "$(url_do_schema)" -v ON
 # O namespace é constante e literal de propósito: ele está gravado no .env de
 # toda instalação viva, e derivá-lo de variável faria o kit antigo (que já está
 # no disco do cliente) e o novo montarem strings diferentes.
+#
+# Esta linha é a ÚNICA fonte do namespace para tudo que executa — os testes do
+# kit a leem em vez de repetir a string. Quem a confere é
+# `tests/unit/namespace-das-imagens.test.ts`, que assere este valor e cobra que
+# `docker-compose.prod.yml`, `.env.hostgator.example` e a matriz de
+# `publish-image.yml` digam o mesmo. Se você é um fork, é lá que está a lista do
+# que trocar junto.
 IMG_NS="ghcr.io/melgarafael"
 IMG_APP="${IMG_NS}/deskcommcrm"
 IMG_WORKER="${IMG_NS}/deskcomm-worker"

--- a/hostgator-setup-kit/diagnostico.sh
+++ b/hostgator-setup-kit/diagnostico.sh
@@ -110,7 +110,7 @@ IMG_APP="$(imagem_do_servico app)"
 #     A primeira versão deste detector decidia pelo NOME da imagem ("tem host,
 #     logo veio de registro") e só consultava os labels quando o nome não tinha
 #     host. Uma sabotagem derrubou isso em um comando: construí local, taguei
-#     como `ghcr.io/melgarafael/deskcomm-worker:falsificado`, e o diagnóstico
+#     como `<namespace>/deskcomm-worker:falsificado`, e o diagnóstico
 #     deu "NÃO afetada" numa instalação afetada. Pior: o comentário ao lado do
 #     código afirmava que os labels pegariam esse caso — a prosa descrevia uma
 #     proteção que o código não implementava.

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -1494,7 +1494,7 @@ STUB
   tag_app="${img_app##*:}"
   for par in "WORKER_IMAGE:deskcomm-worker" "SCHEDULER_IMAGE:deskcomm-scheduler"; do
     chave="${par%%:*}"; repo="${par##*:}"
-    if [ "$(valor_no_env "$VPS_PROJ/.env" "$chave")" != "ghcr.io/melgarafael/${repo}:${tag_app}" ]; then
+    if [ "$(valor_no_env "$VPS_PROJ/.env" "$chave")" != "${IMG_NS}/${repo}:${tag_app}" ]; then
       printf '  ✗ %s não acompanha a versão do app (%s): %s\n' "$chave" "$tag_app" \
         "$(grep -E "^${chave}=" "$VPS_PROJ/.env" || echo '(ausente)')"
       printf '     app numa versão e worker em outra é a matriz que ninguém testou.\n'; exit 1
@@ -1653,7 +1653,7 @@ STUB
 
   for par in "APP_IMAGE:deskcommcrm" "WORKER_IMAGE:deskcomm-worker" "SCHEDULER_IMAGE:deskcomm-scheduler"; do
     chave="${par%%:*}"; repo="${par##*:}"
-    if [ "$(valor_no_env "$VPS_PROJ/.env" "$chave")" != "ghcr.io/melgarafael/${repo}:1.10.0" ]; then
+    if [ "$(valor_no_env "$VPS_PROJ/.env" "$chave")" != "${IMG_NS}/${repo}:1.10.0" ]; then
       printf '  ✗ %s não foi pinado na versão resolvida (1.10.0): %s\n' "$chave" \
         "$(grep -E "^${chave}=" "$VPS_PROJ/.env" || echo '(ausente)')"
       printf '     instalação de cliente NUNCA nasce em tag móvel — docs/doctrine/packaging.md, invariante 3.\n'

--- a/hostgator-setup-kit/update.sh
+++ b/hostgator-setup-kit/update.sh
@@ -57,7 +57,11 @@ CURRENT_TAG="$(git describe --tags --exact-match HEAD 2>/dev/null || true)"
 # (Veio da `main`; a versão por tag cai exatamente na mesma armadilha, porque a
 # comparação de tags também fica satisfeita com a imagem velha no lugar.)
 image_desatualizada() {
-  local img="${APP_IMAGE:-ghcr.io/melgarafael/deskcommcrm:latest}" local_d remote_d
+  # O fallback vem de `IMG_APP` (_common.sh, sourceado no topo deste arquivo) e não de
+  # um literal: num fork com namespace próprio, o literal apontava para a
+  # imagem do UPSTREAM, e um `.env` sem APP_IMAGE comparava o digest local
+  # contra um registry que não é o dele.
+  local img="${APP_IMAGE:-${IMG_APP}:latest}" local_d remote_d
   local_d="$(docker image inspect "$img" --format '{{if .RepoDigests}}{{index .RepoDigests 0}}{{end}}' 2>/dev/null | sed 's/.*@//')"
   [ -z "$local_d" ] && return 0                 # nem baixada ainda → atualizar
   remote_d="$(docker buildx imagetools inspect "$img" 2>/dev/null | awk '/^Digest:/{print $2; exit}')"

--- a/tests/shell/update-guard.test.sh
+++ b/tests/shell/update-guard.test.sh
@@ -29,8 +29,20 @@ set -uo pipefail
 # asserções —, o que amarrava a suíte a UM publicador: um fork que publica as
 # próprias imagens fica vermelho sem ter quebrado nada. O que estes casos provam é
 # que as três imagens andam na MESMA versão, e isso independe de quem publica.
+#
+# O CUSTO DE DERIVAR, e onde ele é pago. Enquanto o literal estava aqui, este
+# arquivo era a única canária do repo contra um IMG_NS errado: um valor trocado
+# reprovava 4 casos (medido). Derivando, ele deixa de reprovar — os testes
+# passam a concordar entre si sobre o valor errado, que é a família do teste que
+# mede a si mesmo. A proteção não sumiu: mudou de lugar, para
+# `tests/unit/namespace-das-imagens.test.ts`, que assere o literal UMA vez e
+# confere que o compose, o `.env` de exemplo e o workflow de publicação dizem o
+# mesmo. Se você veio parar aqui procurando a guarda do namespace, é lá.
 NS="$(sed -n 's/^IMG_NS="\(.*\)"$/\1/p' "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../hostgator-setup-kit" && pwd)/_common.sh" | head -1)"
 [ -n "$NS" ] || { echo "não consegui ler IMG_NS de _common.sh"; exit 1; }
+# Exportado porque o dublê de `docker` (escrito mais abaixo num heredoc quoted)
+# resolve $NS em tempo de execução, já dentro de outro processo.
+export NS
 
 
 # Capturado ANTES de qualquer `cd`: o script muda de diretório várias vezes, e
@@ -388,10 +400,15 @@ WORKER_IMAGE=${NS}/deskcomm-worker:1.3.0
 SCHEDULER_IMAGE=${NS}/deskcomm-scheduler:1.3.0" ""
 pin_caso "app num canal deliberado (:latest) → não é 'metade', silêncio" \
   "APP_IMAGE=${NS}/deskcommcrm:latest" ""
+# As aspas SIMPLES são o objeto deste caso — o `install.sh` grava assim. Elas
+# ficam literais porque estão DENTRO da string de aspas duplas; trocá-las por
+# duplas FECHA a string, e o conteúdo sai sem aspa nenhuma. Medido: nessa forma
+# o caso vira byte-a-byte igual ao "as três na mesma versão" logo acima, e o
+# rótulo passa a mentir sobre o que está sendo exercitado.
 pin_caso "valores entre aspas, como o install grava → silêncio" \
-  "APP_IMAGE="${NS}/deskcommcrm:1.3.0"
-WORKER_IMAGE="${NS}/deskcomm-worker:1.3.0"
-SCHEDULER_IMAGE="${NS}/deskcomm-scheduler:1.3.0"" ""
+  "APP_IMAGE='${NS}/deskcommcrm:1.3.0'
+WORKER_IMAGE='${NS}/deskcomm-worker:1.3.0'
+SCHEDULER_IMAGE='${NS}/deskcomm-scheduler:1.3.0'" ""
 rm -f "$PROJ/.env.pin"
 
 
@@ -410,8 +427,13 @@ cat > "$PIN_DIR/bin/docker" <<'STUBDOCKER'
 #!/usr/bin/env bash
 # inspect de contêiner → devolve o nome da imagem; de imagem → devolve a versão
 case "$*" in
-  *"Config.Image"*)  printf '${NS}/deskcomm-worker:stable
-' ;;
+  # O heredoc é quoted ('STUBDOCKER') para proteger $* e $DUBLE_VERSION, então
+  # $NS NÃO é expandido na escrita: ele chega literal aqui e é resolvido quando o
+  # dublê RODA, lendo do ambiente (por isso o `export NS` lá em cima). Sem essa
+  # resolução o dublê devolvia a string `${NS}/deskcomm-worker:stable` — uma
+  # fixture que não representa instalação nenhuma. O `:?` faz o dublê morrer alto
+  # se a variável não vier, em vez de devolver um nome começando em "/".
+  *"Config.Image"*)  printf '%s/deskcomm-worker:stable\n' "${NS:?dublê de docker sem NS no ambiente}" ;;
   *"image.version"*) printf '%s
 ' "${DUBLE_VERSION:-1.3.0}" ;;
   *) exit 1 ;;

--- a/tests/shell/update-guard.test.sh
+++ b/tests/shell/update-guard.test.sh
@@ -24,6 +24,15 @@
 #      isolam cada uma, provado por sabotagem cirúrgica de cada linha.
 set -uo pipefail
 
+# O namespace das imagens publicadas, lido da FONTE (hostgator-setup-kit/_common.sh)
+# em vez de repetido aqui. Este arquivo tinha o literal em 29 lugares — fixtures e
+# asserções —, o que amarrava a suíte a UM publicador: um fork que publica as
+# próprias imagens fica vermelho sem ter quebrado nada. O que estes casos provam é
+# que as três imagens andam na MESMA versão, e isso independe de quem publica.
+NS="$(sed -n 's/^IMG_NS="\(.*\)"$/\1/p' "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../hostgator-setup-kit" && pwd)/_common.sh" | head -1)"
+[ -n "$NS" ] || { echo "não consegui ler IMG_NS de _common.sh"; exit 1; }
+
+
 # Capturado ANTES de qualquer `cd`: o script muda de diretório várias vezes, e
 # `${BASH_SOURCE[0]}` é relativo ao cwd de quem invocou. Resolvê-lo lá embaixo
 # devolvia string vazia, e o `.` virava `/_common.sh`.
@@ -132,7 +141,7 @@ STUB
 printf 'services:\n  app:\n    image: \${APP_IMAGE:-x}\n' > "$PROJ/docker-compose.prod.yml"
 printf 'select 1;\n' > "$PROJ/supabase/baseline.sql"
 cat > "$PROJ/.env" <<ENV
-APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:latest
+APP_IMAGE=${NS}/deskcommcrm:latest
 APP_PULL_POLICY=always
 SUPABASE_DB_URL=postgresql://x/y
 NEXT_PUBLIC_APP_URL=https://crm.exemplo.com.br
@@ -185,7 +194,7 @@ echo nova > nova.txt; git add -A; git commit --quiet -m "v1.1.0"; git tag v1.1.0
 git checkout --quiet v0.9.0
 run_update --to v1.1.0
 check "a atualização termina com sucesso" test "$RC" -eq 0
-check ".env aponta para a imagem da versão instalada" grep -q '^APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:1.1.0$' .env
+check ".env aponta para a imagem da versão instalada" grep -q "^APP_IMAGE=${NS}/deskcommcrm:1.1.0$" .env
 check "a chave APP_IMAGE não duplicou" test "$(grep -c '^APP_IMAGE=' .env)" -eq 1
 run_update --to v1.1.0 --force
 check "segunda execução também não duplica" test "$(grep -c '^APP_IMAGE=' .env)" -eq 1
@@ -215,9 +224,9 @@ echo "── 4b. As três imagens sobem juntas, na mesma versão"
 # runtime do agente de IA — ficava congelado no código do dia da instalação.
 # Se estas três linhas voltarem a divergir, o defeito voltou.
 check "o worker é pinado na MESMA versão do app" \
-  grep -q '^WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:1.1.0$' .env
+  grep -q "^WORKER_IMAGE=${NS}/deskcomm-worker:1.1.0$" .env
 check "o scheduler é pinado na MESMA versão do app" \
-  grep -q '^SCHEDULER_IMAGE=ghcr.io/melgarafael/deskcomm-scheduler:1.1.0$' .env
+  grep -q "^SCHEDULER_IMAGE=${NS}/deskcomm-scheduler:1.1.0$" .env
 check "o worker herda a política da tag imutável" \
   grep -q '^WORKER_PULL_POLICY=missing$' .env
 check "o scheduler herda a política da tag imutável" \
@@ -246,7 +255,7 @@ echo topo > topo.txt; git add -A; git commit --quiet -m "main, depois da release
 clona_raso() {  # clona_raso <destino> — igual ao install.sh: --depth 1
   git clone --depth 1 --quiet "file://$SRC" "$1"
   cat > "$1/.env" <<ENV
-APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:latest
+APP_IMAGE=${NS}/deskcommcrm:latest
 APP_PULL_POLICY=always
 SUPABASE_DB_URL=postgresql://x/y
 NEXT_PUBLIC_APP_URL=https://crm.exemplo.com.br
@@ -268,7 +277,7 @@ check "aborta com o código de recusa (3), não com falha genérica" test "$RC" 
 check "explica em português que é retrocesso" grep -q "ANTERIOR à que já está instalada" "$OUTFILE"
 check "não chegou a rodar o backup" test ! -f "$BACKUP_MARK"
 check "NÃO rebobinou: o HEAD é o mesmo de antes" test "$(git rev-parse HEAD)" = "$HEAD_ANTES"
-check "a imagem do .env continua intacta" grep -q '^APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:latest$' .env
+check "a imagem do .env continua intacta" grep -q "^APP_IMAGE=${NS}/deskcommcrm:latest$" .env
 check "completou a história para poder decidir (deixou de ser raso)" \
   test "$(git rev-parse --is-shallow-repository)" = "false"
 
@@ -297,7 +306,7 @@ bash hostgator-setup-kit/agent.sh > "$WORK/agente.out" 2>&1
 check "o agente chegou a executar o update (o app de mentira pediu)" \
   grep -q '"kind":"run_progress"\|"kind":"run_result"' "$CURL_LOG"
 check "NÃO reiniciou o container" test -z "$(grep -F 'up -d app' "$DOCKER_LOG" || true)"
-check "NÃO reescreveu a imagem do .env" grep -q '^APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:latest$' .env
+check "NÃO reescreveu a imagem do .env" grep -q "^APP_IMAGE=${NS}/deskcommcrm:latest$" .env
 check "reportou 'failed', não 'failed_rolled_back'" \
   test -n "$(grep -F '"status":"failed"' "$CURL_LOG" || true)"
 check "não reportou rollback nenhum" test -z "$(grep -F 'failed_rolled_back' "$CURL_LOG" || true)"
@@ -368,21 +377,21 @@ pin_caso() {  # pin_caso <descrição> <conteúdo do .env> <esperado>
   check "$d" test "$r" = "$esperado"
 }
 pin_caso "app pinado + worker/scheduler AUSENTES → acusa os dois" \
-  "APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:1.3.0" "worker scheduler"
+  "APP_IMAGE=${NS}/deskcommcrm:1.3.0" "worker scheduler"
 pin_caso "app pinado + worker em canal móvel → acusa" \
-  "APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:1.3.0
-WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:stable
-SCHEDULER_IMAGE=ghcr.io/melgarafael/deskcomm-scheduler:1.3.0" "worker"
+  "APP_IMAGE=${NS}/deskcommcrm:1.3.0
+WORKER_IMAGE=${NS}/deskcomm-worker:stable
+SCHEDULER_IMAGE=${NS}/deskcomm-scheduler:1.3.0" "worker"
 pin_caso "as três na mesma versão → silêncio" \
-  "APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:1.3.0
-WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:1.3.0
-SCHEDULER_IMAGE=ghcr.io/melgarafael/deskcomm-scheduler:1.3.0" ""
+  "APP_IMAGE=${NS}/deskcommcrm:1.3.0
+WORKER_IMAGE=${NS}/deskcomm-worker:1.3.0
+SCHEDULER_IMAGE=${NS}/deskcomm-scheduler:1.3.0" ""
 pin_caso "app num canal deliberado (:latest) → não é 'metade', silêncio" \
-  "APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:latest" ""
+  "APP_IMAGE=${NS}/deskcommcrm:latest" ""
 pin_caso "valores entre aspas, como o install grava → silêncio" \
-  "APP_IMAGE='ghcr.io/melgarafael/deskcommcrm:1.3.0'
-WORKER_IMAGE='ghcr.io/melgarafael/deskcomm-worker:1.3.0'
-SCHEDULER_IMAGE='ghcr.io/melgarafael/deskcomm-scheduler:1.3.0'" ""
+  "APP_IMAGE="${NS}/deskcommcrm:1.3.0"
+WORKER_IMAGE="${NS}/deskcomm-worker:1.3.0"
+SCHEDULER_IMAGE="${NS}/deskcomm-scheduler:1.3.0"" ""
 rm -f "$PROJ/.env.pin"
 
 
@@ -401,7 +410,7 @@ cat > "$PIN_DIR/bin/docker" <<'STUBDOCKER'
 #!/usr/bin/env bash
 # inspect de contêiner → devolve o nome da imagem; de imagem → devolve a versão
 case "$*" in
-  *"Config.Image"*)  printf 'ghcr.io/melgarafael/deskcomm-worker:stable
+  *"Config.Image"*)  printf '${NS}/deskcomm-worker:stable
 ' ;;
   *"image.version"*) printf '%s
 ' "${DUBLE_VERSION:-1.3.0}" ;;
@@ -417,10 +426,10 @@ autopin() {  # autopin <conteúdo do .env> → ecoa o que a função corrigiu
       ". '$KIT_DIR_TESTE/_common.sh'; completar_pin_ausente .env" 2>/dev/null ) || true
 }
 
-R="$(autopin "APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:1.3.0")"
+R="$(autopin "APP_IMAGE=${NS}/deskcommcrm:1.3.0")"
 check "chave AUSENTE → preenche os dois" test "$R" = "worker scheduler"
 check "  e grava a versão da imagem em execução, não um canal" \
-  grep -q "^WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:1.3.0$" "$PIN_DIR/.env"
+  grep -q "^WORKER_IMAGE=${NS}/deskcomm-worker:1.3.0$" "$PIN_DIR/.env"
 check "  com pull_policy de tag imutável" \
   grep -q "^WORKER_PULL_POLICY=missing$" "$PIN_DIR/.env"
 
@@ -432,21 +441,21 @@ check "  e não altera um byte do .env" test "$ANTES_MD5" = "$(md5sum "$PIN_DIR/
 
 # A REGRA QUE PROTEGE O OPERADOR. Se esta cair, o cron passa a sobrescrever
 # escolha explícita — e a decisão de implementar a autocorreção deixa de valer.
-R="$(autopin "APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:1.3.0
-WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:stable
-SCHEDULER_IMAGE=ghcr.io/melgarafael/deskcomm-scheduler:stable")"
+R="$(autopin "APP_IMAGE=${NS}/deskcommcrm:1.3.0
+WORKER_IMAGE=${NS}/deskcomm-worker:stable
+SCHEDULER_IMAGE=${NS}/deskcomm-scheduler:stable")"
 check "canal móvel EXPLÍCITO → não toca (é decisão de quem opera)" test -z "$R"
 check "  o :stable escolhido continua lá, intacto" \
-  grep -q "^WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:stable$" "$PIN_DIR/.env"
+  grep -q "^WORKER_IMAGE=${NS}/deskcomm-worker:stable$" "$PIN_DIR/.env"
 
-R="$(autopin "APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:1.3.0
-WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:1.3.0
-SCHEDULER_IMAGE=ghcr.io/melgarafael/deskcomm-scheduler:1.3.0")"
+R="$(autopin "APP_IMAGE=${NS}/deskcommcrm:1.3.0
+WORKER_IMAGE=${NS}/deskcomm-worker:1.3.0
+SCHEDULER_IMAGE=${NS}/deskcomm-scheduler:1.3.0")"
 check "já pinada → silêncio" test -z "$R"
 
 # Imagem sem o label (build local): não há versão para gravar, e inventar uma
 # seria pior que não fazer nada.
-R="$( printf 'APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:1.3.0\n' > "$PIN_DIR/.env"
+R="$( printf "APP_IMAGE=${NS}/deskcommcrm:1.3.0\n" > "$PIN_DIR/.env"
       cd "$PIN_DIR" && PATH="$PIN_DIR/bin:$PATH" DUBLE_VERSION="<no value>" bash -c \
         ". '$KIT_DIR_TESTE/_common.sh'; completar_pin_ausente .env" 2>/dev/null || true )"
 check "imagem sem label de versão → não inventa pin" test -z "$R"

--- a/tests/unit/namespace-das-imagens.test.ts
+++ b/tests/unit/namespace-das-imagens.test.ts
@@ -1,0 +1,270 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * A ÂNCORA do namespace das imagens publicadas.
+ *
+ * ── Por que este arquivo existe ────────────────────────────────────────────
+ *
+ * `tests/shell/update-guard.test.sh` e `hostgator-setup-kit/test-validators.sh`
+ * repetiam `ghcr.io/melgarafael` à mão em 31 lugares — fixtures E asserções.
+ * Isso amarrava a suíte a UM publicador: um fork que publica as próprias
+ * imagens ficava vermelho em 4 casos sem ter quebrado nada, com a mensagem de
+ * falha apontando para o valor "certo" do upstream. Derivar tudo de `IMG_NS`
+ * conserta isso — e é o que o PR #397 (@Clalber) fez.
+ *
+ * Só que aquele literal repetido era, sem ninguém ter decidido isso, a ÚNICA
+ * canária do repo contra um `IMG_NS` errado. Medido nas duas direções, com a
+ * mesma sabotagem (`IMG_NS="ghcr.io/erradissimo"`):
+ *
+ *   main  → `bash tests/shell/update-guard.test.sh` sai 1, com 4 ✗
+ *   #397  → sai 0. Todo o `pnpm test:shell` fica VERDE
+ *
+ * Derivando em todo lugar, os testes passam a CONCORDAR ENTRE SI sobre o valor
+ * errado — a família do teste que mede a si mesmo. A resposta não é desfazer a
+ * elegância: é derivar em todos os lugares e ter UM ponto, um só, que assere o
+ * valor literal. Este arquivo é esse ponto.
+ *
+ * ── O que uma âncora precisa ter para valer ────────────────────────────────
+ *
+ * Asserir o literal contra ele mesmo seria decorativo. Os casos daqui cruzam
+ * `IMG_NS` com as OUTRAS declarações independentes do mesmo namespace — o
+ * default do compose que o cliente roda, o `.env` de exemplo que ele copia e o
+ * workflow que de fato publica —, e a catraca no fim impede que a repetição
+ * volte a se espalhar. Sabotado nas quatro direções, com a previsão anotada
+ * antes de cada rodada:
+ *
+ *   IMG_NS trocado só no kit          → 7 ✗  (a âncora + as 6 travessias)
+ *   IMG_NS trocado de forma COERENTE  → 1 ✗  (só a âncora — o desenho todo)
+ *   uma imagem renomeada só no kit    → 3 ✗  (compose, .env e a matriz do CI)
+ *   literal de volta num teste        → 1 ✗  (só a catraca)
+ *
+ * Roda em `verify` (check obrigatório), sem shell, sem docker.
+ */
+
+const RAIZ = process.cwd();
+
+const COMUM = fs.readFileSync(path.join(RAIZ, "hostgator-setup-kit/_common.sh"), "utf8");
+const COMPOSE = fs.readFileSync(path.join(RAIZ, "docker-compose.prod.yml"), "utf8");
+const PUBLICA = fs.readFileSync(path.join(RAIZ, ".github/workflows/publish-image.yml"), "utf8");
+const ENV_EXEMPLO = fs.readFileSync(path.join(RAIZ, ".env.hostgator.example"), "utf8");
+
+/** O valor literal que este repositório publica. A âncora. */
+const NAMESPACE_DESTE_REPO = "ghcr.io/melgarafael";
+
+/**
+ * Um fork que publica as próprias imagens muda `IMG_NS` — e precisa mudar junto
+ * os outros dois arquivos que não têm de onde derivar. Esta frase é a que ele lê
+ * quando a âncora fica vermelha, para não procurar defeito onde não há: ela diz
+ * o que fazer, não que ele errou.
+ */
+const RECADO_AO_FORK =
+  "Publicando as próprias imagens? Troque o namespace em três lugares, e só neles: " +
+  "IMG_NS em hostgator-setup-kit/_common.sh, o default das três linhas `image:` de " +
+  "docker-compose.prod.yml, e as três *_IMAGE de .env.hostgator.example. Depois " +
+  "atualize NAMESPACE_DESTE_REPO neste arquivo. Nenhum OUTRO arquivo do repo " +
+  "repete esse valor — todos derivam de IMG_NS, e a catraca no fim deste arquivo " +
+  "existe para que continue assim.";
+
+function imgNs(): string {
+  const m = COMUM.match(/^IMG_NS="([^"]+)"$/m);
+  if (!m) throw new Error("não achei a linha IMG_NS= em hostgator-setup-kit/_common.sh");
+  return m[1];
+}
+
+/** Os três repositórios de imagem, na ordem em que `_common.sh` os declara. */
+function reposDoKit(): string[] {
+  return ["IMG_APP", "IMG_WORKER", "IMG_SCHEDULER"].map((chave) => {
+    const m = COMUM.match(new RegExp(`^${chave}="\\$\\{IMG_NS\\}/([^"]+)"$`, "m"));
+    if (!m) {
+      throw new Error(
+        `${chave} não é mais derivada de \${IMG_NS} em _common.sh. ` +
+          "Se ela passou a repetir o namespace, a fonte única deixou de existir.",
+      );
+    }
+    return m[1];
+  });
+}
+
+describe("o namespace das imagens tem uma âncora, e uma só", () => {
+  it("IMG_NS é o valor literal que este repositório publica", () => {
+    expect(imgNs(), RECADO_AO_FORK).toBe(NAMESPACE_DESTE_REPO);
+  });
+
+  it("IMG_NS tem a forma <registry>/<dono> — a única que o GHCR publica", () => {
+    // O workflow publica em `${REGISTRY}/${github.repository_owner}/${nome}`:
+    // exatamente dois segmentos antes do nome da imagem. Um IMG_NS com três
+    // (ou com um) monta uma referência que o registry nunca vai ter, e o
+    // sintoma chega só no `docker compose pull` da VPS do cliente.
+    expect(imgNs().split("/")).toHaveLength(2);
+  });
+});
+
+describe("o default do compose diz o mesmo que o kit", () => {
+  // Por que isto pega o que a âncora sozinha não pega: `docker-compose.prod.yml`
+  // é a SEGUNDA declaração independente de onde as imagens moram, e a única que
+  // vale quando `APP_IMAGE` não está no `.env`. YAML não deriva de shell, então
+  // as duas só andam juntas se alguém as comparar — é este caso.
+  // Os nomes vêm de `reposDoKit()`, não de literais aqui: assim o compose e o
+  // `.env` de exemplo são conferidos contra IMG_APP/IMG_WORKER/IMG_SCHEDULER, e
+  // renomear uma imagem só no `_common.sh` fica vermelho. Com os nomes fixos
+  // neste arquivo, essa renomeação passaria — o teste concordaria com o compose
+  // sobre um nome que o kit já não usa.
+  //
+  // A leitura acontece DENTRO de cada `it`, não no corpo do describe: lá, um
+  // `_common.sh` fora de forma derrubava a coleta do arquivo inteiro, e o que
+  // chegava ao resumo era "no tests" em vez do caso que reprovou.
+  const CHAVES = ["APP_IMAGE", "WORKER_IMAGE", "SCHEDULER_IMAGE"] as const;
+
+  CHAVES.forEach((chave, i) => {
+    it(`o default de ${chave} usa o namespace de IMG_NS`, () => {
+      const m = COMPOSE.match(new RegExp(`^\\s*image: \\$\\{${chave}:-([^}]+)\\}`, "m"));
+      expect(m, `não achei a linha \`image: \${${chave}:-…}\` em docker-compose.prod.yml`)
+        .not.toBeNull();
+      expect(m![1]).toBe(`${imgNs()}/${reposDoKit()[i]}:stable`);
+    });
+
+    // `.env.hostgator.example` é DADO — um template que o operador copia. Não há
+    // de onde derivar dentro de um arquivo de env, então ele é a última cópia
+    // autorizada do literal, e existe este caso para que ela seja uma cópia
+    // CONFERIDA em vez de uma afirmação solta.
+    it(`o piso de ${chave} no .env de exemplo usa o namespace de IMG_NS`, () => {
+      const m = ENV_EXEMPLO.match(new RegExp(`^${chave}=(\\S+)`, "m"));
+      expect(m, `não achei \`${chave}=\` em .env.hostgator.example`).not.toBeNull();
+      expect(m![1]).toBe(`${imgNs()}/${reposDoKit()[i]}:stable`);
+    });
+  });
+});
+
+describe("o kit aponta para o que o CI realmente publica", () => {
+  it("o registry do kit é o mesmo do workflow de publicação", () => {
+    const m = PUBLICA.match(/^\s*REGISTRY:\s*(\S+)$/m);
+    expect(m, "não achei `REGISTRY:` em .github/workflows/publish-image.yml").not.toBeNull();
+    expect(imgNs().split("/")[0]).toBe(m![1]);
+  });
+
+  it("o workflow ainda deriva o dono do repositório, em vez de fixar um", () => {
+    // Se esta linha virar um literal, o namespace passa a ter três donos e um
+    // fork perde a única parte que já funcionava sozinha para ele.
+    expect(PUBLICA).toContain(
+      "images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.name }}",
+    );
+  });
+
+  it("as três imagens do kit são exatamente as três que o workflow constrói", () => {
+    const naMatriz = [...PUBLICA.matchAll(/^\s{10}- name: (\S+)$/gm)].map((m) => m[1]);
+    expect(naMatriz.length, "a matriz de publish-image.yml não tem mais três imagens").toBe(3);
+    expect([...naMatriz].sort()).toEqual([...reposDoKit()].sort());
+  });
+});
+
+/**
+ * A catraca que mantém a elegância do #397 de pé.
+ *
+ * Sem ela, o literal volta a se espalhar — e uma âncora que convive com 30
+ * cópias não é âncora, é a primeira de 31 afirmações que podem divergir.
+ * A allowlist tem quatro entradas e só encolhe:
+ *
+ *   _common.sh               a FONTE: o literal nasce aqui
+ *   docker-compose.prod.yml  YAML não deriva de shell; conferido acima
+ *   .env.hostgator.example   template que o operador copia; conferido acima
+ *   este arquivo             a âncora, que precisa do literal para ancorar
+ */
+describe("catraca: ninguém mais repete o namespace", () => {
+  const PERMITIDO = new Set([
+    "hostgator-setup-kit/_common.sh",
+    "docker-compose.prod.yml",
+    ".env.hostgator.example",
+    "tests/unit/namespace-das-imagens.test.ts",
+  ]);
+
+  /**
+   * Varre o DISCO (`grep -r`), não o índice do git: arquivo novo ainda
+   * untracked é justamente o que um gate por `git ls-files` não enxerga.
+   *
+   * `grep -r` (minúsculo) não desce por symlink de diretório — o que mantém
+   * `node_modules` de worktree fora do caminho mesmo quando ele é um link.
+   *
+   * A primeira versão fazia isto com `readdirSync` recursivo + `readFileSync`:
+   * levava 8s numa rodada e ESTOUROU o timeout de 15s na seguinte, na mesma
+   * máquina. Um gate que reprova por lentidão não distingue defeito de disco
+   * ocupado — e o conserto para o qual ele empurra é aumentar o timeout.
+   *
+   * De fora ficam artefato e PROSA: documentação cita o namespace de propósito
+   * (ADR, CHANGELOG, runbooks) e não monta string em runtime. A catraca vale
+   * para o que executa.
+   */
+  function reincidentes(): string[] {
+    const excluiDir = [
+      ".git",
+      "node_modules",
+      ".next",
+      "docs",
+      "coverage",
+      "playwright-report",
+      "test-results",
+      ".superpowers",
+      // Prova visual (PNG, trace) e worktrees aninhados — 42 MB e 4,8 s de
+      // varredura entre os dois, medido. Nenhum dos dois monta referência de
+      // imagem: `evidence/` é artefato de QA e `.claude/worktrees/` são OUTRAS
+      // árvores do repo, com o gate delas próprio.
+      "evidence",
+      ".claude",
+    ].map((d) => `--exclude-dir=${d}`);
+    // `.bak`/`.orig`/`.rej`/`~` são sobra de editor e de `sed -i.bak`. Sem isto,
+    // uma sabotagem local deixa o gate vermelho pelo motivo errado.
+    const excluiArq = ["*.md", "*.bak", "*.orig", "*.rej", "*~"].map((g) => `--exclude=${g}`);
+
+    let saida = "";
+    try {
+      saida = execFileSync(
+        "grep",
+        ["-rlF", NAMESPACE_DESTE_REPO, ".", ...excluiDir, ...excluiArq],
+        { cwd: RAIZ, encoding: "utf8", maxBuffer: 8 * 1024 * 1024 },
+      );
+    } catch (e) {
+      // grep sai 1 quando não casa nada — que aqui é o resultado bom. Qualquer
+      // outro código é o INSTRUMENTO quebrado, e ele precisa gritar: um catch
+      // que devolvesse [] daria verde com a varredura morta.
+      const err = e as { status?: number; stderr?: string };
+      if (err.status !== 1) {
+        throw new Error(`a varredura do namespace não rodou (grep saiu ${err.status}): ${err.stderr ?? ""}`);
+      }
+    }
+    return saida
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => l.replace(/^\.\//, ""))
+      .filter((rel) => !PERMITIDO.has(rel))
+      .sort();
+  }
+
+  it("a varredura enxerga o literal onde ele está — senão o silêncio não vale nada", () => {
+    // O controle do instrumento. Sem ele, um `grep` que devolvesse vazio por
+    // qualquer motivo (flag errada, cwd errado) leria como "ninguém repete".
+    //
+    // O alvo é ESTE arquivo, e não o compose: um fork que renomeia o namespace
+    // de forma coerente muda o compose junto, e o controle apontado para lá
+    // ficaria vermelho por tabela — dois vermelhos onde o desenho promete um.
+    // Aqui o literal existe por construção, em `NAMESPACE_DESTE_REPO`.
+    const alvo = "tests/unit/namespace-das-imagens.test.ts";
+    const saida = execFileSync("grep", ["-rlF", NAMESPACE_DESTE_REPO, alvo], {
+      cwd: RAIZ,
+      encoding: "utf8",
+    });
+    expect(saida.trim()).toBe(alvo);
+  });
+
+  it("o literal do namespace só aparece nos arquivos permitidos", () => {
+    expect(
+      reincidentes(),
+      "estes arquivos voltaram a escrever o namespace à mão. Derive de IMG_NS " +
+        "(shell: `source _common.sh`, ou leia-o como tests/shell/update-guard.test.sh faz; " +
+        "TS: leia-o como este arquivo faz) — senão a âncora deixa de ser única e um " +
+        "namespace errado fica verde em todo lugar.",
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/namespace-das-imagens.test.ts
+++ b/tests/unit/namespace-das-imagens.test.ts
@@ -71,7 +71,10 @@ const RECADO_AO_FORK =
 
 function imgNs(): string {
   const m = COMUM.match(/^IMG_NS="([^"]+)"$/m);
-  if (!m) throw new Error("não achei a linha IMG_NS= em hostgator-setup-kit/_common.sh");
+  // O grupo é obrigatório no padrão, mas `noUncheckedIndexedAccess` não sabe
+  // disso — e a checagem explícita é melhor que um `!`: se um dia o padrão
+  // ganhar um grupo opcional, a mensagem aqui diz o que aconteceu.
+  if (!m?.[1]) throw new Error("não achei a linha IMG_NS= em hostgator-setup-kit/_common.sh");
   return m[1];
 }
 
@@ -79,7 +82,7 @@ function imgNs(): string {
 function reposDoKit(): string[] {
   return ["IMG_APP", "IMG_WORKER", "IMG_SCHEDULER"].map((chave) => {
     const m = COMUM.match(new RegExp(`^${chave}="\\$\\{IMG_NS\\}/([^"]+)"$`, "m"));
-    if (!m) {
+    if (!m?.[1]) {
       throw new Error(
         `${chave} não é mais derivada de \${IMG_NS} em _common.sh. ` +
           "Se ela passou a repetir o namespace, a fonte única deixou de existir.",


### PR DESCRIPTION
> Estende o #397 (@Clalber). O trabalho de derivação é dele; este PR devolve a proteção que a derivação removia.

## A pergunta

*"Não tem como ter elegância e proteção ao mesmo tempo?"*

Tem. **Derivar em todos os lugares e ter UM ponto, um só, que assere o valor literal.**

## O problema medido

O #397 está certo no diagnóstico: `ghcr.io/melgarafael` aparecia à mão em 31 lugares — fixtures **e** asserções — e isso amarrava a suíte a um único publicador. Um fork ficava vermelho em 4 casos sem ter quebrado nada, com a mensagem apontando para o valor "certo" do *upstream*. Quem investigasse procuraria defeito onde não há.

Só que aquele literal repetido era, sem ninguém ter decidido isso, a **única canária** do repo contra um `IMG_NS` errado. Mesma sabotagem (`IMG_NS="ghcr.io/erradissimo"`), nas duas bases:

| base | `bash tests/shell/update-guard.test.sh` |
|---|---|
| `main` | sai **1**, com **4 ✗** |
| #397 | sai **0** — e todo o `pnpm test:shell` fica verde |

Derivando em todo lugar, os testes passam a **concordar entre si sobre o valor errado**. É a família do teste que mede a si mesmo.

## A âncora — `tests/unit/namespace-das-imagens.test.ts`

Asserir o literal contra ele mesmo seria decorativo. Os casos cruzam `IMG_NS` com as **outras declarações independentes** do mesmo namespace:

- o default das três linhas `image:` de `docker-compose.prod.yml` — YAML não deriva de shell, e é o valor que vale quando o `.env` não traz `APP_IMAGE`;
- as três `*_IMAGE` de `.env.hostgator.example` — template que o operador copia;
- a **matriz** de `publish-image.yml` (quem de fato constrói as três imagens) e o `REGISTRY:` de lá, que tem de ser o prefixo do `IMG_NS`;
- que o workflow siga derivando `github.repository_owner` em vez de fixar um dono.

E uma **catraca**: nenhum arquivo que *executa* pode repetir o literal, fora os três que não têm de onde derivar. É ela que mantém a elegância do #397 de pé — uma âncora que convive com 30 cópias não é âncora.

Roda em `verify` (check obrigatório). Sem shell, sem docker.

## Sabotado, com a previsão anotada antes de cada rodada

| sabotagem | previ | mediu | quem reprovou |
|---|---|---|---|
| `IMG_NS` trocado só no kit | 7 | **7 ✗** | a âncora + as 6 travessias |
| `IMG_NS` trocado de forma **coerente** nos 3 | 1 | **1 ✗** | **só a âncora** |
| uma imagem renomeada só no kit | 3 | **3 ✗** | compose, `.env`, matriz do CI |
| literal de volta numa asserção do `update-guard` | 1 | **1 ✗** | só a catraca |

A segunda linha é a resposta à pergunta: **renomeação coerente reprova em um lugar, e é o lugar que diz o que trocar.** A mensagem daquele caso lista os três arquivos e não acusa quem seguiu a recomendação.

Duas divergências entre previsão e medida apareceram no caminho, e as duas eram do instrumento, não do desenho: a catraca pegou o `.bak` que meu próprio `sed -i.bak` deixou (filtro adicionado), e o controle do `grep` estava ancorado no compose, que a sabotagem coerente renomeia (repontado para este arquivo, onde o literal existe por construção).

## Dois defeitos no #397, achados ao medir

**1. O caso "valores entre aspas, como o install grava" perdeu as aspas.** As duplas internas *fecham* a string do shell. Medido: o conteúdo sai sem aspa nenhuma, e o caso fica **byte-a-byte igual** ao "as três na mesma versão" três linhas acima. O rótulo passou a mentir sobre o que era exercitado. Aspas simples dentro das duplas resolvem — ficam literais e o `${NS}` ainda expande.

> Ressalva honesta: medi se esse caso distingue a remoção do strip de aspas de `valor_do_env`, e **ele não distingue** — a saída é vazia nos dois cenários. O conserto devolve ao caso o fixture que o nome promete; não afirmo que devolve poder de detecção que ele nunca teve.

**2. O dublê de `docker` vive num heredoc *quoted*** (`<<'STUBDOCKER'`), então `${NS}` não era expandido na escrita: o dublê passou a devolver a string literal `${NS}/deskcomm-worker:stable`. Agora resolve em tempo de execução (daí o `export NS`) e morre alto com `:?` se a variável não vier, em vez de devolver um nome começando em `/`.

```console
$ com NS:  [ghcr.io/melgarafael/deskcomm-worker:stable]
$ sem NS:  docker: linha 10: NS: dublê de docker sem NS no ambiente   exit=1
```

## Dois lugares que o #397 não alcançou — achados pela catraca

- **`hostgator-setup-kit/update.sh`** — o fallback de `image_desatualizada` era o literal, num arquivo que já faz `source _common.sh`. Num fork, um `.env` sem `APP_IMAGE` comparava o digest local contra o registry do *upstream*. Agora deriva de `${IMG_APP}`. **Para este repo o valor é idêntico, byte a byte.**
- **`hostgator-setup-kit/diagnostico.sh`** — prosa citando o namespace concreto num relato de sabotagem, onde `<namespace>` diz o mesmo.

## Gates

| gate | resultado |
|---|---|
| `pnpm test:shell` | **exit 0**, zero `✗` nos 4 scripts |
| `pnpm typecheck` | **exit 0** |
| `pnpm lint` | **exit 0** (289 warnings, todos pré-existentes) |
| `pnpm test:unit` | **exit 0** — `Test Files 575 passed`, `Tests 6409 passed \| 1 expected fail` |

A suíte completa rodou na versão imediatamente anterior ao último commit, que só troca `m[1]` por `m?.[1]` para o `noUncheckedIndexedAccess`; o arquivo novo foi re-rodado isolado depois disso (13/13).

## Sem fragmento em `.changes/`

Nada aqui muda comportamento visível a quem opera uma VPS **deste** repositório: a única mudança de código de produção é o fallback do `update.sh`, e `${IMG_APP}:latest` resolve para exatamente a mesma string que o literal que ele substitui. O resto é teste e comentário. Se o mantenedor preferir um fragmento `nada_mudou`, acrescento.

Co-Authored-By: Clalber

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013edSd7UwyjoaDCwwpksiv1
