### PR TITLE
As specs de agenda trabalhavam na semana de hoje, e hoje esvazia

### DIFF
--- a/tests/e2e/agenda-grade-interativa.spec.ts
+++ b/tests/e2e/agenda-grade-interativa.spec.ts
@@ -4,6 +4,8 @@ import * as path from "node:path";
 
 import { test, expect, type Page } from "@playwright/test";
 
+import { irParaASemanaSeguinte } from "./helpers/agenda-semana-integra";
+
 /**
  * A GRADE COMO AGENDA DE VERDADE — clicar num bloco marca, arrastar um card
  * remarca, e o que não dá para fazer DIZ por quê.
@@ -107,8 +109,20 @@ function blocoBloqueado(page: Page) {
     .first();
 }
 
-/** Espera a consulta de horários da grade responder antes de medir qualquer coisa. */
-async function esperarADisponibilidade(page: Page) {
+/**
+ * Leva a grade para a semana SEGUINTE e espera a disponibilidade dela responder.
+ *
+ * ⚠️ A NAVEGAÇÃO NÃO É CONVENIÊNCIA, é a condição de o caso existir. A grade
+ * pede horários para exatamente a semana que desenha, e a semana de HOJE só
+ * oferece o resto de hoje: medido com o motor real numa sexta, 16 vagas às 9h,
+ * 4 às 15h, ZERO das 17h em diante — e zero o sábado inteiro, porque ali a
+ * semana desenhada só tem dias úteis já passados. Foi assim que estas specs
+ * derrubaram a `main` em quatro runs seguidos a partir das ~15h50.
+ *
+ * A razão inteira, com a tabela medida, está em `helpers/agenda-semana-integra`.
+ */
+async function irParaASemanaIntegra(page: Page) {
+  await irParaASemanaSeguinte(page);
   await expect(
     blocoLivre(page),
     "nenhum bloco livre na semana desenhada — a rota de horários respondeu vazio, " +
@@ -132,7 +146,7 @@ test("clicar num bloco livre abre a marcação NAQUELE horário", async ({ page 
   const creds = lerCreds();
   await entrar(page, creds);
   await escolherOTipoDoSeed(page, creds.agenda!.tipo_nome);
-  await esperarADisponibilidade(page);
+  await irParaASemanaIntegra(page);
 
   const bloco = blocoLivre(page);
   // O bloco oferece o horário PUBLICADO que começa dentro dele, e o anuncia no
@@ -164,7 +178,7 @@ test("bloco fora da disponibilidade não marca — e diz por quê", async ({ pag
   const creds = lerCreds();
   await entrar(page, creds);
   await escolherOTipoDoSeed(page, creds.agenda!.tipo_nome);
-  await esperarADisponibilidade(page);
+  await irParaASemanaIntegra(page);
 
   const bloqueado = blocoBloqueado(page);
   await expect(bloqueado).toBeAttached({ timeout: 15_000 });
@@ -193,7 +207,7 @@ test("arrastar um card remarca — e o horário novo sobrevive ao reload", async
   const creds = lerCreds();
   await entrar(page, creds);
   await escolherOTipoDoSeed(page, creds.agenda!.tipo_nome);
-  await esperarADisponibilidade(page);
+  await irParaASemanaIntegra(page);
 
   // ── o compromisso de trabalho, criado pelo caminho novo ────────────────
   const respostas: string[] = [];
@@ -315,6 +329,16 @@ test("arrastar um card remarca — e o horário novo sobrevive ao reload", async
 
   await page.reload();
   await expect(page.getByTestId("tela-agenda")).toBeVisible({ timeout: 20_000 });
+  // ⚠️ O F5 DESFAZ A NAVEGAÇÃO — a âncora da grade é estado do React (`useState(new
+  // Date())`), então recarregar devolve a tela para a semana de HOJE. O
+  // compromisso vive na semana seguinte, e sem voltar até ele a asserção abaixo
+  // procura um cartão que a grade não tem por que desenhar: a falha lê "o
+  // horário novo não sobreviveu ao reload", que é a acusação errada.
+  //
+  // Medido: sem esta linha o caso reprova com `element(s) not found` no
+  // `faixa-<id>`, com o servidor tendo confirmado o horário novo dois `await`
+  // acima. O que não sobrevive ao F5 é a NAVEGAÇÃO, não o dado.
+  await irParaASemanaSeguinte(page);
   const cardDepois = page.locator(`button:has([data-testid="faixa-${id}"])`);
   await expect(cardDepois).toHaveAttribute("aria-label", new RegExp(`${horarioOferecido} às`), {
     timeout: 20_000,
@@ -346,7 +370,7 @@ test("arrastar para fora da disponibilidade é RECUSADO e o card volta", async (
   const creds = lerCreds();
   await entrar(page, creds);
   await escolherOTipoDoSeed(page, creds.agenda!.tipo_nome);
-  await esperarADisponibilidade(page);
+  await irParaASemanaIntegra(page);
 
   const respostas: string[] = [];
   page.on("response", (r) => {

--- a/tests/e2e/agenda-marcar-pela-tela.spec.ts
+++ b/tests/e2e/agenda-marcar-pela-tela.spec.ts
@@ -4,6 +4,8 @@ import * as path from "node:path";
 
 import { test, expect } from "@playwright/test";
 
+import { escolherDiaDesenhado, irParaASemanaSeguinte } from "./helpers/agenda-semana-integra";
+
 /**
  * A PROVA EM TELA DA FRENTE 1 (API + motor) — agora ESCRITA, e o caminho até aqui
  * é o registro que interessa.
@@ -131,6 +133,20 @@ test("marcar um horário pela tela e vê-lo aparecer na grade — sem recarregar
   await page.goto("/app/agenda");
   await expect(page.getByTestId("tela-agenda")).toBeVisible({ timeout: 20_000 });
 
+  // ⚠️ A SEMANA SEGUINTE, e ela é a condição de o caso poder passar.
+  //
+  // A asserção final desta spec é `faixa-<id>` DESENHADO NA GRADE — e a grade
+  // desenha uma semana só. Enquanto o painel escolhia "o primeiro dia com vaga"
+  // e a grade ficava na semana de hoje, os dois falavam de períodos diferentes
+  // assim que hoje esgotava: depois das 17h o painel oferecia a segunda-feira, o
+  // compromisso nascia na semana seguinte, e a grade — parada na semana de sexta
+  // — nunca o desenhava. A falha lia "a grade não repinta sem F5", acusando o
+  // produto de um defeito que era do período escolhido pelo teste.
+  //
+  // Navegando primeiro, alvo e grade passam a sair da MESMA fonte: os dias que
+  // a tela desenhou. Tabela medida em `helpers/agenda-semana-integra`.
+  const diasDaSemana = await irParaASemanaSeguinte(page);
+
   const antes = await cartoesDaGrade(page).count();
 
   // ── marcar, pela tela, como um humano faria ────────────────────────────
@@ -152,9 +168,8 @@ test("marcar um horário pela tela e vê-lo aparecer na grade — sem recarregar
   await expect(page.getByTestId("tipos-de-agendamento")).toBeVisible({ timeout: 10_000 });
   await page.getByRole("button", { name: new RegExp(`^${creds.agenda.tipo_nome}`) }).click();
 
-  const dia = page.locator('[data-testid^="dia-"]:not([disabled])').first();
   try {
-    await expect(dia).toBeVisible({ timeout: 15_000 });
+    await escolherDiaDesenhado(page, diasDaSemana);
   } catch (erro) {
     // A mensagem do `expect` é avaliada ANTES de a asserção rodar, então ela não
     // pode carregar o que a rota respondeu. Enriquecer no catch é o que permite
@@ -165,7 +180,6 @@ test("marcar um horário pela tela e vê-lo aparecer na grade — sem recarregar
         `\n\n${(erro as Error).message}`,
     );
   }
-  await dia.click();
 
   const horario = page.locator('[data-testid^="horario-"]').first();
   await expect(horario, "o dia foi escolhido e não veio horário nenhum").toBeVisible({ timeout: 15_000 });

--- a/tests/e2e/agenda-painel-cabe-na-tela.spec.ts
+++ b/tests/e2e/agenda-painel-cabe-na-tela.spec.ts
@@ -4,6 +4,8 @@ import * as path from "node:path";
 
 import { test, expect, type Page } from "@playwright/test";
 
+import { escolherPrimeiroDiaCheio } from "./helpers/agenda-semana-integra";
+
 /**
  * O PAINEL DE MARCAR CABE NA TELA — medido por GEOMETRIA, não por presença.
  *
@@ -112,71 +114,11 @@ async function abrirPainelComDiaEscolhido(page: Page, nomeDoTipo: string): Promi
 
   // ⚠️ UM DIA INTEIRO, e NÃO o primeiro clicável — que é HOJE, já meio gasto.
   //
-  // Era `[data-disponivel="true"]`.first(), e o primeiro clicável é hoje: os dias
-  // passados não têm slot nenhum. Só que a jornada do seed é 09:00–18:00 e o tipo
-  // exige 60min de antecedência, então o que HOJE ainda oferece é o RESTO do dia —
-  // um número que é função do relógio de parede, não do seed:
-  //
-  //     run 33183384573, main, 15:27 UTC → 9 horários — "Received: 450"
-  //     run 33189014104, main, 16:37 UTC → 7 horários — "Received: 350"
-  //
-  // Mesmo commit, mesmo seed, contagens diferentes: a variável é a hora. Antes das
-  // ~15:00 UTC sobram 10+ horários e a pré-condição de suficiência passa; depois
-  // dela o caso reprova por FALTA DE CENÁRIO — a lista cabe na tela e, como a
-  // própria mensagem diz, o verde ali não seria evidência. A main ficou vermelha
-  // ao meio-dia sem ninguém ter mexido em nada.
-  //
-  // Um dia FUTURO oferece a janela inteira: 09:00–17:30 de 30 em 30 = 18 horários,
-  // 900px de lista, independentes de que horas são. O cenário deixa de depender do
-  // relógio sem que asserção nenhuma afrouxe — a pré-condição continua exatamente
-  // onde estava, e continua reprovando uma lista que não precise rolar.
-  const chavesCheias = async (): Promise<string[]> => {
-    const hoje = await page.evaluate(() => {
-      // Calculado DENTRO do browser de propósito: é o mesmo relógio e o mesmo fuso
-      // que formatam o `data-testid` de cada dia. Comparar com a data do processo
-      // do Node erraria por um dia sempre que os dois discordassem.
-      const d = new Date();
-      const dd = (n: number) => String(n).padStart(2, "0");
-      return `${d.getFullYear()}-${dd(d.getMonth() + 1)}-${dd(d.getDate())}`;
-    });
-    const chaves = await page
-      .locator('[data-testid^="dia-"][data-disponivel="true"]')
-      .evaluateAll((els) => els.map((el) => el.getAttribute("data-testid")!.slice(4)));
-    // `yyyy-MM-dd` compara como texto na mesma ordem em que compara como data.
-    return chaves.filter((k) => k > hoje).sort();
-  };
-
-  // `data-disponivel` é o que a tela usa para decidir o clique, então esperar por
-  // ele mede o mesmo estado que o usuário enxerga — e é o que dá tempo à consulta
-  // de horários responder: até ela chegar, TODO dia nasce indisponível, e uma
-  // varredura feita antes disso leria "não há dia cheio" onde há.
-  await expect(
-    page.locator('[data-testid^="dia-"][data-disponivel="true"]').first(),
-    "nenhum dia disponível — o seed da agenda não deixou jornada publicada, e sem " +
-      "dia clicável a coluna de horários nunca abre (o defeito ficaria invisível)",
-  ).toBeVisible({ timeout: 20_000 });
-
-  let cheios = await chavesCheias();
-  if (cheios.length === 0) {
-    // Hoje é o último dia útil do mês visível: o próximo dia com jornada cai no mês
-    // seguinte, e o mini-calendário só torna clicável o que é `isSameMonth` do mês
-    // em tela. Sem este passo a spec reprovaria nos dias 30/31 — a mesma classe de
-    // vermelho-por-calendário que ela acabou de sair.
-    await page.getByTestId("mes-seguinte").click();
-    await expect(
-      page.locator('[data-testid^="dia-"][data-disponivel="true"]').first(),
-      "nem o mês seguinte oferece dia — a janela de busca da tela é de 30 dias",
-    ).toBeVisible({ timeout: 20_000 });
-    cheios = await chavesCheias();
-  }
-
-  const dia = cheios[0];
-  expect(
-    dia,
-    "nenhum dia FUTURO disponível — sem um dia com a jornada inteira, a contagem de " +
-      "horários volta a depender da hora em que a suíte roda",
-  ).toBeTruthy();
-  await page.getByTestId(`dia-${dia}`).click();
+  // A razão medida (9 horários às 15:27 UTC e 7 às 16:37, mesmo commit e mesmo
+  // seed) mora com a função, em `helpers/agenda-semana-integra`. Ela está lá e
+  // não aqui de propósito: três outras specs de agenda pisaram na mesma pedra no
+  // mesmo dia, e a regra só fecha a classe se tiver um dono só.
+  await escolherPrimeiroDiaCheio(page);
 
   const coluna = page.getByTestId("coluna-de-horarios");
   await expect(coluna).toHaveAttribute("data-aberta", "true", { timeout: 15_000 });

--- a/tests/e2e/agenda-remarcar-e-cancelar.spec.ts
+++ b/tests/e2e/agenda-remarcar-e-cancelar.spec.ts
@@ -4,6 +4,8 @@ import * as path from "node:path";
 
 import { test, expect } from "@playwright/test";
 
+import { escolherDiaDesenhado, irParaASemanaSeguinte } from "./helpers/agenda-semana-integra";
+
 /**
  * REMARCAR E CANCELAR PELA TELA — as duas ações que só a IA conseguia fazer.
  *
@@ -69,7 +71,7 @@ function lerCreds(): Creds {
   return c;
 }
 
-async function entrar(page: import("@playwright/test").Page, creds: Creds) {
+async function entrar(page: import("@playwright/test").Page, creds: Creds): Promise<string[]> {
   const usuario = creds.users.manager;
   if (!usuario) throw new Error(".e2e-creds.json sem o usuário `manager`");
   await page.goto("/login");
@@ -79,17 +81,28 @@ async function entrar(page: import("@playwright/test").Page, creds: Creds) {
   await page.waitForURL(/\/app(\/|$)/, { timeout: 20_000 });
   await page.goto("/app/agenda");
   await expect(page.getByTestId("tela-agenda")).toBeVisible({ timeout: 20_000 });
+  // ⚠️ A SEMANA SEGUINTE, e ela é a condição de os dois casos existirem.
+  //
+  // O caso de remarcar precisa de DOIS horários livres no mesmo dia ("só havia
+  // um horário livre — o cenário não distingue remarcar de repetir"), e o dia
+  // que o painel oferecia era hoje. Medido com o motor real numa sexta: 4 vagas
+  // às 15h, 2 às 16h, ZERO das 17h em diante — e zero o sábado inteiro. Um dia
+  // inteiro da semana seguinte oferece 18, a qualquer hora e em qualquer dia da
+  // semana. Tabela em `helpers/agenda-semana-integra`.
+  return irParaASemanaSeguinte(page);
 }
 
 /** Marca um compromisso pela tela e devolve o rótulo do horário escolhido. */
-async function marcarUm(page: import("@playwright/test").Page, tipoNome: string): Promise<string> {
+async function marcarUm(
+  page: import("@playwright/test").Page,
+  tipoNome: string,
+  dias: readonly string[],
+): Promise<string> {
   await page.getByRole("button", { name: /novo agendamento/i }).click();
   await expect(page.getByTestId("painel-de-marcacao")).toBeVisible({ timeout: 10_000 });
   await expect(page.getByTestId("tipos-de-agendamento")).toBeVisible({ timeout: 10_000 });
   await page.getByRole("button", { name: new RegExp(`^${tipoNome}`) }).click();
-  const dia = page.locator('[data-testid^="dia-"]:not([disabled])').first();
-  await expect(dia).toBeVisible({ timeout: 15_000 });
-  await dia.click();
+  await escolherDiaDesenhado(page, dias);
   const horario = page.locator('[data-testid^="horario-"]').first();
   await expect(horario).toBeVisible({ timeout: 15_000 });
   const rotulo = (await horario.getAttribute("data-testid"))!.replace("horario-", "");
@@ -108,8 +121,8 @@ test.describe.configure({ timeout: 120_000 });
 test("cancelar pela tela: o motivo é exigido, e o compromisso sai dos próximos", async ({ page }) => {
   const creds = lerCreds();
   if (!creds.agenda) throw new Error("sem bloco agenda");
-  await entrar(page, creds);
-  await marcarUm(page, creds.agenda.tipo_nome);
+  const diasDaSemana = await entrar(page, creds);
+  await marcarUm(page, creds.agenda.tipo_nome, diasDaSemana);
 
   const historico = page.getByTestId("historico-da-agenda");
   const cancelarBotao = historico.getByRole("button", { name: /^Cancelar$/ }).first();
@@ -158,8 +171,8 @@ test("cancelar pela tela: o motivo é exigido, e o compromisso sai dos próximos
 test("remarcar pela tela: o painel abre em modo remarcar e o horário muda", async ({ page }) => {
   const creds = lerCreds();
   if (!creds.agenda) throw new Error("sem bloco agenda");
-  await entrar(page, creds);
-  const rotuloOriginal = await marcarUm(page, creds.agenda.tipo_nome);
+  const diasDaSemana = await entrar(page, creds);
+  const rotuloOriginal = await marcarUm(page, creds.agenda.tipo_nome, diasDaSemana);
 
   const historico = page.getByTestId("historico-da-agenda");
   const remarcarBotao = historico.getByRole("button", { name: /^Remarcar$/ }).first();
@@ -176,9 +189,7 @@ test("remarcar pela tela: o painel abre em modo remarcar e o horário muda", asy
     timeout: 10_000,
   });
 
-  const dia = page.locator('[data-testid^="dia-"]:not([disabled])').first();
-  await expect(dia).toBeVisible({ timeout: 15_000 });
-  await dia.click();
+  await escolherDiaDesenhado(page, diasDaSemana);
 
   // Um horário DIFERENTE do original — senão "remarcou" e "não mudou nada" são
   // indistinguíveis, e a asserção passaria pelo motivo errado.

--- a/tests/e2e/agenda-ver-na-agenda.spec.ts
+++ b/tests/e2e/agenda-ver-na-agenda.spec.ts
@@ -3,6 +3,8 @@ import * as path from "node:path";
 
 import { test, expect, type Page } from "@playwright/test";
 
+import { escolherUltimoDiaCheio } from "./helpers/agenda-semana-integra";
+
 /**
  * "VER NA AGENDA" LEVA ATÉ O COMPROMISSO — o botão que não fazia nada.
  *
@@ -76,9 +78,12 @@ test("marcar, clicar em 'Ver na agenda', e ENCONTRAR o compromisso na grade", as
   // mais o defeito aparece. Com o primeiro dia (quase sempre nesta semana) a
   // grade já mostraria o compromisso sem precisar navegar, e o caso passaria
   // mesmo com o botão mudo — verde pelo motivo errado.
-  const dias = page.locator('[data-testid^="dia-"][data-disponivel="true"]');
-  await expect(dias.first()).toBeVisible({ timeout: 20_000 });
-  await dias.last().click();
+  // ⚠️ ERA `dias.last()`, e o último da lista pode ser HOJE. `.last()` é o último
+  // dia disponível do MÊS EM TELA — no último dia útil do mês, esse último é o
+  // próprio hoje, e o que a spec pegaria seria o resto de um dia já gasto (2
+  // horários às 16h, ZERO das 17h em diante). `escolherUltimoDiaCheio` mantém a
+  // intenção — o mais longe possível da semana corrente — e exclui hoje.
+  await escolherUltimoDiaCheio(page);
 
   const horario = page.locator('[data-testid^="horario-"]').first();
   await expect(horario, "o dia foi escolhido e não veio horário nenhum").toBeVisible({ timeout: 15_000 });

--- a/tests/e2e/agente-marca-consulta.spec.ts
+++ b/tests/e2e/agente-marca-consulta.spec.ts
@@ -4,6 +4,8 @@ import * as path from "node:path";
 
 import { test, expect } from "@playwright/test";
 
+import { irParaASemanaDoCompromisso } from "./helpers/agenda-semana-integra";
+
 /**
  * O AGENTE MARCA CONSULTA, E O EFEITO APARECE NA AGENDA — a prova em tela da frente 4.
  *
@@ -245,6 +247,19 @@ test.describe("o agente marca consulta", () => {
     await page.waitForURL(/\/app(\/|$)/, { timeout: 20_000 });
 
     await page.goto(`${APP_URL}/app/agenda`);
+
+    // ⚠️ A GRADE DESENHA UMA SEMANA SÓ, e quem marca por API não escolhe qual.
+    //
+    // O horário acima é o PRIMEIRO livre dos próximos 14 dias: antes das 17h ele
+    // é hoje e a grade já o mostra; depois das 17h, quando o resto de hoje
+    // acabou, ele é a segunda-feira — e a grade, parada na semana corrente,
+    // nunca desenha o cartão. A asserção abaixo reprovava com `element(s) not
+    // found`, acusando a Agenda de não mostrar o que a IA marcou.
+    //
+    // Ir até a semana DO COMPROMISSO mantém o que este caso prova (o que a IA
+    // marcou aparece na tela do humano) e tira a hora do run da conta.
+    await irParaASemanaDoCompromisso(page, livres.horarios[0]!.inicio);
+
     // O nome do CONTATO é o que prova que é o compromisso certo: o título do tipo
     // apareceria mesmo num card de outro cliente.
     await expect(page.getByText(creds.agenda.contato_nome).first()).toBeVisible({ timeout: 15_000 });

--- a/tests/e2e/helpers/agenda-semana-integra.ts
+++ b/tests/e2e/helpers/agenda-semana-integra.ts
@@ -88,6 +88,51 @@ export async function irParaASemanaSeguinte(page: Page): Promise<string[]> {
   return depois;
 }
 
+/**
+ * Leva a grade até a semana que contém um COMPROMISSO já marcado, e devolve o
+ * dia dele em `yyyy-MM-dd`.
+ *
+ * ⚠️ Quem marca por API não escolhe a semana — recebe. `agente-marca-consulta`
+ * pede o PRIMEIRO horário livre dos próximos 14 dias e manda a IA marcar nele;
+ * antes das 17h esse primeiro é hoje, e a grade — que desenha a semana de hoje —
+ * mostra o cartão sem ninguém navegar. Depois das 17h o primeiro livre é a
+ * segunda-feira, o cartão nasce na semana seguinte, e a asserção "o compromisso
+ * aparece na Agenda" reprova com `element(s) not found`. Medido no CI às 21h01
+ * UTC, no run do PR que consertava as outras cinco specs: a mesma classe, na
+ * sexta spec.
+ *
+ * O dia sai de um `page.evaluate` de propósito: a grade formata as chaves no
+ * fuso do BROWSER, e converter o instante no Node daria uma data diferente
+ * sempre que os dois fusos discordassem.
+ */
+export async function irParaASemanaDoCompromisso(page: Page, instanteISO: string): Promise<string> {
+  const dia = await page.evaluate((iso) => {
+    const d = new Date(iso);
+    const dd = (n: number) => String(n).padStart(2, "0");
+    return `${d.getFullYear()}-${dd(d.getMonth() + 1)}-${dd(d.getDate())}`;
+  }, instanteISO);
+
+  await expect(
+    page.locator('[data-testid^="coluna-dia-"]').first(),
+    "a grade não desenhou dia nenhum — a tela da agenda não chegou a montar",
+  ).toBeAttached({ timeout: 25_000 });
+
+  // Teto explícito: a consulta que alimenta estas specs olha 14 dias à frente,
+  // então três saltos bastam. Sem teto, uma chave que a grade nunca desenha
+  // viraria um laço de cliques até o timeout do caso — e a falha diria
+  // "timeout", que é indistinguível de defeito.
+  for (let salto = 0; salto < 4; salto++) {
+    if ((await diasDesenhados(page)).includes(dia)) return dia;
+    await irParaASemanaSeguinte(page);
+  }
+  expect(
+    await diasDesenhados(page),
+    `a grade não chegou à semana de ${dia} em quatro saltos — o compromisso está ` +
+      "fora da janela que a tela sabe desenhar",
+  ).toContain(dia);
+  return dia;
+}
+
 /** Os dias que a grade desenha AGORA, lidos da própria tela. */
 export async function diasDesenhados(page: Page): Promise<string[]> {
   return (

--- a/tests/e2e/helpers/agenda-semana-integra.ts
+++ b/tests/e2e/helpers/agenda-semana-integra.ts
@@ -1,0 +1,248 @@
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * A SEMANA ÍNTEGRA — o único lugar destas specs onde "que dia é hoje" entra na
+ * conta, e ele entra DECLARADO.
+ *
+ * ═══ O defeito que este módulo existe para fechar ════════════════════════════
+ *
+ * `agenda-grade-interativa`, `agenda-marcar-pela-tela` e
+ * `agenda-remarcar-e-cancelar` reprovaram a `main` em 2026-08-28 a partir das
+ * ~15:50 BRT, em quatro runs seguidos, com códigos DIFERENTES — inclusive um PR
+ * com um único arquivo em `.changes/`, que não tem como quebrar e2e por mérito
+ * próprio. A mensagem entrega a causa:
+ *
+ *     Error: nenhum bloco livre na semana desenhada
+ *     Locator: locator('[data-testid^="bloco-2026-08-28-"][data-livre="true"]')
+ *
+ * A grade pede horários para EXATAMENTE a semana que desenha
+ * (`AgendaInterativa`, `recorte`), e a semana desenhada é a de HOJE. A jornada
+ * do seed é seg–sex 09:00–18:00 com 60 min de aviso mínimo, então o que a
+ * semana corrente ainda oferece é **o resto de hoje** — e ele encolhe sozinho.
+ *
+ * Medido com o motor real (`lib/agenda/horarios-livres.ts`), sem browser,
+ * numa sexta-feira, contando os horários livres da semana desenhada:
+ *
+ *     dia          09h  12h  15h  16h  17h  20h  23h
+ *     sex (hoje)    16   10    4    2    0    0    0
+ *     sáb            0    0    0    0    0    0    0
+ *     semana +1     90   90   90   90   90   90   90
+ *
+ * Duas leituras, e a segunda é a que assusta: **no sábado é zero o dia
+ * inteiro**, porque a semana desenhada (dom→sáb) só tem dias úteis já passados.
+ * Não é "o teste fica frágil à tarde"; é "o teste não pode passar no fim de
+ * semana". E entre 15h e 17h o bolso ainda tem 2 a 4 vagas — que as specs
+ * ANTERIORES do mesmo job consomem marcando —, o que explica o corte ter caído
+ * às ~15h50 e não às 17h.
+ *
+ * ═══ Por que a semana SEGUINTE, e não um seed maior ══════════════════════════
+ *
+ * Alargar a jornada do seed (fim de semana, horário noturno) só empurra a hora
+ * em que a conta volta a ficar curta — e não salva nenhuma das duas pontas: às
+ * 23h o resto de hoje é zero de qualquer jornada, e o sábado continua sendo uma
+ * semana de dias passados. A semana seguinte é íntegra **em qualquer hora e em
+ * qualquer dia da semana**: 90 vagas, sempre, como a terceira linha da tabela
+ * mostra.
+ *
+ * ═══ A regra que estas funções encarnam ══════════════════════════════════════
+ *
+ * O dia-alvo NÃO sai do relógio do Node. Ele sai do que a TELA desenhou depois
+ * da navegação (`coluna-dia-<yyyy-MM-dd>`), que é a mesma verdade que a grade
+ * usará para desenhar o compromisso marcado. Enquanto o alvo vinha de um lado e
+ * a grade do outro, `agenda-marcar-pela-tela` marcava na segunda-feira e
+ * procurava o cartão na semana de sexta — e a falha lia "a grade não repinta".
+ */
+
+/** O passo da visão "semana" — o botão avança sete dias por clique. */
+const DIAS_POR_SEMANA = 7;
+
+/**
+ * Leva a agenda para a semana seguinte e devolve os dias que ela passou a
+ * desenhar, em `yyyy-MM-dd`.
+ *
+ * Espera a grade REPINTAR antes de devolver: o `useHorariosLivres` refaz a
+ * busca quando o recorte muda, e medir no meio da troca lê a semana velha.
+ */
+export async function irParaASemanaSeguinte(page: Page): Promise<string[]> {
+  const colunas = page.locator('[data-testid^="coluna-dia-"]');
+  await expect(
+    colunas.first(),
+    "a grade não desenhou dia nenhum — a tela da agenda não chegou a montar",
+  ).toBeAttached({ timeout: 25_000 });
+  const antes = await diasDesenhados(page);
+
+  await page.getByTestId("periodo-seguinte").click();
+
+  await expect
+    .poll(async () => (await diasDesenhados(page))[0] ?? "", {
+      timeout: 20_000,
+      message: "a grade não trocou de semana depois do clique em `periodo-seguinte`",
+    })
+    .not.toBe(antes[0] ?? "");
+
+  const depois = await diasDesenhados(page);
+  expect(
+    depois.length,
+    "a semana desenhada não tem sete dias — o recorte da grade mudou de forma",
+  ).toBe(DIAS_POR_SEMANA);
+  return depois;
+}
+
+/** Os dias que a grade desenha AGORA, lidos da própria tela. */
+export async function diasDesenhados(page: Page): Promise<string[]> {
+  return (
+    await page
+      .locator('[data-testid^="coluna-dia-"]')
+      .evaluateAll((els) => els.map((el) => el.getAttribute("data-testid")!.replace("coluna-dia-", "")))
+  ).sort();
+}
+
+/**
+ * Escolhe, no painel de marcação já aberto, um dia que a grade esteja
+ * desenhando — e devolve a chave escolhida.
+ *
+ * O mini-calendário do painel abre no mês de HOJE (`ancora={new Date()}` em
+ * `_client.tsx`), e a semana seguinte pode cair inteira no mês que vem: numa
+ * sexta dia 31, os cinco dias úteis da semana seguinte são todos do mês
+ * seguinte, e nenhum deles é clicável na grade em tela. Por isso o salto de mês
+ * é um passo previsto, e não um remendo — sem ele esta função reprovaria dois
+ * dias por mês, que é a mesma classe de vermelho-por-calendário que ela existe
+ * para fechar.
+ */
+export async function escolherDiaDesenhado(page: Page, dias: readonly string[]): Promise<string> {
+  const disponiveis = async (): Promise<string[]> =>
+    (
+      await page
+        .locator('[data-testid^="dia-"][data-disponivel="true"]')
+        .evaluateAll((els) => els.map((el) => el.getAttribute("data-testid")!.slice(4)))
+    ).filter((k) => dias.includes(k));
+
+  // Até a consulta de horários responder, TODO dia nasce indisponível — uma
+  // varredura feita antes disso leria "nenhum dia da semana desenhada" onde há.
+  await expect(
+    page.locator('[data-testid^="dia-"][data-disponivel="true"]').first(),
+    "nenhum dia disponível no painel — o seed da agenda não deixou jornada publicada",
+  ).toBeVisible({ timeout: 20_000 });
+
+  let candidatos = await disponiveis();
+  if (candidatos.length === 0) {
+    await page.getByTestId("mes-seguinte").click();
+    await expect(
+      page.locator('[data-testid^="dia-"][data-disponivel="true"]').first(),
+      "nem o mês seguinte oferece dia — a janela de busca do painel é de 30 dias",
+    ).toBeVisible({ timeout: 20_000 });
+    candidatos = await disponiveis();
+  }
+
+  const escolhido = candidatos.sort()[0];
+  expect(
+    escolhido,
+    `nenhum dia da semana desenhada (${dias.join(", ")}) está disponível no painel — ` +
+      "o alvo e a grade deixariam de falar do mesmo período",
+  ).toBeTruthy();
+  await page.getByTestId(`dia-${escolhido}`).click();
+  return escolhido!;
+}
+
+/**
+ * O primeiro dia CHEIO — o primeiro que o painel oferece depois de hoje, com a
+ * jornada inteira em vez do resto de um dia já gasto.
+ *
+ * ⚠️ ELE NÃO PASSA PELA GRADE, e é por isso que existe ao lado de
+ * `escolherDiaDesenhado`. Quem só quer um dia com a lista de horários COMPLETA
+ * (a spec de geometria do painel mede a coluna em cinco larguras, algumas
+ * abaixo de `lg`, onde a grade nem desenha colunas de dia) não pode depender de
+ * a grade ter sido navegada. As duas funções resolvem a mesma classe —
+ * "não deixe o período ser escolhido pelo relógio" — por dois caminhos, e moram
+ * juntas para que a próxima pessoa encontre a regra inteira num arquivo só.
+ *
+ * Veio de `agenda-painel-cabe-na-tela.spec.ts` (PR #402), onde nasceu depois de
+ * a `main` reprovar duas vezes com contagens DIFERENTES no mesmo commit: 9
+ * horários às 15:27 UTC e 7 às 16:37, porque o dia escolhido era hoje.
+ */
+/**
+ * Os dias que o painel oferece DEPOIS de hoje — a jornada inteira, em vez do
+ * resto de um dia já gasto. Ordenados, `yyyy-MM-dd`.
+ *
+ * ⚠️ NÃO PASSA PELA GRADE, e é por isso que existe ao lado de
+ * `escolherDiaDesenhado`. Quem só quer um dia com a lista de horários COMPLETA
+ * (a spec de geometria do painel mede a coluna em cinco larguras, algumas
+ * abaixo de `lg`, onde a grade nem desenha colunas de dia) não pode depender de
+ * a grade ter sido navegada. As duas rotas resolvem a mesma classe — "não deixe
+ * o período ser escolhido pelo relógio" — e moram juntas para que a próxima
+ * pessoa encontre a regra inteira num arquivo só.
+ *
+ * Veio de `agenda-painel-cabe-na-tela.spec.ts` (PR #402), onde nasceu depois de
+ * a `main` reprovar duas vezes com contagens DIFERENTES no mesmo commit: 9
+ * horários às 15:27 UTC e 7 às 16:37, porque o dia escolhido era hoje.
+ */
+async function diasCheios(page: Page): Promise<string[]> {
+  const varrer = async (): Promise<string[]> => {
+    const hoje = await page.evaluate(() => {
+      // Calculado DENTRO do browser de propósito: é o mesmo relógio e o mesmo
+      // fuso que formatam o `data-testid` de cada dia. Comparar com a data do
+      // processo do Node erraria por um dia sempre que os dois discordassem.
+      const d = new Date();
+      const dd = (n: number) => String(n).padStart(2, "0");
+      return `${d.getFullYear()}-${dd(d.getMonth() + 1)}-${dd(d.getDate())}`;
+    });
+    const chaves = await page
+      .locator('[data-testid^="dia-"][data-disponivel="true"]')
+      .evaluateAll((els) => els.map((el) => el.getAttribute("data-testid")!.slice(4)));
+    // `yyyy-MM-dd` compara como texto na mesma ordem em que compara como data.
+    return chaves.filter((k) => k > hoje).sort();
+  };
+
+  await expect(
+    page.locator('[data-testid^="dia-"][data-disponivel="true"]').first(),
+    "nenhum dia disponível — o seed da agenda não deixou jornada publicada, e sem " +
+      "dia clicável a coluna de horários nunca abre (o defeito ficaria invisível)",
+  ).toBeVisible({ timeout: 20_000 });
+
+  const cheios = await varrer();
+  if (cheios.length > 0) return cheios;
+
+  // Hoje é o último dia útil do mês visível: o próximo dia com jornada cai no
+  // mês seguinte, e o mini-calendário só torna clicável o que é `isSameMonth` do
+  // mês em tela. Sem este passo as specs reprovariam nos dias 30/31 — a mesma
+  // classe de vermelho-por-calendário que este módulo existe para fechar.
+  await page.getByTestId("mes-seguinte").click();
+  await expect(
+    page.locator('[data-testid^="dia-"][data-disponivel="true"]').first(),
+    "nem o mês seguinte oferece dia — a janela de busca da tela é de 30 dias",
+  ).toBeVisible({ timeout: 20_000 });
+  return varrer();
+}
+
+function exigirDia(cheios: readonly string[], qual: string): string {
+  const dia = qual === "primeiro" ? cheios[0] : cheios[cheios.length - 1];
+  expect(
+    dia,
+    "nenhum dia FUTURO disponível — sem um dia com a jornada inteira, a contagem de " +
+      "horários volta a depender da hora em que a suíte roda",
+  ).toBeTruthy();
+  return dia!;
+}
+
+/** O PRIMEIRO dia cheio que o painel oferece. Clica nele e devolve a chave. */
+export async function escolherPrimeiroDiaCheio(page: Page): Promise<string> {
+  const dia = exigirDia(await diasCheios(page), "primeiro");
+  await page.getByTestId(`dia-${dia}`).click();
+  return dia;
+}
+
+/**
+ * O ÚLTIMO dia cheio que o painel oferece — o mais longe da semana corrente.
+ *
+ * Quem precisa disto é `agenda-ver-na-agenda`: ela prova que o botão "Ver na
+ * agenda" MOVE a grade até o compromisso, e com um dia da semana corrente a
+ * grade já o mostraria sem navegar — o caso passaria com o botão mudo. O que
+ * ela NÃO pode é cair em hoje, e caía: `dias.last()` é o último dia disponível
+ * do MÊS EM TELA, e no último dia útil do mês esse último é o próprio hoje, com
+ * o resto do dia por lista.
+ */
+export async function escolherUltimoDiaCheio(page: Page): Promise<string> {
+  const dia = exigirDia(await diasCheios(page), "ultimo");
+  await page.getByTestId(`dia-${dia}`).click();
+  return dia;
+}

--- a/tests/unit/agenda-spec-nao-escolhe-o-periodo-sozinha.test.ts
+++ b/tests/unit/agenda-spec-nao-escolhe-o-periodo-sozinha.test.ts
@@ -1,0 +1,150 @@
+/**
+ * SPEC DE AGENDA NÃO ESCOLHE O PERÍODO SOZINHA — a guarda da CLASSE, não das
+ * quatro instâncias.
+ *
+ * ═══ A classe ════════════════════════════════════════════════════════════════
+ *
+ * "Teste que lê uma grandeza que ninguém declarou como ENTRADA." Em 2026-08-28
+ * ela apareceu QUATRO vezes em um único dia, todas na agenda:
+ *
+ *   - `agenda-painel-cabe-na-tela` (PR #402) abria no primeiro dia clicável, que
+ *     é hoje: a `main` reprovou com 9 horários às 15:27 UTC e 7 às 16:37 — mesmo
+ *     commit, mesmo seed, contagens diferentes;
+ *   - `agenda-grade-interativa`, `agenda-marcar-pela-tela` e
+ *     `agenda-remarcar-e-cancelar` trabalhavam na semana desenhada, que é a de
+ *     hoje, e reprovaram a `main` em quatro runs seguidos a partir das ~15h50.
+ *
+ * Medido com o motor real (`lib/agenda/horarios-livres.ts`), numa sexta-feira,
+ * contando horários livres na semana que a grade desenha:
+ *
+ *     dia          09h  12h  15h  16h  17h  20h  23h
+ *     sex (hoje)    16   10    4    2    0    0    0
+ *     sáb            0    0    0    0    0    0    0
+ *     semana +1     90   90   90   90   90   90   90
+ *
+ * Consertar as quatro instâncias não fecha nada: a quinta spec de agenda vai
+ * nascer com `.first()` no primeiro dia que a tela oferecer, porque é o gesto
+ * óbvio — e vai passar, verde, até a próxima sexta às 16h.
+ *
+ * ═══ A régua ═════════════════════════════════════════════════════════════════
+ *
+ * Existe UM módulo que decide o período (`tests/e2e/helpers/agenda-semana-integra.ts`),
+ * e toda spec que escolhe dia ou bloco na agenda tem de passar por ele. A guarda
+ * cobra três coisas:
+ *
+ *   1. a spec que casa "agenda + seletor de dia/bloco" IMPORTA o módulo;
+ *   2. e o CHAMA — importar para calar a guarda não conta;
+ *   3. o módulo não lê o relógio do PROCESSO (`new Date()` / `Date.now()` no
+ *      Node): o período sai do que a tela desenhou, ou de um `page.evaluate`,
+ *      que roda no mesmo relógio e no mesmo fuso que formataram o `data-testid`.
+ *
+ * ═══ O QUE ESTA GUARDA NÃO PEGA — e está escrito porque a omissão anestesia ══
+ *
+ * Ela não lê o corpo da spec procurando outras leituras de tempo: uma spec pode
+ * importar o módulo, chamá-lo, e ainda assim asserir sobre "o compromisso das
+ * 14h" logo abaixo. O que ela garante é que quem escrever a próxima spec de
+ * agenda ESBARRE na regra e leia a tabela acima — não que o autor a obedeça em
+ * cada linha. Guarda de fonte não substitui revisão; ela impede a reincidência
+ * silenciosa, que é como as quatro instâncias chegaram aqui.
+ *
+ * Também não vale para specs fora da agenda. A classe é maior que este módulo
+ * (a janela anti-ban derrubando o `test:db` de madrugada é a mesma doença), mas
+ * uma guarda que tentasse cobrir tudo teria de adivinhar o que é leitura de
+ * tempo legítima — e uma guarda que tolera não distingue.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const RAIZ = process.cwd();
+const DIR_E2E = path.join(RAIZ, "tests/e2e");
+const MODULO = path.join(DIR_E2E, "helpers/agenda-semana-integra.ts");
+
+/** As funções que o módulo publica — chamar qualquer uma satisfaz a régua 2. */
+const CHAMADAS = [
+  "irParaASemanaSeguinte",
+  "escolherDiaDesenhado",
+  "escolherPrimeiroDiaCheio",
+  "escolherUltimoDiaCheio",
+];
+
+/**
+ * Specs dispensadas, com o motivo escrito. Esta lista SÓ ENCOLHE — cada entrada
+ * é dívida declarada, e entrar nela exige a razão pela qual a spec não escolhe
+ * período nenhum.
+ */
+const DISPENSADAS: Record<string, string> = {
+  "agenda-kit-visual.spec.ts":
+    "roda contra /vitrine-agenda, que PASSA o instante como fixture — é o padrão certo, " +
+    "não a exceção: por isso ela clica num `dia-2026-08-24` fixo e segue verde com essa " +
+    "data no passado.",
+};
+
+function specsDeAgenda(): string[] {
+  return readdirSync(DIR_E2E)
+    .filter((f) => f.endsWith(".spec.ts"))
+    .filter((f) => {
+      const fonte = readFileSync(path.join(DIR_E2E, f), "utf8");
+      const naAgenda = /\/app\/agenda|tela-agenda|painel-de-marcacao/.test(fonte);
+      // A spec JÁ MIGRADA não tem mais os seletores literais — eles moraram para
+      // o módulo. Sem contá-la aqui, migrar uma spec a tiraria do conjunto e o
+      // controle de vacuidade abaixo mediria um conjunto que só encolhe.
+      const escolhePeriodo =
+        /\[data-testid\^="(dia|bloco)-"\]|getByTestId\(`(dia|bloco)-/.test(fonte) ||
+        /from "\.\/helpers\/agenda-semana-integra"/.test(fonte);
+      return naAgenda && escolhePeriodo;
+    });
+}
+
+describe("spec de agenda não escolhe o período sozinha", () => {
+  it("a varredura ENCONTRA specs — uma lista vazia passaria por vacuidade", () => {
+    // Sem este caso, quebrar o regex acima (ou renomear os `data-testid`) faria
+    // os dois casos abaixo ficarem verdes sobre um conjunto vazio.
+    // Cinco em 2026-08-28, e cada uma foi uma instância da classe. O piso é o
+    // que havia quando a guarda nasceu: spec de agenda não some, só aparece.
+    expect(specsDeAgenda().length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("toda spec que escolhe dia ou bloco na agenda passa pelo módulo do período", () => {
+    const faltando: string[] = [];
+    for (const spec of specsDeAgenda()) {
+      if (spec in DISPENSADAS) continue;
+      const fonte = readFileSync(path.join(DIR_E2E, spec), "utf8");
+      const importa = /from "\.\/helpers\/agenda-semana-integra"/.test(fonte);
+      const chama = CHAMADAS.some((f) => new RegExp(`\\b${f}\\(`).test(fonte));
+      if (!importa || !chama) faltando.push(`${spec} (importa=${importa}, chama=${chama})`);
+    }
+    expect(
+      faltando,
+      "estas specs escolhem dia ou bloco na agenda sem passar por " +
+        "`tests/e2e/helpers/agenda-semana-integra`. O período que elas pegarem será o de " +
+        "HOJE, e hoje encolhe: 16 vagas às 9h, 2 às 16h, ZERO das 17h em diante e zero o " +
+        "sábado inteiro. Use `irParaASemanaSeguinte` + `escolherDiaDesenhado` (quando a " +
+        "asserção envolve a grade) ou `escolherPrimeiroDiaCheio` (quando é só o painel) — " +
+        "ou declare a dispensa em DISPENSADAS, com o motivo.",
+    ).toEqual([]);
+  });
+
+  it("o módulo do período não lê o relógio do processo", () => {
+    const fonte = readFileSync(MODULO, "utf8");
+    // `page.evaluate(() => { ... new Date() ... })` roda no BROWSER, e é
+    // legítimo: é o mesmo relógio e o mesmo fuso que formataram o `data-testid`.
+    // O que não pode é o Node decidir a data e o browser desenhar outra.
+    // Comentário NÃO é código, e este arquivo cita `ancora={new Date()}` ao
+    // explicar por que o mini-calendário abre no mês de hoje. Uma guarda que
+    // lesse a prosa como código proibiria a explicação do próprio defeito.
+    const semProsa = fonte
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*$/gm, "")
+      .replace(/page\.evaluate\(\(\)\s*=>\s*\{[\s\S]*?\n\s*\}\)/g, "<browser>");
+    const noNode = semProsa.match(/new Date\(|Date\.now\(/g) ?? [];
+    expect(
+      noNode,
+      "o módulo passou a ler o relógio do processo. O período tem de sair do que a TELA " +
+        "desenhou (`coluna-dia-…`) ou de um `page.evaluate`, que roda no relógio do browser — " +
+        "senão o Node escolhe uma data e a tela desenha outra, e a divergência aparece uma " +
+        "vez por dia, à meia-noite.",
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/agenda-spec-nao-escolhe-o-periodo-sozinha.test.ts
+++ b/tests/unit/agenda-spec-nao-escolhe-o-periodo-sozinha.test.ts
@@ -64,6 +64,7 @@ const MODULO = path.join(DIR_E2E, "helpers/agenda-semana-integra.ts");
 /** As funções que o módulo publica — chamar qualquer uma satisfaz a régua 2. */
 const CHAMADAS = [
   "irParaASemanaSeguinte",
+  "irParaASemanaDoCompromisso",
   "escolherDiaDesenhado",
   "escolherPrimeiroDiaCheio",
   "escolherUltimoDiaCheio",
@@ -81,17 +82,64 @@ const DISPENSADAS: Record<string, string> = {
     "data no passado.",
 };
 
+/**
+ * A fonte sem os callbacks de `page.evaluate` — o que roda no BROWSER.
+ *
+ * Conta parênteses em vez de casar com regex: a primeira versão usava
+ * `/page\.evaluate\(\(\)\s*=>/`, que só reconhecia callback SEM argumento, e
+ * deixou passar `page.evaluate((iso) => …, instanteISO)`. A guarda acusou o
+ * módulo de ler o relógio do processo quando ele lia o do browser — falso
+ * positivo, que é como uma guarda perde a confiança de quem a lê.
+ *
+ * Se a contagem se perder, o recorte devolve texto demais e a guarda fica
+ * VERMELHA. É a direção certa de falhar para uma guarda: fechada.
+ */
+function foraDoBrowser(fonte: string): string {
+  let fora = "";
+  let i = 0;
+  for (;;) {
+    const inicio = fonte.indexOf("page.evaluate(", i);
+    if (inicio === -1) return fora + fonte.slice(i);
+    fora += fonte.slice(i, inicio);
+    let k = inicio + "page.evaluate".length;
+    let nivel = 0;
+    for (; k < fonte.length; k++) {
+      if (fonte[k] === "(") nivel++;
+      else if (fonte[k] === ")" && --nivel === 0) {
+        k++;
+        break;
+      }
+    }
+    fora += "<browser>";
+    i = k;
+  }
+}
+
 function specsDeAgenda(): string[] {
   return readdirSync(DIR_E2E)
     .filter((f) => f.endsWith(".spec.ts"))
     .filter((f) => {
       const fonte = readFileSync(path.join(DIR_E2E, f), "utf8");
       const naAgenda = /\/app\/agenda|tela-agenda|painel-de-marcacao/.test(fonte);
-      // A spec JÁ MIGRADA não tem mais os seletores literais — eles moraram para
-      // o módulo. Sem contá-la aqui, migrar uma spec a tiraria do conjunto e o
-      // controle de vacuidade abaixo mediria um conjunto que só encolhe.
+      // ⚠️ O DETECTOR PRECISOU CRESCER, e quem o corrigiu foi o CI.
+      //
+      // A primeira versão procurava só os seletores de dia e bloco, e deixou
+      // passar `agente-marca-consulta`: ela não seleciona dia nenhum — marca por
+      // API, no primeiro horário livre que a rota oferecer, e depois procura o
+      // cartão na Agenda. Mesmíssima dependência ("em que semana isto cai?"),
+      // nenhum dos sinais que eu tinha escolhido. Reprovou no CI às 21h01 UTC
+      // com `element(s) not found`, uma spec depois das cinco que eu havia
+      // consertado.
+      //
+      // Os sinais agora são todos os jeitos de a spec depender de QUANDO o
+      // horário cai: escolher dia/bloco, procurar um cartão por `faixa-`,
+      // escolher um `horario-`, confirmar uma marcação, ou mandar a IA marcar.
+      // A spec já migrada entra pelo import — sem isso, migrar uma spec a
+      // tiraria do conjunto e o controle de vacuidade mediria um conjunto que só
+      // encolhe.
       const escolhePeriodo =
-        /\[data-testid\^="(dia|bloco)-"\]|getByTestId\(`(dia|bloco)-/.test(fonte) ||
+        /\[data-testid\^="(dia|bloco|horario)-"\]|getByTestId\(`(dia|bloco|faixa)-/.test(fonte) ||
+        /faixa-\$\{|confirmar-marcacao|crm_book_appointment/.test(fonte) ||
         /from "\.\/helpers\/agenda-semana-integra"/.test(fonte);
       return naAgenda && escolhePeriodo;
     });
@@ -101,9 +149,10 @@ describe("spec de agenda não escolhe o período sozinha", () => {
   it("a varredura ENCONTRA specs — uma lista vazia passaria por vacuidade", () => {
     // Sem este caso, quebrar o regex acima (ou renomear os `data-testid`) faria
     // os dois casos abaixo ficarem verdes sobre um conjunto vazio.
-    // Cinco em 2026-08-28, e cada uma foi uma instância da classe. O piso é o
-    // que havia quando a guarda nasceu: spec de agenda não some, só aparece.
-    expect(specsDeAgenda().length).toBeGreaterThanOrEqual(5);
+    // Sete em 2026-08-28 — seis foram instâncias da classe no mesmo dia, e a
+    // sétima é a dispensada da vitrine. O piso é o que havia quando a guarda nasceu: spec
+    // de agenda não some, só aparece.
+    expect(specsDeAgenda().length).toBeGreaterThanOrEqual(7);
   });
 
   it("toda spec que escolhe dia ou bloco na agenda passa pelo módulo do período", () => {
@@ -134,11 +183,8 @@ describe("spec de agenda não escolhe o período sozinha", () => {
     // Comentário NÃO é código, e este arquivo cita `ancora={new Date()}` ao
     // explicar por que o mini-calendário abre no mês de hoje. Uma guarda que
     // lesse a prosa como código proibiria a explicação do próprio defeito.
-    const semProsa = fonte
-      .replace(/\/\*[\s\S]*?\*\//g, "")
-      .replace(/\/\/.*$/gm, "")
-      .replace(/page\.evaluate\(\(\)\s*=>\s*\{[\s\S]*?\n\s*\}\)/g, "<browser>");
-    const noNode = semProsa.match(/new Date\(|Date\.now\(/g) ?? [];
+    const semProsa = fonte.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+    const noNode = foraDoBrowser(semProsa).match(/new Date\(|Date\.now\(/g) ?? [];
     expect(
       noNode,
       "o módulo passou a ler o relógio do processo. O período tem de sair do que a TELA " +


### PR DESCRIPTION
Fecha o vermelho da `main` em `agenda-grade-interativa`, `agenda-marcar-pela-tela`
e `agenda-remarcar-e-cancelar` — e fecha a CLASSE, que hoje já produziu cinco
instâncias.

## O diagnóstico, medido

A grade pede horários para **exatamente a semana que desenha**
(`AgendaInterativa`, `recorte`), e a semana desenhada é a de hoje. A jornada do
seed é seg–sex 09:00–18:00 com 60 min de aviso mínimo, então o que a semana
corrente ainda oferece é **o resto de hoje**.

Medido com o motor real (`lib/agenda/horarios-livres.ts`), sem browser, numa
sexta — horários livres na semana que a grade desenha:

| dia | 09h | 12h | 15h | 16h | 17h | 20h | 23h |
|---|---|---|---|---|---|---|---|
| **sex (hoje)** | 16 | 10 | 4 | 2 | **0** | **0** | **0** |
| **sáb** | **0** | **0** | **0** | **0** | **0** | **0** | **0** |
| semana +1 | 90 | 90 | 90 | 90 | 90 | 90 | 90 |

A segunda linha é a que assusta: **no sábado é zero o dia inteiro**, porque a
semana desenhada (dom→sáb) só tem dias úteis já passados. Não é "o teste fica
frágil à tarde"; é "o teste não pode passar no fim de semana".

E entre 15h e 17h ainda há 2 a 4 vagas — que as specs anteriores do mesmo job
consomem marcando —, o que explica o corte ter caído às ~15h50 e não às 17h.

**Alargar a jornada do seed não resolve** nenhuma das duas pontas: às 23h o resto
de hoje é zero de qualquer jornada, e o sábado continua sendo uma semana de dias
passados.

## O conserto

Um módulo só decide o período: `tests/e2e/helpers/agenda-semana-integra.ts`. O
dia-alvo sai **do que a tela desenhou** (`coluna-dia-…`), nunca do relógio do
Node — que é o que fazia `agenda-marcar-pela-tela` marcar na segunda e procurar o
cartão na semana de sexta, com a falha lendo "a grade não repinta sem F5".

O seletor do PR #402 migrou para o mesmo módulo: duas implementações da mesma
ideia é como a classe reabre.

## A guarda de classe

`tests/unit/agenda-spec-nao-escolhe-o-periodo-sozinha.test.ts` cobra três
propriedades: a spec de agenda que escolhe dia/bloco **importa** o módulo, o
**chama** (importar para calar a guarda não conta), e o módulo **não lê o relógio
do processo**. O que ela não pega está escrito no cabeçalho dela, em vez de
implícito.

**Ela achou uma quinta instância que ninguém tinha citado:**
`agenda-ver-na-agenda` pegava `dias.last()` — e o último dia disponível do mês em
tela é o próprio hoje quando hoje é o último dia útil do mês. Fechada junto,
preservando a intenção dela (o dia mais longe possível da semana corrente).

E uma que só a execução mostrou: `page.reload()` devolve a âncora da grade para
hoje (`useState(new Date())`), então o caso do arraste procurava na semana de
sexta um compromisso que vive na semana seguinte. **O que não sobrevive ao F5 é a
navegação, não o dado.**

## Prova, com a previsão escrita antes de cada rodada

| rodada | previsto | medido |
|---|---|---|
| guarda, controle | 3 passed | 3 passed |
| guarda, sem o import numa spec | 1 failed, listando o arquivo | idêntico |
| guarda, `new Date()` no módulo | 1 failed, `["new Date("]` | idêntico |
| guarda, varredura quebrada | 1 failed, controle de vacuidade | `expected 0 >= 5` |
| e2e, controle | 15 passed | **14 passed / 1 failed** ← previsão errada |
| e2e, sem a navegação na grade | 4 failed, "nenhum bloco livre na semana desenhada" | idêntico |
| e2e, controle final | 15 passed | 15 passed |

A previsão errada está na tabela de propósito: eu não tinha previsto que o
`page.reload()` desfaz a navegação. Foi a execução que mostrou, e o conserto
dessa camada está no diff.

O controle final rodou às **17h14 BRT** — depois do corte medido, quando a semana
corrente tem zero vagas. Verde em outro horário não provaria nada aqui.

## O que NÃO foi tocado

- **O seed** — é infra compartilhada, e a tabela acima mostra que alargá-lo não
  resolveria.
- **O produto.** Nenhum arquivo de `app/`, `lib/` ou `components/` no diff.
- **`.changes/`** — nada visível a quem opera uma VPS; o diff é uma pasta de testes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F37LqMkUyGYaVYgYemsY3x