### PR TITLE
Os fragmentos das cinco contribuições, escritos por quem tria

### DIFF
--- a/.changes/instalacao-nova-nao-exige-verificacao-em-duas-etapas.md
+++ b/.changes/instalacao-nova-nao-exige-verificacao-em-duas-etapas.md
@@ -1,0 +1,15 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Instalação nova não obriga mais a verificação em duas etapas logo de cara
+---
+
+Quem instalava pelo instalador automático caía, logo depois do primeiro acesso,
+numa tela obrigatória pedindo para cadastrar a verificação em duas etapas — um
+passo que o assistente de instalação nunca anunciou. A verificação é opcional
+desde a versão 1.0 e se liga em Configurações › Segurança, mas o instalador não
+acompanhou essa decisão e deixava o valor obrigatório.
+
+Quem já instalou e já configurou a verificação não é afetado: nada é desligado
+de quem já tem. A mudança vale só para instalações novas, que passam a nascer
+como sempre foi a intenção — com a escolha nas mãos de quem administra.

--- a/.changes/o-erro-do-agente-para-de-morrer-no-log.md
+++ b/.changes/o-erro-do-agente-para-de-morrer-no-log.md
@@ -1,0 +1,13 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Quando a IA falha ao responder, o erro deixa de sumir
+---
+
+A peça que faz a IA responder às conversas registrava as próprias falhas apenas
+num log que ninguém lê. Se ela parava de responder por um erro, não havia sinal
+em lugar nenhum — só o silêncio no WhatsApp do cliente. Agora esse erro é
+enviado ao serviço de monitoramento, o mesmo que o resto do sistema já usava.
+
+Quem opera não precisa fazer nada, e nenhum dado de conversa é enviado: o
+sistema já limpa o conteúdo antes de mandar.

--- a/.changes/o-instalador-para-de-engolir-o-valor-da-configuracao.md
+++ b/.changes/o-instalador-para-de-engolir-o-valor-da-configuracao.md
@@ -1,0 +1,14 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O instalador para de confundir comentário com valor de configuração
+---
+
+No arquivo de exemplo que serve de base para a configuração da VPS, as
+explicações ficavam na mesma linha dos valores. O instalador lê esse arquivo
+linha a linha e tratava a explicação como parte do valor — então uma senha, um
+endereço ou uma chave podiam chegar ao servidor com um texto extra colado no
+fim, e o erro só aparecia depois, num lugar sem relação com a causa.
+
+As explicações passaram para a linha de cima. Quem já tem o servidor rodando não
+precisa refazer nada; a mudança protege quem instala do zero a partir de agora.

--- a/.changes/quem-clona-o-projeto-no-windows.md
+++ b/.changes/quem-clona-o-projeto-no-windows.md
@@ -1,0 +1,13 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Quem baixa o projeto no Windows consegue rodar os testes
+---
+
+Isto é do nosso processo de desenvolvimento, não do sistema que você usa. Quem
+baixava o projeto no Windows não conseguia rodar a bateria de testes do banco:
+o sistema operacional alterava os arquivos de banco de dados na cópia, e uma
+conferência de integridade recusava tudo antes de o primeiro teste rodar.
+
+Para quem opera uma VPS nada muda — o servidor sempre rodou em Linux, onde a
+alteração não acontece.

--- a/.changes/tabela-nova-sem-isolamento-nao-passa.md
+++ b/.changes/tabela-nova-sem-isolamento-nao-passa.md
@@ -1,0 +1,14 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Uma rede a mais contra vazamento entre empresas
+---
+
+O sistema separa os dados de cada empresa por uma regra no banco, e essa regra
+precisa ser ligada tabela por tabela. Faltava uma verificação automática que
+recusasse uma tabela nova sem essa proteção — a conferência dependia de alguém
+lembrar. Agora ela é feita a cada mudança, e o que já existe está registrado
+como dívida conhecida, para a lista só diminuir.
+
+Nada muda para quem opera: é uma proteção contra um erro futuro, não a correção
+de um vazamento existente.


### PR DESCRIPTION
Nenhum dos cinco PRs trouxe fragmento, e nenhum autor tinha como saber — a disciplina entrou ontem e três são contribuidores externos. A doutrina de triagem diz o que fazer: **quem tria escreve**, em vez de devolver.

Um por PR, todos `nada_mudou`, escritos da cadeira de quem opera a VPS:

| PR | fragmento |
|---|---|
| #380 | quando a IA falha ao responder, o erro deixa de sumir |
| #386 | uma rede a mais contra vazamento entre empresas |
| #392 | quem baixa o projeto no Windows consegue rodar os testes |
| #395 | instalação nova não obriga a verificação em duas etapas de cara |
| #396 | o instalador para de confundir comentário com valor |

O do **#395** exigiu conferir doutrina: `bootstrap-owner.ts` grava `mfa_required: false` explícito desde 14/08, o `install.sh` não acompanhou. A régua da casa distingue *"ligar por padrão numa instalação nova"* de *"desligar o que alguém já tem"* — só a segunda está vetada.

**Medido com os cinco aplicados juntos**, cada exit lido do comando:

```
TC_EXIT=0    typecheck zerado
LINT_EXIT=0  0 errors
LC_EXIT=0    nenhuma dívida nova
UNIT_EXIT=0  574 arquivos, 6392 testes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)