### PR TITLE
docs(release): a 1.10.0 anunciou quatro consertos que ficaram fora dela

### DIFF
--- a/.changes/a-central-abre-mais-rapido-com-varios-atendentes.md
+++ b/.changes/a-central-abre-mais-rapido-com-varios-atendentes.md
@@ -1,0 +1,22 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A Central de atendimento abre mais rápido quando a equipe é grande
+---
+
+Cada vez que a Central era aberta, o sistema perguntava o nome de cada pessoa
+da equipe que aparecia na página — uma pergunta separada para cada uma, toda
+vez, mesmo quando o nome nem ia ser mostrado na tela.
+
+Numa equipe pequena isso passava despercebido. Numa equipe grande, não: o
+tempo medido era de cerca de 350 milissegundos com dez pessoas atendendo, e de
+mais de um segundo com cinquenta — só para descobrir nomes que o sistema já
+poderia ter guardado.
+
+Agora o nome de quem atende fica guardado junto com a conversa, e é atualizado
+sozinho sempre que o atendimento troca de mãos. A Central abre no mesmo tempo
+com uma pessoa ou com cinquenta.
+
+Nada a fazer: a atualização do banco acontece sozinha quando você roda a
+atualização normal, e os nomes de quem já estava atendendo são preenchidos na
+hora.

--- a/.changes/o-que-a-versao-anterior-anunciou-e-nao-trouxe.md
+++ b/.changes/o-que-a-versao-anterior-anunciou-e-nao-trouxe.md
@@ -11,19 +11,18 @@ entraram no projeto antes do código deles, e a versão foi fechada no meio.
 Se você atualizou para a 1.10.0 esperando alguma destas quatro coisas, elas
 chegam agora:
 
-- **A instalação nova não obriga mais a verificação em duas etapas logo de
-  cara.** Quem instalava pelo instalador automático era parado por uma tela de
-  verificação em duas etapas logo depois do primeiro acesso, sem nunca ter sido
-  avisado disso.
-- **Quando a inteligência artificial falha ao responder, o erro deixa de
-  sumir.** A falha ficava só no registro técnico do servidor e não chegava a
-  ninguém.
-- **O instalador para de confundir comentário com valor de configuração.** No
-  arquivo de exemplo da VPS, um comentário escrito na mesma linha do valor era
-  lido como parte do valor.
-- **Uma rede a mais contra vazamento entre empresas.** Uma tabela nova criada
-  sem a proteção que separa os dados de cada empresa passa a ser recusada antes
-  de chegar a você.
+- **A instalação nova não obriga mais a verificação em duas etapas.**
+  Quem instalava pelo instalador automático era parado por uma tela de
+  verificação em duas etapas logo depois do primeiro acesso, sem nunca ter
+  sido avisado disso.
+- **Quando a inteligência artificial falha ao responder, o erro deixa de sumir.**
+  A falha ficava só no registro técnico do servidor e não chegava a ninguém.
+- **O instalador para de confundir comentário com valor de configuração.**
+  No arquivo de exemplo da VPS, um comentário escrito na mesma linha do valor
+  era lido como parte do valor.
+- **Uma rede a mais contra vazamento entre empresas.**
+  Uma tabela nova criada sem a proteção que separa os dados de cada empresa
+  passa a ser recusada antes de chegar até você.
 
 Nada a fazer além de atualizar normalmente. Quem instalar do zero a partir
 desta versão nunca viu o problema.

--- a/.changes/o-que-a-versao-anterior-anunciou-e-nao-trouxe.md
+++ b/.changes/o-que-a-versao-anterior-anunciou-e-nao-trouxe.md
@@ -1,0 +1,29 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Quatro consertos que a versão anterior anunciou e não trouxe chegam agora
+---
+
+A lista de mudanças da versão 1.10.0 anunciou quatro consertos que não estavam
+dentro dela. Foi um erro nosso de ordem: os textos que descrevem os consertos
+entraram no projeto antes do código deles, e a versão foi fechada no meio.
+
+Se você atualizou para a 1.10.0 esperando alguma destas quatro coisas, elas
+chegam agora:
+
+- **A instalação nova não obriga mais a verificação em duas etapas logo de
+  cara.** Quem instalava pelo instalador automático era parado por uma tela de
+  verificação em duas etapas logo depois do primeiro acesso, sem nunca ter sido
+  avisado disso.
+- **Quando a inteligência artificial falha ao responder, o erro deixa de
+  sumir.** A falha ficava só no registro técnico do servidor e não chegava a
+  ninguém.
+- **O instalador para de confundir comentário com valor de configuração.** No
+  arquivo de exemplo da VPS, um comentário escrito na mesma linha do valor era
+  lido como parte do valor.
+- **Uma rede a mais contra vazamento entre empresas.** Uma tabela nova criada
+  sem a proteção que separa os dados de cada empresa passa a ser recusada antes
+  de chegar a você.
+
+Nada a fazer além de atualizar normalmente. Quem instalar do zero a partir
+desta versão nunca viu o problema.

--- a/.changes/o-que-a-versao-anterior-anunciou-e-nao-trouxe.md
+++ b/.changes/o-que-a-versao-anterior-anunciou-e-nao-trouxe.md
@@ -21,8 +21,10 @@ chegam agora:
   No arquivo de exemplo da VPS, um comentário escrito na mesma linha do valor
   era lido como parte do valor.
 - **Uma rede a mais contra vazamento entre empresas.**
-  Uma tabela nova criada sem a proteção que separa os dados de cada empresa
-  passa a ser recusada antes de chegar até você.
+  Esta é sobre as próximas versões, não sobre a sua instalação de hoje: uma
+  tabela nova que seja criada sem a proteção que separa os dados de cada
+  empresa passa a ser recusada na nossa conferência, antes de virar uma
+  atualização que chega até você.
 
 Nada a fazer além de atualizar normalmente. Quem instalar do zero a partir
 desta versão nunca viu o problema.


### PR DESCRIPTION
## O que aconteceu

A **v1.10.0** está publicada (imagem no GHCR desde 21:56Z) e a seção dela no CHANGELOG anuncia quatro consertos que **não estão dentro da tag**:

| conserto anunciado | PR | está na v1.10.0? |
|---|---|---|
| instalação nova não exige verificação em duas etapas | #395 | **não** |
| quando a IA falha, o erro deixa de sumir | #380 | **não** |
| instalador para de confundir comentário com valor | #396 | **não** |
| uma rede a mais contra vazamento entre empresas | #386 | **não** |
| quem baixa o projeto no Windows roda os testes | #392 | sim |
| o sistema inteiro em espanhol | #375 | sim |

Medido, não deduzido:
```
$ git merge-base --is-ancestor <merge de cada PR> v1.10.0
  #380 FORA   #386 FORA   #388 FORA   #395 FORA   #396 FORA
$ git rev-list --count v1.10.0..origin/main
  20
```

## A causa raiz, e ela é minha

Escrevi os fragmentos dos cinco PRs num **PR separado** (#404, mergeado 15:56 BRT) em vez de cada PR trazer o seu. O corte da 1.10.0 (#412, 21:46 BRT) consumiu esses fragmentos; os PRs correspondentes só entraram entre 21:59 e 22:05.

A doutrina em `docs/doctrine/versionamento.md` diz *"todo PR que muda comportamento traz o **seu** fragmento"* — e este é exatamente o motivo pelo qual ela diz isso. Fragmento separado do código pode ser lançado sem o código. O mecanismo funcionou como projetado; o uso que eu fiz dele é que estava errado.

## Por que não reescrevo a tag

A v1.10.0 já foi puxada por quem quisesse; reescrever tag publicada é pior que o defeito. A **1.10.1** entrega o que a 1.10.0 prometeu, e o texto diz isso com todas as letras — em vez de repetir os quatro itens como se fossem novidade, o que confundiria quem leu os dois.

#388 não tinha fragmento e não foi anunciado: não há promessa quebrada nele.

🤖 Generated with [Claude Code](https://claude.com/claude-code)