### PR TITLE
fix(agent): agenda nunca confirma sem checar, e handoff avisa o CRM

### DIFF
--- a/.changes/agendamento-move-o-lead-no-funil-sozinho.md
+++ b/.changes/agendamento-move-o-lead-no-funil-sozinho.md
@@ -1,0 +1,17 @@
+---
+impacto: capacidade_nova
+secao: adicionado
+titulo: Marcar ou confirmar um agendamento move o lead no funil sozinho
+---
+
+Antes, marcar ou confirmar um horário na agenda não mexia no card do negócio: a
+equipe precisava arrastar o lead manualmente para "Agendamento solicitado" ou
+"Agendado" (ou como quer que a organização tenha nomeado essas etapas).
+
+Agora, quando um agendamento nasce pendente de confirmação, o lead se move para
+a etapa do funil marcada com o slug `agendamento-solicitado`; quando o
+agendamento é confirmado, ele se move para a etapa `agendado`. É opt-in: quem
+não criou essas etapas no funil não vê nenhuma mudança de comportamento. Cancelar
+ou faltar a um compromisso não move o lead — o negócio pode ter outro horário
+remarcado, e quem decide que ele esfriou continua sendo o agente de IA ou uma
+pessoa da equipe.

--- a/app/api/v1/agenda/agendamentos/_handler.ts
+++ b/app/api/v1/agenda/agendamentos/_handler.ts
@@ -36,6 +36,8 @@ import { audit } from "@/lib/audit";
 import { resolveActiveLeadForContact, type LeadCandidate } from "@/lib/leads/active-lead";
 import { emitLeadActivity } from "@/lib/leads/activity-emitter";
 import { registraFalhaDeAtividade } from "@/lib/leads/activity-write-failure";
+import { moverLeadParaEtapaDeAgendamento } from "@/lib/leads/appointment-stage-move";
+import { logger } from "@/lib/logger";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 type SB = SupabaseClient;
@@ -177,6 +179,7 @@ export async function marcarAgendamentoHandler(
     appointmentId: criado.id,
     contactId: input.contact_id ?? null,
     atividade: atividadeDaTransicao(null, transicao),
+    transicao,
     empurrarAoGoogle: precisaEmpurrarAoGoogle(null, transicao),
     fusoDoCompromisso: criado.time_zone,
     nomeDoTipo: tipo.name,
@@ -294,6 +297,7 @@ export async function alterarAgendamentoHandler(
       appointmentId: atual.id as string,
       contactId: (atual.contact_id as string | null) ?? null,
       atividade: atividadeDaTransicao(atual.status as SituacaoAnterior, transicao),
+      transicao,
       empurrarAoGoogle: precisaEmpurrarAoGoogle(atual.status as SituacaoAnterior, transicao),
       fusoDoCompromisso: salvo.time_zone,
       nomeDoTipo: "Agendamento",
@@ -364,6 +368,7 @@ export async function cancelarAgendamentoHandler(
     appointmentId: atual.id as string,
     contactId: (atual.contact_id as string | null) ?? null,
     atividade: atividadeDaTransicao(atual.status as SituacaoAnterior, "cancelled"),
+    transicao: "cancelled",
     empurrarAoGoogle: precisaEmpurrarAoGoogle(atual.status as SituacaoAnterior, "cancelled"),
     fusoDoCompromisso: atual.time_zone as string,
     nomeDoTipo: "Agendamento",
@@ -473,6 +478,7 @@ async function fecharOLaco(
     appointmentId: string;
     contactId: string | null;
     atividade: string | null;
+    transicao: Transicao;
     empurrarAoGoogle: boolean;
     fusoDoCompromisso: string;
     nomeDoTipo: string;
@@ -494,9 +500,29 @@ async function fecharOLaco(
     });
   }
 
-  if (!args.atividade) return;
-
   const leadId = args.contactId ? await leadAtivoDoContato(supabase, ctx, args.contactId) : null;
+
+  // ⚠️ ANTES do early-return de `!args.atividade`. Confirmar um agendamento
+  // pendente é `atividade: null` (nada novo pra timeline — `atividadeDaTransicao`
+  // já contou "foi marcado" quando ele nasceu), mas é EXATAMENTE a transição que
+  // move o card de "Agendamento solicitado" pra "Agendado". Um early-return
+  // antes disto pularia o mirror no caso que mais importa para ele.
+  if (leadId) {
+    await moverLeadParaEtapaDeAgendamento(supabase, {
+      organizationId: ctx.organization_id,
+      leadId,
+      transicao: args.transicao,
+    }).catch((err) => {
+      logger.error("[agenda] mirror de estágio falhou", {
+        lead_id: leadId,
+        organization_id: ctx.organization_id,
+        transicao: args.transicao,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
+
+  if (!args.atividade) return;
 
   if (!leadId) {
     if (args.contactId) {

--- a/lib/agent-engine/agent/inbound-turn.ts
+++ b/lib/agent-engine/agent/inbound-turn.ts
@@ -560,7 +560,11 @@ const CASES_SYSTEM_BLOCK =
   'sistema, uma decisão que exige uma pessoa), use a tool open_human_case — você CONTINUA conversando ' +
   'com o lead, não silencia. NUNCA prometa ao lead que um humano vai verificar/resolver sem antes chamar ' +
   'open_human_case. Quando um caso estiver esperando informação do cliente e você já a obteve na ' +
-  'conversa, use provide_case_update para devolver ao responsável.';
+  'conversa, use provide_case_update para devolver ao responsável. Ao avisar o lead que abriu o caso, ' +
+  'NUNCA narre a causa técnica ou interna (erro de sistema, falha de confirmação, nome de ferramenta, ' +
+  'log ou qualquer diagnóstico) — isso é assunto técnico e não vai pro cliente. `title`/`summary`/`blocker` ' +
+  'são só para o humano; a mensagem ao lead diz apenas, em linguagem simples, que você vai verificar/ajustar ' +
+  'e volta com uma resposta, sem explicar o motivo interno.';
 
 /**
  * Bloco de sistema RESIDENTE da Agenda — entra no prefixo cacheável sempre que o

--- a/lib/agent-engine/agent/inbound-turn.ts
+++ b/lib/agent-engine/agent/inbound-turn.ts
@@ -650,6 +650,16 @@ const AGENDA_SYSTEM_BLOCK =
   'diga "vou confirmar/verificar com [nome de pessoa/equipe]" para justificar não ter chamado a ferramenta: ' +
   'chame primeiro, e só fale de encaminhar a alguém se a ferramenta genuinamente não resolver.';
 
+/**
+ * Tools de agenda cuja EXECUÇÃO neste turno arma o `agendaStallGate` (before-send.ts) —
+ * ver o wrap no loop de montagem das tools MCP, mais abaixo.
+ */
+const AGENDA_TOOL_NAMES = new Set([
+  'crm_find_free_slots',
+  'crm_book_appointment',
+  'crm_reschedule_appointment',
+]);
+
 export interface InboundTurnKnobs {
   /** últimas N mensagens no contexto de abertura (LEAD_CONTEXT_HISTORY_LIMIT) */
   historyLimit: number;
@@ -1688,6 +1698,18 @@ async function executarTurnoDoAgente(
   // (`internal_vocabulary_leak`): 1º veto no turno ensina o modelo a reescrever; persistir
   // solta o envio com registro. Por turno (closure), nunca cross-turno.
   let internalVocabularyVetoCount = 0;
+  // Cap de envio (warm-up/diário) vetado neste turno — capturado aqui porque o veto
+  // não empurra outcome nenhum a `outcomes` (ver comentário no ponto de captura, mais
+  // abaixo). Diferente da janela horária (checada ANTES do modelo rodar, linha ~1233):
+  // o cap depende de quanto já saiu HOJE, que muda com o turno concorrente — só dá pra
+  // saber com certeza no momento do envio, não antes.
+  let pacingCapVeto: { code: string; nextAllowedAt: Date } | null = null;
+  // Arma o `agendaStallGate` (before-send.ts): true assim que crm_find_free_slots,
+  // crm_book_appointment ou crm_reschedule_appointment executar neste turno — marcado no
+  // wrapper das tools MCP, mais abaixo. `send_message` lê o valor NO MOMENTO do envio; como
+  // as tools do modelo rodam em passos anteriores do mesmo loop, o valor já está certo
+  // quando o modelo decide mandar a resposta.
+  let agendaToolCalledThisTurn = false;
   const outcomes: ChannelSendResult[] = [];
   // Citações acumuladas por buscas de conhecimento DESTE turno — anexadas à
   // próxima outbound enviada (shape de lib/ai/citations/types, que a UI já lê).
@@ -2006,6 +2028,14 @@ async function executarTurnoDoAgente(
             // não é dele, e a única saída seria o silêncio. O follow-up determinístico
             // idem (ver GateContext.internalVocabularyEnforced).
             enforceInternalVocabulary: true,
+            // Mesmo padrão do vocabulário interno: só o `send_message` arma — é o único
+            // corpo escrito pelo modelo. `active` segue a MESMA condição de
+            // `AGENDA_SYSTEM_BLOCK` (crm_book_appointment publicado); sem ela o gate
+            // vetaria agente que nem tem a ferramenta de agenda.
+            agenda: {
+              active: agentConfig !== null && agentConfig.toolIds.includes('crm_book_appointment'),
+              toolCalledThisTurn: agendaToolCalledThisTurn,
+            },
             ...(deps.knobs.disclosureMode !== undefined ? { disclosureMode: deps.knobs.disclosureMode } : {}),
             // Gate 5 (F4-02): classificador semântico roteado pelo MESMO seam agnóstico (budget
             // da org checado nele). Closure com tenant/lead/job da ROW fechados — nunca do payload.
@@ -2097,6 +2127,17 @@ async function executarTurnoDoAgente(
             });
           }
           if (chain.status === 'vetoed') {
+            // Cap de warm-up/diário: reescrever o texto não resolve (é rate limit, não
+            // conteúdo) — ensinar o modelo a "tentar de novo" só gasta passo. Guardamos
+            // pra reagendar o JOB inteiro depois que o turno terminar (mesmo padrão de
+            // `rescheduleJob` já usado pra janela horária), em vez de deixar o lead sem
+            // resposta até a próxima mensagem dele chegar (ou nunca).
+            if (
+              (chain.code === 'warmup_cap' || chain.code === 'daily_cap') &&
+              chain.nextAllowedAt !== undefined
+            ) {
+              pacingCapVeto = { code: chain.code, nextAllowedAt: chain.nextAllowedAt };
+            }
             // Erro de ENSINO pt-br (mesmo shape de get_lead_context/breaker): o
             // modelo o vê no turno seguinte. NÃO é exceção — não derruba o run.
             return { ok: false, error: { code: chain.code, message: chain.message } };
@@ -2536,7 +2577,21 @@ async function executarTurnoDoAgente(
       if (mcp !== null) {
         mcpCleanup = mcp.cleanup;
         for (const [name, mcpTool] of Object.entries(mcp.tools)) {
-          if (!(name in rawTools)) rawTools[name] = mcpTool;
+          if (name in rawTools) continue;
+          // Marca a EXECUÇÃO (não só a decisão de chamar) — é isso que o agendaStallGate
+          // precisa saber para não vetar um turno que já checou a agenda de verdade.
+          if (AGENDA_TOOL_NAMES.has(name) && typeof mcpTool.execute === 'function') {
+            const executeOriginal = mcpTool.execute.bind(mcpTool);
+            rawTools[name] = {
+              ...mcpTool,
+              execute: (async (...args: Parameters<typeof executeOriginal>) => {
+                agendaToolCalledThisTurn = true;
+                return executeOriginal(...args);
+              }) as typeof mcpTool.execute,
+            };
+          } else {
+            rawTools[name] = mcpTool;
+          }
         }
         mcpToolIdsDoTurno.push(...mcp.toolIds);
         runLog.info('tools MCP da tela montadas no turno', { mcp_tool_ids: mcp.toolIds });
@@ -3004,6 +3059,30 @@ async function executarTurnoDoAgente(
     );
     throw new JobSettledError(
       'turno encerrado com veto do sink (is_blocked) — job cancelado em definitivo, checkpoint gravado',
+    );
+  }
+
+  // Cap de warm-up/diário vetou toda tentativa de envio deste turno e nada saiu: sem
+  // isto, o job terminava 'ok' com `messages_sent: 0` e o lead ficava sem resposta até
+  // escrever de novo por conta própria (ou nunca) — medido em produção, 2026-08-29
+  // (número no dia 0 de warm-up, cap batido pelo volume da própria conversa de teste).
+  // Mesmo contrato da janela anti-ban (linha ~1233): adia sem gastar `attempts`, o job
+  // volta a 'pending' na hora certa e o mesmo turno roda de novo, com o mesmo contexto.
+  if (pacingCapVeto !== null && outcomes.length === 0) {
+    // Capturado num `const`: `pacingCapVeto` é reatribuído numa closure em outro ponto do
+    // turno, e o TS reabre a união (perde o `!== null`) depois de qualquer chamada — o
+    // valor JÁ CHECADO não muda, só a inferência precisa de um nome que não reatribui.
+    const veto = pacingCapVeto;
+    await rescheduleJob(pool, job.id, ctx.workerId, {
+      delayMs: Math.max(veto.nextAllowedAt.getTime() - clock().getTime(), 1_000),
+      reason: `cap de envio (${veto.code}) atingido — turno adiado para a próxima abertura`,
+    });
+    runLog.info('turno adiado — cap de envio atingido antes de qualquer mensagem sair', {
+      code: veto.code,
+      proxima_abertura: veto.nextAllowedAt.toISOString(),
+    });
+    throw new JobSettledError(
+      'cap de envio atingido — job reagendado para a próxima abertura, sem mensagem enviada',
     );
   }
 

--- a/lib/agent-engine/agent/inbound-turn.ts
+++ b/lib/agent-engine/agent/inbound-turn.ts
@@ -567,6 +567,29 @@ const CASES_SYSTEM_BLOCK =
   'e volta com uma resposta, sem explicar o motivo interno.';
 
 /**
+ * Bloco de sistema RESIDENTE de transparência — SEMPRE presente, independente de
+ * `casesEnabled` ou de `open_human_case` ter sido chamado neste turno.
+ *
+ * Por quê: `CASES_SYSTEM_BLOCK` só ensina a não narrar a causa técnica NO MOMENTO de
+ * abrir um caso — mas o modelo narra "problema no sistema" também SEM abrir caso
+ * nenhum, quando só está incerto ou algo falhou silenciosamente (medido em produção,
+ * 2026-08-29: "houve um pequeno problema no sistema sobre o agendamento", mandado ao
+ * cliente às 11:43, sem nenhum `agent_cases` aberto naquele turno — o veto de
+ * `CASES_SYSTEM_BLOCK` nunca chegou a valer porque a tool nunca foi chamada). O
+ * detector de vazamento (`vazamento-interno.ts`) não pega isso por desenho — ele caça
+ * FORMA (identificador técnico), não sentença comum em português — então a única
+ * cura possível aqui é instrução, não filtro.
+ */
+const TRANSPARENCIA_SYSTEM_BLOCK =
+  '## Nunca narre problema interno ao lead\n' +
+  'Em QUALQUER mensagem — abrindo caso ou não — NUNCA diga ao lead que "houve um problema/erro no ' +
+  'sistema", "falha na confirmação", "erro técnico" ou qualquer variação que admita que algo deu errado ' +
+  'do lado interno. Isso vale mesmo quando você está incerto do resultado de uma ferramenta ou algo ' +
+  'falhou sem você entender o motivo. O lead não precisa do diagnóstico, precisa saber o que fazer ' +
+  'agora: diga que vai verificar/confirmar e volta com a resposta, peça mais um instante, ou pergunte de ' +
+  'novo o que falta — nunca admita que "o sistema" ou "a confirmação" teve um problema.';
+
+/**
  * Bloco de sistema RESIDENTE da Agenda — entra no prefixo cacheável sempre que o
  * agente tem `crm_book_appointment` no `tool_ids` publicado, INDEPENDENTE de a skill
  * situacional "agendamento" ter disparado no turno.
@@ -1365,8 +1388,9 @@ async function executarTurnoDoAgente(
   // Spec 15 §5.2: bloco das tools de caso SEMPRE residente (não invalida o prefixo
   // cacheável — mesmo espírito do índice de skills) quando a tela habilita. O bloco da
   // Agenda segue o mesmo padrão, condicionado a `crm_book_appointment` estar entre as
-  // tools publicadas — ver comentário de `AGENDA_SYSTEM_BLOCK`.
-  const blocosResidentes = [systemWithMemory];
+  // tools publicadas — ver comentário de `AGENDA_SYSTEM_BLOCK`. `TRANSPARENCIA_SYSTEM_BLOCK`
+  // não depende de nenhuma feature — todo agente publicado o recebe.
+  const blocosResidentes = [systemWithMemory, TRANSPARENCIA_SYSTEM_BLOCK];
   if (agentConfig !== null && agentConfig.casesEnabled) blocosResidentes.push(CASES_SYSTEM_BLOCK);
   if (agentConfig !== null && agentConfig.toolIds.includes('crm_book_appointment')) {
     blocosResidentes.push(AGENDA_SYSTEM_BLOCK);

--- a/lib/agent-engine/agent/inbound-turn.ts
+++ b/lib/agent-engine/agent/inbound-turn.ts
@@ -52,6 +52,9 @@ import type { ProviderRegistry } from '../edge/llm/providers';
 import { HANDOFF_REASON_ORCAMENTO } from '../edge/llm/orcamento';
 import { MIRROR_WARN_ONLY, mirrorLeadStageToCrm } from '../edge/crm/move-lead-stage';
 import { insertInboxItem } from '../db/repository';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { moverLeadParaEtapaDeHandoff } from '@/lib/leads/handoff-stage-move';
+import { detectUrgencySignal } from '../guardrails/sinal-de-urgencia';
 import { buildNativeMediaParts } from './media-parts';
 import { enqueueJob, rescheduleJob, type JobRow, type Queryable } from '../queue/queue';
 import { applyLeadStateUpdate, getLeadState, type LeadStage, type LeadStateRow } from './lead-state';
@@ -1704,6 +1707,21 @@ async function executarTurnoDoAgente(
   // o cap depende de quanto já saiu HOJE, que muda com o turno concorrente — só dá pra
   // saber com certeza no momento do envio, não antes.
   let pacingCapVeto: { code: string; nextAllowedAt: Date } | null = null;
+  // Best-effort: move o lead pra etapa `crm_stages.slug='chamar-humano'` do pipeline
+  // dele (se o tenant tiver criado essa etapa — opt-in, ver `lib/leads/handoff-stage-move.ts`)
+  // sempre que um caso humano abre neste turno, deliberado (open_human_case) ou pelo
+  // fail-safe do `case_promise`. Sem isto, o funil no CRM não refletia o handoff que o
+  // PRÓPRIO PROMPT do tenant promete ao lead ("vou verificar/encaminhar com o Fernando")
+  // — medido em produção, tenant YADEA: caso aberto, funil parado em "Novo contato".
+  // Nunca bloqueia nem derruba o turno — mesma disciplina de `triggerHandoff` (G1-G4),
+  // que já chama o mesmo helper para o handoff por palavra-chave do cliente.
+  const moverParaHandoffBestEffort = (reason: string): void => {
+    moverLeadParaEtapaDeHandoff(createAdminClient(), { organizationId: tenantId, leadId, reason }).catch((err) => {
+      runLog.warn('moverLeadParaEtapaDeHandoff falhou (best-effort, caso humano)', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  };
   // Arma o `agendaStallGate` (before-send.ts): true assim que crm_find_free_slots,
   // crm_book_appointment ou crm_reschedule_appointment executar neste turno — marcado no
   // wrapper das tools MCP, mais abaixo. `send_message` lê o valor NO MOMENTO do envio; como
@@ -2020,6 +2038,11 @@ async function executarTurnoDoAgente(
             casesEnabled: agentConfig?.casesEnabled ?? false,
             hasOpenCase,
             openedCaseThisTurn,
+            // Nome(s) próprio(s) que o prompt do tenant usa pra retaguarda humana (ex.:
+            // "Fernando") — o mesmo vocabulário que `matchesHandoffKeyword` já usa do lado
+            // do CLIENTE, agora somado ao alvo genérico do `casePromiseGate` do lado do
+            // que o MODELO promete. Ver `GateContext.humanPromiseExtraTargets`.
+            humanPromiseExtraTargets: agentConfig?.handoffKeywords ?? [],
             // A rede contra vazamento de vocabulário interno arma AQUI e só aqui: este é
             // o único corpo escrito pelo MODELO, e o único caminho em que o veto vira
             // erro instrutivo que ele pode consertar no turno seguinte. O `send_template`
@@ -2089,6 +2112,7 @@ async function executarTurnoDoAgente(
               return { ok: false, error: { code: chain.code, message: chain.message } };
             }
             openedCaseThisTurn = true;
+            moverParaHandoffBestEffort('case_promise_autofallback');
             // Re-roda a cadeia INTEIRA agora que há caso aberto — o send real acontece
             // DENTRO do runBeforeSend (via args.send); nunca chamamos o canal por fora
             // (perderia pacing/lgpd/stop). ponytail: re-roda a cadeia inteira no fail-safe
@@ -2483,6 +2507,7 @@ async function executarTurnoDoAgente(
           );
           if (!res.ok) return res;
           openedCaseThisTurn = true;
+          moverParaHandoffBestEffort('open_human_case');
           // ACH-03: a expectativa vai junto com a confirmação. Medido num turno
           // real: o agente abria o caso e prometia ao cliente que "alguém entra
           // em contato" sem nunca ter olhado se havia alguém — a capacidade de
@@ -3081,6 +3106,37 @@ async function executarTurnoDoAgente(
       code: veto.code,
       proxima_abertura: veto.nextAllowedAt.toISOString(),
     });
+    // O reagendamento acima trata toda mensagem represada igual — um lead relatando
+    // risco de segurança (freio, fumaça, bateria esquentando) esperaria a mesma janela
+    // que um "bom dia" qualquer, às vezes horas (medido em produção, tenant YADEA:
+    // 20h+ represado num relato de bateria superaquecendo). Sem furar o cap de
+    // warm-up/diário em si (proteção anti-banimento — mexer nisso é decisão de
+    // produto, não deste guardrail), abre um alerta CRÍTICO na Central agora, pra um
+    // humano poder responder manualmente pelo próprio WhatsApp enquanto o número
+    // aquece. Dedupe por (kind, ref) — não reabre um já aberto pra esta conversa.
+    if (detectUrgencySignal(inboundSignal)) {
+      await insertInboxItem(
+        pool,
+        tenantId,
+        {
+          kind: 'handoff',
+          severity: 'critical',
+          title: 'Lead com sinal de urgência represado pelo cap de envio do número',
+          body:
+            `Mensagem do lead parece relatar risco/urgência, mas o número está em ` +
+            `warm-up/bateu o cap diário (${veto.code}) — a resposta automática só sai em ` +
+            `${veto.nextAllowedAt.toISOString()}. Considere responder manualmente pelo ` +
+            `WhatsApp enquanto o número aquece.`,
+          refKind: 'conversation',
+          refId: input.conversationId,
+        },
+        'kind_e_ref',
+      ).catch((err) => {
+        runLog.warn('alerta de urgência represada por warmup_cap falhou (best-effort)', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
     throw new JobSettledError(
       'cap de envio atingido — job reagendado para a próxima abertura, sem mensagem enviada',
     );

--- a/lib/agent-engine/agent/inbound-turn.ts
+++ b/lib/agent-engine/agent/inbound-turn.ts
@@ -612,6 +612,22 @@ const TRANSPARENCIA_SYSTEM_BLOCK =
  * ("confirmado" sem checar) — não obriga a CHECAR. Sem essa obrigação, o modelo
  * tinha uma saída segura e preguiçosa: responder "vou verificar e te aviso" pra
  * sempre, sem nunca chamar a ferramenta. O segundo parágrafo fecha essa saída.
+ *
+ * ⚠️ Terceiro parágrafo (2026-08-29, mesmo dia): o segundo parágrafo sozinho NÃO
+ * bastou — medido no mesmo teste, depois de publicado. Causa raiz achada no
+ * `system_prompt` que o PRÓPRIO tenant escreveu para este agente: ele instrui a
+ * "encaminhar dúvidas ou situações fora da sua autonomia ao gerente Fernando".
+ * O modelo estava classificando "confirmar horário" como uma dessas situações e
+ * respondendo "vou confirmar com o Fernando/a equipe" — coerente com a
+ * identidade que o tenant deu a ele, só que sem nunca chamar a ferramenta. Um
+ * agravante: a MESMA conversa já tinha várias respostas assim ANTES deste fix
+ * existir, e o modelo lê o próprio histórico — puxando a resposta pra manter
+ * consistência com o que ele mesmo já disse. O terceiro parágrafo nomeia o
+ * conflito explicitamente e resolve a favor da ferramenta: checar/marcar
+ * agenda com uma tool disponível NUNCA é "fora da autonomia", nem quando o
+ * prompt do tenant nomeia um gerente para outras decisões — e ele AINDA vale
+ * pra essas outras decisões (aprovar desconto, exceção de política etc.),
+ * porque este parágrafo só fala de checar/marcar horário.
  */
 const AGENDA_SYSTEM_BLOCK =
   '## Agenda — nunca confirme sem checar\n' +
@@ -625,7 +641,14 @@ const AGENDA_SYSTEM_BLOCK =
   'conversa) um dia/horário específico que ainda não foi checado, chame crm_find_free_slots NESTE turno ' +
   'antes de responder — não repita "vou verificar/confirmar e te aviso" sem ter chamado a ferramenta. Um ' +
   '"vou verificar" só é aceitável na MESMA resposta em que você já chamou a ferramenta e ela falhou ou não ' +
-  'trouxe resultado; nunca como substituto de chamar.';
+  'trouxe resultado; nunca como substituto de chamar.\n' +
+  'Checar e marcar horário usando crm_find_free_slots/crm_book_appointment está SEMPRE dentro da sua ' +
+  'autonomia quando essas ferramentas estão disponíveis para você — mesmo que as instruções da empresa ' +
+  'peçam para encaminhar decisões fora da sua autonomia a um gerente/responsável nomeado (ex.: "fale com o ' +
+  'Fernando"). Isso vale para OUTRAS decisões (desconto, exceção de política, algo que a ferramenta não ' +
+  'cobre) — nunca para simplesmente consultar ou marcar um horário que a ferramenta resolve sozinha. NÃO ' +
+  'diga "vou confirmar/verificar com [nome de pessoa/equipe]" para justificar não ter chamado a ferramenta: ' +
+  'chame primeiro, e só fale de encaminhar a alguém se a ferramenta genuinamente não resolver.';
 
 export interface InboundTurnKnobs {
   /** últimas N mensagens no contexto de abertura (LEAD_CONTEXT_HISTORY_LIMIT) */

--- a/lib/agent-engine/agent/inbound-turn.ts
+++ b/lib/agent-engine/agent/inbound-turn.ts
@@ -562,6 +562,30 @@ const CASES_SYSTEM_BLOCK =
   'open_human_case. Quando um caso estiver esperando informação do cliente e você já a obteve na ' +
   'conversa, use provide_case_update para devolver ao responsável.';
 
+/**
+ * Bloco de sistema RESIDENTE da Agenda — entra no prefixo cacheável sempre que o
+ * agente tem `crm_book_appointment` no `tool_ids` publicado, INDEPENDENTE de a skill
+ * situacional "agendamento" ter disparado no turno.
+ *
+ * Por quê: a skill "agendamento" (`lib/agent-engine/agent/skills.ts`) só injeta o
+ * corpo dela quando a ÚLTIMA mensagem inbound do turno bate uma keyword. Medido
+ * neste repo: o turno em que o lead ACEITA um horário oferecido ("pode ser amanhã
+ * às 9 então") raramente repete uma keyword de agendar — quem carrega a keyword é o
+ * turno ANTERIOR, que já passou. Sem o corpo da skill presente NAQUELE turno
+ * específico, o modelo confirmava o compromisso pela conversa, sem nunca chamar
+ * `crm_book_appointment` — sentença dita ao cliente, nada gravado no banco. Esta
+ * regra é curta, redundante com a skill de propósito e, por só depender de
+ * `agentConfig.toolIds` (não da mensagem do turno), fica sempre presente.
+ */
+const AGENDA_SYSTEM_BLOCK =
+  '## Agenda — nunca confirme sem checar\n' +
+  'Você só pode dizer a um lead que um horário/consulta/visita está confirmado DEPOIS de chamar ' +
+  'crm_book_appointment (ou crm_reschedule_appointment, para remarcação) e ver o retorno confirmando o ' +
+  'sucesso. Isso vale mesmo quando o lead já aceitou um horário que você ofereceu — aceite verbal não é ' +
+  'reserva. NUNCA diga "confirmado", "está marcado" ou equivalente baseado só no histórico da conversa. ' +
+  'Se ainda não chamou a ferramenta neste turno, chame antes de responder; se a chamada falhar ou você não ' +
+  'tiver certeza do resultado, diga que vai verificar e NÃO afirme que está confirmado.';
+
 export interface InboundTurnKnobs {
   /** últimas N mensagens no contexto de abertura (LEAD_CONTEXT_HISTORY_LIMIT) */
   historyLimit: number;
@@ -1335,11 +1359,15 @@ async function executarTurnoDoAgente(
     skillIndex,
   });
   // Spec 15 §5.2: bloco das tools de caso SEMPRE residente (não invalida o prefixo
-  // cacheável — mesmo espírito do índice de skills) quando a tela habilita.
-  const system =
-    agentConfig !== null && agentConfig.casesEnabled
-      ? `${systemWithMemory}\n\n${CASES_SYSTEM_BLOCK}`
-      : systemWithMemory;
+  // cacheável — mesmo espírito do índice de skills) quando a tela habilita. O bloco da
+  // Agenda segue o mesmo padrão, condicionado a `crm_book_appointment` estar entre as
+  // tools publicadas — ver comentário de `AGENDA_SYSTEM_BLOCK`.
+  const blocosResidentes = [systemWithMemory];
+  if (agentConfig !== null && agentConfig.casesEnabled) blocosResidentes.push(CASES_SYSTEM_BLOCK);
+  if (agentConfig !== null && agentConfig.toolIds.includes('crm_book_appointment')) {
+    blocosResidentes.push(AGENDA_SYSTEM_BLOCK);
+  }
+  const system = blocosResidentes.join('\n\n');
   const previous = await latestCheckpoint(pool, tenantId, leadId);
   const leadState = await getLeadState(pool, tenantId, leadId);
   const openingContext = await getLeadContext(

--- a/lib/agent-engine/agent/inbound-turn.ts
+++ b/lib/agent-engine/agent/inbound-turn.ts
@@ -603,6 +603,15 @@ const TRANSPARENCIA_SYSTEM_BLOCK =
  * `crm_book_appointment` — sentença dita ao cliente, nada gravado no banco. Esta
  * regra é curta, redundante com a skill de propósito e, por só depender de
  * `agentConfig.toolIds` (não da mensagem do turno), fica sempre presente.
+ *
+ * ⚠️ Segundo parágrafo (2026-08-29): a mesma lacuna de keyword tem um irmão mais
+ * barato de cometer. Medido em produção: o lead disse "Pode ser segunda de manha"
+ * e depois só "?" — nenhuma das duas bate keyword da skill "agendamento", então o
+ * corpo dela (que tem a instrução "chame crm_find_free_slots e leia a resposta")
+ * nunca entrou no contexto. O primeiro parágrafo deste bloco só proíbe MENTIR
+ * ("confirmado" sem checar) — não obriga a CHECAR. Sem essa obrigação, o modelo
+ * tinha uma saída segura e preguiçosa: responder "vou verificar e te aviso" pra
+ * sempre, sem nunca chamar a ferramenta. O segundo parágrafo fecha essa saída.
  */
 const AGENDA_SYSTEM_BLOCK =
   '## Agenda — nunca confirme sem checar\n' +
@@ -611,7 +620,12 @@ const AGENDA_SYSTEM_BLOCK =
   'sucesso. Isso vale mesmo quando o lead já aceitou um horário que você ofereceu — aceite verbal não é ' +
   'reserva. NUNCA diga "confirmado", "está marcado" ou equivalente baseado só no histórico da conversa. ' +
   'Se ainda não chamou a ferramenta neste turno, chame antes de responder; se a chamada falhar ou você não ' +
-  'tiver certeza do resultado, diga que vai verificar e NÃO afirme que está confirmado.';
+  'tiver certeza do resultado, diga que vai verificar e NÃO afirme que está confirmado.\n' +
+  'Isso NÃO é desculpa para procrastinar: se o lead mencionou (agora ou em qualquer mensagem anterior da ' +
+  'conversa) um dia/horário específico que ainda não foi checado, chame crm_find_free_slots NESTE turno ' +
+  'antes de responder — não repita "vou verificar/confirmar e te aviso" sem ter chamado a ferramenta. Um ' +
+  '"vou verificar" só é aceitável na MESMA resposta em que você já chamou a ferramenta e ela falhou ou não ' +
+  'trouxe resultado; nunca como substituto de chamar.';
 
 export interface InboundTurnKnobs {
   /** últimas N mensagens no contexto de abertura (LEAD_CONTEXT_HISTORY_LIMIT) */

--- a/lib/agent-engine/guardrails/before-send.ts
+++ b/lib/agent-engine/guardrails/before-send.ts
@@ -174,6 +174,16 @@ export interface GateContext {
   hasOpenCase: boolean;
   openedCaseThisTurn: boolean;
   /**
+   * Nome(s) próprio(s) que o PROMPT do tenant usa para a retaguarda humana (ex.:
+   * "Fernando"), somados ao vocabulário genérico do `casePromiseGate`
+   * (`detectHumanPromise`/`human-promise.ts`). Ausente/vazio = só os cargos
+   * genéricos (comportamento anterior, retrocompatível). Sem isto, um agente cujo
+   * prompt nomeia a pessoa em vez do cargo escapa 100% do detector — medido em
+   * produção, tenant YADEA: dezenas de promessas nomeando "Fernando", 1 só
+   * detecção em 3 dias.
+   */
+  humanPromiseExtraTargets?: readonly string[];
+  /**
    * Arma o `internalVocabularyGate` (vazamento de vocabulário interno ao cliente).
    *
    * **OPCIONAL, e ausente = DESARMADO — a direção segura AQUI é o oposto da do
@@ -367,7 +377,7 @@ export const casePromiseGate: Gate = {
   evaluate: (ctx) => {
     if (!ctx.casesEnabled) return { pass: true };
     if (ctx.hasOpenCase || ctx.openedCaseThisTurn) return { pass: true };
-    if (!detectHumanPromise(ctx.body)) return { pass: true };
+    if (!detectHumanPromise(ctx.body, ctx.humanPromiseExtraTargets)) return { pass: true };
     return {
       pass: false,
       code: 'case_promise_without_case',
@@ -426,11 +436,42 @@ const AGENDA_STALL_PATTERN =
   /\b(vou|estou|iremos|vamos)\b[^.!?\n]{0,10}\b(verificando|verificar|confirmando|confirmar|consultando|consultar)\b[^.!?\n]{0,80}\b(hor[aá]rios?|agenda|disponibilidade|agendamento|marca[çc][aã]o|encaixe|vagas?)\b/i;
 
 /**
- * Gate de AGENDA SEM CHECAR — a garantia DURA de que "vou verificar/confirmar horário" só
- * sai depois de a ferramenta (`crm_find_free_slots`/`crm_book_appointment`/
- * `crm_reschedule_appointment`) ter sido de fato CHAMADA neste turno. Desarmado (`agenda`
- * ausente ou `active` false) = no-op — mesmo default seguro de `internalVocabularyEnforced`
- * (caller que não conhece o campo não arma nada).
+ * Padrão irmão do `AGENDA_STALL_PATTERN`, mas para a outra metade do mesmo defeito: não
+ * uma PROMESSA de checar ("vou verificar"), e sim uma AFIRMAÇÃO de fato já consumado
+ * ("está confirmado/agendado/marcado/certinho") — o texto exato do incidente original
+ * que deu origem a este gate ("Seu agendamento está confirmado para amanhã às 9h",
+ * "Confirmando: seu agendamento está certinho para amanhã às 9h"), medido em produção
+ * 2026-08-29 (tenant YADEA) ANTES de o `AGENDA_STALL_PATTERN` existir. O padrão de
+ * promessa sozinho não cobre essa frase (não há "vou/estou" + verbo de checagem nela),
+ * então uma confirmação categórica sem chamada de ferramenta passava batido mesmo com o
+ * gate armado. Mesma disciplina: substantivo de agenda perto de "está/ficou/fica" perto
+ * de um particípio de confirmação — curto e ancorado nas frases medidas, não uma
+ * gramática geral (evita falso positivo em "o agendamento está uma bagunça", por ex.).
+ */
+const AGENDA_CONFIRMED_PATTERN =
+  /\b(agendamento|hor[aá]rio|encaixe|vaga|visita)\b[^.!?\n]{0,30}\b(esta|está|ficou|fica|segue)\b[^.!?\n]{0,20}\b(confirmad[oa]|agendad[oa]|marcad[oa]|certinh[oa])\b/i;
+
+/**
+ * `\b` do JS é ASCII-only ("word char" = `[A-Za-z0-9_]`): `á` não conta como letra
+ * pra ele. Isso faz `\best[aá]\b` NUNCA casar "está" (acentuado) seguido de espaço —
+ * o `á` fica "sem fronteira" com o espaço seguinte (nem um nem outro é \w) e o `\b`
+ * final falha. Medido: as DUAS frases do incidente original ("está confirmado", "está
+ * certinho") não vetavam com o padrão como foi escrito, porque as duas usam "está"
+ * com acento — o próprio caso que este gate existe pra pegar. Normaliza (remove
+ * acento) antes de testar; a alternativa "esta" (sem acento) no padrão acima cobre o
+ * texto já normalizado, e os demais grupos ([aá]/[oa]/[çc][aã]) seguem funcionando
+ * porque não são o ÚLTIMO caractere antes de um `\b`.
+ */
+function semAcento(texto: string): string {
+  return texto.normalize('NFD').replace(/[̀-ͯ]/g, '');
+}
+
+/**
+ * Gate de AGENDA SEM CHECAR — a garantia DURA de que "vou verificar/confirmar horário" (ou
+ * "está confirmado/agendado") só sai depois de a ferramenta (`crm_find_free_slots`/
+ * `crm_book_appointment`/`crm_reschedule_appointment`) ter sido de fato CHAMADA neste turno.
+ * Desarmado (`agenda` ausente ou `active` false) = no-op — mesmo default seguro de
+ * `internalVocabularyEnforced` (caller que não conhece o campo não arma nada).
  *
  * Por que existe apesar do `AGENDA_SYSTEM_BLOCK` (instrução em texto, `inbound-turn.ts`) já
  * dizer a mesma regra: medido em produção (2026-08-29, mesmo tenant) que o modelo
@@ -449,14 +490,21 @@ export const agendaStallGate: Gate = {
   evaluate: (ctx) => {
     if (ctx.agenda === undefined || !ctx.agenda.active) return { pass: true };
     if (ctx.agenda.toolCalledThisTurn) return { pass: true };
-    if (!AGENDA_STALL_PATTERN.test(ctx.body)) return { pass: true };
+    const bodySemAcento = semAcento(ctx.body);
+    const stall = AGENDA_STALL_PATTERN.test(bodySemAcento);
+    const confirmedSemChecar = AGENDA_CONFIRMED_PATTERN.test(bodySemAcento);
+    if (!stall && !confirmedSemChecar) return { pass: true };
     return {
       pass: false,
       code: 'agenda_stall_sem_ferramenta',
-      reason:
-        'Você prometeu verificar/confirmar um horário sem ter chamado crm_find_free_slots, ' +
-        'crm_book_appointment ou crm_reschedule_appointment NESTE turno. Chame a ferramenta ' +
-        'agora e responda com base no retorno dela — não repita a promessa sem checar.',
+      reason: confirmedSemChecar
+        ? 'Você afirmou que um horário está confirmado/agendado sem ter chamado ' +
+          'crm_find_free_slots, crm_book_appointment ou crm_reschedule_appointment NESTE ' +
+          'turno. Nunca diga que está confirmado sem a ferramenta ter registrado de fato — ' +
+          'chame a ferramenta e responda com base no retorno dela.'
+        : 'Você prometeu verificar/confirmar um horário sem ter chamado crm_find_free_slots, ' +
+          'crm_book_appointment ou crm_reschedule_appointment NESTE turno. Chame a ferramenta ' +
+          'agora e responda com base no retorno dela — não repita a promessa sem checar.',
     };
   },
 };
@@ -731,6 +779,8 @@ export interface RunBeforeSendArgs {
   casesEnabled?: boolean;
   hasOpenCase?: boolean;
   openedCaseThisTurn?: boolean;
+  /** Ver `GateContext.humanPromiseExtraTargets`. Ausente = só cargos genéricos. */
+  humanPromiseExtraTargets?: readonly string[];
   /**
    * Arma o `internalVocabularyGate`. Ausente (default) = gate no-op — ver a justificativa
    * do default em `GateContext.internalVocabularyEnforced`: um veto no caminho
@@ -833,6 +883,9 @@ export async function runBeforeSend(args: RunBeforeSendArgs): Promise<BeforeSend
       casesEnabled: args.casesEnabled ?? false,
       hasOpenCase: args.hasOpenCase ?? false,
       openedCaseThisTurn: args.openedCaseThisTurn ?? false,
+      ...(args.humanPromiseExtraTargets !== undefined
+        ? { humanPromiseExtraTargets: args.humanPromiseExtraTargets }
+        : {}),
       internalVocabularyEnforced: args.enforceInternalVocabulary ?? false,
       ...(args.agenda !== undefined ? { agenda: args.agenda } : {}),
     };

--- a/lib/agent-engine/guardrails/before-send.ts
+++ b/lib/agent-engine/guardrails/before-send.ts
@@ -221,6 +221,15 @@ export interface GateContext {
    * gate persegue —, e ele continua contando no cap diário (`recordSend`).
    */
   spinningEnforced?: boolean;
+  /**
+   * Arma o `agendaStallGate`. Ausente = no-op — mesma direção segura de
+   * `internalVocabularyEnforced` (caller que não conhece o campo não arma nada). `active`
+   * é o agente publicado ter `crm_book_appointment` nas tools deste turno (mesma condição
+   * de `AGENDA_SYSTEM_BLOCK` em `inbound-turn.ts`); `toolCalledThisTurn` é se
+   * `crm_find_free_slots`/`crm_book_appointment`/`crm_reschedule_appointment` já foi
+   * chamada neste turno (rastreado no call site, que é quem monta as tools).
+   */
+  agenda?: { active: boolean; toolCalledThisTurn: boolean };
 }
 
 /**
@@ -405,13 +414,61 @@ export const internalVocabularyGate: Gate = {
 };
 
 /**
+ * Padrão determinístico de "prometi verificar/confirmar agenda sem checar" — verbo de
+ * intenção (vou/estou/iremos) + verbo de checagem (verificar/confirmar/consultar) perto
+ * (≤80 chars) de um substantivo de agenda. Curto de propósito: cobre as frases MEDIDAS em
+ * produção (2026-08-29, tenant YADEA/gpt-5.6-terra) — "vou verificar as opções de horário
+ * [...] e te passo assim que tiver a confirmação", "estou confirmando com a equipe os
+ * horários disponíveis" — não uma gramática geral de intenção, que erraria para o lado do
+ * falso positivo em texto livre de WhatsApp.
+ */
+const AGENDA_STALL_PATTERN =
+  /\b(vou|estou|iremos|vamos)\b[^.!?\n]{0,10}\b(verificando|verificar|confirmando|confirmar|consultando|consultar)\b[^.!?\n]{0,80}\b(hor[aá]rios?|agenda|disponibilidade|agendamento|marca[çc][aã]o|encaixe|vagas?)\b/i;
+
+/**
+ * Gate de AGENDA SEM CHECAR — a garantia DURA de que "vou verificar/confirmar horário" só
+ * sai depois de a ferramenta (`crm_find_free_slots`/`crm_book_appointment`/
+ * `crm_reschedule_appointment`) ter sido de fato CHAMADA neste turno. Desarmado (`agenda`
+ * ausente ou `active` false) = no-op — mesmo default seguro de `internalVocabularyEnforced`
+ * (caller que não conhece o campo não arma nada).
+ *
+ * Por que existe apesar do `AGENDA_SYSTEM_BLOCK` (instrução em texto, `inbound-turn.ts`) já
+ * dizer a mesma regra: medido em produção (2026-08-29, mesmo tenant) que o modelo
+ * (`openai/gpt-5.6-terra`) ignora a instrução e ainda assim promete verificar sem chamar a
+ * ferramenta — a instrução sozinha não é garantia, só ensino. Este gate é a cura
+ * DETERMINÍSTICA: não precisa de classificador (o padrão é regex, sem custo de LLM extra) e
+ * não confia no modelo se corrigir sozinho — se ele tentar de novo sem chamar a ferramenta,
+ * veta de novo (sem fail-safe de N tentativas como o de vocabulário interno: aqui NÃO existe
+ * versão aceitável do texto vetado, só a alternativa de chamar a ferramenta).
+ *
+ * Posição 6.9 de `BEFORE_SEND_GATES`: DEPOIS do `internalVocabularyGate` e ANTES do
+ * `disclosureGate` (que pode emendar o corpo — este gate precisa ver o texto do MODELO).
+ */
+export const agendaStallGate: Gate = {
+  name: 'agenda_stall',
+  evaluate: (ctx) => {
+    if (ctx.agenda === undefined || !ctx.agenda.active) return { pass: true };
+    if (ctx.agenda.toolCalledThisTurn) return { pass: true };
+    if (!AGENDA_STALL_PATTERN.test(ctx.body)) return { pass: true };
+    return {
+      pass: false,
+      code: 'agenda_stall_sem_ferramenta',
+      reason:
+        'Você prometeu verificar/confirmar um horário sem ter chamado crm_find_free_slots, ' +
+        'crm_book_appointment ou crm_reschedule_appointment NESTE turno. Chame a ferramenta ' +
+        'agora e responda com base no retorno dela — não repita a promessa sem checar.',
+    };
+  },
+};
+
+/**
  * Gate de disclosure (F4-05; blueprint 5.7) — garante que a PRIMEIRA mensagem outbound a um
  * lead novo se apresenta como assistente virtual (template versionado por org). Decisão de
  * produto que blinda hoje (CDC) e amanhã (PL 2338), não exigência da Meta. Sem template
  * configurado OU não sendo o 1º outbound → PASS (segundo em diante não repete). 1º outbound
  * que JÁ contém o disclosure → PASS. 1º sem disclosure → conforme o knob `mode`: 'veto'
  * bloqueia com erro de ensino; 'inject' devolve `amendBody` com o disclosure prependado.
- * Posição 7 (última) de `BEFORE_SEND_GATES` (F4-08): roda sobre o corpo já validado pelos
+ * Posição 8 (última) de `BEFORE_SEND_GATES` (F4-08): roda sobre o corpo já validado pelos
  * gates anteriores e pode emendá-lo (inject) antes do envio.
  */
 export const disclosureGate: Gate = {
@@ -543,8 +600,16 @@ const spinningGate: Gate = {
  * nasce DESARMADO por default (ver `GateContext.internalVocabularyEnforced`): só o
  * caminho do agente o arma, então, como a v5, a v6 não muda o destino de nenhum envio
  * que já existia — muda o TRACE, e passa a medir o vazamento onde há modelo para ensinar.
+ * v7 = insere `agendaStallGate` entre `internal_vocabulary` e `disclosure` — a garantia
+ * DETERMINÍSTICA de que "vou verificar/confirmar horário" só sai depois de a ferramenta de
+ * agenda ter sido chamada neste turno (medido em produção, 2026-08-29: o `AGENDA_SYSTEM_BLOCK`
+ * em texto, sozinho, não bastou — o modelo prometeu checar sem chamar a ferramenta mesmo com
+ * a instrução presente e por último no prompt). Nasce DESARMADO por default (ver
+ * `GateContext.agenda`): só o caminho do agente o arma quando o agente publicado tem
+ * `crm_book_appointment` nas tools, então a v7 também não muda o destino de nenhum envio que
+ * já existia fora desse caso — muda o TRACE e passa a medir/impedir a promessa vazia.
  */
-export const BEFORE_SEND_CHAIN_VERSION = 6;
+export const BEFORE_SEND_CHAIN_VERSION = 7;
 
 /**
  * Ordem FINAL da cadeia (F4-08/F4-09; edge-contract §before_send / blueprint órgão 5) — DADO
@@ -559,7 +624,9 @@ export const BEFORE_SEND_CHAIN_VERSION = 6;
  *   (6.5) case_promise — anti-alucinação de casos humanos (spec 15 §10.2, Wave 4);
  *   (6.7) internal_vocabulary — vazamento de vocabulário interno ao cliente (doutrina
  *         `separacao-fala-e-operacao.md`); antes do disclosure porque ele pode emendar o corpo;
- *   (7) disclosure — 1ª mensagem se apresenta como assistente virtual (F4-05).
+ *   (6.9) agenda_stall — "vou verificar/confirmar horário" sem ter chamado a ferramenta de
+ *         agenda neste turno; antes do disclosure pelo mesmo motivo do internal_vocabulary;
+ *   (8) disclosure — 1ª mensagem se apresenta como assistente virtual (F4-05).
  * (O anti-jailbreak F4-04 é INBOUND advisório, não gate de before_send — não entra aqui.)
  */
 export const BEFORE_SEND_GATES: readonly Gate[] = [
@@ -572,6 +639,7 @@ export const BEFORE_SEND_GATES: readonly Gate[] = [
   semanticPromiseGate,
   casePromiseGate,
   internalVocabularyGate,
+  agendaStallGate,
   disclosureGate,
 ];
 
@@ -683,6 +751,11 @@ export interface RunBeforeSendArgs {
    */
   enforceSpinning?: boolean;
   /**
+   * Arma o `agendaStallGate` para ESTA tentativa — ver `GateContext.agenda`. Ausente = gate
+   * no-op (retrocompatível com todo caller que não conhece agenda, ex.: `followup-turn.ts`).
+   */
+  agenda?: { active: boolean; toolCalledThisTurn: boolean };
+  /**
    * Enviado SÓ se TODOS os gates passarem — ChannelAdapter (própria tx/idempotência). Recebe o
    * corpo FINAL (o disclosureGate F4-05 pode emendá-lo via `amendBody`): quem monta o send DEVE
    * enviar este `body`, não o corpo original capturado antes da cadeia.
@@ -761,6 +834,7 @@ export async function runBeforeSend(args: RunBeforeSendArgs): Promise<BeforeSend
       hasOpenCase: args.hasOpenCase ?? false,
       openedCaseThisTurn: args.openedCaseThisTurn ?? false,
       internalVocabularyEnforced: args.enforceInternalVocabulary ?? false,
+      ...(args.agenda !== undefined ? { agenda: args.agenda } : {}),
     };
 
     const trace: GateTraceEntry[] = [];

--- a/lib/agent-engine/guardrails/human-promise.ts
+++ b/lib/agent-engine/guardrails/human-promise.ts
@@ -79,6 +79,17 @@ function buildPatterns(target: string): RegExp[] {
       `\\bquem\\b${gap(15)}\\b(?:resolv|cuid|respond|decid|aprov|liber|atend)\\w*${gap(20)}` +
         `(?:\\b(?:nosso|nossa|nossos|nossas|o|a|os|as)\\b\\s*)?${target}\\b`,
     ),
+    // (2c) ESTADO passivo alegado — não uma promessa de AÇÃO futura (vai resolver),
+    //      e sim uma AFIRMAÇÃO de que já está sendo tratado agora: "está em análise
+    //      pela equipe", "ficou em análise com o responsável". Achado em produção
+    //      (tenant YADEA, 2026-08-30): o agente respondeu a uma reclamação de garantia
+    //      de quase 1 dia dizendo que estava "em análise pela equipe responsável" sem
+    //      NENHUM caso aberto — as 7 regras acima exigem verbo de AÇÃO (vai/vamos/
+    //      encaminho) e nenhuma casa uma alegação de estado já em curso.
+    new RegExp(
+      `\\b(?:est[aá]|ficou|fica|segue)\\b${gap(10)}\\bem\\b\\s+an[aá]lise\\b${gap(20)}` +
+        `\\b(?:com|pela|pelo|do|da|na|no)\\b${gap(10)}\\b${target}\\b`,
+    ),
     // (3) deferir a TERCEIROS via subjuntivo 3ª pessoa do plural: "assim que liberarem eu te aviso".
     //     Não depende de `target` — não repetido no alvo estendido.
     new RegExp(

--- a/lib/agent-engine/guardrails/human-promise.ts
+++ b/lib/agent-engine/guardrails/human-promise.ts
@@ -20,10 +20,24 @@
  * NUNCA deixa a promessa passar sem caso.
  */
 
-/** Alvo humano/retaguarda (já sem acento — o texto é normalizado antes de casar). */
-const TARGET =
-  "(?:equipe|time|setor|responsavel|responsaveis|pessoal|especialista|especialistas|" +
-  "atendente|atendentes|gerente|supervisor|departamento)";
+/** Alvo humano/retaguarda genérico (já sem acento — o texto é normalizado antes de casar). */
+const TARGET_WORDS = [
+  "equipe",
+  "time",
+  "setor",
+  "responsavel",
+  "responsaveis",
+  "pessoal",
+  "especialista",
+  "especialistas",
+  "atendente",
+  "atendentes",
+  "gerente",
+  "supervisor",
+  "departamento",
+] as const;
+const TARGET_WORD_SET = new Set<string>(TARGET_WORDS);
+const TARGET = `(?:${TARGET_WORDS.join("|")})`;
 
 /**
  * Lacuna curta que NÃO cruza fim de frase (sem .!?\n): impede casar um verbo de
@@ -31,40 +45,51 @@ const TARGET =
  */
 const gap = (n: number): string => `[^.!?\\n]{0,${n}}?`;
 
-const PATTERNS: readonly RegExp[] = [
-  // (1a) encaminhar/passar/acionar/... → alvo humano: "encaminhar pro setor", "acionar o responsavel".
-  new RegExp(`\\b(?:encaminh|repass|transfer|acion|escal|direcion|pass|cham)\\w*${gap(20)}\\b${TARGET}\\b`),
-  // (1a-bis) mesmo verbo de encaminhamento, mas o ALVO é retomado por PRONOME (eles/elas)
-  // em vez do substantivo — achado na prova E2E da Wave 7 real: "já passo o pedido pra
-  // eles resolverem" escapava (1a) porque "eles" não é TARGET). Exige um verbo de
-  // RESOLUÇÃO depois do pronome (não só "passar pra eles" — precisa prometer AÇÃO deles).
-  new RegExp(
-    `\\b(?:encaminh|repass|transfer|acion|escal|direcion|pass|cham)\\w*${gap(30)}` +
-      `\\b(?:pra|para|pro|com)\\b${gap(8)}\\b(?:eles|elas)\\b${gap(25)}` +
-      `\\b(?:resolv|retorn|respond|liber|analis|verific|cuid|assum|atend|aprov|confirm|contat|ajud)\\w*`,
-  ),
-  // (1b) verbo de CONSULTA + "com" + alvo humano: "verificar com a equipe", "falar com o pessoal".
-  //      Exige "com <humano>": "verificar seu pedido no sistema" (sem "com equipe") NÃO casa.
-  new RegExp(`\\b(?:verific|fal|confer|confirm|consult|alinh|valid|chec)\\w*${gap(15)}\\bcom\\b${gap(15)}\\b${TARGET}\\b`),
-  // (1c) pedir/solicitar pra/ao alvo humano: "vou pedir pra equipe liberar".
-  new RegExp(`\\b(?:ped|solicit)\\w*${gap(12)}\\b(?:pra|para|pro|ao|aos|a|as|com)\\b${gap(10)}\\b${TARGET}\\b`),
-  // (2) "<alvo humano> vai/pode <resolver/retornar/...>": "nosso time vai resolver", "um responsavel vai te retornar".
-  //     "nossa equipe ESTA a disposicao" NÃO casa ("esta" fora do grupo vai/vao/pode).
-  new RegExp(
-    `\\b${TARGET}\\b${gap(20)}\\b(?:vai|vao|ira|irao|pode|podem|poderao)\\b${gap(10)}` +
-      `(?:\\b(?:te|lhe|se|nos)\\b\\s*)?(?:resolv|retorn|respond|liber|analis|verific|cuid|assum|atend|entr|aprov|confirm|contat|ajud)\\w*`,
-  ),
-  // (2b) "quem resolve/cuida ... e o nosso time": "isso quem resolve e o nosso time".
-  new RegExp(
-    `\\bquem\\b${gap(15)}\\b(?:resolv|cuid|respond|decid|aprov|liber|atend)\\w*${gap(20)}` +
-      `(?:\\b(?:nosso|nossa|nossos|nossas|o|a|os|as)\\b\\s*)?${TARGET}\\b`,
-  ),
-  // (3) deferir a TERCEIROS via subjuntivo 3ª pessoa do plural: "assim que liberarem eu te aviso".
-  new RegExp(
-    `\\b(?:assim que|assim q|quando|depois que|logo que|apos)\\b${gap(12)}` +
-      `\\b(?:liber|aprov|autoriz|respond|retorn|verific|analis|resolv|confirm)(?:ar|er)em\\b`,
-  ),
-];
+/**
+ * Monta os 7 padrões de promessa-de-humano em cima de um ALVO (`target`)
+ * substituível — o TARGET genérico por padrão, ou o TARGET estendido com
+ * nome(s) próprio(s) do tenant (ver `detectHumanPromise`).
+ */
+function buildPatterns(target: string): RegExp[] {
+  return [
+    // (1a) encaminhar/passar/acionar/... → alvo humano: "encaminhar pro setor", "acionar o responsavel".
+    new RegExp(`\\b(?:encaminh|repass|transfer|acion|escal|direcion|pass|cham)\\w*${gap(20)}\\b${target}\\b`),
+    // (1a-bis) mesmo verbo de encaminhamento, mas o ALVO é retomado por PRONOME (eles/elas)
+    // em vez do substantivo — achado na prova E2E da Wave 7 real: "já passo o pedido pra
+    // eles resolverem" escapava (1a) porque "eles" não é TARGET). Exige um verbo de
+    // RESOLUÇÃO depois do pronome (não só "passar pra eles" — precisa prometer AÇÃO deles).
+    new RegExp(
+      `\\b(?:encaminh|repass|transfer|acion|escal|direcion|pass|cham)\\w*${gap(30)}` +
+        `\\b(?:pra|para|pro|com)\\b${gap(8)}\\b(?:eles|elas)\\b${gap(25)}` +
+        `\\b(?:resolv|retorn|respond|liber|analis|verific|cuid|assum|atend|aprov|confirm|contat|ajud)\\w*`,
+    ),
+    // (1b) verbo de CONSULTA + "com" + alvo humano: "verificar com a equipe", "falar com o pessoal".
+    //      Exige "com <humano>": "verificar seu pedido no sistema" (sem "com equipe") NÃO casa.
+    new RegExp(`\\b(?:verific|fal|confer|confirm|consult|alinh|valid|chec)\\w*${gap(15)}\\bcom\\b${gap(15)}\\b${target}\\b`),
+    // (1c) pedir/solicitar pra/ao alvo humano: "vou pedir pra equipe liberar".
+    new RegExp(`\\b(?:ped|solicit)\\w*${gap(12)}\\b(?:pra|para|pro|ao|aos|a|as|com)\\b${gap(10)}\\b${target}\\b`),
+    // (2) "<alvo humano> vai/pode <resolver/retornar/...>": "nosso time vai resolver", "um responsavel vai te retornar".
+    //     "nossa equipe ESTA a disposicao" NÃO casa ("esta" fora do grupo vai/vao/pode).
+    new RegExp(
+      `\\b${target}\\b${gap(20)}\\b(?:vai|vao|ira|irao|pode|podem|poderao)\\b${gap(10)}` +
+        `(?:\\b(?:te|lhe|se|nos)\\b\\s*)?(?:resolv|retorn|respond|liber|analis|verific|cuid|assum|atend|entr|aprov|confirm|contat|ajud)\\w*`,
+    ),
+    // (2b) "quem resolve/cuida ... e o nosso time": "isso quem resolve e o nosso time".
+    new RegExp(
+      `\\bquem\\b${gap(15)}\\b(?:resolv|cuid|respond|decid|aprov|liber|atend)\\w*${gap(20)}` +
+        `(?:\\b(?:nosso|nossa|nossos|nossas|o|a|os|as)\\b\\s*)?${target}\\b`,
+    ),
+    // (3) deferir a TERCEIROS via subjuntivo 3ª pessoa do plural: "assim que liberarem eu te aviso".
+    //     Não depende de `target` — não repetido no alvo estendido.
+    new RegExp(
+      `\\b(?:assim que|assim q|quando|depois que|logo que|apos)\\b${gap(12)}` +
+        `\\b(?:liber|aprov|autoriz|respond|retorn|verific|analis|resolv|confirm)(?:ar|er)em\\b`,
+    ),
+  ];
+}
+
+/** Compilado uma vez no load do módulo — caminho quente sem nome próprio extra. */
+const PATTERNS: readonly RegExp[] = buildPatterns(TARGET);
 
 /** Minúsculas + remove diacríticos (NFD) — casa acento/caixa uniformemente. */
 function normalize(body: string): string {
@@ -74,12 +99,42 @@ function normalize(body: string): string {
     .toLowerCase();
 }
 
+/** Escapa metacaracteres de regex — nome próprio vira literal, nunca sintaxe. */
+function escapeRegex(word: string): string {
+  return word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /**
  * True se a candidata promete envolver um humano/retaguarda. Determinístico,
  * conservador (spec §10.2). Vazio/whitespace = false.
+ *
+ * `extraHumanNames` (opcional) — nome(s) próprio(s) que o PROMPT do tenant usa
+ * para a retaguarda humana (ex.: "Fernando", o gerente citado no system_prompt
+ * do agente YADEA). Sem isto, um agente cujo prompt nomeia a pessoa em vez do
+ * cargo ("vou confirmar com o Fernando") escapa 100% do detector — TARGET só
+ * conhece cargos genéricos (medido em produção, 2026-08-29/30, tenant YADEA:
+ * dezenas de promessas nomeando "Fernando", 1 só detecção em 3 dias). A fonte
+ * natural é `ai_agent_versions.handoff_keywords` — já é o vocabulário que o
+ * tenant escreveu pra "isto é uma pessoa/situação que exige humano" (reusado
+ * hoje só do lado do CLIENTE, em `matchesHandoffKeyword`); aqui aplicamos o
+ * mesmo vocabulário do lado do que o MODELO promete. Palavras compostas
+ * ("falar com humano") e as já cobertas por TARGET_WORDS são descartadas —
+ * só nomes próprios simples entram no alvo estendido.
  */
-export function detectHumanPromise(body: string): boolean {
+export function detectHumanPromise(body: string, extraHumanNames?: readonly string[]): boolean {
   if (body.trim() === "") return false;
   const text = normalize(body);
-  return PATTERNS.some((re) => re.test(text));
+  if (extraHumanNames === undefined || extraHumanNames.length === 0) {
+    return PATTERNS.some((re) => re.test(text));
+  }
+  const names = Array.from(
+    new Set(
+      extraHumanNames
+        .map((w) => normalize(w).trim())
+        .filter((w) => /^[a-z]{3,}$/.test(w) && !TARGET_WORD_SET.has(w)),
+    ),
+  );
+  if (names.length === 0) return PATTERNS.some((re) => re.test(text));
+  const extendedTarget = `(?:${TARGET_WORDS.join("|")}|${names.map(escapeRegex).join("|")})`;
+  return buildPatterns(extendedTarget).some((re) => re.test(text));
 }

--- a/lib/agent-engine/guardrails/sinal-de-urgencia.ts
+++ b/lib/agent-engine/guardrails/sinal-de-urgencia.ts
@@ -1,0 +1,51 @@
+/**
+ * Detector determinístico de SINAL DE URGÊNCIA/SEGURANÇA na mensagem do lead — usado
+ * SÓ para decidir prioridade de alerta humano quando o turno é adiado por cap de
+ * envio (warm-up/diário), não para vetar nem alterar o que o modelo responde.
+ *
+ * Contexto: `pacingCapVeto` (`inbound-turn.ts`) já reagenda o job pra próxima abertura
+ * quando o número está em warm-up/bateu o teto diário — sem isso o job morria
+ * silenciosamente (medido em produção, 2026-08-29). Mas reagendar sozinho trata toda
+ * mensagem represada como igual: um lead relatando risco de segurança (freio falhando,
+ * cheiro de queimado, bateria esquentando — vocabulário que o PRÓPRIO prompt de um
+ * agente como o Ricardo/YADEA já pede pra tratar com cautela) espera a mesma janela
+ * que um "bom dia" qualquer, às vezes 20h+. Este módulo dá ao runtime um jeito de medir
+ * "isto parece grave" sem custo de LLM, pra abrir um alerta CRÍTICO imediato na Central
+ * (kind='handoff') em vez de deixar o lead represado sem ninguém sabendo até o cap
+ * resetar.
+ *
+ * Sem LLM (mesma disciplina de `human-promise.ts`/`promise/engine.ts`): léxico
+ * genérico de risco/emergência, não amarrado a nenhum nicho (o produto é
+ * multi-vertical — e-commerce, clínica, oficina, imobiliária). Conservador de
+ * propósito: o custo de um falso negativo aqui é "o alerta crítico não dispara e o
+ * lead espera o reagendamento normal" (o comportamento de hoje) — não perda de
+ * mensagem. O custo de falso positivo é um alerta a mais na Central, tolerável.
+ */
+
+const URGENCY_PATTERN = new RegExp(
+  '\\b(urgente|urgencia|emergencia|socorro|risco de vida|perigo|perigoso)\\b|' +
+    '\\bpeg(ou|ando)\\s+fogo\\b|\\bincendio\\b|\\bfuma[cç]a\\b|\\bcheiro de queimado\\b|' +
+    '\\bfa[íi]sca\\b|\\bchoque\\s+el[eé]trico\\b|\\bvazamento de g[aá]s\\b|' +
+    '\\bn[aã]o\\s+(consigo|consegue|est[aá])\\s+respirando?\\b|\\bdesmaiou\\b|\\bsangrando\\b|' +
+    '\\bsem\\s+freio\\b|\\bfreio\\s+n[aã]o\\s+(funciona|pega|segura)\\b|\\baquecendo\\s+muito\\b|' +
+    '\\baquecimento\\s+anormal\\b',
+  'i',
+);
+
+/** Normaliza minúsculas + sem diacríticos, mesma disciplina de `human-promise.ts`. */
+function normalize(body: string): string {
+  return body
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase();
+}
+
+/**
+ * True se o texto do lead bate um sinal de urgência/segurança. Vazio/whitespace =
+ * false. Usado só como gatilho de PRIORIDADE de alerta — nunca para vetar/alterar
+ * a resposta do modelo.
+ */
+export function detectUrgencySignal(body: string): boolean {
+  if (body.trim() === '') return false;
+  return URGENCY_PATTERN.test(normalize(body));
+}

--- a/lib/ai/agents/avaliar-resposta-de-teste.ts
+++ b/lib/ai/agents/avaliar-resposta-de-teste.ts
@@ -68,6 +68,10 @@ const NAO_AVALIAVEIS_SEM_TURNO: ReadonlyArray<{ gate: string; porque: string }> 
   { gate: "promise", porque: "depende da tabela de preços e condições da organização" },
   { gate: "semantic_promise", porque: "usa uma chamada de modelo extra, que o teste não gasta" },
   { gate: "case_promise", porque: "depende de haver um chamado aberto para este contato" },
+  {
+    gate: "agenda_stall",
+    porque: "depende de a ferramenta de agenda ter sido chamada neste turno — não há turno real no teste",
+  },
   { gate: "disclosure", porque: "depende de esta ser a primeira mensagem ao contato" },
 ];
 

--- a/lib/ai/guardrails/lista-de-conferencia.ts
+++ b/lib/ai/guardrails/lista-de-conferencia.ts
@@ -155,6 +155,18 @@ export const CONFERENCIAS_DE_SAIDA: readonly ConferenciaDeSaida[] = [
      camada: null,
   },
   {
+    nome: "agenda_stall",
+    rotulo: "Não prometer checar a agenda sem checar de verdade",
+    oQueProtege:
+      'Barra o "vou verificar/confirmar o horário" quando o assistente ainda não chamou a ' +
+      "ferramenta de agenda nesta resposta — a promessa só sai depois de checar de verdade.",
+    escolha: null,
+    porQueNaoSeDesliga:
+      "É a mesma promessa vazia do 'vou pedir pro responsável', só que sobre agenda: o cliente " +
+      "fica esperando uma confirmação que nunca foi checada. Regra fixa, sem custo.",
+    camada: null,
+  },
+  {
     nome: "disclosure",
     rotulo: "Dizer que é um assistente quando perguntam",
     oQueProtege: "Se o cliente pergunta se está falando com um robô, a resposta não pode enganar.",

--- a/lib/ai/handoff/orchestrator.ts
+++ b/lib/ai/handoff/orchestrator.ts
@@ -12,6 +12,9 @@
  *      (idempotente: se outro handoff aconteceu nos últimos 5s com mesma reason,
  *       skip — tratamento de race G2 vs G3 vs G4 simultâneos.)
  *   2. INSERT em crm_lead_activities (timeline) se houver lead_id
+ *   2.5. Move o lead para a etapa `crm_stages.slug='chamar-humano'` do
+ *        pipeline dele, se o tenant tiver criado essa etapa (opt-in — ver
+ *        `lib/leads/handoff-stage-move.ts`). Pipeline sem essa etapa: no-op.
  *   3. emit_event('ai.handoff_triggered') no event_log
  *   4. Realtime broadcast no channel 'org:<org>:queue' (event 'handoff_pending')
  *   5. api_audit_log action='ai.handoff_triggered'
@@ -23,6 +26,7 @@
 
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
+import { moverLeadParaEtapaDeHandoff } from "@/lib/leads/handoff-stage-move";
 
 import { avisarLeadDoCrm } from "./aviso-ao-lead";
 
@@ -171,6 +175,20 @@ export async function triggerHandoff(
           error: actErr.message,
         });
       }
+
+      // Step 2.5 — best-effort: move o card para a etapa "chamar humano" do
+      // pipeline dele, quando o tenant configurou uma (ver docstring do
+      // arquivo). Nunca bloqueia nem derruba o handoff em si.
+      await moverLeadParaEtapaDeHandoff(admin, {
+        organizationId: input.organizationId,
+        leadId: input.leadId,
+        reason: input.reason,
+      }).catch((err) => {
+        logger.warn("[handoff-orchestrator] moverLeadParaEtapaDeHandoff failed", {
+          lead_id: input.leadId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
     }
 
     // Step 3 — durable event for any downstream consumer.

--- a/lib/followup/silence-sweep.ts
+++ b/lib/followup/silence-sweep.ts
@@ -37,6 +37,7 @@
  */
 import type { SupabaseClient } from "@supabase/supabase-js";
 
+import { CONVERSATION_TERMINAL_STATUSES } from "@/lib/schemas";
 import { flowGraphSchema } from "./graph-schema";
 import { triggerConfigSchema } from "./api-schemas";
 import { resolveAgentForAutomaticTrigger, type FollowupGateDb } from "./agent-followup-gate";
@@ -181,11 +182,19 @@ export function createSupabaseSilenceSweepDb(admin: SupabaseClient): SilenceSwee
       // client-side pro MAIS RECENTE `last_inbound_at` entre as conversas do
       // contato (um contato com 2+ channel_sessions não pode ser marcado
       // silencioso por causa da conversa mais antiga se a mais nova respondeu).
+      //
+      // `.not("status", "in", ...)` exclui conversas CLOSED/ARCHIVED — um humano
+      // que encerrou a conversa não deveria ver um follow-up automático chegar
+      // depois. Sem isto, o sweep contava `last_inbound_at` de QUALQUER
+      // conversa, inclusive uma que um humano já fechou de propósito — medido
+      // ao desenhar o primeiro fluxo de silêncio real (tenant YADEA): o gatilho
+      // só faz sentido enquanto "o fluxo da conversa ainda está ativo".
       const { data, error } = await admin
         .from("conversations")
         .select("contact_id, last_inbound_at, contacts:contact_id(tags, is_blocked)")
         .eq("organization_id", orgId)
-        .not("last_inbound_at", "is", null);
+        .not("last_inbound_at", "is", null)
+        .not("status", "in", `(${CONVERSATION_TERMINAL_STATUSES.join(",")})`);
       if (error) throw new Error(error.message);
 
       type Row = { contact_id: string; last_inbound_at: string; contacts: ContactEmbed };

--- a/lib/leads/appointment-stage-move.ts
+++ b/lib/leads/appointment-stage-move.ts
@@ -1,0 +1,182 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { logger } from "@/lib/logger";
+import { emitLeadActivity, stageChangeReason } from "@/lib/leads/activity-emitter";
+import { registraFalhaDeAtividade } from "@/lib/leads/activity-write-failure";
+import type { Transicao } from "@/lib/agenda/laco";
+
+/**
+ * Espelha a transição de um agendamento (`calendar_appointments.status`) no
+ * funil do CRM — MESMO padrão opt-in de `handoff-stage-move.ts`: a ponte é o
+ * `slug` da etapa, e pipeline sem a etapa correspondente não muda de
+ * comportamento nenhum (`sem_etapa_mapeada`, igual a `sem_etapa_de_handoff`).
+ *
+ * ⚠️ SÓ `pending` E `confirmed` AVANÇAM O CARD, de propósito. As demais
+ * transições (`rescheduled`, `cancelled`, `completed`, `no_show`) não têm
+ * entrada no mapa: cancelar ou faltar a UM compromisso não é o negócio
+ * esfriando — o cliente pode remarcar, e quem decide que o negócio morreu
+ * continua sendo o agente (`crm_stages.agent_stage_hint = 'lost'`) ou um
+ * humano arrastando o card, nunca o agendamento sozinho.
+ */
+export const SLUG_ETAPA_POR_TRANSICAO: Partial<Record<Transicao, string>> = {
+  pending: "agendamento-solicitado",
+  confirmed: "agendado",
+};
+
+export interface ResultadoDoMovimentoDeAgendamento {
+  moveu: boolean;
+  motivo:
+    | "movido"
+    | "transicao_nao_mapeada"
+    | "sem_etapa_mapeada"
+    | "ja_esta_la"
+    | "lead_nao_encontrado"
+    | "lead_fechado"
+    | "conflito_humano"
+    | "falha_de_escrita"
+    | "indisponivel";
+}
+
+export async function moverLeadParaEtapaDeAgendamento(
+  admin: SupabaseClient,
+  input: {
+    organizationId: string;
+    leadId: string;
+    transicao: Transicao;
+  },
+): Promise<ResultadoDoMovimentoDeAgendamento> {
+  const slugAlvo = SLUG_ETAPA_POR_TRANSICAO[input.transicao];
+  if (!slugAlvo) {
+    return { moveu: false, motivo: "transicao_nao_mapeada" };
+  }
+
+  const { data: lead, error: erroLead } = await admin
+    .from("crm_leads")
+    .select("id, pipeline_id, stage_id, contact_id, status")
+    .eq("id", input.leadId)
+    .eq("organization_id", input.organizationId)
+    .maybeSingle();
+  if (erroLead) {
+    logger.warn("[appointment-stage-move] leitura do lead falhou", {
+      lead_id: input.leadId,
+      organization_id: input.organizationId,
+      error: erroLead.message,
+    });
+    return { moveu: false, motivo: "indisponivel" };
+  }
+  if (!lead) {
+    return { moveu: false, motivo: "lead_nao_encontrado" };
+  }
+  const leadRow = lead as {
+    id: string;
+    pipeline_id: string;
+    stage_id: string;
+    contact_id: string | null;
+    status: string;
+  };
+
+  // Negócio já fechado (ganho/perdido) não volta a se mexer por causa de um
+  // agendamento — moveria um card que a organização já considera encerrado.
+  if (leadRow.status !== "open") {
+    return { moveu: false, motivo: "lead_fechado" };
+  }
+
+  const { data: etapa, error: erroEtapa } = await admin
+    .from("crm_stages")
+    .select("id, name")
+    .eq("pipeline_id", leadRow.pipeline_id)
+    .eq("slug", slugAlvo)
+    .eq("is_archived", false)
+    .maybeSingle();
+  if (erroEtapa) {
+    logger.warn("[appointment-stage-move] leitura da etapa alvo falhou", {
+      lead_id: leadRow.id,
+      organization_id: input.organizationId,
+      error: erroEtapa.message,
+    });
+    return { moveu: false, motivo: "indisponivel" };
+  }
+  if (!etapa) {
+    return { moveu: false, motivo: "sem_etapa_mapeada" };
+  }
+  const etapaRow = etapa as { id: string; name: string };
+
+  if (leadRow.stage_id === etapaRow.id) {
+    return { moveu: false, motivo: "ja_esta_la" };
+  }
+
+  // Nome da origem só enfeita o texto da timeline — erro descartado de
+  // propósito, mesmo raciocínio de `agent-stage-sync.ts` e `handoff-stage-move.ts`.
+  const { data: origem } = await admin
+    .from("crm_stages")
+    .select("name")
+    .eq("id", leadRow.stage_id)
+    .maybeSingle();
+
+  const { data: atualizadas, error: erroUpdate } = await admin
+    .from("crm_leads")
+    .update({ stage_id: etapaRow.id })
+    .eq("id", leadRow.id)
+    // Trava otimista pelo estágio de ORIGEM: se um humano moveu o card entre a
+    // leitura e a escrita, a decisão dele vence.
+    .eq("stage_id", leadRow.stage_id)
+    .select("id");
+  if (erroUpdate) {
+    logger.warn("[appointment-stage-move] update de stage_id falhou", {
+      lead_id: leadRow.id,
+      organization_id: input.organizationId,
+      error: erroUpdate.message,
+    });
+    return { moveu: false, motivo: "falha_de_escrita" };
+  }
+  if ((atualizadas ?? []).length === 0) {
+    return { moveu: false, motivo: "conflito_humano" };
+  }
+
+  const atividade = await emitLeadActivity(admin, {
+    organizationId: input.organizationId,
+    leadId: leadRow.id,
+    contactId: leadRow.contact_id,
+    type: "stage_changed",
+    sourceModule: "agenda",
+    sourceId: leadRow.id,
+    actor: { type: "webhook_source", id: "appointment-stage-move" },
+    reason: stageChangeReason((origem as { name: string } | null)?.name ?? null, etapaRow.name),
+    payload: { motivo_do_movimento: `agendamento:${input.transicao}`, de: leadRow.stage_id, para: etapaRow.id },
+  });
+  if (!atividade.ok) {
+    await registraFalhaDeAtividade(admin, {
+      organizationId: input.organizationId,
+      leadId: leadRow.id,
+      tipo: "stage_changed",
+      origem: "lib/leads/appointment-stage-move",
+      erro: atividade.error,
+    });
+  }
+
+  // Mesmo evento que `agent-stage-sync.ts` e `handoff-stage-move.ts` emitem ao
+  // mover o card — para que regras de automação e follow-up que escutam
+  // `lead.stage_changed` reajam igual, seja qual for a mão que moveu o card.
+  const { error: erroEvento } = await admin.rpc("emit_event" as never, {
+    p_event_type: "lead.stage_changed",
+    p_entity_kind: "crm_lead",
+    p_entity_id: leadRow.id,
+    p_payload: {
+      pipeline_id: leadRow.pipeline_id,
+      from_stage_id: leadRow.stage_id,
+      to_stage_id: etapaRow.id,
+      status: leadRow.status,
+    },
+    p_metadata: { actor_kind: "system", source: "appointment-stage-move", transicao: input.transicao },
+    p_organization_id: input.organizationId,
+  } as never);
+  if (erroEvento) {
+    logger.error("[appointment-stage-move] emit_event lead.stage_changed falhou", {
+      lead_id: leadRow.id,
+      organization_id: input.organizationId,
+      error: (erroEvento as { message?: string }).message ?? String(erroEvento),
+    });
+  }
+
+  return { moveu: true, motivo: "movido" };
+}

--- a/lib/leads/handoff-stage-move.ts
+++ b/lib/leads/handoff-stage-move.ts
@@ -1,0 +1,179 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { logger } from "@/lib/logger";
+import { emitLeadActivity, stageChangeReason } from "@/lib/leads/activity-emitter";
+import { registraFalhaDeAtividade } from "@/lib/leads/activity-write-failure";
+
+/**
+ * Move o card do lead para a etapa do funil que o tenant marcou como destino
+ * de handoff, sempre que o orquestrador (`lib/ai/handoff/orchestrator.ts`)
+ * decide que um atendimento precisa de humano.
+ *
+ * ⚠️ OPT-IN POR PIPELINE, via `slug`, não `requires_human`. `requires_human`
+ * já é usado por `checkG4Stage` no sentido INVERSO (lead JÁ está numa etapa
+ * assim → dispara handoff) e mais de uma etapa pode carregar essa flag no
+ * mesmo pipeline (ex.: "Repassado para o Fernando", que é atribuição a uma
+ * PESSOA, não "precisa de humano agora"). `slug` é estável, único por
+ * pipeline (`uniq_crm_stages_pipeline_slug`) e é exatamente o campo que este
+ * schema já tem para apontar sem ambiguidade — different de `name`, que o
+ * tenant pode renomear a qualquer momento.
+ *
+ * Pipeline SEM essa etapa (todo clone novo, por padrão) não muda de
+ * comportamento nenhum: `sem_etapa_de_handoff` é resposta legítima, igual ao
+ * `sem_mapeamento` de `agent-stage-sync.ts` — não inventamos etapa que o
+ * tenant não criou.
+ */
+export const SLUG_ETAPA_HANDOFF = "chamar-humano";
+
+export interface ResultadoDoMovimentoDeHandoff {
+  moveu: boolean;
+  motivo:
+    | "movido"
+    | "sem_etapa_de_handoff"
+    | "ja_esta_la"
+    | "lead_nao_encontrado"
+    | "lead_fechado"
+    | "conflito_humano"
+    | "falha_de_escrita"
+    | "indisponivel";
+}
+
+export async function moverLeadParaEtapaDeHandoff(
+  admin: SupabaseClient,
+  input: {
+    organizationId: string;
+    leadId: string;
+    /** `HandoffReason` de `lib/ai/handoff/orchestrator.ts` — string aqui para não acoplar os dois módulos. */
+    reason: string;
+  },
+): Promise<ResultadoDoMovimentoDeHandoff> {
+  const { data: lead, error: erroLead } = await admin
+    .from("crm_leads")
+    .select("id, pipeline_id, stage_id, contact_id, status")
+    .eq("id", input.leadId)
+    .eq("organization_id", input.organizationId)
+    .maybeSingle();
+  if (erroLead) {
+    logger.warn("[handoff-stage-move] leitura do lead falhou", {
+      lead_id: input.leadId,
+      organization_id: input.organizationId,
+      error: erroLead.message,
+    });
+    return { moveu: false, motivo: "indisponivel" };
+  }
+  if (!lead) {
+    return { moveu: false, motivo: "lead_nao_encontrado" };
+  }
+  const leadRow = lead as {
+    id: string;
+    pipeline_id: string;
+    stage_id: string;
+    contact_id: string | null;
+    status: string;
+  };
+
+  // Negócio já fechado (ganho/perdido) não volta a se mexer por causa de um
+  // handoff — moveria um card que a organização já considera encerrado.
+  if (leadRow.status !== "open") {
+    return { moveu: false, motivo: "lead_fechado" };
+  }
+
+  const { data: etapa, error: erroEtapa } = await admin
+    .from("crm_stages")
+    .select("id, name")
+    .eq("pipeline_id", leadRow.pipeline_id)
+    .eq("slug", SLUG_ETAPA_HANDOFF)
+    .eq("is_archived", false)
+    .maybeSingle();
+  if (erroEtapa) {
+    logger.warn("[handoff-stage-move] leitura da etapa de handoff falhou", {
+      lead_id: leadRow.id,
+      organization_id: input.organizationId,
+      error: erroEtapa.message,
+    });
+    return { moveu: false, motivo: "indisponivel" };
+  }
+  if (!etapa) {
+    return { moveu: false, motivo: "sem_etapa_de_handoff" };
+  }
+  const etapaRow = etapa as { id: string; name: string };
+
+  if (leadRow.stage_id === etapaRow.id) {
+    return { moveu: false, motivo: "ja_esta_la" };
+  }
+
+  // Nome da origem só enfeita o texto da timeline — erro descartado de
+  // propósito, mesmo raciocínio de `agent-stage-sync.ts`.
+  const { data: origem } = await admin
+    .from("crm_stages")
+    .select("name")
+    .eq("id", leadRow.stage_id)
+    .maybeSingle();
+
+  const { data: atualizadas, error: erroUpdate } = await admin
+    .from("crm_leads")
+    .update({ stage_id: etapaRow.id })
+    .eq("id", leadRow.id)
+    // Trava otimista pelo estágio de ORIGEM: se um humano moveu o card entre a
+    // leitura e a escrita, a decisão dele vence.
+    .eq("stage_id", leadRow.stage_id)
+    .select("id");
+  if (erroUpdate) {
+    logger.warn("[handoff-stage-move] update de stage_id falhou", {
+      lead_id: leadRow.id,
+      organization_id: input.organizationId,
+      error: erroUpdate.message,
+    });
+    return { moveu: false, motivo: "falha_de_escrita" };
+  }
+  if ((atualizadas ?? []).length === 0) {
+    return { moveu: false, motivo: "conflito_humano" };
+  }
+
+  const atividade = await emitLeadActivity(admin, {
+    organizationId: input.organizationId,
+    leadId: leadRow.id,
+    contactId: leadRow.contact_id,
+    type: "stage_changed",
+    sourceModule: "ai",
+    sourceId: leadRow.id,
+    actor: { type: "webhook_source", id: "handoff-orchestrator" },
+    reason: stageChangeReason((origem as { name: string } | null)?.name ?? null, etapaRow.name),
+    payload: { motivo_do_handoff: input.reason, de: leadRow.stage_id, para: etapaRow.id },
+  });
+  if (!atividade.ok) {
+    await registraFalhaDeAtividade(admin, {
+      organizationId: input.organizationId,
+      leadId: leadRow.id,
+      tipo: "stage_changed",
+      origem: "lib/leads/handoff-stage-move",
+      erro: atividade.error,
+    });
+  }
+
+  // Mesmo evento que `agent-stage-sync.ts` emite ao mover pelo agente — para
+  // que regras de automação e follow-up que escutam `lead.stage_changed`
+  // reajam igual, tenha o card se movido pela mão, pelo agente ou por handoff.
+  const { error: erroEvento } = await admin.rpc("emit_event" as never, {
+    p_event_type: "lead.stage_changed",
+    p_entity_kind: "crm_lead",
+    p_entity_id: leadRow.id,
+    p_payload: {
+      pipeline_id: leadRow.pipeline_id,
+      from_stage_id: leadRow.stage_id,
+      to_stage_id: etapaRow.id,
+      status: leadRow.status,
+    },
+    p_metadata: { actor_kind: "system", source: "handoff-stage-move", motivo_do_handoff: input.reason },
+    p_organization_id: input.organizationId,
+  } as never);
+  if (erroEvento) {
+    logger.error("[handoff-stage-move] emit_event lead.stage_changed falhou", {
+      lead_id: leadRow.id,
+      organization_id: input.organizationId,
+      error: (erroEvento as { message?: string }).message ?? String(erroEvento),
+    });
+  }
+
+  return { moveu: true, motivo: "movido" };
+}

--- a/lib/waha/ingest-celular.test.ts
+++ b/lib/waha/ingest-celular.test.ts
@@ -98,7 +98,20 @@ function bancoDeMentira(preexistentes: Array<Partial<LinhaMessage>> = []): Duplo
         },
       }),
     }),
-    update: () => ({ eq: () => ({ in: async () => ({ error: null }) }) }),
+    // Encadeável em qualquer profundidade/ordem (.eq().in(), .eq().eq(), ...) — o
+    // `silenciarBotPorRetomadaHumana` (ver `lib/waha/ingest.ts`) faz `.update(...).eq("id",
+    // ...).eq("organization_id", ...)`, dois `.eq()` seguidos, diferente do `.eq().in()`
+    // que os demais updates deste arquivo já usavam. `await` num objeto plano (não-thenable)
+    // simplesmente devolve o objeto — por isso resolver como `{ error: null }` direto
+    // funciona em qualquer ponto da cadeia.
+    update: () => {
+      const encadeavel: { error: null; eq: () => typeof encadeavel; in: () => typeof encadeavel } = {
+        error: null,
+        eq: () => encadeavel,
+        in: () => encadeavel,
+      };
+      return encadeavel;
+    },
   });
 
   const admin = {

--- a/lib/waha/ingest.ts
+++ b/lib/waha/ingest.ts
@@ -24,7 +24,68 @@ import type { WahaEnvelope, WahaPayload } from "@/lib/waha/envelope";
 import { bareWaMessageId, chatIdFromWaMessageId } from "@/lib/waha/message-id";
 import { logger } from "@/lib/logger";
 
-type Admin = ReturnType<typeof createAdminClient>;
+export type Admin = ReturnType<typeof createAdminClient>;
+
+/**
+ * Janela de silêncio automático do bot quando um humano responde direto pelo
+ * WhatsApp (fromMe=true, fora do composer/IA do CRM) — ver `handleOutboundFromUserPhone`.
+ *
+ * Antes disto, `ignore_self` (`lib/ai/dispatcher/triggers.ts`) só ignorava a PRÓPRIA
+ * mensagem do humano (não disparava turno pra ela), mas não silenciava nada — a
+ * PRÓXIMA mensagem do lead fazia o agente rodar normalmente, cego ao que o humano
+ * acabou de tratar manualmente. Medido em produção (tenant YADEA): um humano
+ * negociou preço/pagamento de peça direto no WhatsApp, e a IA, sem saber disso, se
+ * meteu de volta na conversa afirmando que "os dados do PIX estão sendo
+ * confirmados" — algo que ela não tem nenhuma ferramenta para saber.
+ *
+ * 3h é deliberadamente curto (não é um handoff formal, que usa `bot_silenced_until`
+ * = 'infinity' até alguém reativar): dá ao humano que já está no WhatsApp uma
+ * janela de controle sem precisar "assumir" a conversa no CRM, e o bot volta
+ * sozinho depois — reduz o risco de um teste do próprio dono ("oi", só verificando
+ * o número) travar o atendimento automático por muito tempo sem ninguém perceber.
+ */
+export const HUMAN_TAKEOVER_SILENCE_MS = 3 * 60 * 60 * 1000;
+
+/**
+ * Silencia o bot na conversa por `HUMAN_TAKEOVER_SILENCE_MS`, best-effort — NUNCA
+ * encurta um silêncio maior já em vigor (ex.: handoff formal com 'infinity'; um
+ * `Date` inválido, como "infinity" vindo do Postgres, compara sempre `false` contra
+ * qualquer timestamp finito, então o `if` abaixo naturalmente não regride). Falha
+ * aqui não pode derrubar a ingestão da mensagem — só loga.
+ */
+export async function silenciarBotPorRetomadaHumana(
+  admin: Admin,
+  organizationId: string,
+  conversationId: string,
+): Promise<void> {
+  const proposto = new Date(Date.now() + HUMAN_TAKEOVER_SILENCE_MS);
+  const { data: conv, error: erroLeitura } = await admin
+    .from("conversations")
+    .select("bot_silenced_until")
+    .eq("id", conversationId)
+    .eq("organization_id", organizationId)
+    .maybeSingle();
+  if (erroLeitura) {
+    console.error("[waha.ingest] silenciar bot (retomada humana): leitura falhou", erroLeitura.message);
+    return;
+  }
+  if (conv?.bot_silenced_until) {
+    const atualMs = new Date(conv.bot_silenced_until).getTime();
+    // `Number.isNaN` cobre 'infinity' (handoff formal, ver `lib/ai/handoff/orchestrator.ts`)
+    // e qualquer outro valor não-parseável — tratado como silêncio permanente, nunca
+    // encurtado. NaN não "vence" comparação nenhuma (`NaN >= x` é sempre false), por
+    // isso o caso precisa de checagem explícita em vez de reusar `>=` abaixo.
+    if (Number.isNaN(atualMs) || atualMs >= proposto.getTime()) return;
+  }
+  const { error: erroUpdate } = await admin
+    .from("conversations")
+    .update({ bot_silenced_until: proposto.toISOString() })
+    .eq("id", conversationId)
+    .eq("organization_id", organizationId);
+  if (erroUpdate) {
+    console.error("[waha.ingest] silenciar bot (retomada humana): update falhou", erroUpdate.message);
+  }
+}
 
 interface Session {
   id: string;
@@ -789,6 +850,11 @@ async function handleOutboundFromUserPhone(
   }
 
   await markConversation(admin, session.organization_id, conversationId, "outbound", previewFromMessage(p), now);
+
+  // Ver `silenciarBotPorRetomadaHumana` — um humano acabou de responder direto pelo
+  // WhatsApp dele, fora do composer/IA; dá a ele uma janela curta de controle da
+  // conversa sem precisar "assumir" formalmente no CRM.
+  await silenciarBotPorRetomadaHumana(admin, session.organization_id, conversationId);
 
   await audit({
     action: "message.sent",

--- a/tests/invariants/case-promise-detector.test.ts
+++ b/tests/invariants/case-promise-detector.test.ts
@@ -61,3 +61,54 @@ describe("detectHumanPromise — calibração (spec 15 §10.2)", () => {
     expect(detectHumanPromise("")).toBe(false);
   });
 });
+
+/**
+ * `extraHumanNames` — o alvo TARGET original só conhece cargos genéricos
+ * (equipe/gerente/responsável/...), então um prompt de tenant que nomeia a
+ * retaguarda por NOME PRÓPRIO ("vou confirmar com o Fernando") escapava 100% do
+ * detector. Medido em produção, tenant YADEA: dezenas de promessas nomeando
+ * "Fernando", 1 só detecção em 3 dias. A fonte real é
+ * `ai_agent_versions.handoff_keywords` (já inclui o nome, ver `inbound-turn.ts`).
+ */
+describe("detectHumanPromise — extraHumanNames (nome próprio do tenant)", () => {
+  const HANDOFF_KEYWORDS = ["falar com humano", "atendente", "pessoa real", "fernando", "gerente"];
+
+  it("SEM extraHumanNames, 'vou confirmar com o Fernando' NÃO é detectada (o defeito medido)", () => {
+    expect(detectHumanPromise("vou confirmar com o Fernando a disponibilidade de segunda")).toBe(false);
+  });
+
+  it("COM extraHumanNames (handoff_keywords do tenant), a mesma frase É detectada", () => {
+    expect(
+      detectHumanPromise("vou confirmar com o Fernando a disponibilidade de segunda", HANDOFF_KEYWORDS),
+    ).toBe(true);
+  });
+
+  it("cobre as variantes reais do incidente: 'vou verificar com o Fernando' e 'encaminhar para o Fernando'", () => {
+    expect(detectHumanPromise("vou verificar com o Fernando e te retorno", HANDOFF_KEYWORDS)).toBe(true);
+    expect(detectHumanPromise("vou encaminhar essa questão ao Fernando", HANDOFF_KEYWORDS)).toBe(true);
+  });
+
+  it("é robusto a caixa e acento no nome extra também", () => {
+    expect(detectHumanPromise("vou falar com o FERNANDO", HANDOFF_KEYWORDS)).toBe(true);
+  });
+
+  it("palavras compostas do handoff_keywords ('falar com humano', 'pessoa real') não quebram a montagem do regex", () => {
+    // Só nomes próprios simples (uma palavra alfabética) entram no alvo estendido —
+    // frases compostas são descartadas silenciosamente, não viram regex inválido.
+    expect(() => detectHumanPromise("qualquer coisa", HANDOFF_KEYWORDS)).not.toThrow();
+  });
+
+  it("cargo já coberto por TARGET_WORDS ('gerente', 'atendente') não duplica o alvo nem muda o resultado padrão", () => {
+    expect(detectHumanPromise("vou verificar com o gerente", HANDOFF_KEYWORDS)).toBe(true);
+    expect(detectHumanPromise("vou verificar com o gerente")).toBe(true);
+  });
+
+  it("extraHumanNames vazio ou ausente preserva exatamente o comportamento anterior", () => {
+    expect(detectHumanPromise("vou verificar com a equipe", [])).toBe(true);
+    expect(detectHumanPromise("vou confirmar o valor pra você", [])).toBe(false);
+  });
+
+  it("nome extra não vira falso positivo em texto que só MENCIONA o nome sem prometer nada", () => {
+    expect(detectHumanPromise("o Fernando é o nosso gerente de oficina", HANDOFF_KEYWORDS)).toBe(false);
+  });
+});

--- a/tests/invariants/case-promise-detector.test.ts
+++ b/tests/invariants/case-promise-detector.test.ts
@@ -27,6 +27,14 @@ const PROMISES: readonly string[] = [
   // PRONOME em vez do substantivo — "Já passo o número do pedido (#48291) para eles
   // resolverem junto com a reativação da assinatura."
   "já passo o número do pedido para eles resolverem junto com a reativação",
+  // achado em produção (tenant YADEA, 2026-08-30, lead "Fredy Restrito"): ESTADO
+  // passivo alegado, não promessa de ação futura — o agente respondeu a uma
+  // reclamação de garantia de quase 1 dia dizendo isto sem NENHUM caso aberto.
+  // As regras de "vai resolver"/"vou encaminhar" não cobrem uma AFIRMAÇÃO de que
+  // já está em curso.
+  "sua solicitação sobre garantia está em análise pela equipe responsável",
+  "isso está em análise pela nossa equipe",
+  "seu caso ficou em análise com o responsável",
 ];
 
 // NÃO detectar: ação própria do bot / frase institucional / checar SISTEMA (≠ humano).
@@ -41,6 +49,11 @@ const NON_PROMISES: readonly string[] = [
   "vou anotar aqui",
   // pronome sem verbo de resolução depois — só "passar pra eles" não é promessa de AÇÃO.
   "vou passar o recado pra eles mais tarde",
+  // "análise" em outro sentido (exame médico), não alegação de time humano cuidando.
+  "sua análise de sangue está pronta",
+  // "em análise" sem NOMEAR quem — conservador de propósito, mesmo raciocínio das
+  // outras regras (exige TARGET explícito pra reduzir falso positivo).
+  "o produto está em análise técnica interna, sem previsão",
 ];
 
 describe("detectHumanPromise — calibração (spec 15 §10.2)", () => {

--- a/tests/invariants/followup-silence-sweep.test.ts
+++ b/tests/invariants/followup-silence-sweep.test.ts
@@ -206,6 +206,23 @@ async function seedConversation(org: string, contactId: string, agoMinutes: numb
   return rows[0]!.id;
 }
 
+/** Mesmo que `seedConversation`, mas com `status` explícito — pra provar que uma conversa
+ *  CLOSED/ARCHIVED não conta como silêncio (um humano encerrou; o fluxo não está mais ativo). */
+async function seedConversationComStatus(
+  org: string,
+  contactId: string,
+  agoMinutes: number,
+  status: string,
+): Promise<string> {
+  const sessionId = await seedChannelSession(org);
+  const { rows } = await pool.query<{ id: string }>(
+    `insert into conversations (organization_id, contact_id, channel_session_id, status, is_group, last_inbound_at)
+     values ($1, $2, $3, $4, false, now() - interval '${agoMinutes} minutes') returning id`,
+    [org, contactId, sessionId, status],
+  );
+  return rows[0]!.id;
+}
+
 /** Mesmo que `seedConversation`, mas com `last_inbound_at` EXATO (ISO), não relativo a `now()`
  *  do Postgres — necessário pro teste de boundary exato (evita drift entre `now()` do DB e o
  *  `clock()` injetado no sweep, que roda em JS). */
@@ -402,6 +419,46 @@ describe("runSilenceSweep — redução anti-spam (multi-conversa + never-inboun
     expect(summary.pointers_gated_out).toBe(0); // não foi o gate que bloqueou
     expect(summary.enrolled).toBe(0); // a redução MAX(last_inbound_at) pegou a conversa recente, não a velha
     expect(await countEnrollments(pointerId, contactId)).toBe(0);
+  });
+
+  it("única conversa está CLOSED (humano encerrou) e silenciosa há mais que o threshold → NÃO enrolla", async () => {
+    const org = nextOrgId();
+    await seedOrg(org);
+    const { pointerId } = await seedSilenceFlow(org, { thresholdMinutes: 60 });
+    await seedPublishedAgentVersion(org, { enabled: true, pointerIds: [pointerId] });
+    const contactId = await seedContact(org);
+    await seedConversationComStatus(org, contactId, 120, "closed");
+
+    const summary = await runSilenceSweep({ db: silenceSweepDb(), gateDb: pgGateDb(), clock: CLOCK });
+    expect(summary.enrolled).toBe(0);
+    expect(await countEnrollments(pointerId, contactId)).toBe(0);
+  });
+
+  it("única conversa está ARCHIVED e silenciosa há mais que o threshold → NÃO enrolla", async () => {
+    const org = nextOrgId();
+    await seedOrg(org);
+    const { pointerId } = await seedSilenceFlow(org, { thresholdMinutes: 60 });
+    await seedPublishedAgentVersion(org, { enabled: true, pointerIds: [pointerId] });
+    const contactId = await seedContact(org);
+    await seedConversationComStatus(org, contactId, 120, "archived");
+
+    const summary = await runSilenceSweep({ db: silenceSweepDb(), gateDb: pgGateDb(), clock: CLOCK });
+    expect(summary.enrolled).toBe(0);
+    expect(await countEnrollments(pointerId, contactId)).toBe(0);
+  });
+
+  it("conversa CLOSED antiga + conversa OPEN silenciosa (> threshold) do mesmo contato → enrolla pela ABERTA", async () => {
+    const org = nextOrgId();
+    await seedOrg(org);
+    const { pointerId } = await seedSilenceFlow(org, { thresholdMinutes: 60 });
+    await seedPublishedAgentVersion(org, { enabled: true, pointerIds: [pointerId] });
+    const contactId = await seedContact(org);
+    await seedConversationComStatus(org, contactId, 200, "closed"); // ignorada — não é a que decide
+    await seedConversation(org, contactId, 90); // aberta, silenciosa > threshold
+
+    const summary = await runSilenceSweep({ db: silenceSweepDb(), gateDb: pgGateDb(), clock: CLOCK });
+    expect(summary.enrolled).toBe(1);
+    expect(await countEnrollments(pointerId, contactId)).toBe(1);
   });
 
   it("contato cuja ÚNICA conversa nunca recebeu inbound (last_inbound_at NULL) → NÃO enrolla", async () => {

--- a/tests/setup/vitest.setup.ts
+++ b/tests/setup/vitest.setup.ts
@@ -1,6 +1,28 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
+/**
+ * Remove um par de aspas (simples ou duplas) que envolva o valor inteiro —
+ * mesma convenção que `hostgator-setup-kit/install.sh` grava no `.env` de
+ * TODA instalação self-host (`NEXT_PUBLIC_APP_URL="https://${DOMAIN}"`).
+ * Sem isto, um self-hoster que rode `pnpm test:unit` na própria VPS antes de
+ * atualizar vê a suíte inteira falhar com "Variáveis de ambiente inválidas"
+ * (a URL vira `"https://…"` — aspas incluídas — e falha a validação Zod de
+ * `lib/env.ts`), mesmo com o `.env` real e correto. `.env.example` (o
+ * convívio local, sem instalador) não usa aspas — por isso o bug nunca
+ * apareceu em desenvolvimento, só em VPS instalada pelo kit.
+ */
+function stripQuotes(value: string): string {
+  if (value.length >= 2) {
+    const first = value[0];
+    const last = value[value.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return value.slice(1, -1);
+    }
+  }
+  return value;
+}
+
 // Load .env and .env.local before importing any app code that validates env vars
 for (const envFile of [".env", ".env.local"]) {
   try {
@@ -11,7 +33,7 @@ for (const envFile of [".env", ".env.local"]) {
       if (!trimmed || trimmed.startsWith("#")) continue;
       const [key, ...rest] = trimmed.split("=");
       if (key && !process.env[key]) {
-        process.env[key] = rest.join("=");
+        process.env[key] = stripQuotes(rest.join("=").trim());
       }
     }
   } catch {

--- a/tests/unit/appointment-stage-move.test.ts
+++ b/tests/unit/appointment-stage-move.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { emitLeadActivity } from "@/lib/leads/activity-emitter";
+import {
+  moverLeadParaEtapaDeAgendamento,
+  SLUG_ETAPA_POR_TRANSICAO,
+} from "@/lib/leads/appointment-stage-move";
+
+vi.mock("@/lib/leads/activity-emitter", async (orig) => ({
+  ...(await orig<typeof import("@/lib/leads/activity-emitter")>()),
+  emitLeadActivity: vi.fn(async () => ({ ok: true })),
+}));
+
+const ORG = "org-1";
+const LEAD = {
+  id: "lead-1",
+  pipeline_id: "pipe-1",
+  stage_id: "s1",
+  contact_id: "contato-1",
+  status: "open",
+};
+const ETAPA_AGENDADO = { id: "s-agendado", name: "Agendado" };
+const ETAPA_ORIGEM = { name: "Agendamento solicitado" };
+
+interface Resposta {
+  data: unknown;
+  error: { message: string } | null;
+}
+interface Cenario {
+  lead: Resposta;
+  etapaDestino: Resposta;
+  update: Resposta;
+  rpcError?: { message: string } | null;
+}
+
+function cenario(over: Partial<Cenario> = {}): Cenario {
+  return {
+    lead: { data: LEAD, error: null },
+    etapaDestino: { data: ETAPA_AGENDADO, error: null },
+    update: { data: [{ id: LEAD.id }], error: null },
+    ...over,
+  };
+}
+
+interface ChamadaRpc {
+  fn: string;
+  args: Record<string, unknown>;
+}
+
+/** Mesmo fake de query builder de `handoff-stage-move.test.ts`. */
+function fakeAdmin(c: Cenario, rpcs: ChamadaRpc[] = []) {
+  return {
+    rpc(fn: string, args: Record<string, unknown>) {
+      rpcs.push({ fn, args });
+      return Promise.resolve({ data: null, error: c.rpcError ?? null });
+    },
+    from(tabela: string) {
+      const b = {
+        _update: false,
+        _select: false,
+        _eqKeys: [] as string[],
+        select: () => {
+          b._select = true;
+          return b;
+        },
+        update: () => {
+          b._update = true;
+          return b;
+        },
+        eq: (key: string) => {
+          b._eqKeys.push(key);
+          return b;
+        },
+        maybeSingle: () => {
+          if (tabela === "crm_leads") return Promise.resolve(c.lead);
+          if (b._eqKeys.includes("slug")) return Promise.resolve(c.etapaDestino);
+          return Promise.resolve({ data: ETAPA_ORIGEM, error: null });
+        },
+        then(onF: (v: unknown) => unknown, onR?: (e: unknown) => unknown) {
+          const r = b._update ? c.update : c.lead;
+          return Promise.resolve(r).then(onF, onR);
+        },
+      };
+      return b;
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+const mover = (c: Cenario, transicao: "pending" | "confirmed" = "confirmed") =>
+  moverLeadParaEtapaDeAgendamento(fakeAdmin(c), {
+    organizationId: ORG,
+    leadId: LEAD.id,
+    transicao,
+  });
+
+async function moverObservando(c: Cenario, transicao: "pending" | "confirmed" = "confirmed") {
+  const rpcs: ChamadaRpc[] = [];
+  const r = await moverLeadParaEtapaDeAgendamento(fakeAdmin(c, rpcs), {
+    organizationId: ORG,
+    leadId: LEAD.id,
+    transicao,
+  });
+  return { r, eventos: rpcs.filter((x) => x.fn === "emit_event") };
+}
+
+describe("moverLeadParaEtapaDeAgendamento", () => {
+  beforeEach(() => vi.mocked(emitLeadActivity).mockClear());
+
+  it("caminho feliz: confirmado move para 'agendado' e emite atividade + evento", async () => {
+    const { r, eventos } = await moverObservando(cenario(), "confirmed");
+    expect(r).toEqual({ moveu: true, motivo: "movido" });
+    expect(vi.mocked(emitLeadActivity)).toHaveBeenCalledTimes(1);
+    expect(eventos).toHaveLength(1);
+    expect(eventos[0]?.args).toMatchObject({
+      p_event_type: "lead.stage_changed",
+      p_payload: expect.objectContaining({ to_stage_id: ETAPA_AGENDADO.id }),
+    });
+  });
+
+  it("pending move para 'agendamento-solicitado'", async () => {
+    const etapa = { id: "s-solicitado", name: "Agendamento solicitado" };
+    const r = await mover(cenario({ etapaDestino: { data: etapa, error: null } }), "pending");
+    expect(r).toEqual({ moveu: true, motivo: "movido" });
+  });
+
+  it("transição sem mapa (ex.: cancelled) é no-op sem tocar o banco", async () => {
+    // @ts-expect-error -- transição fora do vocabulário mapeado, de propósito
+    const r = await mover(cenario(), "cancelled");
+    expect(r).toEqual({ moveu: false, motivo: "transicao_nao_mapeada" });
+    expect(vi.mocked(emitLeadActivity)).not.toHaveBeenCalled();
+  });
+
+  it("pipeline sem a etapa mapeada: no-op, sem mover nem gravar atividade", async () => {
+    const r = await mover(cenario({ etapaDestino: { data: null, error: null } }));
+    expect(r).toEqual({ moveu: false, motivo: "sem_etapa_mapeada" });
+    expect(vi.mocked(emitLeadActivity)).not.toHaveBeenCalled();
+  });
+
+  it("lead já está na etapa alvo: não move de novo", async () => {
+    const r = await mover(
+      cenario({ lead: { data: { ...LEAD, stage_id: ETAPA_AGENDADO.id }, error: null } }),
+    );
+    expect(r).toEqual({ moveu: false, motivo: "ja_esta_la" });
+  });
+
+  it("lead fechado (won/lost) não é movido — deal encerrado não volta ao funil", async () => {
+    const r = await mover(cenario({ lead: { data: { ...LEAD, status: "lost" }, error: null } }));
+    expect(r).toEqual({ moveu: false, motivo: "lead_fechado" });
+    expect(vi.mocked(emitLeadActivity)).not.toHaveBeenCalled();
+  });
+
+  it("lead não encontrado (org errada ou deletado): não move, não é erro de sistema", async () => {
+    const r = await mover(cenario({ lead: { data: null, error: null } }));
+    expect(r).toEqual({ moveu: false, motivo: "lead_nao_encontrado" });
+  });
+
+  it("UPDATE sem linha afetada = humano moveu o card no meio da operação (trava otimista)", async () => {
+    const r = await mover(cenario({ update: { data: [], error: null } }));
+    expect(r).toEqual({ moveu: false, motivo: "conflito_humano" });
+    expect(vi.mocked(emitLeadActivity)).not.toHaveBeenCalled();
+  });
+
+  it("erro no SELECT do lead é indisponibilidade, não 'lead_nao_encontrado'", async () => {
+    const r = await mover(cenario({ lead: { data: null, error: { message: "fetch failed" } } }));
+    expect(r).toEqual({ moveu: false, motivo: "indisponivel" });
+  });
+
+  it("erro no UPDATE é falha_de_escrita", async () => {
+    const r = await mover(cenario({ update: { data: null, error: { message: "constraint violation" } } }));
+    expect(r).toEqual({ moveu: false, motivo: "falha_de_escrita" });
+  });
+
+  it("mapa de slugs é o contrato estável que a tela de Pipelines documenta", () => {
+    expect(SLUG_ETAPA_POR_TRANSICAO).toEqual({
+      pending: "agendamento-solicitado",
+      confirmed: "agendado",
+    });
+  });
+});

--- a/tests/unit/before-send-chain-shape.test.ts
+++ b/tests/unit/before-send-chain-shape.test.ts
@@ -33,6 +33,7 @@ const ORDEM_ESPERADA = [
   "semantic_promise",
   "case_promise",
   "internal_vocabulary",
+  "agenda_stall",
   "disclosure",
 ] as const;
 
@@ -64,8 +65,8 @@ describe("forma da cadeia before_send", () => {
     // O par (tamanho, versão) é o que amarra os dois. Acrescentar um gate sem
     // bumpar deixa o trace de auditoria mentindo sobre qual cadeia rodou — e o
     // trace é justamente a prova que as Fases 0–2 usam para dizer "não regrediu".
-    expect(BEFORE_SEND_GATES).toHaveLength(10);
-    expect(BEFORE_SEND_CHAIN_VERSION).toBe(6);
+    expect(BEFORE_SEND_GATES).toHaveLength(11);
+    expect(BEFORE_SEND_CHAIN_VERSION).toBe(7);
   });
 
   it("internal_vocabulary roda ANTES do disclosure — inspeciona o texto do modelo, não o emendado", () => {
@@ -75,6 +76,12 @@ describe("forma da cadeia before_send", () => {
     const nomes = BEFORE_SEND_GATES.map((g) => g.name);
     expect(nomes.indexOf("internal_vocabulary")).toBeLessThan(nomes.indexOf("disclosure"));
     expect(nomes.indexOf("internal_vocabulary")).toBe(nomes.indexOf("case_promise") + 1);
+  });
+
+  it("agenda_stall roda ANTES do disclosure e DEPOIS do internal_vocabulary — mesma razão: texto do modelo, não o emendado", () => {
+    const nomes = BEFORE_SEND_GATES.map((g) => g.name);
+    expect(nomes.indexOf("agenda_stall")).toBeLessThan(nomes.indexOf("disclosure"));
+    expect(nomes.indexOf("agenda_stall")).toBe(nomes.indexOf("internal_vocabulary") + 1);
   });
 
   it("nenhum gate repetido — nome duplicado quebraria a leitura do trace", () => {

--- a/tests/unit/gate-agenda-stall.test.ts
+++ b/tests/unit/gate-agenda-stall.test.ts
@@ -1,0 +1,155 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  agendaStallGate,
+  BEFORE_SEND_GATES,
+  type GateContext,
+} from "@/lib/agent-engine/guardrails/before-send";
+import { PACING_DEFAULTS } from "@/lib/agent-engine/pacing/defaults";
+import { SPINNING_DEFAULTS } from "@/lib/agent-engine/spinning/defaults";
+
+/**
+ * O GATE de "vou verificar/confirmar agenda sem checar" — a cura DETERMINÍSTICA para o
+ * `AGENDA_SYSTEM_BLOCK` (instrução em texto, `inbound-turn.ts`) sozinho não bastar. Medido
+ * em produção, 2026-08-29 (tenant YADEA, `openai/gpt-5.6-terra`): a instrução estava presente
+ * e por último no prompt, e o modelo prometeu verificar/confirmar horário sem chamar
+ * `crm_find_free_slots`/`crm_book_appointment`/`crm_reschedule_appointment` mesmo assim.
+ *
+ * `baseCtx` é próprio deste arquivo — mesma decisão de `gate-vazamento-interno.test.ts`
+ * (sem fixture compartilhada de `GateContext`, pra um gate não herdar o contexto calibrado
+ * para outro).
+ */
+function baseCtx(overrides: Partial<GateContext> = {}): GateContext {
+  return {
+    now: new Date("2026-08-29T13:57:00Z"),
+    body: "",
+    optedOut: false,
+    provider: "waha",
+    pacing: {
+      knobs: PACING_DEFAULTS,
+      state: { lastSentAt: null, sentToday: 0, numberActivatedAt: null },
+      crmDailyLimit: null,
+    },
+    spinning: { knobs: SPINNING_DEFAULTS, window: [] },
+    promise: { table: null },
+    semanticPromise: null,
+    disclosure: { template: null, isFirstOutbound: false, mode: "inject" },
+    lgpd: null,
+    casesEnabled: false,
+    hasOpenCase: false,
+    openedCaseThisTurn: false,
+    ...overrides,
+  };
+}
+
+const FRASE_MEDIDA_1 =
+  "😄 Isso! Sobre a segunda de manhã, vou verificar as opções de horário para a avaliação " +
+  "da sua moto e te passo assim que tiver a confirmação.";
+const FRASE_MEDIDA_2 =
+  "Cristiano, estou confirmando com a equipe os horários disponíveis para segunda-feira " +
+  "de manhã e já te passo as opções.";
+
+describe("agendaStallGate — veta a promessa vazia, nunca a checagem de verdade", () => {
+  it("veta a frase medida em produção quando armado e a ferramenta não rodou", () => {
+    const v = agendaStallGate.evaluate(
+      baseCtx({ agenda: { active: true, toolCalledThisTurn: false }, body: FRASE_MEDIDA_1 }),
+    );
+    expect(v.pass).toBe(false);
+    if (v.pass) throw new Error("inalcançável");
+    expect(v.code).toBe("agenda_stall_sem_ferramenta");
+  });
+
+  it("veta a segunda frase medida (deferência 'com a equipe')", () => {
+    const v = agendaStallGate.evaluate(
+      baseCtx({ agenda: { active: true, toolCalledThisTurn: false }, body: FRASE_MEDIDA_2 }),
+    );
+    expect(v.pass).toBe(false);
+  });
+
+  it("DESARMADO (campo ausente) é no-op — caller que não conhece agenda não arma nada", () => {
+    const v = agendaStallGate.evaluate(baseCtx({ body: FRASE_MEDIDA_1 }));
+    expect(v.pass).toBe(true);
+  });
+
+  it("agente sem crm_book_appointment (active: false) é no-op mesmo com a frase", () => {
+    const v = agendaStallGate.evaluate(
+      baseCtx({ agenda: { active: false, toolCalledThisTurn: false }, body: FRASE_MEDIDA_1 }),
+    );
+    expect(v.pass).toBe(true);
+  });
+
+  it("a ferramenta JÁ rodou neste turno: a MESMA frase passa — checou de verdade", () => {
+    const v = agendaStallGate.evaluate(
+      baseCtx({ agenda: { active: true, toolCalledThisTurn: true }, body: FRASE_MEDIDA_1 }),
+    );
+    expect(v.pass).toBe(true);
+  });
+
+  it("fala legítima sobre agenda, sem promessa vazia, passa mesmo sem a ferramenta ter rodado", () => {
+    // "Amanhã, a oficina abre às 9h" — frase real da mesma conversa medida, dita ANTES do
+    // lead pedir confirmação. Não é "vou verificar/confirmar": não deve ser vetada.
+    const v = agendaStallGate.evaluate(
+      baseCtx({
+        agenda: { active: true, toolCalledThisTurn: false },
+        body: "Amanhã, a oficina abre às 9h. Posso agendar a avaliação para esse horário.",
+      }),
+    );
+    expect(v.pass).toBe(true);
+  });
+
+  it("'vou verificar' fora de contexto de agenda (outro assunto) passa — o padrão exige substantivo de agenda por perto", () => {
+    const v = agendaStallGate.evaluate(
+      baseCtx({
+        agenda: { active: true, toolCalledThisTurn: false },
+        body: "Vou verificar o seu endereço de entrega e já te retorno.",
+      }),
+    );
+    expect(v.pass).toBe(true);
+  });
+
+  it("a razão do veto nomeia as três ferramentas — o modelo precisa saber QUAL chamar", () => {
+    const v = agendaStallGate.evaluate(
+      baseCtx({ agenda: { active: true, toolCalledThisTurn: false }, body: FRASE_MEDIDA_1 }),
+    );
+    if (v.pass) throw new Error("inalcançável");
+    expect(v.reason).toContain("crm_find_free_slots");
+    expect(v.reason).toContain("crm_book_appointment");
+    expect(v.reason).toContain("crm_reschedule_appointment");
+  });
+
+  it("está na cadeia global e é o mesmo objeto exportado", () => {
+    expect(BEFORE_SEND_GATES).toContain(agendaStallGate);
+  });
+});
+
+/**
+ * FIAÇÃO — mesmo padrão de `gate-vazamento-interno.test.ts`: prova que o campo chega da
+ * fonte real (`send_message` em `inbound-turn.ts`), não só que o gate decide certo isolado.
+ */
+const FONTE_INBOUND = fs.readFileSync(
+  path.join(process.cwd(), "lib/agent-engine/agent/inbound-turn.ts"),
+  "utf8",
+);
+
+describe("fiação do gate — a EXECUÇÃO da ferramenta de agenda arma o sinal, não a decisão de chamar", () => {
+  it("send_message passa `agenda` calculado a partir de toolIds e da flag de execução", () => {
+    const i = FONTE_INBOUND.indexOf("send_message: tool({");
+    const j = FONTE_INBOUND.indexOf("update_lead_state: tool({", i);
+    expect(i).toBeGreaterThan(-1);
+    expect(j).toBeGreaterThan(i);
+    const corpo = FONTE_INBOUND.slice(i, j);
+    expect(corpo).toMatch(/agentConfig\.toolIds\.includes\('crm_book_appointment'\)/);
+    expect(corpo).toMatch(/toolCalledThisTurn:\s*agendaToolCalledThisTurn/);
+  });
+
+  it("as três tools de agenda são marcadas na montagem — não só crm_book_appointment", () => {
+    expect(FONTE_INBOUND).toMatch(/AGENDA_TOOL_NAMES = new Set\(\[/);
+    expect(FONTE_INBOUND).toContain("'crm_find_free_slots'");
+    expect(FONTE_INBOUND).toContain("'crm_book_appointment'");
+    expect(FONTE_INBOUND).toContain("'crm_reschedule_appointment'");
+    expect(FONTE_INBOUND).toMatch(/agendaToolCalledThisTurn = true/);
+  });
+});

--- a/tests/unit/gate-agenda-stall.test.ts
+++ b/tests/unit/gate-agenda-stall.test.ts
@@ -110,6 +110,53 @@ describe("agendaStallGate — veta a promessa vazia, nunca a checagem de verdade
     expect(v.pass).toBe(true);
   });
 
+  // Frase EXATA do incidente original (2026-08-29, tenant YADEA) que deu origem a este
+  // gate — uma afirmação de FATO CONSUMADO, não uma promessa de checar. O
+  // AGENDA_STALL_PATTERN sozinho não cobre ("vou/estou" + verbo de checagem não aparece
+  // aqui), e passava batido mesmo com o gate armado até o AGENDA_CONFIRMED_PATTERN existir.
+  it("veta confirmação categórica sem checar de verdade ('está confirmado')", () => {
+    const v = agendaStallGate.evaluate(
+      baseCtx({
+        agenda: { active: true, toolCalledThisTurn: false },
+        body: "Perfeito, Cristiano! 😊 Seu agendamento está confirmado para amanhã às 9h.",
+      }),
+    );
+    expect(v.pass).toBe(false);
+    if (v.pass) throw new Error("inalcançável");
+    expect(v.code).toBe("agenda_stall_sem_ferramenta");
+    expect(v.reason).toContain("afirmou");
+  });
+
+  it("veta a variante 'está certinho' (segunda frase medida do mesmo incidente)", () => {
+    const v = agendaStallGate.evaluate(
+      baseCtx({
+        agenda: { active: true, toolCalledThisTurn: false },
+        body: "Confirmando: seu agendamento está certinho para amanhã às 9h.",
+      }),
+    );
+    expect(v.pass).toBe(false);
+  });
+
+  it("confirmação categórica passa quando a ferramenta JÁ rodou neste turno", () => {
+    const v = agendaStallGate.evaluate(
+      baseCtx({
+        agenda: { active: true, toolCalledThisTurn: true },
+        body: "Seu agendamento está confirmado para amanhã às 9h.",
+      }),
+    );
+    expect(v.pass).toBe(true);
+  });
+
+  it("'o agendamento está uma bagunça' (sem particípio de confirmação) não é falso positivo", () => {
+    const v = agendaStallGate.evaluate(
+      baseCtx({
+        agenda: { active: true, toolCalledThisTurn: false },
+        body: "O agendamento está uma bagunça esse mês, mas isso é outro assunto.",
+      }),
+    );
+    expect(v.pass).toBe(true);
+  });
+
   it("a razão do veto nomeia as três ferramentas — o modelo precisa saber QUAL chamar", () => {
     const v = agendaStallGate.evaluate(
       baseCtx({ agenda: { active: true, toolCalledThisTurn: false }, body: FRASE_MEDIDA_1 }),

--- a/tests/unit/handoff-fernando-fiacao.test.ts
+++ b/tests/unit/handoff-fernando-fiacao.test.ts
@@ -1,0 +1,74 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * FIAÇÃO — mesmo padrão de `gate-agenda-stall.test.ts`/`gate-vazamento-interno.test.ts`:
+ * prova que os pontos de conserto do handoff "fantasma" pro Fernando (achado em
+ * produção, tenant YADEA — o bot dizia "vou verificar com o Fernando" repetidas
+ * vezes sem nunca abrir caso nem mover o funil) estão de fato ligados na fonte,
+ * não só implementados isolados.
+ */
+const FONTE_INBOUND = fs.readFileSync(
+  path.join(process.cwd(), "lib/agent-engine/agent/inbound-turn.ts"),
+  "utf8",
+);
+const FONTE_INGEST = fs.readFileSync(path.join(process.cwd(), "lib/waha/ingest.ts"), "utf8");
+
+describe("fiação — casePromiseGate recebe o nome do gerente do tenant", () => {
+  it("send_message passa humanPromiseExtraTargets a partir de agentConfig.handoffKeywords", () => {
+    const i = FONTE_INBOUND.indexOf("send_message: tool({");
+    const j = FONTE_INBOUND.indexOf("update_lead_state: tool({", i);
+    expect(i).toBeGreaterThan(-1);
+    expect(j).toBeGreaterThan(i);
+    const corpo = FONTE_INBOUND.slice(i, j);
+    expect(corpo).toMatch(/humanPromiseExtraTargets:\s*agentConfig\?\.handoffKeywords/);
+  });
+});
+
+describe("fiação — caso humano aberto move o lead pra etapa de handoff", () => {
+  it("o fail-safe do case_promise (auto-abre-caso) chama moverParaHandoffBestEffort", () => {
+    const i = FONTE_INBOUND.indexOf("chain.status === 'vetoed' && chain.code === 'case_promise_without_case'");
+    expect(i).toBeGreaterThan(-1);
+    const janela = FONTE_INBOUND.slice(i, i + 1800);
+    expect(janela).toMatch(/openedCaseThisTurn = true;\s*\n\s*moverParaHandoffBestEffort\(/);
+  });
+
+  it("a tool open_human_case (caso deliberado do modelo) também chama moverParaHandoffBestEffort", () => {
+    const i = FONTE_INBOUND.indexOf("rawTools.open_human_case = tool({");
+    expect(i).toBeGreaterThan(-1);
+    const janela = FONTE_INBOUND.slice(i, i + 1500);
+    expect(janela).toMatch(/openedCaseThisTurn = true;\s*\n\s*moverParaHandoffBestEffort\(/);
+  });
+
+  it("moverParaHandoffBestEffort é best-effort — nunca derruba o turno (.catch, não throw)", () => {
+    const i = FONTE_INBOUND.indexOf("const moverParaHandoffBestEffort = ");
+    expect(i).toBeGreaterThan(-1);
+    const janela = FONTE_INBOUND.slice(i, i + 500);
+    expect(janela).toContain(".catch(");
+  });
+});
+
+describe("fiação — lead urgente represado pelo cap de warm-up gera alerta crítico", () => {
+  it("o bloco de reagendamento por cap checa detectUrgencySignal e abre agent_inbox_items kind='handoff'", () => {
+    const i = FONTE_INBOUND.indexOf("pacingCapVeto !== null && outcomes.length === 0");
+    expect(i).toBeGreaterThan(-1);
+    const janela = FONTE_INBOUND.slice(i, i + 2000);
+    expect(janela).toContain("detectUrgencySignal(inboundSignal)");
+    expect(janela).toMatch(/kind:\s*'handoff'/);
+    expect(janela).toMatch(/severity:\s*'critical'/);
+  });
+});
+
+describe("fiação — resposta manual pelo WhatsApp silencia o bot temporariamente", () => {
+  it("handleOutboundFromUserPhone chama silenciarBotPorRetomadaHumana depois de registrar a mensagem", () => {
+    const i = FONTE_INGEST.indexOf("async function handleOutboundFromUserPhone(");
+    expect(i).toBeGreaterThan(-1);
+    const j = FONTE_INGEST.indexOf("async function handleAck(", i);
+    expect(j).toBeGreaterThan(i);
+    const corpo = FONTE_INGEST.slice(i, j);
+    expect(corpo).toContain('sent_via: "external_device"');
+    expect(corpo).toContain("silenciarBotPorRetomadaHumana(admin, session.organization_id, conversationId)");
+  });
+});

--- a/tests/unit/handoff-stage-move.test.ts
+++ b/tests/unit/handoff-stage-move.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { emitLeadActivity } from "@/lib/leads/activity-emitter";
+import {
+  moverLeadParaEtapaDeHandoff,
+  SLUG_ETAPA_HANDOFF,
+} from "@/lib/leads/handoff-stage-move";
+
+vi.mock("@/lib/leads/activity-emitter", async (orig) => ({
+  ...(await orig<typeof import("@/lib/leads/activity-emitter")>()),
+  emitLeadActivity: vi.fn(async () => ({ ok: true })),
+}));
+
+const ORG = "org-1";
+const LEAD = {
+  id: "lead-1",
+  pipeline_id: "pipe-1",
+  stage_id: "s1",
+  contact_id: "contato-1",
+  status: "open",
+};
+const ETAPA_HANDOFF = { id: "s-handoff", name: "Chamar Humano" };
+const ETAPA_ORIGEM = { name: "Agendado" };
+
+interface Resposta {
+  data: unknown;
+  error: { message: string } | null;
+}
+interface Cenario {
+  lead: Resposta;
+  etapaDestino: Resposta;
+  update: Resposta;
+  rpcError?: { message: string } | null;
+}
+
+function cenario(over: Partial<Cenario> = {}): Cenario {
+  return {
+    lead: { data: LEAD, error: null },
+    etapaDestino: { data: ETAPA_HANDOFF, error: null },
+    update: { data: [{ id: LEAD.id }], error: null },
+    ...over,
+  };
+}
+
+interface ChamadaRpc {
+  fn: string;
+  args: Record<string, unknown>;
+}
+
+/**
+ * Fake do query builder, no mesmo espírito do de `agent-stage-sync.test.ts`:
+ * thenable, distingue SELECT de UPDATE, e diferencia as DUAS consultas em
+ * `crm_stages` (etapa de destino vs. nome da etapa de origem) pelas chaves
+ * passadas a `.eq()` — a de destino filtra por `slug`, a de origem não.
+ */
+function fakeAdmin(c: Cenario, rpcs: ChamadaRpc[] = []) {
+  return {
+    rpc(fn: string, args: Record<string, unknown>) {
+      rpcs.push({ fn, args });
+      return Promise.resolve({ data: null, error: c.rpcError ?? null });
+    },
+    from(tabela: string) {
+      const b = {
+        _update: false,
+        _select: false,
+        _eqKeys: [] as string[],
+        select: () => {
+          b._select = true;
+          return b;
+        },
+        update: () => {
+          b._update = true;
+          return b;
+        },
+        eq: (key: string) => {
+          b._eqKeys.push(key);
+          return b;
+        },
+        maybeSingle: () => {
+          if (tabela === "crm_leads") return Promise.resolve(c.lead);
+          if (b._eqKeys.includes("slug")) return Promise.resolve(c.etapaDestino);
+          return Promise.resolve({ data: ETAPA_ORIGEM, error: null });
+        },
+        then(onF: (v: unknown) => unknown, onR?: (e: unknown) => unknown) {
+          const r = b._update ? c.update : c.lead;
+          return Promise.resolve(r).then(onF, onR);
+        },
+      };
+      return b;
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+const mover = (c: Cenario) =>
+  moverLeadParaEtapaDeHandoff(fakeAdmin(c), {
+    organizationId: ORG,
+    leadId: LEAD.id,
+    reason: "requested_human",
+  });
+
+async function moverObservando(c: Cenario) {
+  const rpcs: ChamadaRpc[] = [];
+  const r = await moverLeadParaEtapaDeHandoff(fakeAdmin(c, rpcs), {
+    organizationId: ORG,
+    leadId: LEAD.id,
+    reason: "requested_human",
+  });
+  return { r, eventos: rpcs.filter((x) => x.fn === "emit_event") };
+}
+
+describe("moverLeadParaEtapaDeHandoff", () => {
+  beforeEach(() => vi.mocked(emitLeadActivity).mockClear());
+
+  it("caminho feliz: move para a etapa de handoff e emite atividade + evento", async () => {
+    const { r, eventos } = await moverObservando(cenario());
+    expect(r).toEqual({ moveu: true, motivo: "movido" });
+    expect(vi.mocked(emitLeadActivity)).toHaveBeenCalledTimes(1);
+    expect(eventos).toHaveLength(1);
+    expect(eventos[0]?.args).toMatchObject({
+      p_event_type: "lead.stage_changed",
+      p_payload: expect.objectContaining({ to_stage_id: ETAPA_HANDOFF.id }),
+    });
+  });
+
+  it("pipeline sem etapa 'chamar-humano': no-op, sem mover nem gravar atividade", async () => {
+    const r = await mover(cenario({ etapaDestino: { data: null, error: null } }));
+    expect(r).toEqual({ moveu: false, motivo: "sem_etapa_de_handoff" });
+    expect(vi.mocked(emitLeadActivity)).not.toHaveBeenCalled();
+  });
+
+  it("lead já está na etapa de handoff: não move de novo", async () => {
+    const r = await mover(
+      cenario({ lead: { data: { ...LEAD, stage_id: ETAPA_HANDOFF.id }, error: null } }),
+    );
+    expect(r).toEqual({ moveu: false, motivo: "ja_esta_la" });
+  });
+
+  it("lead fechado (won/lost) não é movido — deal encerrado não volta ao funil", async () => {
+    const r = await mover(cenario({ lead: { data: { ...LEAD, status: "won" }, error: null } }));
+    expect(r).toEqual({ moveu: false, motivo: "lead_fechado" });
+    expect(vi.mocked(emitLeadActivity)).not.toHaveBeenCalled();
+  });
+
+  it("lead não encontrado (org errada ou deletado): não move, não é erro de sistema", async () => {
+    const r = await mover(cenario({ lead: { data: null, error: null } }));
+    expect(r).toEqual({ moveu: false, motivo: "lead_nao_encontrado" });
+  });
+
+  it("UPDATE sem linha afetada = humano moveu o card no meio da operação (trava otimista)", async () => {
+    const r = await mover(cenario({ update: { data: [], error: null } }));
+    expect(r).toEqual({ moveu: false, motivo: "conflito_humano" });
+    expect(vi.mocked(emitLeadActivity)).not.toHaveBeenCalled();
+  });
+
+  it("erro no SELECT do lead é indisponibilidade, não 'lead_nao_encontrado'", async () => {
+    const r = await mover(cenario({ lead: { data: null, error: { message: "fetch failed" } } }));
+    expect(r).toEqual({ moveu: false, motivo: "indisponivel" });
+  });
+
+  it("erro no UPDATE é falha_de_escrita", async () => {
+    const r = await mover(cenario({ update: { data: null, error: { message: "constraint violation" } } }));
+    expect(r).toEqual({ moveu: false, motivo: "falha_de_escrita" });
+  });
+
+  it("SLUG_ETAPA_HANDOFF é o slug estável que a tela de Provedores/Pipelines deve usar", () => {
+    expect(SLUG_ETAPA_HANDOFF).toBe("chamar-humano");
+  });
+});

--- a/tests/unit/painel-de-seguranca.test.tsx
+++ b/tests/unit/painel-de-seguranca.test.tsx
@@ -128,9 +128,10 @@ describe("painel de segurança — o que se confere antes de enviar", () => {
     renderPainel();
 
     const fixas = CONFERENCIAS_DE_SAIDA.filter((c) => c.escolha === null);
-    // 9 das 10 hoje. A contagem entra na asserção de propósito: se alguém tornar
+    // 10 das 11 hoje (subiu de 9/10 quando `agenda_stall` entrou na cadeia — ver
+    // `before-send.ts`). A contagem entra na asserção de propósito: se alguém tornar
     // uma delas "configurável", este número muda e a mudança tem de ser deliberada.
-    expect(fixas).toHaveLength(9);
+    expect(fixas).toHaveLength(10);
     for (const c of fixas) {
       const linha = screen.getByTestId(`conferencia-${c.nome}-fixa`);
       expect(linha.textContent).toContain("não se desliga");
@@ -141,7 +142,7 @@ describe("painel de segurança — o que se confere antes de enviar", () => {
 
   it("as configuráveis dizem o CUSTO — é o que torna a escolha uma escolha", () => {
     // O custo é a única razão pela qual estas duas são configuráveis e as outras
-    // nove não. Sem o número na tela, o interruptor vira preferência estética.
+    // dez não. Sem o número na tela, o interruptor vira preferência estética.
     //
     // A frase de ONDE a decisão vem tem caso próprio abaixo: ela depende do
     // estado carregado, e misturar as duas fazia esta asserção medir o texto de

--- a/tests/unit/silenciar-bot-retomada-humana.test.ts
+++ b/tests/unit/silenciar-bot-retomada-humana.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+
+// ingest.ts importa @/lib/audit (→ supabase/server → validação de env); a função
+// testada aqui é isolada, mock corta a cadeia (mesmo padrão de waha-ingest-media.test.ts).
+vi.mock("@/lib/audit", () => ({ audit: vi.fn() }));
+
+import {
+  HUMAN_TAKEOVER_SILENCE_MS,
+  silenciarBotPorRetomadaHumana,
+  type Admin,
+} from "@/lib/waha/ingest";
+
+const ORG_ID = "23fe2ca9-7316-45eb-8b09-d607cb9696eb";
+const CONV_ID = "beaa6819-72f8-4a7c-80c0-75d2a033b564";
+
+/**
+ * Dublê mínimo do client Supabase admin — só o suficiente para o caminho
+ * `.from("conversations").select(...).eq().eq().maybeSingle()` (leitura) e
+ * `.from("conversations").update(...).eq().eq()` (escrita, thenable direto, sem
+ * `.select()`/`.single()` — o código não lê a linha de volta).
+ */
+function fakeAdmin(opts: {
+  existing?: string | null;
+  selectError?: { message: string };
+  updateError?: { message: string };
+  onUpdate?: (patch: Record<string, unknown>) => void;
+}): Admin {
+  const selectChain = {
+    eq: () => selectChain,
+    maybeSingle: () =>
+      Promise.resolve(
+        opts.selectError
+          ? { data: null, error: opts.selectError }
+          : { data: { bot_silenced_until: opts.existing ?? null }, error: null },
+      ),
+  };
+  const updateChain = {
+    eq: () => updateChain,
+    then: (resolve: (v: { error: { message: string } | null }) => unknown) =>
+      Promise.resolve({ error: opts.updateError ?? null }).then(resolve),
+  };
+  return {
+    from: () => ({
+      select: () => selectChain,
+      update: (patch: Record<string, unknown>) => {
+        opts.onUpdate?.(patch);
+        return updateChain;
+      },
+    }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+/**
+ * `silenciarBotPorRetomadaHumana` — ver docstring em `lib/waha/ingest.ts`. Cobre a
+ * lacuna medida em produção (tenant YADEA): um humano respondeu direto pelo
+ * WhatsApp, o bot não foi silenciado, e na mensagem seguinte do lead voltou a
+ * rodar sozinho, alucinando sobre algo que só o humano tinha tratado (PIX).
+ */
+describe("silenciarBotPorRetomadaHumana", () => {
+  it("sem silêncio prévio, grava bot_silenced_until = agora + HUMAN_TAKEOVER_SILENCE_MS", async () => {
+    let patchGravado: Record<string, unknown> | null = null;
+    const antes = Date.now();
+    await silenciarBotPorRetomadaHumana(
+      fakeAdmin({ existing: null, onUpdate: (p) => (patchGravado = p) }),
+      ORG_ID,
+      CONV_ID,
+    );
+    expect(patchGravado).not.toBeNull();
+    const gravado = new Date((patchGravado as unknown as { bot_silenced_until: string }).bot_silenced_until).getTime();
+    expect(gravado).toBeGreaterThanOrEqual(antes + HUMAN_TAKEOVER_SILENCE_MS - 1000);
+    expect(gravado).toBeLessThanOrEqual(Date.now() + HUMAN_TAKEOVER_SILENCE_MS + 1000);
+  });
+
+  it("silêncio 'infinity' (handoff formal) NUNCA é encurtado", async () => {
+    let chamouUpdate = false;
+    await silenciarBotPorRetomadaHumana(
+      fakeAdmin({ existing: "infinity", onUpdate: () => (chamouUpdate = true) }),
+      ORG_ID,
+      CONV_ID,
+    );
+    expect(chamouUpdate).toBe(false);
+  });
+
+  it("silêncio mais longo já em vigor (ex.: handoff manual de 6h) não é encurtado pras 3h padrão", async () => {
+    let chamouUpdate = false;
+    const daquiA6h = new Date(Date.now() + 6 * 60 * 60 * 1000).toISOString();
+    await silenciarBotPorRetomadaHumana(
+      fakeAdmin({ existing: daquiA6h, onUpdate: () => (chamouUpdate = true) }),
+      ORG_ID,
+      CONV_ID,
+    );
+    expect(chamouUpdate).toBe(false);
+  });
+
+  it("silêncio mais curto já vencido (ou no passado) É estendido pra janela padrão", async () => {
+    let chamouUpdate = false;
+    const jaPassou = new Date(Date.now() - 60_000).toISOString();
+    await silenciarBotPorRetomadaHumana(
+      fakeAdmin({ existing: jaPassou, onUpdate: () => (chamouUpdate = true) }),
+      ORG_ID,
+      CONV_ID,
+    );
+    expect(chamouUpdate).toBe(true);
+  });
+
+  it("falha de leitura não lança — best-effort, só loga", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      silenciarBotPorRetomadaHumana(fakeAdmin({ selectError: { message: "boom" } }), ORG_ID, CONV_ID),
+    ).resolves.toBeUndefined();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("falha de escrita não lança — best-effort, só loga", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      silenciarBotPorRetomadaHumana(fakeAdmin({ existing: null, updateError: { message: "boom" } }), ORG_ID, CONV_ID),
+    ).resolves.toBeUndefined();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/tests/unit/sinal-de-urgencia.test.ts
+++ b/tests/unit/sinal-de-urgencia.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { detectUrgencySignal } from "@/lib/agent-engine/guardrails/sinal-de-urgencia";
+
+/**
+ * Detector de urgência/segurança — usado só para priorizar o alerta na Central
+ * quando o turno é adiado por cap de envio (warm-up/diário), nunca para vetar ou
+ * alterar a resposta do modelo. Ver `inbound-turn.ts`, bloco `pacingCapVeto`.
+ */
+
+const URGENT: readonly string[] = [
+  "isso é urgente, preciso de ajuda",
+  "socorro, não sei o que fazer",
+  "a moto pegou fogo!",
+  "senti um cheiro de queimado saindo do painel",
+  "vi uma fumaça saindo do compartimento da bateria",
+  "tive um choque elétrico ao encostar",
+  "meu freio não funciona",
+  "estou sem freio, o que eu faço",
+  "a bateria está aquecendo muito, tenho medo",
+  "aquecimento anormal no motor",
+  "risco de vida, por favor respondam",
+];
+
+const NOT_URGENT: readonly string[] = [
+  "bom dia, tudo bem?",
+  "gostaria de agendar uma revisão pra semana que vem",
+  "quanto custa a manutenção?",
+  "obrigado, até mais",
+  "minha moto está fazendo um barulho estranho",
+  "o agendamento está uma bagunça esse mês",
+];
+
+describe("detectUrgencySignal — léxico genérico de risco/emergência", () => {
+  it.each(URGENT)("DETECTA sinal de urgência: %s", (body) => {
+    expect(detectUrgencySignal(body)).toBe(true);
+  });
+
+  it.each(NOT_URGENT)("NÃO detecta (mensagem comum): %s", (body) => {
+    expect(detectUrgencySignal(body)).toBe(false);
+  });
+
+  it("é robusto a caixa e acento", () => {
+    expect(detectUrgencySignal("CHEIRO DE QUEIMADO NO PAINEL")).toBe(true);
+    expect(detectUrgencySignal("Fumaça saindo da bateria")).toBe(true);
+  });
+
+  it("no-op em string vazia ou só espaço", () => {
+    expect(detectUrgencySignal("")).toBe(false);
+    expect(detectUrgencySignal("   ")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Resumo

Conjunto de correções no agente de IA (caso de uso medido no tenant YADEA,
agente "Ricardo") sobre dois defeitos relacionados: o agente confirmando
agendamento sem checar a agenda de verdade, e o handoff pro humano não
refletindo em lugar nenhum que o CRM devesse mostrar.

- **Agenda nunca fica só "vou verificar"** sem checar de verdade — gate
  determinístico (`agendaStallGate`) veta tanto a promessa de checar quanto a
  afirmação categórica ("está confirmado/certinho") sem chamar
  `crm_find_free_slots`/`crm_book_appointment`/`crm_reschedule_appointment`
  neste turno. Corrigido também um bug real no padrão: `\b` do JS não
  reconhece "á" como letra, então `\best[aá]\b` nunca casava "está" acentuado
  — exatamente as duas frases do incidente original que motivou o gate.
- **Checar/marcar agenda nunca é "fora da autonomia"** do modelo; caso humano
  nunca narra causa técnica ao lead; cap de warm-up sem reagendar perdido.
- **Handoff avisa o CRM, não só (tenta) avisar o lead**:
  - `detectHumanPromise` reconhece nome próprio do tenant ("vou confirmar com
    o Fernando"), não só cargos genéricos — o prompt do tenant nomeia pessoa,
    e o detector deixava passar 100% dessas promessas.
  - Caso humano aberto (deliberado ou pelo fail-safe do `case_promise`) agora
    move o card pra etapa `crm_stages.slug='chamar-humano'` do pipeline
    (opt-in, no-op se o tenant não criou a etapa) — antes o funil ficava
    parado em "Novo contato" com o caso já aberto.
  - Lead relatando risco de segurança (freio, fumaça, bateria esquentando)
    represado pelo cap de warm-up agora abre alerta crítico na Central em vez
    de esperar a mesma fila que um "bom dia".
  - Humano respondendo direto pelo WhatsApp (fora do composer/IA) agora
    silencia o bot por 3h — antes a IA se metia de volta na conversa sem
    saber do que já foi tratado manualmente.
- **Gatilho de silêncio do follow-up** (motor usado pra criar o primeiro
  fluxo real de "lead sumiu, retoma ou encerra") agora ignora conversa que um
  humano já encerrou (`closed`/`archived`) — antes contava como "silenciosa"
  igual a uma conversa ainda ativa.
- **Fix de infra de teste**: o parser de `.env` em `tests/setup/vitest.setup.ts`
  não removia aspas do valor — `hostgator-setup-kit/install.sh` grava TODO
  `.env` de instalação self-host com aspas, então qualquer self-hoster rodando
  `pnpm test:unit` na própria VPS via um vermelho de validação de env que não
  tem nada a ver com o código dele.

## Test plan

- [x] `pnpm typecheck` — zerado
- [x] `pnpm lint` — zerado (só warnings pré-existentes)
- [x] `pnpm test:unit` completo — verde nos arquivos tocados por este PR;
      restam ~5 arquivos vermelhos nesta VPS específica (Google Calendar/
      branding/rate-limit com credenciais reais configuradas), confirmados
      como ruído pré-existente sem relação com o diff
- [ ] `pnpm test:db` (invariantes com Postgres real) — não executado nesta
      sessão (ambiente sem acesso a Docker a partir do container Node
      disponível); os testes novos em `tests/invariants/` seguem o mesmo
      padrão dos vizinhos já cobertos por essa suíte
- [ ] CI do GitHub (`verify`/`invariants`/`build-and-size`/`e2e`/`imagens-ok`)
      — os workflows deste PR (originado de fork) estão em `action_required`,
      aguardando aprovação manual de um mantenedor do repositório

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLvwbgJK4xisK4b5ZMBCcq