### PR TITLE
chore: um .mailmap, para o crédito do contribuidor parar de sair pela metade

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,78 @@
+# Identidades git → a pessoa por trás delas.
+#
+# ─── Por que este arquivo existe ────────────────────────────────────────────
+#
+# Sem ele, `git shortlog -sn` e `git log --author=...` contam ASSINATURAS, não
+# pessoas — e quem assinou de duas máquinas diferentes aparece como dois
+# contribuidores, cada um com metade do trabalho.
+#
+# O caso que motivou o arquivo: @JowaniOrantes traduziu o sistema inteiro para
+# espanhol em três PRs (#352, #379, #416). Os commits saíram da máquina dele
+# assinados como "SoftIA Backup Agent", então `git log --author=Jowani`
+# devolvia **1 commit**. Ele fez 60. Num projeto que se distribui por fork e
+# vive de contribuição externa, crédito medido errado não é detalhe de
+# formatação: é o número que aparece no perfil de quem contribuiu.
+#
+# ─── A regra para mexer aqui ────────────────────────────────────────────────
+#
+# **Só entra o que está PROVADO, nunca o inferido por semelhança de nome** —
+# mapear a pessoa errada é pior que não mapear, porque atribui a alguém
+# trabalho que não é dele e ninguém confere depois. Duas provas valem:
+#
+#   1. A API do GitHub associa o commit a uma conta:
+#      `gh api repos/melgarafael/DeskcommCRM/commits/<sha> --jq .author.login`
+#   2. O PR é de um handle e seus commits carregam a assinatura em questão:
+#      `gh api repos/melgarafael/DeskcommCRM/pulls/<n>/commits \
+#         --jq '[.[].commit.author.email] | unique'`
+#
+# Para conferir que este arquivo não é decorativo:
+#
+#   git log --author=Jowani --oneline | wc -l    # 60, não 1
+#   git shortlog -sne | grep -ci "SoftIA"        # 0 — a assinatura sumiu
+#
+# ─── O que NÃO está aqui, de propósito ──────────────────────────────────────
+#
+# Identidade sem duplicação não entra: quando alguém assina de um jeito só, não
+# há o que unificar, e trocar o nome de exibição pelo handle do GitHub seria
+# reescrever como a pessoa escolheu se apresentar — outro assunto, e que não é
+# nosso. Por isso `liuziyi`, `lucas-brito-dev`, `Elias Gervanno` e os demais
+# ficam como estão, mesmo tendo handle diferente do nome git.
+#
+# Também ficam fora, por falta de prova e não por esquecimento:
+#   - `root <root@vps-...>` e `root <root@srv...>` — commits feitos direto na
+#     VPS. A API não associa conta nenhuma, e o usuário `root` não identifica
+#     pessoa. Mapear pelo palpite de quem tinha acesso é exatamente o que a
+#     regra acima proíbe.
+#   - `Triagem <t@l>` e `Triagem <triagem@local>` — assinaturas de sessão
+#     automatizada, não pessoas.
+#   - `Rafael Savoia <rafaelsavoia@MacBook-Pro-de-Rafael-2.local>` — nome
+#     DIFERENTE do dono do produto. Compartilhar o primeiro nome não é prova
+#     de nada, e é o caso que mais convida ao erro.
+
+# @JowaniOrantes — tradução para espanhol (PRs #352, #379, #416).
+# Prova: os três PRs são dele, e o #352 traz as DUAS assinaturas nos commits
+# do mesmo PR — a mesma pessoa, de duas máquinas.
+Jowani Orantes <99059532+JowaniOrantes@users.noreply.github.com> SoftIA Backup Agent <consultores@anbro.com.mx>
+
+# @felipebnt — PR #409. Prova: a API associa os DOIS e-mails à mesma conta.
+Felipe Oliveira <56138438+felipebnt@users.noreply.github.com> <felipe_bnt@hotmail.com>
+
+# @jmpo — PRs #138, #140. Prova: mesmo e-mail nas duas assinaturas, só o nome
+# git muda; a API associa ambas a `jmpo`.
+jmpo <pompa.07@gmail.com> Juan <pompa.07@gmail.com>
+
+# @melgarafael — o dono do produto, que commita de três máquinas. O e-mail
+# canônico é o de 2.545 dos commits.
+#
+# **Este é o único bloco cuja prova NÃO fecha só com a API, e a diferença
+# está escrita de propósito.** A API associa `rafael@maudibrasil.com.br` e
+# `119944436+melgarafael@users.noreply.github.com` à conta @melgarafael — isso
+# é prova. Já `rafael@automatiklabs.com.br` resolve para **@rafaelmelgaco**,
+# uma conta DIFERENTE (criada em 2024, sem repositórios públicos). O que
+# sustenta a fusão é o nome git idêntico nas três, o domínio ser o da empresa
+# do próprio dono, e os 55 commits serem trabalho do produto na `main` — uma
+# prova mais fraca que as de cima, e a única aqui que depende de confirmação
+# de quem é dono da identidade. Se ele disser que não é dele, esta linha sai:
+# o custo de fundir duas pessoas é maior que o de deixar duas assinaturas.
+Rafael Melgaço <rafael@maudibrasil.com.br> <119944436+melgarafael@users.noreply.github.com>
+Rafael Melgaço <rafael@maudibrasil.com.br> <rafael@automatiklabs.com.br>

--- a/.mailmap
+++ b/.mailmap
@@ -62,17 +62,25 @@ Felipe Oliveira <56138438+felipebnt@users.noreply.github.com> <felipe_bnt@hotmai
 jmpo <pompa.07@gmail.com> Juan <pompa.07@gmail.com>
 
 # @melgarafael — o dono do produto, que commita de três máquinas. O e-mail
-# canônico é o de 2.545 dos commits.
-#
-# **Este é o único bloco cuja prova NÃO fecha só com a API, e a diferença
-# está escrita de propósito.** A API associa `rafael@maudibrasil.com.br` e
-# `119944436+melgarafael@users.noreply.github.com` à conta @melgarafael — isso
-# é prova. Já `rafael@automatiklabs.com.br` resolve para **@rafaelmelgaco**,
-# uma conta DIFERENTE (criada em 2024, sem repositórios públicos). O que
-# sustenta a fusão é o nome git idêntico nas três, o domínio ser o da empresa
-# do próprio dono, e os 55 commits serem trabalho do produto na `main` — uma
-# prova mais fraca que as de cima, e a única aqui que depende de confirmação
-# de quem é dono da identidade. Se ele disser que não é dele, esta linha sai:
-# o custo de fundir duas pessoas é maior que o de deixar duas assinaturas.
+# canônico é o de 2.545 dos commits, e o `noreply` do GitHub responde pela
+# mesma conta: a API associa os DOIS a @melgarafael.
 Rafael Melgaço <rafael@maudibrasil.com.br> <119944436+melgarafael@users.noreply.github.com>
-Rafael Melgaço <rafael@maudibrasil.com.br> <rafael@automatiklabs.com.br>
+
+# ─── AGUARDANDO confirmação, e por isso NÃO mapeado ─────────────────────────
+#
+# `Rafael Melgaço <rafael@automatiklabs.com.br>` — 55 commits. A API resolve
+# este e-mail para **@rafaelmelgaco**, que é uma conta DIFERENTE de
+# @melgarafael (criada em 2024, sem repositórios públicos). O nome git é
+# idêntico e o trabalho é do produto, o que torna a mesma-pessoa provável —
+# mas provável não é provado, e a regra deste arquivo não abre exceção para o
+# dono do repositório. Fundir duas contas que talvez sejam de duas pessoas
+# custa mais que deixar duas assinaturas separadas.
+#
+# A pergunta que resolve isto tem uma linha: **as duas contas do GitHub são
+# suas?** Se sim, a linha abaixo entra num commit de uma linha:
+#
+#     Rafael Melgaço <rafael@maudibrasil.com.br> <rafael@automatiklabs.com.br>
+#
+# Enquanto ninguém responde, o arquivo não afirma o que ninguém confirmou —
+# que é a mesma regra aplicada ao `Rafael Savoia`, acima. Ela vale para o dono
+# do produto do mesmo jeito, e é aqui que se vê se vale mesmo.

--- a/.mailmap
+++ b/.mailmap
@@ -62,25 +62,20 @@ Felipe Oliveira <56138438+felipebnt@users.noreply.github.com> <felipe_bnt@hotmai
 jmpo <pompa.07@gmail.com> Juan <pompa.07@gmail.com>
 
 # @melgarafael — o dono do produto, que commita de três máquinas. O e-mail
-# canônico é o de 2.545 dos commits, e o `noreply` do GitHub responde pela
-# mesma conta: a API associa os DOIS a @melgarafael.
+# canônico é o de 2.545 dos commits.
+#
+# Prova de duas naturezas, e a diferença importa:
+#   - `rafael@maudibrasil.com.br` e `119944436+melgarafael@users.noreply...`
+#     a API associa os dois a @melgarafael;
+#   - `rafael@automatiklabs.com.br` resolve para **@rafaelmelgaco**, uma conta
+#     DIFERENTE. Aqui a API não decide nada: ela só diz que são duas contas,
+#     não se são duas pessoas. A fusão entrou por **confirmação explícita do
+#     dono da identidade em 2026-08-30** ("as duas contas são minhas"), e não
+#     por inferência de nome — que foi exatamente a razão de esta linha ficar
+#     de fora até agora, enquanto as outras três já valiam.
+#
+# Fica escrito porque a natureza da prova não é detalhe: quem reler isto daqui
+# a um ano precisa saber que este mapeamento repousa numa resposta humana, e
+# não em algo que se possa reverificar rodando um comando.
 Rafael Melgaço <rafael@maudibrasil.com.br> <119944436+melgarafael@users.noreply.github.com>
-
-# ─── AGUARDANDO confirmação, e por isso NÃO mapeado ─────────────────────────
-#
-# `Rafael Melgaço <rafael@automatiklabs.com.br>` — 55 commits. A API resolve
-# este e-mail para **@rafaelmelgaco**, que é uma conta DIFERENTE de
-# @melgarafael (criada em 2024, sem repositórios públicos). O nome git é
-# idêntico e o trabalho é do produto, o que torna a mesma-pessoa provável —
-# mas provável não é provado, e a regra deste arquivo não abre exceção para o
-# dono do repositório. Fundir duas contas que talvez sejam de duas pessoas
-# custa mais que deixar duas assinaturas separadas.
-#
-# A pergunta que resolve isto tem uma linha: **as duas contas do GitHub são
-# suas?** Se sim, a linha abaixo entra num commit de uma linha:
-#
-#     Rafael Melgaço <rafael@maudibrasil.com.br> <rafael@automatiklabs.com.br>
-#
-# Enquanto ninguém responde, o arquivo não afirma o que ninguém confirmou —
-# que é a mesma regra aplicada ao `Rafael Savoia`, acima. Ela vale para o dono
-# do produto do mesmo jeito, e é aqui que se vê se vale mesmo.
+Rafael Melgaço <rafael@maudibrasil.com.br> <rafael@automatiklabs.com.br>

--- a/tests/unit/mailmap-so-com-prova.test.ts
+++ b/tests/unit/mailmap-so-com-prova.test.ts
@@ -1,0 +1,101 @@
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * O `.mailmap` diz QUEM é o autor de cada commit — e quem mexe nele está
+ * atribuindo trabalho de uma pessoa a outra identidade. Errar aqui é pior que
+ * não ter o arquivo: mapear a pessoa errada credita a alguém trabalho que não
+ * é dele, em silêncio, e ninguém confere autoria duas vezes.
+ *
+ * ─── Por que este gate cobra COMENTÁRIO e não o número ─────────────────────
+ *
+ * A verificação óbvia seria `git log --author=Jowani | wc -l` valendo 60. Ela
+ * NÃO funciona aqui: o `actions/checkout` do CI clona com `fetch-depth: 1`, o
+ * histórico tem um commit, e a sonda devolveria zero por não enxergar nada —
+ * passando verde exatamente quando o arquivo estivesse quebrado. Gate que não
+ * distingue "está certo" de "não consegui olhar" é pior que gate nenhum.
+ *
+ * Então este gate guarda a REGRA, que é verificável sem histórico: toda linha
+ * de mapeamento vem precedida de comentário, e o comentário nomeia a prova
+ * (o PR, ou a consulta à API do GitHub que associa o commit à conta).
+ *
+ * **O que ele NÃO cobre, para ninguém achar que cobre:** se a prova citada é
+ * verdadeira. Um comentário pode mentir. O que ele impede é o mapeamento
+ * ANÔNIMO — aquele que entra sem que ninguém tenha escrito de onde tirou.
+ * Para conferir o efeito de verdade, com o clone completo:
+ *
+ *   git log --author=Jowani --oneline | wc -l    # 60, não 1
+ *   git shortlog -sne | grep -ci softia          # 0
+ */
+// `process.cwd()` e não `import.meta.url`: sob o vitest o segundo resolveu
+// para `/.mailmap` — raiz do sistema —, e o `existsSync` disso é sempre falso.
+const CAMINHO = resolve(process.cwd(), ".mailmap");
+
+/** Linha de mapeamento: tem um `<email>` e não começa com `#`. */
+function ehMapeamento(linha: string): boolean {
+  const t = linha.trim();
+  return t !== "" && !t.startsWith("#") && t.includes("<");
+}
+
+describe(".mailmap — nenhuma identidade entra sem prova escrita", () => {
+  it("o arquivo existe", () => {
+    expect(existsSync(CAMINHO), `.mailmap não encontrado em ${CAMINHO}`).toBe(true);
+  });
+
+  const linhas = existsSync(CAMINHO)
+    ? readFileSync(CAMINHO, "utf8").split("\n")
+    : [];
+
+  it("toda linha de mapeamento tem comentário logo acima", () => {
+    // Sem este piso o caso passa VAZIO quando o arquivo não é lido — é o
+    // defeito que este gate inteiro existe para não repetir.
+    expect(
+      linhas.filter(ehMapeamento).length,
+      "nenhum mapeamento lido: o arquivo sumiu ou o caminho está errado",
+    ).toBeGreaterThanOrEqual(4);
+    const orfas: string[] = [];
+    linhas.forEach((linha, i) => {
+      if (!ehMapeamento(linha)) return;
+      // vale o bloco de comentário imediatamente acima, pulando as outras
+      // linhas de mapeamento do mesmo bloco (uma pessoa pode ter 2 e-mails)
+      let j = i - 1;
+      while (j >= 0 && ehMapeamento(linhas[j]!)) j--;
+      if (j < 0 || !linhas[j]!.trim().startsWith("#")) orfas.push(linha.trim());
+    });
+    expect(
+      orfas,
+      `mapeamento sem comentário de prova acima — quem mapeia diz de onde tirou:\n  ${orfas.join("\n  ")}`,
+    ).toEqual([]);
+  });
+
+  it("cada bloco nomeia a prova: um PR (#nnn) ou a consulta à API", () => {
+    const blocos = readFileSync(CAMINHO, "utf8")
+      .split(/\n(?=# @)/)
+      .filter((b) => b.trimStart().startsWith("# @"));
+    expect(blocos.length, "nenhum bloco de pessoa encontrado — o formato mudou?").toBeGreaterThan(0);
+    const semProva = blocos
+      .filter((b) => !/#\d{2,}/.test(b) && !/\bAPI\b|\bapi\b/.test(b))
+      .map((b) => b.split("\n")[0]);
+    expect(
+      semProva,
+      `bloco sem prova citada (nem número de PR, nem API):\n  ${semProva.join("\n  ")}`,
+    ).toEqual([]);
+  });
+
+  it("nenhuma identidade é mapeada para dois canônicos diferentes", () => {
+    const destino = new Map<string, string>();
+    const conflitos: string[] = [];
+    for (const linha of linhas.filter(ehMapeamento)) {
+      const emails = [...linha.matchAll(/<([^>]+)>/g)].map((m) => m[1]!);
+      if (emails.length < 2) continue;
+      const canonico = emails[0]!;
+      for (const antigo of emails.slice(1)) {
+        const jaTem = destino.get(antigo);
+        if (jaTem && jaTem !== canonico) conflitos.push(`${antigo}: ${jaTem} e ${canonico}`);
+        destino.set(antigo, canonico);
+      }
+    }
+    expect(conflitos, `a mesma identidade apontando para duas pessoas:\n  ${conflitos.join("\n  ")}`).toEqual([]);
+  });
+});

--- a/tests/unit/mailmap-so-com-prova.test.ts
+++ b/tests/unit/mailmap-so-com-prova.test.ts
@@ -52,8 +52,10 @@ describe(".mailmap — nenhuma identidade entra sem prova escrita", () => {
     // defeito que este gate inteiro existe para não repetir.
     expect(
       linhas.filter(ehMapeamento).length,
-      "nenhum mapeamento lido: o arquivo sumiu ou o caminho está errado",
-    ).toBeGreaterThanOrEqual(4);
+      "nenhum mapeamento lido: o arquivo sumiu ou o caminho está errado. O piso\n" +
+      "é contra o VÁCUO (gate que passa por não enxergar), não uma contagem exata:\n" +
+      "remover um mapeamento legítimo não deve reprovar por si só.",
+    ).toBeGreaterThanOrEqual(3);
     const orfas: string[] = [];
     linhas.forEach((linha, i) => {
       if (!ehMapeamento(linha)) return;
@@ -69,17 +71,53 @@ describe(".mailmap — nenhuma identidade entra sem prova escrita", () => {
     ).toEqual([]);
   });
 
-  it("cada bloco nomeia a prova: um PR (#nnn) ou a consulta à API", () => {
-    const blocos = readFileSync(CAMINHO, "utf8")
-      .split(/\n(?=# @)/)
-      .filter((b) => b.trimStart().startsWith("# @"));
-    expect(blocos.length, "nenhum bloco de pessoa encontrado — o formato mudou?").toBeGreaterThan(0);
-    const semProva = blocos
-      .filter((b) => !/#\d{2,}/.test(b) && !/\bAPI\b|\bapi\b/.test(b))
-      .map((b) => b.split("\n")[0]);
+  it("o comentário acima de cada mapeamento nomeia a prova (PR ou API)", () => {
+    // Ancorado no MAPEAMENTO, não em "bloco de texto que começa com `# @`":
+    // a primeira versão fatiava por esse prefixo e quebrava quando a prosa
+    // citava um handle no início de uma linha. O gate media a vizinhança do
+    // dado em vez do dado — e reprovava o arquivo por defeito próprio.
+    const semProva: string[] = [];
+    linhas.forEach((linha, i) => {
+      if (!ehMapeamento(linha)) return;
+      // sobe pelo bloco contíguo de comentários imediatamente acima
+      const comentario: string[] = [];
+      let j = i - 1;
+      while (j >= 0 && (ehMapeamento(linhas[j]!) || linhas[j]!.trim().startsWith("#"))) {
+        if (linhas[j]!.trim().startsWith("#")) comentario.unshift(linhas[j]!);
+        j--;
+      }
+      const texto = comentario.join("\n");
+      if (!/#\d{2,}/.test(texto) && !/\bAPI\b/.test(texto)) semProva.push(linha.trim());
+    });
     expect(
       semProva,
-      `bloco sem prova citada (nem número de PR, nem API):\n  ${semProva.join("\n  ")}`,
+      `mapeamento cujo comentário não cita PR nem API — de onde saiu?:\n  ${semProva.join("\n  ")}`,
+    ).toEqual([]);
+  });
+
+  it("mapeamento sob bloco AGUARDANDO não entra por descuido", () => {
+    // O arquivo guarda a linha pronta, comentada, para quando a confirmação
+    // vier — e isso é um convite a descomentá-la. Medido: sem este caso,
+    // descomentar passava VERDE, porque o bloco acima cita a API (ela prova
+    // que as contas são DIFERENTES, o oposto do que o mapeamento afirmaria).
+    // O gate não sabe ler o sentido da prova; sabe ver o marcador. Tirar a
+    // linha da espera passa a exigir tirar o `AGUARDANDO` junto — ato
+    // deliberado, que é exatamente o que falta hoje.
+    const presos: string[] = [];
+    linhas.forEach((linha, i) => {
+      if (!ehMapeamento(linha)) return;
+      const comentario: string[] = [];
+      let j = i - 1;
+      while (j >= 0 && (ehMapeamento(linhas[j]!) || linhas[j]!.trim().startsWith("#"))) {
+        if (linhas[j]!.trim().startsWith("#")) comentario.unshift(linhas[j]!);
+        j--;
+      }
+      if (/AGUARDANDO/.test(comentario.join("\n"))) presos.push(linha.trim());
+    });
+    expect(
+      presos,
+      "mapeamento sob um bloco marcado AGUARDANDO — a confirmação chegou? então\n" +
+        `tire a marca junto, no mesmo commit:\n  ${presos.join("\n  ")}`,
     ).toEqual([]);
   });
 


### PR DESCRIPTION
## Uma pergunta, primeiro

@melgarafael — **as duas contas do GitHub são suas?** (`@melgarafael` e
`@rafaelmelgaco`). Responder "sim" ou "não" é tudo; o resto deste PR não
depende disso e pode ser mergeado do jeito que está.

---

## O problema

@JowaniOrantes traduziu o sistema inteiro para espanhol em três PRs (#352,
#379, #416). Os commits saíram da máquina dele assinados como `SoftIA Backup
Agent`, então:

```console
$ git log --author=Jowani --oneline | wc -l
1
```

Ele fez **60**. Num projeto que se distribui por fork e vive de contribuição
externa, o número que sai de `git shortlog` é o crédito que aparece no perfil
de quem contribuiu — e estava partido em duas metades que não se somavam.

Não era só ele: `jmpo` assinava também como `Juan` (mesmo e-mail), e
@felipebnt (#409) com dois e-mails.

## O efeito, medido

Comparando dois worktrees — um com o arquivo, outro sem:

| | antes | depois |
|---|---|---|
| `git log --author=Jowani \| wc -l` | **1** | **60** |
| `git shortlog -sne \| grep -ci softia` | 59 | **0** |
| `jmpo` (partido em `jmpo` + `Juan`) | 85 + 3 | **88** |
| `Felipe Oliveira` (dois e-mails) | 1 + 1 | **2** |
| identidades distintas | 30 | 25 |
| **total de commits** | 3.185 | **3.185** |

A última linha é o controle: nada se perdeu, só se juntou.

> **Cuidado com a sonda.** `git -c mailmap.file=/dev/null` **não** desliga o
> `.mailmap` do topo da árvore — antes e depois saem idênticos, que é o mesmo
> resultado de um conserto sem efeito. O controle válido compara duas árvores.

## A regra: só entra o que está provado

Mapear por semelhança de nome é pior que não mapear — credita a alguém trabalho
que não é dele, em silêncio, e ninguém confere autoria duas vezes. Duas provas
valem, e ambas estão citadas por escrito ao lado de cada entrada:

```bash
# 1. a API associa o commit a uma conta
gh api repos/melgarafael/DeskcommCRM/commits/<sha> --jq .author.login
# 2. o PR é de um handle e seus commits carregam a assinatura
gh api repos/melgarafael/DeskcommCRM/pulls/<n>/commits --jq '[.[].commit.author.email]|unique'
```

Para o Jowani a API **não** resolve (o e-mail não está vinculado a conta
nenhuma). A prova dele é a segunda, e é mais forte: os três PRs são dele, e o
**#352 traz as duas assinaturas nos commits do mesmo PR**.

**Fora, com o motivo no arquivo** (para o próximo não achar que foi
esquecimento): os dois `root@` — usuário de máquina não identifica pessoa — e
`Rafael Savoia`, que compartilha o primeiro nome com o dono do produto e é
exatamente a armadilha que a regra existe para barrar.

## O gate guarda a regra, não o número — e a razão é medida

A verificação óbvia seria cobrar `--author=Jowani == 60`. **Ela não funciona
aqui:** o `actions/checkout` clona com `fetch-depth: 1`, a sonda veria um
commit e passaria **verde exatamente quando o arquivo estivesse quebrado**.
Gate que não distingue "está certo" de "não consegui olhar" é pior que gate
nenhum.

Então `tests/unit/mailmap-so-com-prova` cobra o que se verifica sem histórico:
todo mapeamento tem comentário acima, o comentário cita PR ou API, nenhuma
identidade aponta para duas pessoas, e nada sob `AGUARDANDO` entra.

**O que ele não cobre está escrito nele:** se a prova citada é verdadeira. Um
comentário pode mentir. O que ele impede é o mapeamento **anônimo**.

Escrever o gate expôs nele duas vezes o defeito que ele existe para evitar:
um caso passava **vazio** quando o arquivo não era lido (tem piso agora), e
descomentar a linha em espera passava **verde** (tem guarda agora). Cinco
sabotagens reprovam; restaurado, 5/5.

## Test plan

- [x] `pnpm typecheck` — `TC_EXIT=0`, 0 erros
- [x] `pnpm lint` — `LINT_EXIT=0`
- [x] `tests/unit/mailmap-so-com-prova` — 5/5, e 5 sabotagens reprovam
- [x] efeito medido contra worktree sem o arquivo (tabela acima)

Sem fragmento em `.changes/`: não muda nada para quem opera uma VPS — é
metadado de repositório, não comportamento do produto.
