### PR TITLE
feat(mcp): a IA passa a escrever nos campos personalizados do funil

### DIFF
--- a/.changes/ia-preenche-campos-do-funil.md
+++ b/.changes/ia-preenche-campos-do-funil.md
@@ -1,0 +1,18 @@
+---
+impacto: capacidade_nova
+secao: adicionado
+titulo: A IA passa a preencher os campos que você criou no funil
+---
+
+Você pode declarar até 50 campos por funil — prescritor, metragem do imóvel,
+convênio, o que o seu negócio precisa — e a ficha do lead desenha todos eles.
+Só que nenhum agente de IA conseguia escrever num campo desses: ele lia a
+conversa, entendia o dado e não tinha onde guardar.
+
+Agora tem. Quando o agente descobre uma informação que você declarou como campo
+do funil, ele grava ali — e a mudança aparece na linha do tempo do lead como
+qualquer outra edição, com o autor identificado.
+
+Nada muda para quem não usa campos personalizados, e nada muda no que os agentes
+já faziam. Quem instrui o agente a preencher um campo passa a ser obedecido; quem
+não instrui, segue igual.

--- a/lib/mcp/tools/leads.test.ts
+++ b/lib/mcp/tools/leads.test.ts
@@ -1,0 +1,82 @@
+/**
+ * O agente consegue escrever nos campos que o dono declarou no funil?
+ *
+ * A cadeia tinha quatro elos e três estavam prontos: `updateLeadSchema` aceitava
+ * `custom_fields`, `updateLeadHandler` fazia o merge com o que já existia, e a
+ * mudança virava atividade na linha do tempo. O quarto — o shape da FERRAMENTA —
+ * não declarava a chave, e como o handler monta `{...rest}` a partir dele, o
+ * valor era descartado antes de chegar ao schema que o aceitaria.
+ *
+ * O modo de falha era mudo: nenhum erro, nenhum log, o `crm_update_lead`
+ * devolvia sucesso e o campo continuava vazio na ficha.
+ *
+ * Por isso o teste não se contenta em olhar o shape. Ele reproduz o caminho do
+ * handler (destructuring + `updateLeadSchema.parse`) e cobra o valor do outro
+ * lado — e traz o CONTROLE NEGATIVO junto: uma chave não declarada tem de
+ * continuar sendo descartada, senão o teste passaria mesmo com o defeito de
+ * volta, provando apenas que zod aceita objeto.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { updateLeadSchema } from "@/lib/schemas/leads";
+
+import { crmUpdateLead } from "./leads";
+
+/** O mesmo caminho do handler: tira `lead_id`, entrega o resto ao schema. */
+function comoOHandlerFaz(entrada: Record<string, unknown>) {
+  const doShape = z.object(crmUpdateLead.inputSchema).parse(entrada);
+  const { lead_id: _ignorado, ...resto } = doShape as Record<string, unknown>;
+  return updateLeadSchema.parse(resto);
+}
+
+const LEAD_ID = "11111111-2222-4333-8444-555555555555";
+
+describe("crm_update_lead — campos personalizados do funil", () => {
+  it("leva o valor até o schema que o handler usa", () => {
+    const saida = comoOHandlerFaz({
+      lead_id: LEAD_ID,
+      custom_fields: { prescritor: "Dra. Ana", forma_farmaceutica: "capsula" },
+    });
+
+    expect(saida.custom_fields).toEqual({
+      prescritor: "Dra. Ana",
+      forma_farmaceutica: "capsula",
+    });
+  });
+
+  it("aceita qualquer chave, porque quem as nomeia é o dono do funil", () => {
+    // O vocabulário é do nicho: uma farmácia de manipulação declara `ativos`,
+    // uma imobiliária declara `metragem`. O schema não pode ter uma lista.
+    const saida = comoOHandlerFaz({
+      lead_id: LEAD_ID,
+      custom_fields: { metragem: 82, aceita_permuta: true, ativos: null },
+    });
+
+    expect(saida.custom_fields).toEqual({
+      metragem: 82,
+      aceita_permuta: true,
+      ativos: null,
+    });
+  });
+
+  it("continua descartando chave que a ferramenta não declara (controle)", () => {
+    // Sem esta asserção, o teste acima passaria mesmo com o defeito de volta:
+    // provaria só que `z.object` aceita um objeto, não que a chave sobrevive.
+    const saida = comoOHandlerFaz({
+      lead_id: LEAD_ID,
+      title: "Fórmula da Dra. Ana",
+      campo_que_ninguem_declarou: "some aqui",
+    });
+
+    expect(saida).not.toHaveProperty("campo_que_ninguem_declarou");
+    expect(saida.title).toBe("Fórmula da Dra. Ana");
+  });
+
+  it("segue opcional — mexer só em tags não obriga a mandar custom_fields", () => {
+    const saida = comoOHandlerFaz({ lead_id: LEAD_ID, tags: ["controlado"] });
+
+    expect(saida.tags).toEqual(["controlado"]);
+    expect(saida.custom_fields).toBeUndefined();
+  });
+});

--- a/lib/mcp/tools/leads.ts
+++ b/lib/mcp/tools/leads.ts
@@ -227,6 +227,21 @@ const updateInputShape = {
     .regex(/^\d{4}-\d{2}-\d{2}$/)
     .optional(),
   tags: z.array(z.string()).optional(),
+  /**
+   * Os campos que o DONO declarou em `pipeline.settings.fields`.
+   *
+   * Faltava aqui, e só aqui: `updateLeadSchema` já aceita a chave, o
+   * `updateLeadHandler` já faz o merge com o que existe, e a mudança já vira
+   * atividade na linha do tempo ("os campos personalizados"). Como o handler
+   * monta `{...rest}` a partir DESTE shape, e `z.object` descarta chave que não
+   * declarou, o valor morria antes de chegar ao schema que o aceitaria.
+   *
+   * Efeito da ausência: o produto deixa criar até 50 campos por funil, desenha
+   * todos na ficha do lead — e nenhum agente conseguia preencher um. Quem
+   * modelou o funil no vocabulário do próprio nicho recebia a IA como leitora,
+   * nunca como escrivã.
+   */
+  custom_fields: z.record(z.string(), z.unknown()).optional(),
 };
 
 export const crmUpdateLead: McpToolDefinition<typeof updateInputShape> = {


### PR DESCRIPTION
## O buraco

O produto deixa declarar até 50 campos personalizados por funil (`pipeline.settings.fields`), desenha todos na ficha do lead — e **nenhum agente de IA consegue preencher um**. Ele lê a conversa, entende o dado e não tem onde guardar.

Não é limitação de desenho: **três dos quatro elos já estavam prontos.**

| Elo | Estado |
|---|---|
| `lib/schemas/leads.ts` — `updateLeadSchema` aceita `custom_fields` | ✅ |
| `app/api/v1/leads/_handler.ts` — `updateLeadHandler` grava e faz merge com o que existe | ✅ |
| `lib/leads/activity-vocabulary.ts` — vira atividade na linha do tempo ("os campos personalizados") | ✅ |
| `lib/mcp/tools/leads.ts` — `updateInputShape` declara a chave | ❌ |

O handler do `crm_update_lead` monta `{...rest}` a partir de `updateInputShape`, e `z.object` descarta chave não declarada. O valor morria antes de alcançar o schema que o aceitaria.

**O modo de falha era mudo:** sem erro, sem log — `crm_update_lead` devolvia sucesso e o campo continuava vazio na ficha.

## A mudança

Uma linha em `updateInputShape`:

```ts
custom_fields: z.record(z.string(), z.unknown()).optional(),
```

`z.record` e não uma lista de chaves porque **quem nomeia os campos é o dono do funil**: uma farmácia de manipulação declara `ativos` e `forma_farmaceutica`, uma imobiliária declara `metragem`. O schema não tem como ter uma lista.

## O teste

`lib/mcp/tools/leads.test.ts` — 4 casos. Ele **não olha o shape**: reproduz o caminho do handler (destructuring de `lead_id` + `updateLeadSchema.parse`) e cobra o valor do outro lado, que é onde o defeito estava.

Traz o **controle negativo** junto: uma chave não declarada tem de continuar sendo descartada. Sem ele, o teste passaria mesmo com o defeito de volta — provaria apenas que zod aceita objeto.

Sabotado para conferir que vigia. Trocando `custom_fields` por outro nome no shape:

```
AssertionError: expected undefined to deeply equal { prescritor: 'Dra. Ana', …(1) }
AssertionError: expected undefined to deeply equal { metragem: 82, …(2) }
 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

Os 2 que continuam passando são exatamente os de controle — que é o desenho.

## Verificação

- `pnpm typecheck` — 0 erros
- `pnpm exec eslint` nos dois arquivos — 0 problemas
- `pnpm exec vitest run lib/mcp/tools/leads.test.ts` — 4 passed
- `pnpm release:conferir` — `1.10.1 + minor = 1.11.0`, 1 fragmento
- `pnpm test:unit` completo: **21 falhas, nenhuma minha.** Rodei os mesmos 10 arquivos em `main` limpa (`26d384c6`) e 20 falham lá também; a 21ª (`namespace-das-imagens`) passa isolada na branch (13/13), então é interferência entre testes na suíte completa, não regressão. Todas parecem de ambiente local (tag do git, telemetria, tradução, marca, env) — se rodarem verdes no CI de vocês, melhor ainda.

## Fragmento

`.changes/ia-preenche-campos-do-funil.md`, `impacto: capacidade_nova`.

## De onde veio

Apareceu numa instalação real: farmácia de manipulação que modelou o funil no vocabulário do próprio nicho (prescritor, ativos, forma farmacêutica, se exige receita física retida) e descobriu que o agente lia tudo isso na conversa e não conseguia gravar em lugar nenhum.
