### PR TITLE
fix(ia): pausar um agente passa a calá-lo em todos os caminhos

### DIFF
--- a/.changes/agente-pausado-nao-atende.md
+++ b/.changes/agente-pausado-nao-atende.md
@@ -1,0 +1,15 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Pausar um agente de IA agora o cala de verdade
+---
+
+Pausar o único agente publicado da organização fazia um agente que a tela
+chamava de "Rascunho" voltar a responder no WhatsApp pelo caminho antigo de
+resposta — com o texto do cadastro, sem as ferramentas nem os limites da versão
+publicada.
+
+Junto disso, a tela passou a dizer a mesma coisa que o motor faz: o seletor de
+dono de negócio deixou de esconder agentes publicados (e de oferecer os
+pausados), e o selo da Inbox só diz "Automático" quando existe mesmo alguém para
+atender.

--- a/app/api/v1/ai/agents/assignable/route.ts
+++ b/app/api/v1/ai/agents/assignable/route.ts
@@ -9,11 +9,26 @@
  * deliberada e MÍNIMA que a rota de humanos já documenta. Exposto o mínimo: id,
  * nome e a versão PUBLICADA no momento da leitura.
  *
- * Esta rota é um PICKER, e só isso: `is_active` e `archived_at` filtrados de
- * propósito, porque agente desligado não deve receber negócio novo. Quem é o
- * dono ATUAL de um lead é outra pergunta e NÃO se responde aqui — vem resolvido
- * do board (`owner_agent`), sem esses filtros. Relaxar os filtros daqui para
- * "consertar" um nome que não aparece no card é consertar no lugar errado.
+ * Esta rota é um PICKER, e só isso: agente desligado não deve receber negócio
+ * novo. Quem é o dono ATUAL de um lead é outra pergunta e NÃO se responde aqui
+ * — vem resolvido do board (`owner_agent`), sem esses filtros. Relaxar o filtro
+ * daqui para "consertar" um nome que não aparece no card é consertar no lugar
+ * errado.
+ *
+ * ⚠️ O filtro era `.eq("is_active", true)`, e ele errava nos DOIS sentidos —
+ * porque `is_active` não é "está ligado" para `mcp_agent`, que é o que a tela
+ * cria:
+ *
+ *   - **escondia quem atende:** "Novo agente" grava `is_active: false`
+ *     (`app/app/ai/agents/[id]/_actions.ts`) e publicar nunca religa. Todo
+ *     agente criado pela tela e publicado ficava fora deste picker enquanto
+ *     respondia no WhatsApp;
+ *   - **oferecia quem não atende:** pausar limpa `published_version_id` e
+ *     deixa `is_active` de pé, então o agente pausado seguia listado como
+ *     destino de negócio.
+ *
+ * A régua agora é `agenteAtende` (`lib/ai/agents/no-ar.ts`), a mesma da tela e
+ * dos workers.
  *
  * Auth: cookie session; organization_id vem do JWT — nunca do body/query.
  * RLS-scoped (createClient), sem admin client: não há nada aqui que a RLS do
@@ -24,6 +39,7 @@ import type { NextRequest } from "next/server";
 
 import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
+import { agenteAtende } from "@/lib/ai/agents/no-ar";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -44,20 +60,22 @@ export async function GET(_req: NextRequest): Promise<Response> {
   const supabase = await createClient();
   const { data: agents, error } = await supabase
     .from("ai_agents")
-    .select("id, name, published_version_id")
+    .select("id, name, published_version_id, kind, is_active, archived_at")
     .eq("organization_id", orgId)
-    .eq("is_active", true)
     .is("archived_at", null)
     .order("priority", { ascending: false })
     .order("created_at", { ascending: true });
 
   if (error) return fail("internal_error", error.message, 500, { requestId });
 
-  const rows = (agents ?? []) as Array<{
+  const rows = ((agents ?? []) as Array<{
     id: string;
     name: string;
     published_version_id: string | null;
-  }>;
+    kind: string | null;
+    is_active: boolean | null;
+    archived_at: string | null;
+  }>).filter(agenteAtende);
 
   const publishedIds = rows.map((a) => a.published_version_id).filter((v): v is string => !!v);
   const versionById = new Map<string, number>();

--- a/app/api/v1/ai/automatico-ativo/route.ts
+++ b/app/api/v1/ai/automatico-ativo/route.ts
@@ -15,16 +15,23 @@
  * quem não precisa. Esta devolve UM booleano: o mínimo que a tela precisa para
  * parar de afirmar o que não sabe.
  *
- * O predicado é o mesmo que o worker usa para escolher agente
- * (`is_active` + não arquivado), e não `published_version_id`: o motor moderno
- * exige versão publicada, mas o worker legado responde sem ela — perguntar pela
- * versão diria "não há automático" numa org onde há.
+ * O predicado é `agenteAtende` (`lib/ai/agents/no-ar.ts`), a MESMA régua que o
+ * worker legado e a tela usam — e não `published_version_id` sozinho: o motor
+ * moderno exige versão publicada, mas o worker legado responde sem ela, e
+ * perguntar só pela versão diria "não há automático" numa org onde há.
+ *
+ * Este parágrafo já disse "o mesmo predicado que o worker usa: `is_active` +
+ * não arquivado", e isso VENCEU quando o worker parou de escolher por
+ * `is_active` — a rota seguiu contando agente pausado como automático de pé,
+ * afirmando "IA atendendo" logo depois de o dono pausar. É por isso que os dois
+ * lados agora importam a mesma função em vez de descreverem um ao outro.
  */
 import { randomUUID } from "node:crypto";
 import type { NextRequest } from "next/server";
 
 import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
+import { agenteAtende } from "@/lib/ai/agents/no-ar";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -35,14 +42,16 @@ export async function GET(_req: NextRequest): Promise<Response> {
   if (!authz.ok) return authz.response;
 
   const supabase = await createClient();
-  const { count, error } = await supabase
+  // `head: true` + `count` não serve mais: a régua olha quatro colunas por
+  // linha, e uma contagem no banco não sabe respondê-la sem duplicar a regra em
+  // SQL — que é como ela se desencontrou da primeira vez.
+  const { data, error } = await supabase
     .from("ai_agents")
-    .select("id", { count: "exact", head: true })
+    .select("kind, is_active, published_version_id, archived_at")
     .eq("organization_id", authz.org.orgId)
-    .eq("is_active", true)
     .is("archived_at", null);
 
   if (error) return fail("internal_error", error.message, 500, { requestId });
 
-  return ok({ ativo: (count ?? 0) > 0 }, { requestId });
+  return ok({ ativo: (data ?? []).some(agenteAtende) }, { requestId });
 }

--- a/app/app/ai/agents/_components/AgentStatusBadge.test.ts
+++ b/app/app/ai/agents/_components/AgentStatusBadge.test.ts
@@ -12,30 +12,45 @@ const base = {
 } as unknown as AgentRow;
 
 describe("deriveAgentStatus", () => {
-  it("sem versão publicada é RASCUNHO, mesmo ativo", () => {
-    // O defeito de origem: o agente criado no onboarding (rag_bot, ativo, sem
-    // versão) aparecia como "Publicado" enquanto os dois runtimes o ignoram —
-    // ambos resolvem o agente por join com ai_agent_versions.
-    expect(deriveAgentStatus({ ...base, is_active: true, published_version_id: null })).toBe("draft");
+  it("mcp_agent sem versão publicada é RASCUNHO — a config dele vive na versão", () => {
+    // O defeito de origem: o agente do onboarding aparecia como "Publicado"
+    // enquanto nenhum runtime o executava. `createDefaultAgent.ts` grava
+    // `kind: "mcp_agent"`, e um mcp_agent sem ponteiro não é executável por
+    // motor nenhum — prompt, tools, funis e guardrails moram em
+    // `ai_agent_versions`. Este é o caso que aquele conserto protegia, e ele
+    // continua protegido.
     expect(deriveAgentStatus({ ...base, kind: "mcp_agent", published_version_id: null } as AgentRow)).toBe("draft");
+  });
+
+  it("rag_bot legado ATIVO e sem versão é PUBLICADO — porque ele responde ao cliente", () => {
+    // Este caso dizia "draft", com a justificativa de que "os dois runtimes o
+    // ignoram". MEDIDO como falso: existe um terceiro runtime,
+    // `workers/ai-response-worker.ts`, que seleciona exatamente por
+    // `is_active` e responde ao cliente por ele — ver
+    // `tests/unit/agente-pausado-nao-atende.test.ts`, caso "rag_bot legado
+    // ATIVO e nunca publicado continua atendendo", onde a requisição sai para
+    // api.anthropic.com. A tela chamava de "Rascunho" um agente no ar.
+    expect(deriveAgentStatus({ ...base, is_active: true, published_version_id: null })).toBe("published");
+  });
+
+  it("rag_bot legado DESATIVADO e sem versão é RASCUNHO", () => {
+    expect(deriveAgentStatus({ ...base, is_active: false, published_version_id: null })).toBe("draft");
   });
 
   it("com versão publicada e ativo é PUBLICADO", () => {
     expect(deriveAgentStatus({ ...base, published_version_id: "v1" } as AgentRow)).toBe("published");
   });
 
-  it("com versão publicada e inativo é PAUSADO (rag_bot legado)", () => {
-    expect(deriveAgentStatus({ ...base, published_version_id: "v1", is_active: false } as AgentRow)).toBe("paused");
-  });
-
-  it("mcp_agent publicado é PUBLICADO mesmo com is_active false", () => {
-    // `is_active` é semântica do rag_bot legado. Para mcp_agent os dois runtimes
-    // (lib/ai/dispatcher e lib/agent-engine/agent/agent-config) resolvem o agente
-    // só por published_version_id + archived_at — nenhum dos dois lê is_active.
-    // Lendo a coluna aqui, o badge dizia "Pausado" para um agente que está no ar,
-    // e o menu não oferecia saída: "Despausar" fica disabled para mcp_agent e
-    // unpauseAgentAction recusa com publish_required. Republicar também não
-    // liberava, porque fn_publish_ai_agent_version não toca is_active.
+  it("com versão publicada é PUBLICADO mesmo com is_active false — em QUALQUER kind", () => {
+    // `is_active` não decide nada quando há versão publicada: nem o
+    // agent-engine (`loadPublishedAgentConfig`) nem o dispatcher leem a coluna.
+    // O badge dizia "Pausado" para o rag_bot nessa situação — um agente que
+    // está no ar — e não oferecia saída: "Despausar" fica disabled para
+    // mcp_agent, `unpauseAgentAction` recusa com publish_required, e
+    // `fn_publish_ai_agent_version` não toca `is_active`.
+    expect(
+      deriveAgentStatus({ ...base, published_version_id: "v1", is_active: false } as AgentRow),
+    ).toBe("published");
     expect(
       deriveAgentStatus({
         ...base,

--- a/app/app/ai/agents/_components/AgentStatusBadge.tsx
+++ b/app/app/ai/agents/_components/AgentStatusBadge.tsx
@@ -1,32 +1,45 @@
 "use client";
 import { Badge } from "@/components/ui/badge";
-import { useT } from "@/hooks/i18n/useT";
+import { estadoDoAgente } from "@/lib/ai/agents/no-ar";
 import type { AgentRow } from "@/hooks/ai/useAgent";
 
 export type AgentStatus = "published" | "draft" | "paused" | "archived" | "invalid";
 
 /**
- * "Publicado" tem que significar "está no ar", e quem decide isso é o runtime:
- * tanto o dispatcher do CRM quanto o agent-engine só enxergam o agente pelo
- * `join ai_agent_versions on v.id = a.published_version_id`. Sem versão
- * publicada, o agente não responde a nada.
+ * "Publicado" tem que significar "está no ar", e quem decide isso é o runtime.
  *
- * Antes, para os agentes que não são `mcp_agent`, o badge saía apenas de
- * `is_active` — e o agente criado no onboarding (ativo, sem versão) aparecia
- * como "Publicado" enquanto era invisível para os dois runtimes. O dono do CRM
- * terminava a instalação achando que tinha um atendente de IA no ar.
+ * A régua mora em `lib/ai/agents/no-ar.ts` e é a MESMA que os workers e as
+ * rotas de picker importam. Ela morava aqui, e enquanto morou aqui foi copiada
+ * errado três vezes — a cópia do `ai-response-worker` (`.eq("is_active", true)`
+ * e nada mais) chegou a responder ao cliente por um agente que esta função
+ * rotulava "Rascunho".
+ *
+ * Duas coisas que este badge já afirmou e que foram MEDIDAS como falsas:
+ *
+ *   1. "o agente ativo sem versão é invisível para os dois runtimes" — ele é
+ *      visível para um terceiro, `workers/ai-response-worker.ts`, que responde
+ *      ao cliente por ele. Um `rag_bot` legado ativo e sem versão está NO AR, e
+ *      chamá-lo de "Rascunho" era a tela escondendo quem atende. O caso que
+ *      motivou aquele texto — o agente do onboarding — não regride: hoje
+ *      `createDefaultAgent.ts` grava `kind: "mcp_agent"`, e `mcp_agent` sem
+ *      ponteiro continua "Rascunho", porque a config dele vive na versão.
+ *   2. "com versão publicada e inativo é Pausado" — nem o agent-engine
+ *      (`loadPublishedAgentConfig`) nem o dispatcher leem `is_active`. Com
+ *      versão publicada o agente responde, e o rótulo honesto é "Publicado".
+ *
+ * `paused` continua no vocabulário do componente porque `AgentRowMenu` e os
+ * filtros da lista o consomem; ele deixou de ter emissor aqui.
  */
 export function deriveAgentStatus(agent: AgentRow): AgentStatus {
-  if (agent.archived_at) return "archived";
-  if (!agent.published_version_id) return "draft";
-  // `is_active` só tem semântica no rag_bot legado. Para mcp_agent, "no ar" é
-  // published_version_id + não arquivado — é assim que o dispatcher do CRM e o
-  // agent-engine escolhem o agente, e nenhum dos dois lê a coluna. Consultá-la
-  // aqui marcava como "Pausado" um agente que está respondendo, sem saída pela
-  // UI: "Despausar" fica disabled para mcp_agent, unpauseAgentAction recusa com
-  // publish_required, e republicar não mexe em is_active.
-  if (agent.kind === "mcp_agent") return "published";
-  return agent.is_active ? "published" : "paused";
+  switch (estadoDoAgente(agent)) {
+    case "arquivado":
+      return "archived";
+    case "no_ar":
+    case "no_ar_legado":
+      return "published";
+    case "parado":
+      return "draft";
+  }
 }
 
 const LABEL: Record<AgentStatus, string> = {
@@ -46,10 +59,9 @@ const VARIANT: Record<AgentStatus, "default" | "secondary" | "outline" | "destru
 };
 
 export function AgentStatusBadge({ status }: { status: AgentStatus }) {
-  const t = useT();
   return (
-    <Badge variant={VARIANT[status]} aria-label={`${t("status")}: ${t(LABEL[status])}`}>
-      {t(LABEL[status])}
+    <Badge variant={VARIANT[status]} aria-label={`status: ${LABEL[status]}`}>
+      {LABEL[status]}
     </Badge>
   );
 }

--- a/docs/handoff/agente-pausado-assume-conversa.md
+++ b/docs/handoff/agente-pausado-assume-conversa.md
@@ -1,0 +1,442 @@
+# Handoff — "agente pausado continua assumindo conversa"
+
+> Doc VIVO. Mantido até a tarefa terminar. Toda sessão que retomar isto lê daqui primeiro.
+
+## Relato do dono (2026-08-28)
+
+Na VPS (`ssh hg-vps`, `deskcommcrm-app-1` @ `1.9.1`):
+
+- O agente **publicado** é o **Suporte Deskcomm**.
+- Quem **pega as conversas para atender** é o **Atendente Clínica Vitalis**, que está **PAUSADO**.
+- Antes, quem estava ativo era o Vitalis. Hipótese do dono: ele "impregnou" — o agente que
+  um dia esteve publicado continua assumindo mesmo depois de desativado.
+- Suspeita de que o defeito seja **geral**, alcançando o roteador de intenção e a
+  **prioridade** entre agentes.
+
+**Resultado esperado:** agente publicado assume a conversa; agente pausado NÃO assume;
+o que a UI diz é o que acontece na execução.
+
+## Estado
+
+| Etapa | Status |
+|---|---|
+| Mapear caminhos de seleção de agente | feito |
+| Medir estado real do banco da VPS | feito |
+| Causa raiz identificada | **SIM — não é o seletor** |
+| Teste que reprova o defeito | feito (vermelho observado) |
+| Correção | feita — 6 sítios |
+| Prova em tela (Playwright) | em curso |
+
+## O que já se sabe do código (SHA 481c24c4, working tree limpo)
+
+- `lib/agent-engine/agent/agent-config.ts`
+  - `loadPublishedAgentConfig(db, org, channelSessionId)` — join `ai_agents` ⋈
+    `ai_agent_versions ON v.id = a.published_version_id`, com
+    `archived_at is null`, `v.status='published'`, `v.channel_session_id = $2`,
+    `order by a.priority desc, a.created_at asc limit 1`.
+  - `loadPublishedAgentConfigById(db, org, agentId)` — mesma coisa **sem** o filtro de
+    `channel_session_id` (usada pelos membros do Intent Router).
+- `app/api/v1/ai/agents/[id]/pause/route.ts` — pausar limpa `published_version_id` e
+  marca a versão como `superseded`. Ou seja, no papel, pausar deveria bastar.
+- Memória `project_inbox_quem_manda`: existe atribuição de conversa
+  (`assignee_kind='ai_agent'`) e o motor já teve o defeito de não lê-la.
+
+## Hipóteses abertas
+
+1. **Atribuição grudada** — a conversa foi atribuída ao Vitalis quando ele era publicado;
+   algum caminho do motor honra `conversations.assignee_id` sem reconferir se aquele
+   agente ainda está publicado.
+2. **Outro seletor** — o dispatcher do CRM (`lib/ai/dispatcher/`) ou o worker
+   (`workers/ai-response-worker.ts`) selecionam por critério diferente do loader acima.
+3. **Router com membro morto** — `ai_router_members` aponta para agente despublicado e
+   `loadPublishedAgentConfigById` (ou o fallback do router) não reprova.
+4. **Job antigo na fila** — o turno carrega `agent_id`/`version_id` congelado no payload
+   do job em vez de resolver no início do turno.
+
+## Impedimentos registrados
+
+(nada ainda)
+
+
+---
+
+## MEDIÇÃO NA VPS (2026-08-28, banco `aws-1-us-west-2.pooler.supabase.com`)
+
+Org medida: `988371bf-b118-4090-b4f3-dc07ae9366c9` (Deskcomm Administracao Ltda).
+Sessão de canal VIVA: `66491066-1b9f-4e8e-ad9e-91052db0e66b` ("Lia", `WORKING`).
+
+### 1. O seletor de agente está CERTO. Medido, não inferido.
+
+`ai_agents` na org:
+
+| agente | priority | `published_version_id` | arquivado |
+|---|---|---|---|
+| Suporte DeskcommCRM (`13858061`) | 1000 | **preenchido** (`99ad9c50`, v5) | não |
+| Vitoria - Atendente Clinica Vitalis (`726a3eb6`) | 999 | **NULL** | não |
+
+O pause fez o que promete: `published_version_id = null` + versão `superseded`.
+
+Log do worker no turno de hoje (job `bce692bd-1261-450f-a09a-bba834651d6b`):
+
+```
+"config do agente publicada em uso" agent_id=13858061-... agent_version_id=99ad9c50-...
+                                    model=gpt-5.6-terra router_outcome=no_match
+"llm: chamada concluída" purpose=agent_turn origem_da_escolha="agente_publicado"
+                         inputTokens=22270
+```
+
+**O agente escolhido foi o publicado.** `loadPublishedAgentConfig` e
+`loadPublishedAgentConfigById` ambos filtram `published_version_id` + `v.status='published'`
++ `archived_at is null` — um agente pausado não é carregável por nenhum dos dois.
+
+### 2. O sintoma é REAL, e a causa é outra: as camadas por-ORG do prompt
+
+Mesma conversa, mesmo turno, resposta que saiu no WhatsApp às 18:32:52:
+
+> "Oi, Rafael! **Sou a assistente virtual da Vitalis.** Como posso te ajudar hoje?"
+
+Numa conversa **nova** (primeira inbound "i" às 18:32:05) — logo, não é histórico.
+
+`lib/agent-engine/agent/inbound-turn.ts:1317-1340` monta o system prompt de TRÊS camadas:
+
+```ts
+const playbook = await loadPlaybook(pool, tenantId,
+  agentConfig !== null ? { agentLayer: agentConfig.systemPrompt } : undefined);  // ← POR AGENTE
+const skills    = await loadSkills(pool, tenantId);                              // ← POR ORG
+const orgMemory = await loadOrgMemory(pool, tenantId);                           // ← POR ORG
+const systemWithMemory = composeSystemPrompt({
+  playbookPrompt: playbook.prompt, orgMemoryBlock: renderOrgMemory(orgMemory), skillIndex });
+```
+
+Trocar o agente publicado troca **uma** das três. As outras duas seguem intactas — e na
+VPS as duas são da Clínica Vitalis:
+
+- `org_memory_pointers.version_id = 50c3ce89` → conteúdo em vigor abre com
+  *"A Vitalis é uma clínica odontológica especializada em Divinópolis/MG"* e
+  *"Quem escreve é chamado de PACIENTE, nunca de cliente ou lead"*.
+  O bloco é renderizado com o rótulo **"valem para TODO atendimento"**
+  (`org-memory.ts:43`).
+- `skill_versions.body` (`e4660130`) → *"Currículo: e-mail contato@clinicavitalis.com.br,
+  aos cuidados da Aline"*, *"Este contato NÃO entra no funil comercial"*.
+
+Varredura do banco por `ilike '%vitalis%'` achou resíduo em 25 pares tabela/coluna,
+entre eles `skill_versions.body`, `org_memory_versions.content`, `crm_pipelines.name`,
+`lead_checkpoints.rolling_summary` (13 linhas).
+
+**É a "impregnação" que o dono descreveu — só que o portador não é o seletor de agente,
+são as camadas de contexto que o seletor nem toca.**
+
+### 3. Dois defeitos adjacentes, medidos no mesmo banco
+
+- **`conversations.active_ai_agent_id` aponta para agente despublicado — e isso é
+  INERTE.** 3 conversas seguem com `active_ai_agent_id = 726a3eb6` (Vitalis,
+  despublicado em 26/08 17:56), e nada limpa o ponteiro no pause.
+
+  **Não é defeito, e a primeira versão deste documento errou ao chamá-lo assim.**
+  O sticky só vira desfecho passando por `loadMatchedOrFallback`
+  (`resolve-turn-agent.ts:155-171`), que chama `loadPublishedAgentConfigById` —
+  cujo inner join com a versão publicada não casa para agente pausado. O resultado
+  é `log.warn` + queda para o fallback, coberto por
+  `resolve-turn-agent.test.ts:241-256`. E o ponteiro **se auto-cura**: a escrita de
+  `inbound-turn.ts:1262-1268` grava o agente que RESOLVEU o turno, não o sticky
+  lido. O agente pausado é *consultado*, nunca *executado*.
+
+  Fica registrado porque a tela pode vir a exibir esse campo, e aí o valor obsoleto
+  vira mentira visível. Hoje nenhuma tela o lê.
+- **Router ATIVO com ZERO membros e sem fallback na sessão viva.**
+  `ai_routers 60bebc5a` ("Roteador - CLinica X"), `is_active=t`, 0 membros,
+  `fallback_agent_id` NULL. Toda decisão sai `no_match` (15/15 em
+  `ai_router_decisions`). Hoje é inócuo — a regra 5 de `resolve-turn-agent.ts` faz
+  cair no agente publicado da sessão — mas gasta **uma chamada de classificador por
+  turno** (`purpose=intent_router`, medido no log) para não classificar nada.
+
+---
+
+## A CAUSA RAIZ (medida no código, SHA 481c24c4)
+
+O dono estava certo sobre o efeito e a intuição ("impregnou"). O portador não é o
+resolvedor do turno — é **`ai_agents.is_active`, uma coluna que a pausa não desliga e
+que dois workers ainda usam como critério de "quem atende"**.
+
+### A cadeia, sítio por sítio
+
+1. **Pausar um `mcp_agent` não desliga `is_active`.**
+   `app/app/ai/agents/_actions.ts:77`
+   ```ts
+   // Legacy rag_bot: também flip is_active para refletir no badge.
+   if (existing.kind !== "mcp_agent") updates.is_active = false;
+   ```
+   E a rota REST `app/api/v1/ai/agents/[id]/pause/route.ts` **nunca** escreve
+   `is_active`, para nenhum `kind`.
+
+2. **O badge ignora `is_active` para `mcp_agent` — e está certo.**
+   `AgentStatusBadge.tsx:27` devolve `published` por `published_version_id`. A tela
+   diz a verdade sobre o engine. O problema é que `is_active` continua ligado embaixo,
+   sem nada na tela apontando para ele.
+
+3. **O worker legado escolhe agente por `is_active`.**
+   `workers/ai-response-worker.ts:642-654`
+   ```ts
+   .from("ai_agents").select("id, ..., is_active, is_default")
+     .eq("organization_id", input.organizationId)
+     .eq("is_active", true)
+     .order("is_default", { ascending: false })
+     .order("created_at", { ascending: true }).limit(1)
+   ```
+   Sem `archived_at`, sem `published_version_id`, sem `kind`. O mesmo padrão em
+   `workers/ai-sentiment-worker.ts:120-128`.
+
+4. **A trava que segura o worker legado é ORG-WIDE.**
+   `workers/ai-response-worker.ts:677`: ele só desiste (`skip("engine_owns_reply")`) se
+   existir **algum** agente com `published_version_id` na organização inteira.
+
+### O que isso produz
+
+> **Pausar o único agente publicado da organização faz um agente que a tela chama de
+> "Rascunho" voltar a responder no WhatsApp** — pelo caminho legado, com o
+> `system_prompt` da tabela `ai_agents` (o do cadastro, não o da versão), sem as
+> ferramentas, sem os funis e sem os guardrails da versão publicada.
+
+Na VPS isso está armado agora: a org tem `is_active=true` em **dois** agentes —
+`13858061` (Suporte DeskcommCRM, publicado) e `fceb2e33` ("Atendente IA", `rag_bot`,
+`is_default=true`, **não publicado, tela diz "Rascunho"**). Pausar o Suporte
+DeskcommCRM entrega o atendimento ao "Atendente IA".
+
+Prova de que o worker legado está vivo em produção — log de hoje:
+```
+[ai-response-worker] skip reason=engine_owns_reply conversation_id=ed439beb-...
+```
+Ele roda em todo inbound. A única coisa que o segura é a existência de um publicado.
+
+### E a tela também mente sobre isso
+
+`app/api/v1/ai/automatico-ativo/route.ts:42` responde "automático ativo" contando
+`is_active=true` — a régua que **nenhum** dos dois motores usa. Depois de pausar o
+publicado, ela continua dizendo que a IA está atendendo.
+
+### O sintoma que o dono viu (persona da Vitalis) tem causa PRÓPRIA
+
+Ver a seção de medição acima: memória da org + skills são **por organização**, o
+prompt do agente é **por agente**, e trocar o publicado troca só a terceira camada.
+Os dois defeitos são independentes e os dois precisam de conserto.
+
+
+---
+
+## O QUE FOI CORRIGIDO (branch `fix/agente-pausado-nao-atende`)
+
+### A régua única: `lib/ai/agents/no-ar.ts` (arquivo novo)
+
+`estadoDoAgente()` devolve `arquivado | no_ar | no_ar_legado | parado`, e dois
+predicados saem dela: `agenteAtende()` (responde por ALGUM motor) e
+`elegivelParaWorkerLegado()` (o worker antigo pode responder por ele).
+
+Falha FECHADA na ação: exige `kind === "rag_bot"` explícito para o ramo legado, de
+modo que um `.select()` que esqueça a coluna não faça o worker responder por um
+agente sobre o qual não se sabe nada.
+
+### Os seis sítios
+
+| arquivo | era | virou |
+|---|---|---|
+| `workers/ai-response-worker.ts` | `.eq("is_active", true).limit(1)` | lista + `.find(elegivelParaWorkerLegado)` |
+| `workers/ai-sentiment-worker.ts` | idem | lista + `.find(agenteAtende)` |
+| `app/api/v1/ai/automatico-ativo/route.ts` | `count` por `is_active` | `.some(agenteAtende)` |
+| `app/api/v1/ai/agents/assignable/route.ts` | `.eq("is_active", true)` | `.filter(agenteAtende)` |
+| `app/app/.../AgentStatusBadge.tsx` | régua própria duplicada | delega a `estadoDoAgente` |
+| `lib/agent-engine/edge/crm/drain.ts` | portão contava LINHA de membro | conta membro/fallback **publicado** |
+
+O `.limit(1)` saiu do worker de propósito: cortar antes de filtrar faria um
+`mcp_agent` pausado — que é `is_default` na instalação que o onboarding cria —
+esconder o `rag_bot` legítimo logo abaixo dele.
+
+### Testes
+
+- `tests/unit/agente-pausado-nao-atende.test.ts` (novo, 4 casos) — mede o EFEITO:
+  a requisição sai para `api.anthropic.com` ou não. Vermelho observado antes do
+  conserto: *"o worker chamou o provider por um agente PAUSADO (destinos:
+  api.anthropic.com)"*.
+- `tests/invariants/portao-de-capacidade-mede-quem-executa.test.ts` (novo, 7 casos,
+  Postgres real) — o portão do drain nas duas direções.
+- `AgentStatusBadge.test.ts` — reescrito; duas justificativas que ele carregava
+  foram medidas como FALSAS e estão corrigidas no próprio arquivo.
+
+### Sabotagem (prova de que a guarda vigia)
+
+| sabotagem | previsão | medido |
+|---|---|---|
+| tirar `.find(elegivelParaWorkerLegado)` | 1 falha (só o PAUSADO) | 1 falha ✓ |
+| tirar `.is("archived_at", null)` | 0 falhas (régua JS cobre) | 0 falhas ✓ |
+
+A segunda revela que o filtro SQL de `archived_at` é **redundante** — está escrito
+no código, para que ninguém o confunda com a guarda.
+
+## Impedimentos encontrados
+
+1. **Suíte quebrou em 19 casos após o conserto** — 4 dublês de teste devolviam
+   `maybeSingle()` para `ai_agents` e a consulta virou lista. Resolvido ajustando
+   os dublês (incluindo `kind: "rag_bot"`, que eles não declaravam e o banco tem
+   como `NOT NULL DEFAULT`). Não houve enfraquecimento: as asserções são as mesmas.
+2. **`lib/ai/dispatcher/rate-limit.test.ts` falha em 5 casos localmente** — vermelho
+   conhecido e alheio (Redis do `.env.local` fora do ar), documentado no `CLAUDE.md`.
+3. **Crase dentro de template literal** — comentário SQL com `` `x` `` fechava a
+   template string do TS. Comentários dentro de SQL embutido vão sem crase.
+4. **Processo de teste órfão** — um `nohup ... &` dentro de comando já em background
+   devolveu "exit 0" do shell enquanto o vitest seguia vivo, e dois runs
+   concorreram com o build. Rodar a suíte pelo background do harness, sem `&`.
+
+
+---
+
+## O QUE FOI INVESTIGADO E **NÃO** É DEFEITO
+
+Seis hipóteses plausíveis caíram sob verificação. Ficam escritas para que a próxima
+sessão não gaste tempo nelas de novo:
+
+1. **O resolvedor do turno seleciona agente pausado** — não. `loadPublishedAgentConfig`
+   e `loadPublishedAgentConfigById` fazem inner join em `published_version_id` e
+   exigem `v.status='published'` + `archived_at is null`. Um agente pausado não é
+   carregável por nenhum dos dois. Confirmado no log de produção
+   (`origem_da_escolha: "agente_publicado"`).
+2. **O sticky da conversa prende a conversa no agente pausado** — não, ver acima.
+3. **O job congela `agent_id` no payload** — não. O payload de `inbound_turn` leva só
+   ponteiros de CRM (`drain.ts:274-280`); o agente é resolvido no início de cada turno.
+4. **`lib/ai/dispatcher/index.ts` seleciona sem conferir publicação** — o código é esse
+   mesmo, mas o caminho está **morto**: `dispatchAgents` não tem um único chamador de
+   produção, e `app/api/v1/cron/agent-dispatcher/route.ts` nem importa o módulo
+   (devolve `{ skipped: true, deprecated: true }`). Idem `lib/ai/runtime/agent.ts:274`.
+5. **`duplicate.ts` grava `is_active: true` na cópia** — grava, mas a cópia nunca é a
+   escolhida (`order by is_default desc, created_at asc`), e ela é `mcp_agent`, que a
+   régua nova recusa para o caminho legado.
+6. **`archiveAgentAction` contraria seu próprio comentário** — não contraria: o
+   comentário declara o escopo ("para o LEGADO") e a implementação o segue.
+
+## O QUE **NÃO** ESTÁ CONSERTADO (e é do dono decidir)
+
+**A persona da Clínica Vitalis na resposta do Suporte Deskcomm não é bug de código.**
+A memória da organização (`/app/ai/memory`) e as skills (`/app/ai/skills`) são
+deliberadamente **por organização** — a própria tela diz "Regras e aprendizados que
+TODOS os agentes de IA desta organização seguem em qualquer conversa". A org
+`988371bf` foi reaproveitada de uma demo de clínica odontológica, e esses dois
+acervos continuam falando pela Vitalis, com 9.730 caracteres ativos.
+
+Trocar o agente publicado troca **uma** das três camadas do prompt. As outras duas
+são dado do usuário, e apagá-las é decisão dele — não minha.
+
+O que a engenharia deve a isto: a tela do AGENTE não menciona que existem duas
+camadas acima do prompt dele. Quem publica um agente vê só o próprio texto. Essa é
+uma lacuna de produto real, e está fora deste conserto.
+
+---
+
+## PROVA EM TELA (Playwright, app local em modo produção)
+
+Ambiente: `pnpm build` + `pnpm start` na 3000, Supabase local (`54321/54322`), login
+real por senha + TOTP como `e2e-admin@deskcomm.test`.
+
+Cenário montado para reproduzir o mundo real da VPS:
+
+| agente | `kind` | `is_active` | publicado |
+|---|---|---|---|
+| Atendente Publicado | mcp_agent | **false** (como "Novo agente" grava) | sim |
+| Atendente Pausado | mcp_agent | **true** (a pausa não desliga) | não |
+| Bot Padrão E2E | rag_bot | true | não |
+
+### Com um agente publicado
+
+- **Tela `/app/ai/agents`:** `Atendente Pausado → Rascunho`,
+  `Atendente Publicado → Publicado`, `Bot Padrão E2E → Publicado`.
+  (`Bot Padrão E2E` dizia "Rascunho" antes — e atendia.)
+- **`GET /ai/agents/assignable`** → `["Atendente Publicado (v1)", "Bot Padrão E2E (v-)"]`.
+  Antes: escondia o "Atendente Publicado" (`is_active=false`) e oferecia o
+  "Atendente Pausado" (`is_active=true`). Errava nos dois sentidos.
+- **Inbox, cabeçalho da conversa:** `Aberta · AU · Automático`.
+
+### Depois de pausar TODOS (pelo caminho que a tela usa)
+
+- **Tela:** os três em `Rascunho`.
+- **`assignable`** → `[]`.
+- **`automatico-ativo`** → `{ ativo: false }`.
+- **Inbox, cabeçalho da mesma conversa:** `Aberta · Sem responsável`.
+
+### A divergência isolada, sobre os MESMOS dados
+
+```
+     estado     | regua_ANTIGA (is_active) | regua_NOVA
+----------------+--------------------------+------------
+ COM publicado  | t                        | t
+ TODOS pausados | t   ← a mentira          | f
+```
+
+A régua antiga dizia "há automático atendendo" com todos os agentes pausados,
+porque o pausado mantém `is_active=true`. É o selo "Automático" na Inbox de uma
+organização onde ninguém responde.
+
+## Gates
+
+| gate | resultado |
+|---|---|
+| `npx tsc --noEmit` | limpo |
+| `pnpm lint` | 0 erros (299 warnings pré-existentes) |
+| `pnpm test:unit` | **574 de 575 arquivos verdes** — 6403 casos passando |
+| `pnpm build` | `BUILD_EXIT=0` |
+| `pnpm release:conferir` | fragmento aceito (`1.9.1 + patch = 1.9.2`) |
+| `pnpm lint:channels` | ok (60 arquivos de dívida conhecida, nenhum novo) |
+| **`pnpm test:db`** | **137 de 137 arquivos, 1050 casos verdes** |
+
+### O invariante novo nasceu vermelho — e o motivo era o fixture, não o portão
+
+Primeira rodada: `6 failed`, todos com `duplicate key ... "ai_agents_name_unique"`.
+A constraint é **por organização**, e os sete cenários dividem a mesma org — o
+literal `'Agente Portão'` matava o segundo insert em 23505, e seis casos ficavam
+vermelhos **sem nunca chegar a exercitar o portão**. Um vermelho que lê como
+defeito e é erro de fixture.
+
+Conserto: nome próprio por agente. Controle anexado ao commit —
+`git diff | grep -E "^[+-].*(expect|it\()"` devolve **vazio**: nenhuma asserção e
+nenhum título de caso mudaram. (O commit precisou de
+`DESKCOMM_GOV_INVARIANTS_EDIT=1`: a catraca de `tests/invariants/**` bloqueia
+edição de invariante, e está certa em bloquear — a exceção está justificada na
+mensagem do commit.)
+
+### Sabotagem do portão (com previsão declarada ANTES de rodar)
+
+Revertido o predicado do drain para o antigo (existência de linha de membro):
+
+| previsão | medido |
+|---|---|
+| 2 falhas: `MEMBRO está pausado` e `FALLBACK está pausado` | **exatamente essas duas** |
+
+Os outros 5 casos e os 136 arquivos restantes seguiram verdes — a guarda morde
+onde deve e só onde deve. `drain.ts` restaurado (diff vazio contra o commit).
+
+A única suíte vermelha é `lib/ai/dispatcher/rate-limit.test.ts` (5 casos) — o
+vermelho conhecido e **alheio** que o `CLAUDE.md` documenta: o `.env.local` tem
+`UPSTASH_REDIS_REST_URL` apontando para um Redis local que não está de pé.
+Conferido que não toquei em `lib/ai/dispatcher/` neste trabalho.
+
+Controle do rodapé contra o grep, como manda o `CLAUDE.md`:
+`rodapé: 5 failed | grep contou: 5` — batem.
+
+## INCIDENTE — outra sessão apagou este trabalho do git (recuperado)
+
+Durante a sessão, o commit `8238b8e7` ("docs(release): o fragmento do conserto de
+namespace no update.sh (#403)"), feito por **outra sessão no mesmo worktree**,
+entrou nesta branch e **deletou do índice**:
+
+```
+docs/handoff/agente-pausado-assume-conversa.md   | 210 ---
+lib/ai/agents/no-ar.ts                           | 101 ---
+tests/unit/agente-pausado-nao-atende.test.ts     | 301 ---
+workers/ai-response-worker.ts                    |  30 +-
+```
+
+**Nada foi perdido** — os arquivos continuaram no working tree como untracked, e
+foram recommitados em `e1533012` com `git commit --only` de lista explícita.
+
+O sintoma que denunciou: `git diff --name-only origin/main...HEAD` devolveu
+arquivos que não eram meus (`.gitattributes`, `hostgator-setup-kit/install.sh`) e
+**não** devolveu os meus. Quem retomar isto: confira `git log --oneline -3` e
+`git worktree list` antes de confiar em qualquer diff, e nunca use `git add -A`
+neste worktree — `.gitattributes` e `hostgator-setup-kit/install.sh` seguem
+modificados por outra sessão e não devem entrar em commit deste trabalho.

--- a/docs/handoff/agente-pausado-assume-conversa.md
+++ b/docs/handoff/agente-pausado-assume-conversa.md
@@ -440,3 +440,56 @@ arquivos que não eram meus (`.gitattributes`, `hostgator-setup-kit/install.sh`)
 `git worktree list` antes de confiar em qualquer diff, e nunca use `git add -A`
 neste worktree — `.gitattributes` e `hostgator-setup-kit/install.sh` seguem
 modificados por outra sessão e não devem entrar em commit deste trabalho.
+
+---
+
+## ENTREGA — PR, release e VPS
+
+### PR
+
+**#408** — `fix/pausar-agente-cala-em-todos-os-caminhos` → `main`.
+
+A branch de trabalho original (`fix/agente-pausado-nao-atende`) **não** foi usada
+para o PR: ela carregava o commit `8238b8e7` de outra sessão, cujos arquivos
+(`.gitattributes`, `hostgator-setup-kit/install.sh`,
+`.changes/o-fork-checa-...`) já têm PR próprio — o **#405**. Abrir o PR daquela
+branch misturaria dois assuntos e duplicaria o #405. O PR saiu de um worktree
+novo criado a partir de `origin/main`, com os 17 arquivos deste trabalho e nada
+mais.
+
+### O caminho até a VPS (não é o merge)
+
+A VPS **não** segue a `main`. Ela roda `hostgator-setup-kit/update.sh`, que puxa
+imagem **por número de versão**:
+
+```
+git tag -l 'v*' --sort=-v:refname | head -1      # o alvo do update.sh
+APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:1.9.1  # o que está lá hoje
+```
+
+Então merge do #408 **não basta**. A sequência é:
+
+1. merge do #408 na `main`;
+2. disparar o workflow `release` (`workflow_dispatch`) → ele lê `.changes/`,
+   calcula **v1.9.2** e abre um PR de release;
+3. merge do PR de release → o CI cria a tag `v1.9.2` → `publish-image.yml`
+   publica as três imagens;
+4. na VPS: `bash hostgator-setup-kit/update.sh`.
+
+A tag nasce no CI de propósito (`docs/doctrine/versionamento.md`): tag criada na
+máquina de alguém é o ponto onde o número deixa de ser revisável, e **a tag é o
+seletor do que cada VPS baixa**.
+
+### Estado da VPS antes do deploy (medido)
+
+| item | valor |
+|---|---|
+| árvore dona do projeto Docker | `/root/DeskcommCRM` (via label `working_dir`) |
+| versão | tag exata `v1.9.1`, commit `9507920c` |
+| domínio | responde **307** (redireciona ao login — o esperado) |
+| contêineres | `app`, `worker`, `scheduler` todos `healthy` |
+| proxy | **Caddy**, não Traefik — o `-f docker-compose.traefik.yml` NÃO se aplica aqui |
+| `.update.lock` | resíduo de 27/08 do `agent.sh`; é `flock`, e o `update.sh` não o usa |
+
+O `update.sh` faz backup automático antes e re-aplica `supabase/baseline.sql`
+(idempotente). Este PR **não muda schema**, então a re-aplicação é no-op.

--- a/lib/agent-engine/edge/crm/drain.ts
+++ b/lib/agent-engine/edge/crm/drain.ts
@@ -179,8 +179,16 @@ async function processEvent(
   // Também cobre a instalação recém-feita que ainda não configurou agente
   // nenhum: hoje ela pagaria por cada mensagem recebida.
   //
-  // Roteador COM membros ou COM fallback continua passando: ali existe quem
-  // atenda, e o caminho genérico de "classificou e não bateu" segue valendo.
+  // Roteador com membro PUBLICADO ou fallback PUBLICADO continua passando: ali
+  // existe quem atenda, e o caminho genérico de "classificou e não bateu" segue
+  // valendo.
+  //
+  // Este parágrafo dizia "roteador COM membros ou COM fallback", e a diferença
+  // não é de redação: pausar um agente não apaga a linha dele em
+  // `ai_router_members` nem zera `ai_routers.fallback_agent_id`. Medir a
+  // EXISTÊNCIA da linha deixava o portão aberto para um roteador cujos membros
+  // foram todos pausados — exatamente o caso que o parágrafo acima diz estar
+  // cobrindo, entrando pela outra porta.
   const { rows: capacidade } = await pool.query<{
     tem_agente: boolean;
     tem_roteador: boolean;
@@ -197,8 +205,29 @@ async function processEvent(
          where r.organization_id = $1 and r.is_active
            and r.channel_session_id = $2
            and (
-             r.fallback_agent_id is not null
-             or exists (select 1 from ai_router_members m where m.router_id = r.id)
+             -- O fallback e os membros contam pelo que PODEM EXECUTAR, não por
+             -- existirem. A versão anterior media fallback_agent_id is not null
+             -- e a existência de LINHA em ai_router_members — e as duas
+             -- sobrevivem à pausa do agente, que só limpa published_version_id.
+             -- Um roteador cujos membros foram todos pausados continuava
+             -- abrindo o portão: a organização pagava o classificador e o turno
+             -- inteiro por mensagem recebida, para responder pelo genérico.
+             -- O predicado aqui é o MESMO que loadPublishedAgentConfigById
+             -- aplica na hora de executar (agent-config.ts) — é o que garante
+             -- que o portão não promete um agente que o resolvedor vai recusar.
+             exists (
+               select 1 from ai_agents fa
+               join ai_agent_versions fv on fv.id = fa.published_version_id
+               where fa.id = r.fallback_agent_id and fa.organization_id = $1
+                 and fa.archived_at is null and fv.status = 'published'
+             )
+             or exists (
+               select 1 from ai_router_members m
+               join ai_agents ma on ma.id = m.agent_id
+               join ai_agent_versions mv on mv.id = ma.published_version_id
+               where m.router_id = r.id and ma.organization_id = $1
+                 and ma.archived_at is null and mv.status = 'published'
+             )
            )
        ) as tem_roteador`,
     [event.organization_id, p.channel_session_id],

--- a/lib/ai/agents/no-ar.ts
+++ b/lib/ai/agents/no-ar.ts
@@ -1,0 +1,122 @@
+/**
+ * "Este agente está no ar?" — a pergunta com UMA resposta.
+ *
+ * ## O defeito que este arquivo existe para consertar
+ *
+ * A pergunta tinha TRÊS respostas, e as três discordavam sobre o mesmo agente:
+ *
+ *   1. `AgentStatusBadge.deriveAgentStatus` — o que a TELA escreve: arquivado,
+ *      senão `published_version_id`, e `is_active` só para o `rag_bot` legado.
+ *   2. `lib/agent-engine/agent/agent-config.ts` — o que o ENGINE executa:
+ *      `join ai_agent_versions on v.id = a.published_version_id` + não
+ *      arquivado + `v.status = 'published'`.
+ *   3. `workers/ai-response-worker.ts` — o que o worker LEGADO executa:
+ *      `.eq("is_active", true)`, e nada mais. Sem `archived_at`, sem
+ *      `published_version_id`, sem `kind`.
+ *
+ * (1) e (2) concordam. (3) discorda dos dois — e é o que respondia ao cliente
+ * sempre que a organização ficava sem nenhum agente publicado, porque a trava
+ * que o segura (`skip("engine_owns_reply")`) é ORG-WIDE.
+ *
+ * Medido na VPS de produção em 2026-08-28: pausar o único `mcp_agent` publicado
+ * desarma essa trava e devolve o atendimento ao worker legado — que continua
+ * enxergando o agente recém-pausado, porque `pauseAgentAction` só desligava
+ * `is_active` quando `kind !== "mcp_agent"`. O dono pausa, a tela escreve
+ * **Rascunho**, e o agente responde no WhatsApp com o `system_prompt` do
+ * CADASTRO (não o da versão), sem ferramentas, funis nem guardrails.
+ *
+ * ## Por que uma função pura, e não mais um filtro no SQL
+ *
+ * Um quarto `.eq()` espalhado seria a quarta régua. A doutrina DIRC manda
+ * **C**alcular antes de duplicar, e aqui não nasce estado novo: é uma função
+ * sobre colunas que as consultas JÁ trazem. Quem chama filtra no SQL o que é
+ * barato e estreito (`organization_id`, `archived_at`) e decide aqui.
+ *
+ * ## Por que "no ar" tem DOIS estados e não um
+ *
+ * `rag_bot` ativo e nunca publicado responde — é o caminho que o worker legado
+ * existe para servir, e a instalação que nunca publicou versão nenhuma depende
+ * dele. Ele é `no_ar_legado`: está no ar, por outro motor e com outra config.
+ *
+ * Colapsar os dois num booleano só perderia justamente a distinção que o worker
+ * precisa fazer (`elegivelParaWorkerLegado`), e foi tentador colapsar: a TELA
+ * trata os dois como "Publicado", porque para quem olha a lista a pergunta é
+ * "este agente responde?" e a resposta é sim nos dois casos. São perguntas
+ * diferentes sobre o mesmo estado, e por isso `agenteAtende` e
+ * `elegivelParaWorkerLegado` são funções separadas em vez de uma com um
+ * parâmetro.
+ */
+
+/**
+ * As colunas de que a régua precisa — nada além.
+ *
+ * `undefined` é aceito de propósito e significa **"o SELECT não pediu esta
+ * coluna"**, não "false". Um chamador que esquece `kind` no `.select()` é o
+ * modo de falha mais provável deste arquivo, e ele tem que ser seguro: ver o
+ * ramo do legado em `estadoDoAgente`.
+ */
+export interface FatosDoAgente {
+  kind?: string | null;
+  is_active?: boolean | null;
+  published_version_id?: string | null;
+  archived_at?: string | null;
+}
+
+export type EstadoDoAgente =
+  /** Arquivado. Não atende por caminho nenhum. */
+  | "arquivado"
+  /** Tem versão publicada: o agent-engine é o dono da resposta. */
+  | "no_ar"
+  /**
+   * `rag_bot` legado, ativo, sem versão publicada: quem o atende é
+   * `workers/ai-response-worker.ts`, com a config da própria linha de
+   * `ai_agents`. Está no ar — por outro motor.
+   */
+  | "no_ar_legado"
+  /** Existe e não responde: nem versão publicada, nem `is_active` legado. */
+  | "parado";
+
+export function estadoDoAgente(a: FatosDoAgente): EstadoDoAgente {
+  if (a.archived_at != null) return "arquivado";
+  // `!= null` cobre o `undefined` do select incompleto do mesmo jeito que o
+  // `null` do banco: sem ponteiro conhecido, não se afirma que está no ar.
+  if (a.published_version_id != null) return "no_ar";
+  // Sem versão publicada, só o legado tem para onde ir — e a porta é ESTREITA:
+  // exige `kind === "rag_bot"` explícito, em vez de "qualquer coisa que não
+  // seja mcp_agent".
+  //
+  // A diferença aparece quando o `.select()` de quem chama esquece a coluna:
+  // `kind` chega `undefined`, e a versão larga concluiria "legado" — mandando o
+  // worker responder ao cliente por um agente sobre o qual não se sabe nada.
+  // Falha fechada na AÇÃO: sem saber o kind, o agente não atende.
+  //
+  // O CHECK do banco (`ai_agents_kind_check`) só admite 'rag_bot' e
+  // 'mcp_agent', e o default da coluna é 'rag_bot' NOT NULL — então nenhuma
+  // linha real é perdida por este aperto; o que ele pega é o select incompleto.
+  if (a.kind !== "rag_bot") return "parado";
+  return a.is_active === true ? "no_ar_legado" : "parado";
+}
+
+/**
+ * O agente responde a mensagem de cliente por ALGUM motor?
+ *
+ * Inclui o legado de propósito: a pergunta é "o cliente recebe resposta deste
+ * agente?", e para quem nunca publicou a resposta é sim.
+ */
+export function agenteAtende(a: FatosDoAgente): boolean {
+  const estado = estadoDoAgente(a);
+  return estado === "no_ar" || estado === "no_ar_legado";
+}
+
+/**
+ * Este agente é elegível para o worker LEGADO responder por ele?
+ *
+ * É a régua que faltava em `workers/ai-response-worker.ts`. `no_ar` fica de
+ * fora porque, quando existe versão publicada, o dono da resposta é o
+ * agent-engine e o worker já cede por `engine_owns_reply` — deixá-lo aqui
+ * abriria a porta para os dois responderem a mesma mensagem, que é o defeito
+ * que a issue #129 fechou.
+ */
+export function elegivelParaWorkerLegado(a: FatosDoAgente): boolean {
+  return estadoDoAgente(a) === "no_ar_legado";
+}

--- a/tests/invariants/portao-de-capacidade-mede-quem-executa.test.ts
+++ b/tests/invariants/portao-de-capacidade-mede-quem-executa.test.ts
@@ -1,0 +1,246 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import pg from "pg";
+
+import { drainTick } from "@/lib/agent-engine/edge/crm/drain";
+import { createLogger } from "@/lib/agent-engine/obs/logger";
+
+/**
+ * O PORTÃO DE CUSTO TEM QUE MEDIR QUEM EXECUTA, NÃO QUEM EXISTE.
+ *
+ * `drain.ts` decide, antes de enfileirar o turno, se há alguém capaz de
+ * atender aquela sessão — e pula o evento quando não há, para que "pausei o
+ * agente" signifique "parou de gastar". A pergunta tem dois braços:
+ * `tem_agente` (versão publicada para a sessão) e `tem_roteador`.
+ *
+ * O braço do roteador media EXISTÊNCIA DE LINHA: `fallback_agent_id is not
+ * null` ou `exists (select 1 from ai_router_members ...)`. Nenhuma das duas
+ * sobrevive à pergunta certa, porque pausar um agente **não apaga a linha de
+ * membro nem zera o `fallback_agent_id`** — só limpa `published_version_id`.
+ *
+ * Resultado, com todos os agentes de um roteador pausados: o portão abria, a
+ * organização pagava o classificador de intenção e o turno inteiro por
+ * mensagem recebida, e ninguém publicado atendia — a resposta saía pelo
+ * caminho genérico. É o mesmo desperdício que o braço `tem_agente` já barrava,
+ * entrando pela outra porta.
+ *
+ * Este arquivo congela o portão nas DUAS direções. Só a metade que fecha
+ * seria satisfeita por um portão que nunca abre — e um portão que nunca abre
+ * é a IA muda, que é pior que o gasto.
+ */
+
+const container = process.env.TEST_DB_CONTAINER;
+if (!container) {
+  throw new Error("TEST_DB_CONTAINER not set — rode via `pnpm test:invariants` (scripts/test-db.sh)");
+}
+
+const PORT = Number(process.env.TEST_DB_PORT ?? 54329);
+const pool = new pg.Pool({
+  connectionString: `postgresql://postgres:postgres@127.0.0.1:${PORT}/postgres`,
+  max: 2,
+});
+const log = createLogger();
+
+const ORG = "cca00000-0000-4000-8000-000000000001";
+const CONTACT = "cca00000-0000-4000-8000-000000000002";
+
+const DRAIN_KNOBS = {
+  batchSize: 20,
+  intervalMs: 100,
+  idleIntervalMs: 100,
+  debounceMs: 0,
+  reapTimeoutMs: 300_000,
+};
+
+/** Um cenário completo e isolado: uma sessão de canal só dele. */
+interface Cenario {
+  session: string;
+  conv: string;
+  msg: string;
+}
+
+let seq = 0;
+function proximoId(): string {
+  seq += 1;
+  return `cca00000-0000-4000-8000-${String(seq).padStart(12, "0")}`;
+}
+
+async function montarCenario(nome: string): Promise<Cenario> {
+  const session = proximoId();
+  const conv = proximoId();
+  const msg = proximoId();
+  await pool.query(
+    `insert into channel_sessions (id, organization_id, waha_session_name, status, webhook_secret_encrypted)
+     values ($1, $2, $3, 'WORKING', '\\x00'::bytea)`,
+    [session, ORG, `cap-${nome}`],
+  );
+  await pool.query(
+    `insert into conversations (id, organization_id, contact_id, channel_session_id, status, is_group)
+     values ($1, $2, $3, $4, 'open', false)`,
+    [conv, ORG, CONTACT, session],
+  );
+  await pool.query(
+    `insert into messages (id, organization_id, conversation_id, channel_session_id, contact_id,
+                           type, direction, status, body, sent_via, sent_at)
+     values ($1, $2, $3, $4, $5, 'text', 'inbound', 'delivered', 'oi', 'external_device', now())`,
+    [msg, ORG, conv, session, CONTACT],
+  );
+  return { session, conv, msg };
+}
+
+/**
+ * Cria um agente. `publicado: false` reproduz EXATAMENTE o que a pausa deixa
+ * no banco — a versão existe e virou `superseded`, e `published_version_id`
+ * ficou nulo. Criar o agente sem versão nenhuma seria um estado mais fácil, e
+ * o portão poderia passar por um motivo que a pausa real não produz.
+ */
+async function criarAgente(
+  sessionId: string,
+  opts: { publicado: boolean; nome: string },
+): Promise<string> {
+  const agent = proximoId();
+  const version = proximoId();
+  // O nome vem de fora porque `ai_agents_name_unique` é por organização, e
+  // todos os cenários deste arquivo dividem a mesma org: um literal fixo aqui
+  // faz o segundo insert morrer em 23505 e o caso nunca chega a exercitar o
+  // portão — ele fica vermelho por erro de fixture, que lê como defeito.
+  await pool.query(
+    `insert into ai_agents (id, organization_id, name, system_prompt, kind)
+     values ($1, $2, $3, 'você é um atendente', 'mcp_agent')`,
+    [agent, ORG, `Agente Portão ${opts.nome}`],
+  );
+  await pool.query(
+    `insert into ai_agent_versions (id, organization_id, agent_id, version_number, system_prompt,
+                                    provider, model, channel_session_id, status, published_at)
+     values ($1, $2, $3, 1, 'você é um atendente', 'anthropic', 'claude-sonnet-4-6', $4, $5, now())`,
+    [version, ORG, agent, sessionId, opts.publicado ? "published" : "superseded"],
+  );
+  if (opts.publicado) {
+    await pool.query(`update ai_agents set published_version_id = $1 where id = $2`, [version, agent]);
+  }
+  return agent;
+}
+
+async function criarRouter(
+  sessionId: string,
+  opts: { fallback?: string | null; membro?: string | null },
+): Promise<string> {
+  const router = proximoId();
+  await pool.query(
+    `insert into ai_routers (id, organization_id, name, channel_session_id, is_active, fallback_agent_id)
+     values ($1, $2, 'Roteador Portão', $3, true, $4)`,
+    [router, ORG, sessionId, opts.fallback ?? null],
+  );
+  if (opts.membro) {
+    await pool.query(
+      `insert into ai_router_members (organization_id, router_id, agent_id, intent_name, intent_description)
+       values ($1, $2, $3, 'suporte', 'dúvidas de suporte')`,
+      [ORG, router, opts.membro],
+    );
+  }
+  return router;
+}
+
+/** Drena o evento do cenário e responde: nasceu job? */
+async function drenaEGeraJob(c: Cenario): Promise<boolean> {
+  const { rows } = await pool.query<{ id: string }>(
+    `insert into event_log (organization_id, event_type, entity_kind, entity_id, payload, status)
+     values ($1::uuid, 'ai_agent.dispatch_requested', 'message', $2::uuid,
+             jsonb_build_object('organization_id', $1::text, 'conversation_id', $3::text,
+                                'contact_id', $4::text, 'channel_session_id', $5::text,
+                                'inbound_message_id', $2::text),
+             'pending')
+     returning id`,
+    [ORG, c.msg, c.conv, CONTACT, c.session],
+  );
+  const eventId = rows[0]!.id;
+
+  await drainTick(pool, DRAIN_KNOBS, log);
+
+  const { rows: jobs } = await pool.query<{ n: number }>(
+    "select count(*)::int as n from job_queue where source_event_id = $1",
+    [eventId],
+  );
+  return jobs[0]!.n > 0;
+}
+
+beforeAll(async () => {
+  await pool.query(
+    `insert into organizations (id, slug, legal_name, display_name)
+     values ($1, 'portao-capacidade', 'Portao Capacidade', 'Portao Capacidade')
+     on conflict (id) do nothing`,
+    [ORG],
+  );
+  await pool.query(
+    `insert into contacts (id, organization_id, name, phone_number)
+     values ($1, $2, 'Lead Portão', '+5511900000099') on conflict (id) do nothing`,
+    [CONTACT, ORG],
+  );
+});
+
+afterAll(async () => {
+  await pool.end();
+});
+
+describe("portão de capacidade do drain — mede quem EXECUTA", () => {
+  it("agente publicado para a sessão: o turno é enfileirado", async () => {
+    const c = await montarCenario("publicado");
+    await criarAgente(c.session, { publicado: true, nome: "publicado" });
+
+    expect(await drenaEGeraJob(c)).toBe(true);
+  });
+
+  it("agente PAUSADO e sem roteador: nada é enfileirado — pausar tem que parar o gasto", async () => {
+    const c = await montarCenario("pausado");
+    await criarAgente(c.session, { publicado: false, nome: "pausado" });
+
+    expect(await drenaEGeraJob(c)).toBe(false);
+  });
+
+  it("roteador ativo cujo MEMBRO está pausado: nada é enfileirado", async () => {
+    // O defeito: a linha em ai_router_members sobrevive à pausa do agente, e o
+    // portão a contava como "existe quem atenda".
+    const c = await montarCenario("membro-pausado");
+    const membro = await criarAgente(c.session, { publicado: false, nome: "membro-pausado" });
+    await criarRouter(c.session, { membro });
+
+    expect(await drenaEGeraJob(c)).toBe(false);
+  });
+
+  it("roteador ativo com MEMBRO publicado: o turno é enfileirado", async () => {
+    const c = await montarCenario("membro-publicado");
+    const membro = await criarAgente(c.session, { publicado: true, nome: "membro-publicado" });
+    // O membro é publicado, mas a versão dele aponta para ESTA sessão, o que
+    // também faria `tem_agente` passar. Um router cujo membro é publicado é o
+    // caso que tem de abrir o portão de qualquer um dos dois braços.
+    await criarRouter(c.session, { membro });
+
+    expect(await drenaEGeraJob(c)).toBe(true);
+  });
+
+  it("roteador ativo cujo FALLBACK está pausado: nada é enfileirado", async () => {
+    const c = await montarCenario("fallback-pausado");
+    const fallback = await criarAgente(c.session, { publicado: false, nome: "fallback-pausado" });
+    await criarRouter(c.session, { fallback });
+
+    expect(await drenaEGeraJob(c)).toBe(false);
+  });
+
+  it("roteador ativo com FALLBACK publicado: o turno é enfileirado", async () => {
+    const c = await montarCenario("fallback-publicado");
+    const fallback = await criarAgente(c.session, { publicado: true, nome: "fallback-publicado" });
+    await criarRouter(c.session, { fallback });
+
+    expect(await drenaEGeraJob(c)).toBe(true);
+  });
+
+  it("agente ARQUIVADO com versão publicada: nada é enfileirado", async () => {
+    // Arquivar não supersede a versão (medido em `_actions.ts`), então o
+    // `v.status='published'` sozinho não basta — o `archived_at is null` do
+    // portão é que segura.
+    const c = await montarCenario("arquivado");
+    const agente = await criarAgente(c.session, { publicado: true, nome: "arquivado" });
+    await pool.query(`update ai_agents set archived_at = now() where id = $1`, [agente]);
+
+    expect(await drenaEGeraJob(c)).toBe(false);
+  });
+});

--- a/tests/unit/agente-pausado-nao-atende.test.ts
+++ b/tests/unit/agente-pausado-nao-atende.test.ts
@@ -1,0 +1,301 @@
+/**
+ * PAUSAR TEM QUE CALAR — inclusive pelo caminho legado.
+ *
+ * ─── O defeito, medido em produção (VPS `crm.deskcomm.com.br`, 2026-08-28) ───
+ *
+ * O dono pausa um agente na tela. A tela passa a mostrar **Rascunho**. E ele
+ * volta a responder no WhatsApp. A cadeia tem quatro elos, todos na fonte:
+ *
+ *   1. `pauseAgentAction` (app/app/ai/agents/_actions.ts) limpava
+ *      `published_version_id` mas só desligava `is_active` quando
+ *      `kind !== "mcp_agent"` — e `mcp_agent` é o que o onboarding cria
+ *      (`createDefaultAgent.ts`, `kind: "mcp_agent"`, `is_active: true`).
+ *      A rota REST `/api/v1/ai/agents/:id/pause` não escrevia `is_active`
+ *      para kind NENHUM.
+ *   2. `deriveAgentStatus` ignora `is_active` para `mcp_agent` — e está certo:
+ *      quem decide "no ar" para o engine é `published_version_id`. Só que a
+ *      coluna continua ligada embaixo, sem nada na tela apontando para ela.
+ *   3. `workers/ai-response-worker.ts` escolhe o agente por `.eq("is_active",
+ *      true)`, sem `archived_at`, sem `published_version_id` e sem `kind`.
+ *   4. A trava que segura esse worker (`skip("engine_owns_reply")`) é
+ *      ORG-WIDE: ela só age se existir ALGUM agente publicado na organização.
+ *
+ * Logo: **pausar o último agente publicado desarma a trava do elo 4 e entrega
+ * o atendimento ao elo 3, que ainda enxerga o agente pausado pelo elo 1.**
+ * Ele responde com o `system_prompt` da tabela `ai_agents` (o do cadastro, não
+ * o da versão publicada), sem as ferramentas, os funis nem os guardrails que a
+ * versão carregava.
+ *
+ * Este arquivo prende o COMPORTAMENTO nas duas pontas — o que o dono pausou
+ * fica calado, e o que ele nunca pausou continua atendendo. Só a primeira
+ * metade seria satisfeita por um worker que não responde nunca.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const envMock: Record<string, string> = {
+  ANTHROPIC_API_KEY: "sk-ant-teste",
+  AI_GATEWAY_API_KEY: "",
+  AI_GATEWAY_BASE_URL: "",
+  OPENROUTER_API_KEY: "",
+  OPENROUTER_BASE_URL: "",
+  OPENAI_API_KEY: "",
+};
+vi.mock("@/lib/env", () => ({
+  get env() {
+    return envMock;
+  },
+}));
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { processMessageReceived } from "@/workers/ai-response-worker";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { EventRow } from "@/lib/event-log/dispatcher";
+
+const ORG_ID = "22222222-2222-4222-8222-222222222222";
+const CONV_ID = "44444444-4444-4444-8444-444444444444";
+const MSG_ID = "55555555-5555-4555-8555-555555555555";
+const CONTACT_ID = "66666666-6666-4666-8666-666666666666";
+const AGENT_ID = "88888888-8888-4888-8888-888888888888";
+const VERSION_ID = "99999999-9999-4999-8999-999999999999";
+
+/** Neutro de propósito: gatilho de handoff desviaria antes da escolha do agente. */
+const INBOUND_BODY = "bom dia, qual o prazo de entrega?";
+
+/** A linha de `ai_agents` do jeito que o banco a entrega ao worker. */
+interface AgenteNoBanco {
+  kind: string;
+  is_active: boolean;
+  published_version_id: string | null;
+  archived_at: string | null;
+}
+
+function makeAdminStub(agente: AgenteNoBanco) {
+  const from = (table: string) => {
+    const single: Record<string, unknown> | null =
+      table === "conversations"
+        ? {
+            id: CONV_ID,
+            organization_id: ORG_ID,
+            contact_id: CONTACT_ID,
+            channel_session_id: "77777777-7777-4777-8777-777777777777",
+            last_inbound_at: new Date().toISOString(),
+            bot_silenced_until: null,
+            last_handoff_at: null,
+            assignee_kind: "ai",
+            contacts: {
+              id: CONTACT_ID,
+              display_name: null, // sem PII em teste (LGPD)
+              locale: "pt-BR",
+              is_blocked: false,
+              force_human: false,
+            },
+          }
+        : table === "messages"
+          ? { id: MSG_ID, body: INBOUND_BODY, direction: "inbound", organization_id: ORG_ID }
+          : table === "ai_agents"
+            ? {
+                id: AGENT_ID,
+                organization_id: ORG_ID,
+                model: "anthropic/claude-sonnet-4-6",
+                system_prompt: "Você é um atendente.",
+                config: { confidence_threshold: 0 },
+                guardrails: {},
+                active_kb_version_id: VERSION_ID,
+                is_active: agente.is_active,
+                is_default: true,
+                kind: agente.kind,
+                published_version_id: agente.published_version_id,
+                archived_at: agente.archived_at,
+              }
+            : null;
+
+    /**
+     * O dublê precisa DIZER em que mundo está. O worker faz DUAS perguntas à
+     * mesma tabela: "quem é o agente?" e "esta org tem algum publicado?". Um
+     * Proxy que devolve a mesma linha às duas faria o worker ceder sempre
+     * (`engine_owns_reply`) e o teste ficaria verde medindo o skip errado.
+     *
+     * A discriminação é o filtro `.not("published_version_id", "is", null)` —
+     * e a resposta dela vem do MESMO estado do agente, que é o que torna o
+     * dublê fiel: um agente pausado não é publicado para nenhuma das duas.
+     */
+    let consultaDePublicado = false;
+    let filtraNaoArquivado = false;
+    let filtraAtivo = false;
+    const filtrosDeAgente: string[] = [];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const terminais: any = {
+      maybeSingle: () => {
+        if (table !== "ai_agents") return Promise.resolve({ data: single, error: null });
+        if (consultaDePublicado) {
+          const publicado = agente.published_version_id !== null && agente.archived_at === null;
+          return Promise.resolve({ data: publicado ? { id: AGENT_ID } : null, error: null });
+        }
+        return Promise.resolve({ data: linhasDeAgente()[0] ?? null, error: null });
+      },
+      single: () => Promise.resolve({ data: single, error: null }),
+      insert: (row: Record<string, unknown>) => {
+        inserted.push({ table, row });
+        return {
+          select: () => ({
+            single: () =>
+              Promise.resolve({ data: { id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }, error: null }),
+          }),
+          then: (resolve: (v: unknown) => unknown) =>
+            Promise.resolve({ data: null, error: null }).then(resolve),
+        };
+      },
+      then: (resolve: (v: unknown) => unknown) =>
+        Promise.resolve({
+          data:
+            table === "messages"
+              ? [
+                  {
+                    id: MSG_ID,
+                    body: INBOUND_BODY,
+                    direction: "inbound",
+                    created_at: new Date().toISOString(),
+                  },
+                ]
+              : table === "ai_agents"
+                ? linhasDeAgente()
+                : [],
+          error: null,
+        }).then(resolve),
+    };
+
+    /**
+     * O que o SELECT de agentes devolve, HONRANDO os filtros que o worker
+     * pediu. Sem isto o dublê entregaria a linha mesmo quando o worker filtrou
+     * corretamente, e os dois casos de controle (`rag_bot` desativado,
+     * arquivado) passariam pelo motivo errado — provando o dublê, não o código.
+     */
+    function linhasDeAgente(): Array<Record<string, unknown>> {
+      if (single === null) return [];
+      if (filtraAtivo && agente.is_active !== true) return [];
+      if (filtraNaoArquivado && agente.archived_at !== null) return [];
+      return [single];
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const chain: any = new Proxy(terminais, {
+      get: (alvo, prop) =>
+        prop in alvo
+          ? alvo[prop as keyof typeof alvo]
+          : (...args: unknown[]) => {
+              if (table === "ai_agents") {
+                if (prop === "not" && args[0] === "published_version_id") consultaDePublicado = true;
+                if (prop === "is" && args[0] === "archived_at") filtraNaoArquivado = true;
+                if (prop === "eq" && args[0] === "is_active") filtraAtivo = true;
+                if (typeof args[0] === "string") filtrosDeAgente.push(`${String(prop)}:${args[0]}`);
+              }
+              return chain;
+            },
+    });
+    return chain;
+  };
+
+  const inserted: Array<{ table: string; row: Record<string, unknown> }> = [];
+  const rpc = () => Promise.resolve({ data: [], error: null });
+  return { stub: { from, rpc }, inserted };
+}
+
+const eventRow = {
+  organization_id: ORG_ID,
+  entity_id: MSG_ID,
+  payload: { message_id: MSG_ID, conversation_id: CONV_ID },
+} as unknown as EventRow;
+
+let fetchOriginal: typeof globalThis.fetch;
+let destinos: string[];
+
+function armar(agente: AgenteNoBanco) {
+  const { stub, inserted } = makeAdminStub(agente);
+  vi.mocked(createAdminClient).mockReturnValue(stub as unknown as ReturnType<typeof createAdminClient>);
+  return inserted;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  destinos = [];
+  fetchOriginal = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" || input instanceof URL ? String(input) : input.url;
+    destinos.push(new URL(url).host);
+    return new Response(
+      JSON.stringify({
+        id: "msg_stub",
+        type: "message",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "Nosso prazo é de 3 dias úteis." }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 10, output_tokens: 8 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = fetchOriginal;
+});
+
+describe("worker legado — o que a tela chama de Rascunho/Arquivado não responde", () => {
+  it("mcp_agent PAUSADO (sem versão publicada) não fala com o cliente", async () => {
+    // Exatamente o estado que `pauseAgentAction` deixava para trás: o ponteiro
+    // de publicação limpo (tela mostra "Rascunho") e `is_active` intacto.
+    armar({ kind: "mcp_agent", is_active: true, published_version_id: null, archived_at: null });
+
+    const result = await processMessageReceived(eventRow);
+
+    expect(
+      destinos,
+      `o worker chamou o provider por um agente PAUSADO (destinos: ${destinos.join(", ") || "nenhum"})`,
+    ).toEqual([]);
+    expect(result.status).not.toBe("sent_to_dispatch");
+  });
+
+  it("mcp_agent ARQUIVADO não fala com o cliente, mesmo com is_active de pé", async () => {
+    // `archiveAgentAction` tem a mesma lacuna de kind; o worker nunca filtrou
+    // `archived_at`, então o buraco existe pelos dois lados.
+    armar({
+      kind: "mcp_agent",
+      is_active: true,
+      published_version_id: null,
+      archived_at: "2026-08-01T00:00:00.000Z",
+    });
+
+    const result = await processMessageReceived(eventRow);
+
+    expect(destinos, "o worker respondeu por um agente ARQUIVADO").toEqual([]);
+    expect(result.status).not.toBe("sent_to_dispatch");
+  });
+
+  it("rag_bot legado ATIVO e nunca publicado continua atendendo — o caminho que este worker existe para servir", async () => {
+    // A outra ponta, e ela não é decorativa: um conserto que só silencia
+    // deixaria este caso verde por acidente. Quem nunca publicou versão nenhuma
+    // depende deste worker — é o que o comentário de `engine_owns_reply` promete.
+    armar({ kind: "rag_bot", is_active: true, published_version_id: null, archived_at: null });
+
+    const result = await processMessageReceived(eventRow);
+
+    expect(
+      destinos,
+      `o worker legado deixou de atender quem depende dele (status: ${result.status}, reason: ${result.reason ?? "-"})`,
+    ).toContain("api.anthropic.com");
+  });
+
+  it("rag_bot DESATIVADO não fala com o cliente", async () => {
+    armar({ kind: "rag_bot", is_active: false, published_version_id: null, archived_at: null });
+
+    const result = await processMessageReceived(eventRow);
+
+    expect(destinos).toEqual([]);
+    expect(result.status).not.toBe("sent_to_dispatch");
+  });
+});

--- a/tests/unit/ai-response-bot-veto.test.ts
+++ b/tests/unit/ai-response-bot-veto.test.ts
@@ -48,6 +48,9 @@ function makeAdminStub(tables: StubTables, queried: string[]) {
     const chain: any = {
       select: () => chain,
       eq: () => chain,
+      // `.is("archived_at", null)`: o worker legado passou a filtrar agente
+      // arquivado no SELECT, e um dublê literal quebra a cada filtro novo.
+      is: () => chain,
       order: () => chain,
       limit: () => chain,
       maybeSingle: () => Promise.resolve({ data: result, error: null }),

--- a/tests/unit/ai-response-worker-model-routing.test.ts
+++ b/tests/unit/ai-response-worker-model-routing.test.ts
@@ -114,6 +114,13 @@ function makeAdminStub() {
                 active_kb_version_id: "99999999-9999-4999-8999-999999999999",
                 is_active: true,
                 is_default: true,
+                // O banco tem `kind` NOT NULL DEFAULT 'rag_bot' e os dois ponteiros:
+                // sem eles o dublê descreveria uma linha que não existe, e a régua
+                // de `lib/ai/agents/no-ar.ts` — que falha FECHADA quando o select
+                // não trouxe `kind` — recusaria o agente pelo motivo errado.
+                kind: "rag_bot",
+                published_version_id: null,
+                archived_at: null,
               }
             : null; // ai_budgets sem linha = sem throttle; crm_leads sem lead
 
@@ -150,7 +157,12 @@ function makeAdminStub() {
           data:
             table === "messages"
               ? [{ id: MSG_ID, body: INBOUND_BODY, direction: "inbound", created_at: new Date().toISOString() }]
-              : [],
+              // A seleção de agente do worker legado é uma LISTA (ele filtra os
+              // candidatos pela régua de `lib/ai/agents/no-ar.ts` em vez de cortar
+              // com `.limit(1)` antes de saber quem serve). O dublê acompanha.
+              : table === "ai_agents"
+                ? (single ? [single] : [])
+                : [],
           error: null,
         }).then(resolve),
     };

--- a/tests/unit/ai-response-worker-sent-via.test.ts
+++ b/tests/unit/ai-response-worker-sent-via.test.ts
@@ -136,6 +136,13 @@ function makeAdminStub(confidenceThreshold: number) {
                 active_kb_version_id: "99999999-9999-4999-8999-999999999999",
                 is_active: true,
                 is_default: true,
+                // O banco tem `kind` NOT NULL DEFAULT 'rag_bot' e os dois ponteiros:
+                // sem eles o dublê descreveria uma linha que não existe, e a régua
+                // de `lib/ai/agents/no-ar.ts` — que falha FECHADA quando o select
+                // não trouxe `kind` — recusaria o agente pelo motivo errado.
+                kind: "rag_bot",
+                published_version_id: null,
+                archived_at: null,
               }
             : null; // ai_budgets sem linha = sem throttle; crm_leads sem lead
 
@@ -192,7 +199,12 @@ function makeAdminStub(confidenceThreshold: number) {
                     created_at: new Date().toISOString(),
                   },
                 ]
-              : [],
+              // A seleção de agente do worker legado é uma LISTA (ele filtra os
+              // candidatos pela régua de `lib/ai/agents/no-ar.ts` em vez de cortar
+              // com `.limit(1)` antes de saber quem serve). O dublê acompanha.
+              : table === "ai_agents"
+                ? (single ? [single] : [])
+                : [],
           error: null,
         }).then(resolve),
     };

--- a/tests/unit/orcamento-caminho-legado.test.ts
+++ b/tests/unit/orcamento-caminho-legado.test.ts
@@ -147,6 +147,13 @@ function makeAdminStub(
                 active_kb_version_id: "99999999-9999-4999-8999-999999999999",
                 is_active: true,
                 is_default: true,
+                // O banco tem `kind` NOT NULL DEFAULT 'rag_bot' e os dois ponteiros:
+                // sem eles o dublê descreveria uma linha que não existe, e a régua
+                // de `lib/ai/agents/no-ar.ts` — que falha FECHADA quando o select
+                // não trouxe `kind` — recusaria o agente pelo motivo errado.
+                kind: "rag_bot",
+                published_version_id: null,
+                archived_at: null,
               }
             : null;
 
@@ -194,7 +201,12 @@ function makeAdminStub(
                     created_at: new Date().toISOString(),
                   },
                 ]
-              : [],
+              // A seleção de agente do worker legado é uma LISTA (ele filtra os
+              // candidatos pela régua de `lib/ai/agents/no-ar.ts` em vez de cortar
+              // com `.limit(1)` antes de saber quem serve). O dublê acompanha.
+              : table === "ai_agents"
+                ? (single ? [single] : [])
+                : [],
           count,
           error: null,
         }).then(resolve);

--- a/tests/unit/telemetria-diz-o-modelo-do-painel.test.ts
+++ b/tests/unit/telemetria-diz-o-modelo-do-painel.test.ts
@@ -99,6 +99,13 @@ function makeAdminStub() {
                 active_kb_version_id: "99999999-9999-4999-8999-999999999999",
                 is_active: true,
                 is_default: true,
+                // O banco tem `kind` NOT NULL DEFAULT 'rag_bot' e os dois ponteiros:
+                // sem eles o dublê descreveria uma linha que não existe, e a régua
+                // de `lib/ai/agents/no-ar.ts` — que falha FECHADA quando o select
+                // não trouxe `kind` — recusaria o agente pelo motivo errado.
+                kind: "rag_bot",
+                published_version_id: null,
+                archived_at: null,
               }
             : null;
 
@@ -127,7 +134,12 @@ function makeAdminStub() {
                     created_at: new Date().toISOString(),
                   },
                 ]
-              : [],
+              // A seleção de agente do worker legado é uma LISTA (ele filtra os
+              // candidatos pela régua de `lib/ai/agents/no-ar.ts` em vez de cortar
+              // com `.limit(1)` antes de saber quem serve). O dublê acompanha.
+              : table === "ai_agents"
+                ? (single ? [single] : [])
+                : [],
           error: null,
         }).then(resolve),
     };

--- a/workers/ai-response-worker.ts
+++ b/workers/ai-response-worker.ts
@@ -35,6 +35,7 @@ import {
 } from "@/lib/agent-engine/edge/llm/orcamento";
 import { computeCost } from "@/lib/ai/cost";
 import { logInvocation } from "@/lib/ai/log-invocation";
+import { elegivelParaWorkerLegado } from "@/lib/ai/agents/no-ar";
 import { renderSystemPrompt } from "@/lib/ai/render-system-prompt";
 import { triggerHandoff } from "@/lib/ai/handoff/orchestrator";
 import { checkG1, checkG3, checkG4Legal, checkG4Stage } from "@/lib/ai/handoff/triggers";
@@ -638,18 +639,40 @@ async function buildContext(input: BuildContextInput): Promise<GuardDecision> {
   const inbound_body = (msg.body ?? "").trim();
   if (!inbound_body) return skip("empty_inbound_body");
 
-  // Default agent for this tenant.
-  const { data: agent } = await admin
+  // O agente legado desta organização.
+  //
+  // `is_active` sozinho NÃO é "quem atende", e tratá-lo como se fosse era o
+  // buraco: pausar um `mcp_agent` limpa `published_version_id` e deixa
+  // `is_active` de pé, então este SELECT continuava trazendo o agente que o dono
+  // acabara de pausar — e a trava `engine_owns_reply` logo abaixo, que é
+  // ORG-WIDE, deixa de valer exatamente quando o último publicado é pausado.
+  // Resultado medido em produção: pausar o agente o fazia VOLTAR a responder,
+  // com o `system_prompt` do cadastro no lugar do da versão publicada.
+  //
+  // A régua agora é a mesma que a tela usa (`lib/ai/agents/no-ar.ts`).
+  //
+  // ⚠️ Quem PROTEGE é a régua, não o `.is("archived_at", null)` abaixo — medido
+  // por sabotagem: apagar o filtro deixa os 4 casos de
+  // `tests/unit/agente-pausado-nao-atende.test.ts` verdes, porque
+  // `estadoDoAgente` já devolve "arquivado". O filtro fica por ser mais barato
+  // não trazer do banco o que vai ser descartado; não confie nele como guarda.
+  // Sem `.limit(1)`: o primeiro da ordem pode ser justamente o que a régua
+  // recusa, e cortar antes de filtrar faria um `mcp_agent` pausado — que é
+  // `is_default` na instalação que o onboarding cria — esconder o `rag_bot`
+  // legítimo logo abaixo dele. A ordem (`is_default`, depois `created_at`) é a
+  // de sempre; o que muda é que ela agora escolhe entre os ELEGÍVEIS.
+  const { data: candidatos } = await admin
     .from("ai_agents")
     .select(
-      "id, organization_id, model, system_prompt, config, guardrails, active_kb_version_id, is_active, is_default",
+      "id, organization_id, model, system_prompt, config, guardrails, active_kb_version_id, is_active, is_default, kind, published_version_id, archived_at",
     )
     .eq("organization_id", input.organizationId)
     .eq("is_active", true)
+    .is("archived_at", null)
     .order("is_default", { ascending: false })
-    .order("created_at", { ascending: true })
-    .limit(1)
-    .maybeSingle();
+    .order("created_at", { ascending: true });
+
+  const agent = (candidatos ?? []).find(elegivelParaWorkerLegado) ?? null;
 
   if (!agent) return skip("agent_inactive_or_missing");
 

--- a/workers/ai-sentiment-worker.ts
+++ b/workers/ai-sentiment-worker.ts
@@ -16,6 +16,7 @@
 import { generateObject } from "ai";
 import { z } from "zod";
 
+import { agenteAtende } from "@/lib/ai/agents/no-ar";
 import { computeCost } from "@/lib/ai/cost";
 import { DEFAULT_CLASSIFIER_MODEL, isAiGatewayConfigured } from "@/lib/ai/gateway";
 import { resolverModeloDoPonto } from "@/lib/ai/gateway-binding";
@@ -117,15 +118,20 @@ export async function processSentiment(event: EventRow): Promise<SentimentResult
     }
 
     // ── Load active agent to read sentiment_threshold config ──────────────
-    const { data: agent } = await admin
+    //
+    // Mesma régua da tela e do ai-response-worker (`lib/ai/agents/no-ar.ts`).
+    // Antes era `.eq("is_active", true)` sozinho, e pausar um `mcp_agent` não
+    // desliga essa coluna: o limiar de sentimento continuava saindo do agente
+    // que o dono acabara de pausar.
+    const { data: candidatos } = await admin
       .from("ai_agents")
-      .select("id, config")
+      .select("id, config, kind, is_active, published_version_id, archived_at")
       .eq("organization_id", event.organization_id)
-      .eq("is_active", true)
+      .is("archived_at", null)
       .order("is_default", { ascending: false })
-      .order("created_at", { ascending: true })
-      .limit(1)
-      .maybeSingle();
+      .order("created_at", { ascending: true });
+
+    const agent = (candidatos ?? []).find(agenteAtende) ?? null;
 
     const agentConfig = (agent?.config as Record<string, unknown> | null) ?? {};
     const threshold =


### PR DESCRIPTION
## O defeito

`ai_agents.is_active` é semântica do `rag_bot` legado, e **pausar um `mcp_agent` não desliga essa coluna** — `pauseAgentAction` só o faz quando `kind !== "mcp_agent"`, e a rota REST de pausa nunca a escreve.

`workers/ai-response-worker.ts` escolhia o agente por `.eq("is_active", true)`, sem `archived_at`, sem `published_version_id` e sem `kind`. E a trava que segura esse worker (`skip("engine_owns_reply")`) é **ORG-WIDE**.

> **Pausar o último agente publicado da organização desarma a trava e devolve o atendimento ao worker legado — que segue enxergando o agente recém-pausado.** Ele responde com o `system_prompt` do CADASTRO (não o da versão publicada), sem as ferramentas, os funis nem os guardrails que a versão carregava. A tela, nesse momento, mostra o agente como **"Rascunho"**.

Medido na VPS de produção em 2026-08-28.

**O resolvedor do turno do agent-engine está CORRETO e não faz parte do defeito** — o log de produção diz `origem_da_escolha: "agente_publicado"`, e `loadPublishedAgentConfig[ById]` fazem inner join em `published_version_id` + `v.status='published'`. Quem erra é o caminho legado.

## O conserto

A régua de "quem está no ar" vivia duplicada em três lugares que discordavam. Agora é uma só — `lib/ai/agents/no-ar.ts` (`estadoDoAgente` → `arquivado | no_ar | no_ar_legado | parado`) — importada por:

| sítio | era | virou |
|---|---|---|
| `workers/ai-response-worker.ts` | `.eq("is_active", true).limit(1)` | lista + `.find(elegivelParaWorkerLegado)` |
| `workers/ai-sentiment-worker.ts` | idem | lista + `.find(agenteAtende)` |
| `app/api/v1/ai/automatico-ativo/route.ts` | `count` por `is_active` | `.some(agenteAtende)` |
| `app/api/v1/ai/agents/assignable/route.ts` | `.eq("is_active", true)` | `.filter(agenteAtende)` |
| `AgentStatusBadge.tsx` | régua própria duplicada | delega a `estadoDoAgente` |
| `lib/agent-engine/edge/crm/drain.ts` | portão contava LINHA de membro | conta membro/fallback **publicado** |

A régua **falha fechada na ação**: exige `kind === 'rag_bot'` explícito para o ramo legado, de modo que um `.select()` que esqueça a coluna não faça o worker responder por um agente sobre o qual não se sabe nada.

O `.limit(1)` saiu do SELECT do worker de propósito: cortar antes de filtrar faria um `mcp_agent` pausado — que é `is_default` na instalação que o onboarding cria — esconder o `rag_bot` legítimo logo abaixo dele.

## Três erros de sinal que vieram junto

1. **Portão de custo do drain** contava LINHA de `ai_router_members` em vez de membro publicável. Roteador com todos os membros pausados seguia abrindo o portão: uma chamada de classificador por mensagem recebida, para não classificar nada.
2. **Picker de dono de negócio** (`assignable`) errava nos **dois** sentidos — escondia agente publicado ("Novo agente" grava `is_active: false` e publicar nunca religa) e oferecia agente pausado.
3. **`/ai/automatico-ativo`** dizia "IA atendendo" depois de o dono pausar tudo, porque contava `is_active`. O selo da Inbox sai dali.

## Verificação

| gate | resultado |
|---|---|
| `pnpm test:unit` | 574/575 arquivos verdes |
| `pnpm test:db` | **137/137 arquivos, 1050 casos** |
| `pnpm build` / `tsc --noEmit` / `pnpm lint` | verdes (0 erros) |
| `pnpm lint:channels` | ok, nenhuma dívida nova |

A única suíte vermelha localmente é `lib/ai/dispatcher/rate-limit.test.ts` — o vermelho conhecido e **alheio** que o `CLAUDE.md` documenta (Redis do `.env.local` fora do ar). Conferido que este PR não toca `lib/ai/dispatcher/`.

### Provado em tela

Playwright dirigindo o app local em modo produção, login real com senha + TOTP. Com tudo pausado: os três agentes viram "Rascunho", o picker fica vazio e a Inbox passa de **"Automático"** para **"Sem responsável"**. Republicando um agente, volta para "Automático".

A divergência isolada sobre os mesmos dados:

```
     estado     | régua ANTIGA (is_active) | régua NOVA
----------------+--------------------------+------------
 COM publicado  | t                        | t
 TODOS pausados | t   <- a mentira         | f
```

### Sabotagem (previsão declarada ANTES de rodar)

| sabotagem | previsão | medido |
|---|---|---|
| tirar `.find(elegivelParaWorkerLegado)` | 1 falha (só o PAUSADO) | 1 ✓ |
| tirar `.is("archived_at", null)` | 0 (a régua JS já cobre) | 0 ✓ |
| portão do drain de volta ao predicado antigo | 2: MEMBRO e FALLBACK pausados | exatamente essas 2 ✓ |

A segunda linha está escrita no próprio código: o filtro SQL de `archived_at` é redundante e não deve ser confundido com a guarda.

## Não entra aqui

**Sem mudança de schema** — nenhuma migration necessária.

O relato de origem incluía a IA respondendo com a persona de outra empresa. Isso tem causa **separada e não é bug**: memória da org (`/app/ai/memory`) e skills (`/app/ai/skills`) são por **organização**, e trocar o agente publicado troca só uma das três camadas do prompt. Registrado em `docs/handoff/agente-pausado-assume-conversa.md`, junto com os seis becos investigados e descartados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
