### PR TITLE
fix(opt-out): espanhol cobria só o vocabulário do #275 — as construções reais não casavam

### DIFF
--- a/.changes/opt-out-em-espanhol-agora-reconhece-como-as-pessoas-escrevem.md
+++ b/.changes/opt-out-em-espanhol-agora-reconhece-como-as-pessoas-escrevem.md
@@ -1,0 +1,19 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Quem pede para sair em espanhol passa a ser atendido
+---
+
+Pedir para sair em espanhol só funcionava numa forma: a palavra sozinha, ou
+"no quiero recibir". As formas que as pessoas realmente escrevem — "deja de
+escribirme", "no quiero más mensajes", "dame de baja" — não casavam padrão
+nenhum, e o pedido se perdia em silêncio.
+
+O sinal que faz o robô parar de responder e chamar uma pessoa (o nível
+"ambíguo", usado quando o pedido não é claro o bastante para bloquear
+sozinho) também não existia em espanhol: nenhuma frase daquele idioma
+chegava a ativá-lo, então esse cliente nunca era escalado.
+
+De passagem, corrige um caso em português que só apareceu ao testar os dois
+idiomas juntos: "pare de mandar o pedido nesse endereço" bloqueava um
+cliente que só queria mudar a entrega.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,10 +111,12 @@ DeskcommCRM é um sistema operacional de vendas open source com agentes de IA na
   com OBJETO DE COMUNICAÇÃO ("parar de me mandar", "sair da lista"). Enquanto eram duas
   regras, a ingestão bloqueava paciente que perguntou "tem como parar a dor?" — medido em
   clínica, 12 falsos positivos num corpus de 32 frases de nicho.
-  Para ver o vocabulário em vigor sem confiar nesta linha:
+  Cobre português e espanhol, nos dois níveis (inequívoco e ambíguo) — foi preciso um PR
+  além do #275 (que só tinha coberto o vocabulário inequívoco) para o espanhol ganhar a
+  camada ambígua e as construções com pronome preso ("escribirme"). Para ver o vocabulário
+  em vigor sem confiar nesta linha:
   `grep -n 'PALAVRAS_DE_OPT_OUT' -A20 lib/opt-out/deteccao.ts`, e as frases de controle em
-  `tests/unit/opt-out-deteccao.test.ts`. **Espanhol ainda NÃO é coberto** (`baja`, `salir`,
-  `no quiero recibir`) — ver PR #275.
+  `tests/unit/opt-out-deteccao.test.ts`.
 - Mídia: subir pro Supabase Storage primeiro, passar URL ao WAHA (não inline base64)
 - Multi-device: assinar `message.any` (não só `message`); tratar `fromMe=true` sem duplicar
 - Grupos: SKIP CRM binding se `chatId.endsWith('@g.us')`. Sender é `p.author`, não `p.from`

--- a/lib/opt-out/deteccao.ts
+++ b/lib/opt-out/deteccao.ts
@@ -268,7 +268,20 @@ const FRASES_AMBIGUAS_DE_OPT_OUT: readonly RegExp[] = [
   // fala espanhola, por mais claro que o sinal seja.
   /\b(?:dejame|dejenme)\s+en\s+paz\b/u,
   /\bya\s+(?:te\s+)?dije\s+que\s+no\s+(?:quiero|me\s+interesa)\b/u,
-  /\b(?:ya\s+)?no\s+me\s+interesa(?:\s+mas)?\b/u,
+  // "ya no me interesa" / "no me interesa mas" — e NÃO "no me interesa" nu.
+  //
+  // O que faz desta frase um sinal de opt-out não é a recusa: é a marca de
+  // REPETIÇÃO. "No me interesa" sozinho é a objeção comercial mais comum do
+  // funil — "no me interesa ese plan, pero sí el otro", "no me interesa,
+  // gracias" —, e o agente precisa seguir vendendo ali, não parar e escalar.
+  // Com os dois trechos opcionais, sete frases de objeção medidas passavam a
+  // escalar; com um dos dois marcadores exigido, nenhuma. E as 89 frases do
+  // corpus deste arquivo não mudam de veredito: as duas formas que ele testa
+  // ("ya no me interesa", "ya te dije que no me interesa") têm marcador.
+  //
+  // É o espelho exato do português, que sempre exigiu o "mais":
+  // `/\bnao\s+(?:me\s+)?interessa\s+mais\b/` — a assimetria era o defeito.
+  /\b(?:ya\s+no\s+me\s+interesa|no\s+me\s+interesa\s+mas)\b/u,
   /\b(?:ya\s+basta|basta\s+ya)\b/u,
   /\bno\s+me\s+molest(?:e|en|es)\b/u,
 ];

--- a/lib/opt-out/deteccao.ts
+++ b/lib/opt-out/deteccao.ts
@@ -137,6 +137,20 @@ const OBJETOS_NAO_COMUNICATIVOS =
   "cobro|cobros|producto|productos|pauta|pautas|presupuesto|presupuestos";
 
 /**
+ * Determinantes que podem vir entre o verbo e o objeto não comunicativo —
+ * "o pedido", "el paquete". Compartilhado pt/es, e não só por DRY: os dois
+ * padrões de cessação abaixo (`par(?:ar|a|e|em)` em português e
+ * `dej(?:ar|a|e|en)|par(?:ar|a|e|en)` em espanhol) casam a MESMA forma
+ * "pare"/"para" nos dois idiomas — "pare" é alcançado pela alternativa "e"
+ * de AMBOS. Um lookahead só com determinantes de um idioma deixa "pare de
+ * mandar o pedido" escapar pelo padrão espanhol, que não reconhece "o" como
+ * determinante e portanto não vê o objeto excluído. Medido.
+ */
+const DETERMINANTES_DE_OBJETO =
+  "o|a|os|as|el|los|la|las|meu|minha|meus|minhas|seu|sua|seus|suas|" +
+  "mi|mis|tu|tus|esse|essa|esses|essas|ese|esa|esos|esas|nesse|nessa";
+
+/**
  * Pedidos INEQUÍVOCOS de descadastro escritos por extenso. Todos exigem o objeto
  * de comunicação; nenhum casa a palavra solta.
  *
@@ -146,8 +160,20 @@ const OBJETOS_NAO_COMUNICATIVOS =
  * `tests/unit/opt-out-deteccao.test.ts` e reprovam o CI.
  */
 const FRASES_DE_OPT_OUT: readonly RegExp[] = [
-  // "pare de me mandar", "parar de receber", "para de mandar mensagem"
-  new RegExp(`\\bpar(?:ar|a|e|em)\\s+de\\s+(?:me\\s+)?(?:${VERBOS_DE_COMUNICACAO})\\b`, "u"),
+  // "pare de me mandar", "parar de receber", "para de mandar mensagem" — mas
+  // NÃO "pare de mandar o pedido nesse endereço": o padrão ancorava só no
+  // VERBO ("mandar"), e "mandar" é verbo de comunicação mesmo quando o
+  // OBJETO é outra coisa. Medido: sem o lookahead, esta frase de e-commerce
+  // bloqueava um cliente pedindo para mudar a ENTREGA — o mesmo defeito que
+  // este arquivo existe para impedir ("tem como parar a dor?"), só que
+  // introduzido pela própria regra que consertou o primeiro caso. O
+  // lookahead (OBJETOS_NAO_COMUNICATIVOS) é o mesmo que já protege o
+  // padrão de cessação espanhol, abaixo.
+  new RegExp(
+    `\\bpar(?:ar|a|e|em)\\s+de\\s+(?:me\\s+)?(?:${VERBOS_DE_COMUNICACAO})\\b` +
+      `(?!\\s+(?:${DETERMINANTES_DE_OBJETO})?\\s*(?:${OBJETOS_NAO_COMUNICATIVOS})\\b)`,
+    "u",
+  ),
   // "não quero (mais) receber" — mas "não quero receber ligação, só whatsapp" é
   // troca de canal, não descadastro: quem diz isso QUER continuar no WhatsApp.
   /\bnao\s+(?:quero|desejo|gostaria)\s+(?:de\s+)?(?:mais\s+)?receber\b(?!\s+(?:ligacao|ligacoes|chamada|chamadas|telefonema|telefonemas|telefone)\b)/u,
@@ -206,7 +232,7 @@ const FRASES_DE_OPT_OUT: readonly RegExp[] = [
   new RegExp(
     `\\b(?:dej(?:ar|a|e|en)|par(?:ar|a|e|en))\\s+de\\s+` +
       `(?:${VERBOS_DE_COMUNICACAO})(?:me|nos|le|les)?\\b` +
-      `(?!\\s+(?:el|los|la|las|mi|mis|tu|tus|ese|esa|esos|esas)?\\s*(?:${OBJETOS_NAO_COMUNICATIVOS})\\b)`,
+      `(?!\\s+(?:${DETERMINANTES_DE_OBJETO})?\\s*(?:${OBJETOS_NAO_COMUNICATIVOS})\\b)`,
     "u",
   ),
   // "dar de baja" já É o pedido — a plantilla usa a palavra nesse sentido.

--- a/lib/opt-out/deteccao.ts
+++ b/lib/opt-out/deteccao.ts
@@ -118,6 +118,21 @@ const VERBOS_DE_COMUNICACAO =
   "recibir|recibe|escribir|escribe|escriban|molestar|molesta|llamar|llama|mandes|envien";
 
 /**
+ * Objetos que aparecem depois de um verbo de comunicação mas NÃO são a
+ * comunicação em si — pedido, fatura, orçamento, campanha publicitária.
+ * Compartilhada entre português e espanhol: sem este lookahead, "parar de
+ * mandar o pedido" ou "deja de mandar el pedido" bloqueariam um cliente
+ * que está pedindo para CONTINUAR sendo atendido, só que sobre outro
+ * assunto — o mesmo risco que o padrão de "não quero receber" já trata
+ * para "ligação", só que agora no verbo de cessação em vez do verbo isolado.
+ */
+const OBJETOS_NAO_COMUNICATIVOS =
+  "pedido|pedidos|encomenda|encomendas|pacote|pacotes|entrega|entregas|" +
+  "fatura|faturas|boleto|boletos|cobranca|cobrancas|produto|produtos|" +
+  "paquete|paquetes|envio|envios|factura|facturas|boleta|boletas|" +
+  "cobro|cobros|producto|productos|pauta|pautas|presupuesto|presupuestos";
+
+/**
  * Pedidos INEQUÍVOCOS de descadastro escritos por extenso. Todos exigem o objeto
  * de comunicação; nenhum casa a palavra solta.
  *
@@ -157,6 +172,19 @@ const FRASES_DE_OPT_OUT: readonly RegExp[] = [
   ),
   /\bno\s+quiero\s+recibir\s+mas\b/u,
   /\bno\s+me\s+(?:escriba|escriban|escribas|mande|manden|mandes|llame|llamen)\s+mas\b/u,
+  // "deja de escribirme", "para de mandarme mensajes" — o pronome PRESO ao
+  // infinitivo ("escribirme"), diferente do português, onde ele vem solto
+  // ANTES do verbo ("de me mandar"). Sem o sufixo opcional, a construção
+  // mais comum de pedir descadastro em espanhol não casava padrão nenhum.
+  // Mesmo lookahead de objeto não comunicativo do padrão português de
+  // "parar de", acima — o risco de capturar o objeto errado é o mesmo nos
+  // dois idiomas.
+  new RegExp(
+    `\\b(?:dej(?:ar|a|e|en)|par(?:ar|a|e|en))\\s+de\\s+` +
+      `(?:${VERBOS_DE_COMUNICACAO})(?:me|nos|le|les)?\\b` +
+      `(?!\\s+(?:el|los|la|las|mi|mis|tu|tus|ese|esa|esos|esas)?\\s*(?:${OBJETOS_NAO_COMUNICATIVOS})\\b)`,
+    "u",
+  ),
   // "dar de baja" já É o pedido — a plantilla usa a palavra nesse sentido.
   /\b(?:dar|darme|doy)\s+de\s+baja\s+(?:la\s+)?(?:suscripcion|lista|publicidad|promociones)\b/u,
   /\bdarme\s+de\s+baja\b/u,

--- a/lib/opt-out/deteccao.ts
+++ b/lib/opt-out/deteccao.ts
@@ -115,7 +115,11 @@ const VERBOS_DE_COMUNICACAO =
   "chamar|chama|ligar|liga|perturbar|perturba|encher|enche|insistir|insiste|" +
   // espanhol — mesma âncora, outra língua. Sem eles "no quiero recibir mas
   // mensajes" não casa nenhum padrão e o pedido se perde.
-  "recibir|recibe|escribir|escribe|escriban|molestar|molesta|llamar|llama|mandes|envien";
+  "recibir|recibe|escribir|escribe|escriban|molestar|molesta|llamar|llama|mandes|envien|" +
+  // `contactar` faltava — "no me contacten más" e "deja de contactarme" não
+  // casavam nenhum padrão, embora sejam pedido de descadastro tão direto
+  // quanto "no me escriba".
+  "contactar|contacta|contacte|contacten|contactes";
 
 /**
  * Objetos que aparecem depois de um verbo de comunicação mas NÃO são a
@@ -171,7 +175,27 @@ const FRASES_DE_OPT_OUT: readonly RegExp[] = [
     "u",
   ),
   /\bno\s+quiero\s+recibir\s+mas\b/u,
-  /\bno\s+me\s+(?:escriba|escriban|escribas|mande|manden|mandes|llame|llamen)\s+mas\b/u,
+  // "no quiero más mensajes/publicidad/promociones" — o objeto é um
+  // SUBSTANTIVO, não um verbo, e por isso não casava no padrão de cima
+  // (que exige verbo de comunicação depois de "no quiero"). Espelho direto
+  // de "não quero mais mensagem/contato" em português: faltava por
+  // assimetria, não por decisão.
+  /\bno\s+quiero\s+mas\s+(?:mensajes?|publicidad|promociones|nada\s+de\s+ustedes)\b/u,
+  // Imperativo com pronome preso — "dame de baja" é como a pessoa responde
+  // de fato à própria plantilla que pede "Respondé BAJA". `dar de baja`
+  // (sem pronome) segue de fora de propósito: sem objeto, é a frase que o
+  // corpus de testes marca como ambígua/fora de escopo (pausar campanha),
+  // não pedido de descadastro.
+  /\b(?:dame|deme|denme|danos)\s+de\s+baja\b/u,
+  // "no quiero que me contacten" — outra estrutura para o mesmo pedido que
+  // a extensão de `contacte|contacten|contactes` acima já cobre na forma
+  // "no me contacten mas".
+  /\bno\s+quiero\s+que\s+me\s+contact(?:e|en|es)\b/u,
+  // Remoção de "contactos" ou "base de datos" — mesma família da regra de
+  // `lista`, abaixo, mas objeto diferente: quem pede isto não está trocando
+  // de assunto, está pedindo para ser esquecido.
+  /\b(?:borrame|borrar|eliminame|elimina|sacame|quitame)\s+de\s+(?:tus\s+|mis\s+|la\s+)?(?:contactos|base\s+de\s+datos)\b/u,
+  /\bno\s+me\s+(?:escriba|escriban|escribas|mande|manden|mandes|llame|llamen|contacte|contacten|contactes)\s+mas\b/u,
   // "deja de escribirme", "para de mandarme mensajes" — o pronome PRESO ao
   // infinitivo ("escribirme"), diferente do português, onde ele vem solto
   // ANTES do verbo ("de me mandar"). Sem o sufixo opcional, a construção

--- a/lib/opt-out/deteccao.ts
+++ b/lib/opt-out/deteccao.ts
@@ -79,8 +79,13 @@ export const PALAVRAS_DE_OPT_OUT: ReadonlySet<string> = new Set([
   // denúncia de spam derruba o quality rating e faz a plataforma recusar
   // definições novas: perde-se as aprovadas, não só a linha.
   //
-  // `baja` sozinha É o pedido. "Doy de baja la pauta?" tem quatro palavras e
-  // cai no ambíguo, que é onde deve cair.
+  // `baja` sozinha É o pedido. "Doy de baja la pauta?" tem quatro palavras:
+  // não bloqueia — é pergunta sobre pausar publicidade (o objeto é "la
+  // pauta", fora de `suscripcion|lista|publicidad|promociones`, abaixo), não
+  // pedido de descadastro. Este comentário chamava o resultado de "cai no
+  // ambíguo"; estava errado — o espanhol não tinha UMA frase ambígua sequer
+  // até este PR acrescentar as de baixo em `FRASES_AMBIGUAS_DE_OPT_OUT`. Cai
+  // em NADA, e é onde deve cair: pergunta de negócio não é sinal de opt-out.
   "baja",
   "bajar",
   // `salir` é o `sair` em espanhol, e `sair` está nesta lista desde sempre —
@@ -91,9 +96,10 @@ export const PALAVRAS_DE_OPT_OUT: ReadonlySet<string> = new Set([
   // recebendo — no idioma em que a plantilla é a fonte do pedido.
   //
   // Não alarga a regra: continua valendo só a palavra SOZINHA (mensagem inteira
-  // = a palavra). "Voy a salir ahora" tem três palavras e cai no ambíguo, que é
-  // onde deve cair — a mesma proteção que faz "tem como parar a dor?" não
-  // bloquear paciente de clínica.
+  // = a palavra). "Voy a salir ahora" tem três palavras: não bloqueia — a
+  // mesma proteção que faz "tem como parar a dor?" não bloquear paciente de
+  // clínica. Cai em NADA, não em "ambíguo" — mesma correção do comentário de
+  // `baja`, acima.
   "salir",
   "desuscribir",
   "desuscribirme",
@@ -172,6 +178,21 @@ const FRASES_AMBIGUAS_DE_OPT_OUT: readonly RegExp[] = [
   /\bja\s+(?:disse|falei)\s+que\s+nao\s+(?:quero|tenho\s+interesse)\b/u,
   /\bnao\s+(?:me\s+)?interessa\s+mais\b/u,
   /\bpara\s+com\s+isso\b/u,
+  // ── espanhol ──────────────────────────────────────────────────────────────
+  //
+  // Esta lista tinha ZERO entradas em espanhol. Não por decisão: o ambíguo é
+  // uma segunda lista, com curadoria própria, e ninguém a preencheu quando o
+  // espanhol entrou — o comentário de `baja`/`salir` acima chegou a AFIRMAR
+  // que certas frases "caem no ambíguo" sem que essa lista tivesse uma
+  // entrada em espanhol capaz de pegá-las. Efeito medido: em espanhol,
+  // `ehOptOutProvavel` nunca soma nada além do inequívoco —
+  // `detectAmbiguousOptOut` (o runtime do agente) nunca escala um cliente de
+  // fala espanhola, por mais claro que o sinal seja.
+  /\b(?:dejame|dejenme)\s+en\s+paz\b/u,
+  /\bya\s+(?:te\s+)?dije\s+que\s+no\s+(?:quiero|me\s+interesa)\b/u,
+  /\b(?:ya\s+)?no\s+me\s+interesa(?:\s+mas)?\b/u,
+  /\b(?:ya\s+basta|basta\s+ya)\b/u,
+  /\bno\s+me\s+molest(?:e|en|es)\b/u,
 ];
 
 /** A mensagem inteira é a palavra-chave (ignorando pontuação e emoji de borda). */

--- a/tests/unit/opt-out-deteccao.test.ts
+++ b/tests/unit/opt-out-deteccao.test.ts
@@ -88,6 +88,16 @@ const ESPANHOL_PEDE_PARA_SAIR = [
   "darme de baja",
   "dar de baja la suscripcion",
   "quiero dar de baja la suscripcion",
+  // Pronome PRESO ao infinitivo — a construção mais comum de pedir
+  // descadastro em espanhol, e a que não casava padrão nenhum até este PR.
+  // Diferente do português, onde o pronome vem solto ANTES do verbo.
+  "deja de escribirme",
+  "dejen de mandarme mensajes",
+  "deja de enviarme promociones",
+  "para de escribirme",
+  "para de mandarme mensajes",
+  "deja de escribirme por favor",
+  "deja de escribir",
   // `salir` é o `sair` em espanhol, e `sair` já estava na lista em português.
   // Faltava, e a promessa do CHANGELOG da 1.4.0 ("`baja`, `salir` e
   // `no quiero recibir` descadastram") era falsa exatamente nesta palavra —
@@ -121,6 +131,12 @@ const ESPANHOL_NAO_PEDE = [
   "voy a salir ahora",
   "puedo salir mas temprano?",
   "el pedido va a salir hoy?",
+  // CONTROLE do lookahead novo de OBJETOS_NAO_COMUNICATIVOS: o mesmo achado
+  // de "pare de mandar o pedido" (português), em espanhol. Sem o lookahead,
+  // "deja de mandar el pedido a esa dirección" bloquearia um cliente que
+  // está pedindo para mudar a ENTREGA, não para parar de ser atendido.
+  "deja de mandar el pedido a esa direccion",
+  "deja de cobrarme el envio",
 ];
 
 describe("espanhol — a palavra que a plantilla pede", () => {

--- a/tests/unit/opt-out-deteccao.test.ts
+++ b/tests/unit/opt-out-deteccao.test.ts
@@ -162,6 +162,19 @@ const ESPANHOL_NAO_PEDE = [
   // está pedindo para mudar a ENTREGA, não para parar de ser atendido.
   "deja de mandar el pedido a esa direccion",
   "deja de cobrarme el envio",
+  // OBJEÇÃO COMERCIAL — o buraco que faltava neste corpus, e por onde um
+  // falso positivo entrou. `ESPANHOL_NAO_PEDE` tinha controle de clínica, de
+  // e-commerce e de troca de canal, mas nenhum da recusa de VENDA: a frase
+  // mais comum do funil, e a que o agente precisa contornar em vez de fugir
+  // dela. Sem estes casos, `no me interesa` nu escalava para humano e a
+  // suíte ficava verde.
+  "no me interesa",
+  "no me interesa, gracias",
+  "no me interesa ese plan, pero si el otro",
+  "por ahora no me interesa, quizas el mes que viene",
+  "no me interesa el seguro, quiero solo el producto",
+  "la verdad no me interesa el precio, me interesa la calidad",
+  "no me interesa pagar mas, hay algo mas barato?",
 ];
 
 describe("espanhol — a palavra que a plantilla pede", () => {
@@ -174,6 +187,32 @@ describe("espanhol — a palavra que a plantilla pede", () => {
   for (const texto of ESPANHOL_NAO_PEDE) {
     it(`NÃO bloqueia: ${texto}`, () => {
       expect(ehPedidoDeOptOut(texto)).toBe(false);
+    });
+  }
+});
+
+/**
+ * O lado negativo do corpus verificava só o BLOQUEIO, e não a ESCALADA.
+ *
+ * São dois níveis com custos diferentes: `ehPedidoDeOptOut` grava
+ * `is_blocked=true` e o contato para de ser atendido; `ehOptOutProvavel` faz o
+ * agente parar de responder e chamar um humano. O segundo é mais barato, mas
+ * não é grátis — num sistema de vendas ele desliga a automação exatamente na
+ * objeção, que é o momento em que ela deveria trabalhar.
+ *
+ * Enquanto só o bloqueio era verificado, uma frase podia entrar na lista
+ * ambígua e o corpus inteiro seguir verde: `ehPedidoDeOptOut` devolve `false`
+ * para ela, que é tudo que se perguntava. Foi por essa porta que
+ * `no me interesa` (sem marca de repetição) passou a escalar toda objeção
+ * comercial em espanhol sem nenhum caso vermelhar.
+ *
+ * Medido ao escrever: com a regra corrigida, ZERO frases dos dois corpora
+ * negativos escalam. O gate nasce verde e trava a volta.
+ */
+describe("o lado negativo também não pode ESCALAR, não só não bloquear", () => {
+  for (const texto of [...ESPANHOL_NAO_PEDE, ...NAO_PEDE_PARA_SAIR]) {
+    it(`não escala para humano: ${texto}`, () => {
+      expect(ehOptOutProvavel(texto), texto).toBe(false);
     });
   }
 });
@@ -192,6 +231,11 @@ describe("espanhol — o ambíguo, que não existia", () => {
     "déjenme en paz",
     "ya te dije que no me interesa",
     "ya no me interesa",
+    // CONTROLE do lado positivo: o marcador de repetição é o que separa o
+    // sinal da objeção. "ya" numa, "mas" na outra — sem nenhum dos dois, a
+    // frase está em `ESPANHOL_NAO_PEDE`, acima.
+    "no me interesa mas",
+    "ya no me interesa nada de esto",
     "basta ya",
     "ya basta con esto",
     "no me molesten",

--- a/tests/unit/opt-out-deteccao.test.ts
+++ b/tests/unit/opt-out-deteccao.test.ts
@@ -98,6 +98,22 @@ const ESPANHOL_PEDE_PARA_SAIR = [
   "para de mandarme mensajes",
   "deja de escribirme por favor",
   "deja de escribir",
+  // Objeto SUSTANTIVO em vez de verbo — "no quiero más mensajes" não tem
+  // verbo de comunicação depois de "no quiero", então o padrão geral (que
+  // exige verbo) não pega. Espelho de "não quero mais mensagem/contato".
+  "no quiero mas mensajes",
+  "no quiero mas publicidad",
+  "ya no quiero mas promociones",
+  "no quiero mas nada de ustedes",
+  // Imperativo com pronome preso — como a pessoa responde de fato à
+  // plantilla "Respondé BAJA".
+  "dame de baja",
+  "denme de baja",
+  // `contactar`, que faltava na lista de verbos de comunicação.
+  "no me contacten mas",
+  "no quiero que me contacten",
+  "borrame de tus contactos",
+  "eliminame de la base de datos",
   // `salir` é o `sair` em espanhol, e `sair` já estava na lista em português.
   // Faltava, e a promessa do CHANGELOG da 1.4.0 ("`baja`, `salir` e
   // `no quiero recibir` descadastram") era falsa exatamente nesta palavra —

--- a/tests/unit/opt-out-deteccao.test.ts
+++ b/tests/unit/opt-out-deteccao.test.ts
@@ -137,6 +137,33 @@ describe("espanhol — a palavra que a plantilla pede", () => {
   }
 });
 
+/**
+ * O espanhol tinha ZERO frases ambíguas — `ehOptOutProvavel` nunca somava
+ * nada além do inequívoco nesse idioma, e o comentário de `baja`/`salir` em
+ * `deteccao.ts` chegou a afirmar que duas frases "caem no ambíguo" sem que
+ * essa camada existisse para pegá-las. Espelha o corpus português de baixo
+ * ("me deixa em paz", "já disse que não quero", "para com isso") — mesma
+ * forma, outra língua.
+ */
+describe("espanhol — o ambíguo, que não existia", () => {
+  it.each([
+    "déjame en paz",
+    "déjenme en paz",
+    "ya te dije que no me interesa",
+    "ya no me interesa",
+    "basta ya",
+    "ya basta con esto",
+    "no me molesten",
+  ])("reconhece o sinal ambíguo: %s", (texto) => {
+    expect(ehOptOutProvavel(texto)).toBe(true);
+  });
+
+  it("o ambíguo em espanhol também NÃO autoriza bloqueio por si só", () => {
+    expect(ehOptOutProvavel("déjame en paz")).toBe(true);
+    expect(ehPedidoDeOptOut("déjame en paz")).toBe(false);
+  });
+});
+
 describe("ehPedidoDeOptOut — pedido INEQUÍVOCO, o que autoriza bloquear", () => {
   it.each(PEDE_PARA_SAIR)("respeita o pedido: %s", (texto) => {
     expect(ehPedidoDeOptOut(texto), `deveria ter reconhecido "${texto}"`).toBe(true);

--- a/tests/unit/opt-out-deteccao.test.ts
+++ b/tests/unit/opt-out-deteccao.test.ts
@@ -37,6 +37,10 @@ const PEDE_PARA_SAIR = [
   "não me mande mais mensagens",
   "me tira dessa lista",
   "me remove da lista por favor",
+  // CONTROLE do lookahead novo: continua bloqueando quando o objeto É a
+  // comunicação — o lookahead exclui só a lista fechada de objetos não
+  // comunicativos, não apaga o padrão inteiro.
+  "pare de mandar essas fotos",
   "quero sair da lista",
   "quero cancelar a inscrição",
   "me descadastra aí",
@@ -44,6 +48,11 @@ const PEDE_PARA_SAIR = [
 
 /** Frases do dia a dia que usam a palavra e NÃO são pedido de descadastro. */
 const NAO_PEDE_PARA_SAIR = [
+  // e-commerce — o padrão de cessação ancorava só no VERBO ("mandar"), e
+  // "mandar" é verbo de comunicação mesmo quando o objeto é outra coisa.
+  // Bloquearia um cliente pedindo para mudar a ENTREGA.
+  "pare de mandar o pedido nesse endereco",
+  "para de mandar a fatura por aqui",
   // clínica — o caso que motivou este arquivo
   "tem como parar a dor?",
   "dá pra parar o sangramento em casa?",


### PR DESCRIPTION
## Medição

Sonda de 39 frases (positivas, ambíguas e controles de falso positivo) contra as funções reais, antes deste PR:

```
total: 39   fallos: 25
fallos por grupo: A=7  B=4  C=2  D=4  E=7  F=1
```

Depois:

```
total: 39   fallos: 1
fallos por grupo: F=1
```

A única que fica de fora ("quiero dar de baja la pauta pero seguir con el resto") é uma pergunta de negócio sobre pausar uma campanha mantendo o resto — não é sinal de opt-out em nenhum dos dois níveis, e por isso corretamente fora do escopo deste detector.

**Corrigindo o próprio arquivo:** o comentário de `baja`/`salir` afirmava que "Doy de baja la pauta?" e "Voy a salir ahora" "caem no ambíguo, que é onde devem cair" — medido antes deste PR, as duas devolviam `NADA`, porque `FRASES_AMBIGUAS_DE_OPT_OUT` tinha **zero** entradas em espanhol. `ehOptOutProvavel` nunca somava nada além do inequívoco nesse idioma, e `detectAmbiguousOptOut` (o runtime do agente) nunca escalava um cliente de fala espanhola para um humano, por mais claro que o sinal ambíguo fosse.

## O que estava faltando, por que

O espanhol tinha o vocabulário do **#275** (`baja`, `salir`, `no quiero recibir` — inequívoco, sem a camada ambígua). O que faltava era a forma como as pessoas realmente escrevem:

| Construção | Exemplo | Por que não casava |
|---|---|---|
| Pronome preso ao infinitivo | "deja de **escribirme**" | O padrão de cessação exigia o pronome SOLTO antes do verbo ("de me mandar"), como em português. Em espanhol o pronome gruda no infinitivo. |
| Objeto substantivo | "no quiero más **mensajes**" | O padrão de "no quiero" exige um VERBO depois; quando o objeto é direto, não casa. |
| Imperativo com clítico | "**dame** de baja" | Como a pessoa responde de fato à própria plantilla ("Respondé BAJA"). |
| `contactar` | "no me **contacten** más" | Verbo ausente de `VERBOS_DE_COMUNICACAO` inteiro. |
| Camada ambígua | "**déjame en paz**" | Zero entradas em espanhol — arquitetura que existe em português e nunca foi replicada. |

## O achado em português

Testando os dois padrões de cessação juntos (novo em espanhol + existente em português), apareceu um caso vivo: **"pare de mandar o pedido nesse endereço"** bloqueava um cliente de e-commerce pedindo para mudar a entrega — o padrão ancorava só no verbo ("mandar"), e "mandar" é verbo de comunicação mesmo quando o objeto é outra coisa. Mesmo defeito que este arquivo existe para impedir, reintroduzido pela própria regra que consertou o primeiro caso.

Consertado com um lookahead de `OBJETOS_NAO_COMUNICATIVOS`, compartilhado entre os dois idiomas — e precisou de um ajuste que só apareceu ao testar os dois padrões juntos: "pare" é alcançado pela alternativa `e` tanto do padrão português (`par(?:ar|a|e|em)`) quanto do espanhol (`par(?:ar|a|e|en)`), então um lookahead com determinantes de um idioma só deixava a frase escapar pelo padrão do outro. Os dois compartilham `DETERMINANTES_DE_OBJETO` agora.

## Commits

1. `fix(opt-out): o espanhol nunca teve frase ambígua` — a lacuna que torna falsas as duas afirmações do próprio arquivo, corrigida junto com o comentário.
2. `fix(opt-out): pronome enclítico derrubava a regra de cessação inteira em espanhol` — introduz `OBJETOS_NAO_COMUNICATIVOS`, necessário desde o primeiro padrão novo.
3. `fix(opt-out): "no quiero más mensajes" e "dame de baja" não casavam padrão nenhum` — vocabulário.
4. `fix(opt-out): "pare de mandar o pedido nesse endereço" bloqueava cliente de e-commerce` — o achado em português, isolado para reverter sozinho se preferir tratá-lo à parte.
5. `docs(claude)` — a linha do `CLAUDE.md` dizia "Espanhol ainda NÃO é coberto — ver PR #275", desatualizada desde 24/08. Trocada por comando (`grep`), não por novo estado que também vai vencer.

## Test plan

- [x] `pnpm typecheck` — limpo
- [x] `pnpm lint` — 0 erros (295 warnings de baseline preexistentes, nenhum nos arquivos deste PR)
- [x] `pnpm test:unit` (sem filtro de caminho, não só `tests/unit/`) — 583 arquivos, 6474 passed, 0 failed
- [x] `pnpm release:conferir` — fragmento válido, calcula patch (1.10.1 → 1.10.2)
- [x] Sonda de 39 frases, reproduzível — script anexo neste PR na descrição do commit 1, resultado acima

Não roda `pnpm test:db` (sem mudança de schema/RLS) nem QA visual (função pura, sem tela nova — o próprio corpus do módulo é o gate desta calibração).

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
