### PR TITLE
feat(agenda): o lembrete de compromisso passa a sair

### DIFF
--- a/.changes/lembrete-de-agendamento-que-sai.md
+++ b/.changes/lembrete-de-agendamento-que-sai.md
@@ -1,0 +1,22 @@
+---
+impacto: capacidade_nova
+secao: adicionado
+titulo: O lembrete de compromisso passa a sair de verdade
+---
+
+O tipo de agendamento sempre teve "avisar o cliente antes" e quantos minutos
+antes avisar. Você ligava, e nada saía — a configuração existia, o aviso não.
+
+Agora sai. Quem tem compromisso marcado recebe uma mensagem no WhatsApp com o
+que é, quando e onde, na antecedência que você escolheu no tipo de agendamento.
+
+Só chega a quem está vinculado ao compromisso: agendamento sem pessoa vinculada
+continua sendo só uma linha na sua agenda, como era. E o aviso respeita a janela
+de envio do canal — ninguém é acordado às seis da manhã por causa de uma retirada
+às dez.
+
+Quem recusou receber campanha **continua recebendo** o lembrete do próprio
+compromisso: avisar alguém de que o pedido dele está pronto não é propaganda.
+
+Se você quiser escrever o texto do aviso, aponte um modelo de mensagem no campo
+de lembrete do tipo de agendamento — ele passa a valer no lugar do texto padrão.

--- a/app/api/v1/cron/agenda-reminder/route.test.ts
+++ b/app/api/v1/cron/agenda-reminder/route.test.ts
@@ -1,0 +1,149 @@
+/**
+ * O lembrete só é útil se acertar a HORA e não vazar entre organizações.
+ *
+ * As duas regras são testadas de formas diferentes de propósito:
+ *
+ * - `estaNaHora` e `montarLembrete` são puras, então o teste as exercita de
+ *   verdade, inclusive nas bordas (cedo demais, tarde demais, exatamente na
+ *   hora) — que é onde um lembrete deixa de ser lembrete.
+ *
+ * - O isolamento entre organizações é ESTRUTURAL: ele não vive numa função, vive
+ *   no encadeamento da consulta. Montar um dublê de Supabase para provar isso
+ *   testaria o dublê. O que prende é ler a fonte e cobrar o filtro — o mesmo
+ *   estilo de `tests/unit/cron-audita-so-quando-ha-efeito.test.ts`, que varre o
+ *   AST das rotas deste diretório.
+ *
+ * O medo é explícito no código que criou a coluna
+ * (`app/api/v1/agenda/agendamentos/_handler.ts`): "no dia em que o worker de
+ * lembrete nascer, esta linha vira a organização A mandando WhatsApp para o
+ * cliente da B". Este é o dia, e esta é a cerca.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { estaNaHora, montarLembrete } from "./route";
+
+const MIN = 60_000;
+
+describe("estaNaHora", () => {
+  const agora = new Date("2026-08-31T12:00:00Z");
+
+  it("não avisa cedo demais", () => {
+    // compromisso em 3h, antecedência de 60 min: ainda não.
+    const comeca = new Date(agora.getTime() + 180 * MIN);
+    expect(estaNaHora(agora, comeca, 60)).toBe(false);
+  });
+
+  it("avisa quando a antecedência é alcançada", () => {
+    const comeca = new Date(agora.getTime() + 59 * MIN);
+    expect(estaNaHora(agora, comeca, 60)).toBe(true);
+  });
+
+  it("avisa no instante exato da fronteira", () => {
+    const comeca = new Date(agora.getTime() + 60 * MIN);
+    expect(estaNaHora(agora, comeca, 60)).toBe(true);
+  });
+
+  it("NÃO avisa compromisso que já começou", () => {
+    // Lembrar às 15h de uma retirada das 14h não é lembrete, é ruído.
+    const comeca = new Date(agora.getTime() - 1 * MIN);
+    expect(estaNaHora(agora, comeca, 1440)).toBe(false);
+  });
+
+  it("NÃO avisa compromisso que começa exatamente agora", () => {
+    expect(estaNaHora(agora, new Date(agora.getTime()), 1440)).toBe(false);
+  });
+
+  it("antecedência longa não antecipa o que ainda está longe", () => {
+    // 30 dias de antecedência (o teto da coluna) com compromisso em 31 dias.
+    const comeca = new Date(agora.getTime() + 31 * 24 * 60 * MIN);
+    expect(estaNaHora(agora, comeca, 43_200)).toBe(false);
+  });
+});
+
+describe("montarLembrete", () => {
+  const quando = new Date("2026-08-31T12:45:00Z"); // 09:45 em São Paulo
+
+  it("diz o quê, quando e onde", () => {
+    const texto = montarLembrete({
+      nomeDoContato: "Rose",
+      titulo: "Retirada de manipulado — Poços de Caldas",
+      quando,
+      timezone: "America/Sao_Paulo",
+      local: "R. Ceará, 300 — Centro",
+    });
+
+    expect(texto).toContain("Rose");
+    expect(texto).toContain("Retirada de manipulado — Poços de Caldas");
+    expect(texto).toContain("09:45");
+    expect(texto).toContain("R. Ceará, 300 — Centro");
+  });
+
+  it("respeita o fuso da organização", () => {
+    const emManaus = montarLembrete({
+      nomeDoContato: null,
+      titulo: "Retirada",
+      quando,
+      timezone: "America/Manaus", // uma hora atrás de São Paulo
+      local: null,
+    });
+    expect(emManaus).toContain("08:45");
+    expect(emManaus).not.toContain("09:45");
+  });
+
+  it("sem nome, cumprimenta sem inventar", () => {
+    const texto = montarLembrete({
+      nomeDoContato: null,
+      titulo: "Retirada",
+      quando,
+      timezone: "America/Sao_Paulo",
+      local: null,
+    });
+    expect(texto.startsWith("Oi!")).toBe(true);
+    expect(texto).not.toContain("null");
+    expect(texto).not.toContain("undefined");
+  });
+
+  it("sem endereço, não promete um", () => {
+    const texto = montarLembrete({
+      nomeDoContato: "Ana",
+      titulo: "Retirada",
+      quando,
+      timezone: "America/Sao_Paulo",
+      local: null,
+    });
+    expect(texto).not.toContain("Endereço");
+  });
+});
+
+describe("isolamento entre organizações (estrutural)", () => {
+  const fonte = readFileSync(join(__dirname, "route.ts"), "utf8");
+
+  it("resolve o contato DENTRO da organização do compromisso", () => {
+    // O trecho tem de conter a busca em `contacts` filtrada por organization_id.
+    // Sem isso, um contact_id de outra organização viraria WhatsApp enviado ao
+    // cliente dela — o defeito que o handler de agendamentos antecipa.
+    const buscaDeContato = fonte.slice(fonte.indexOf('.from("contacts")'));
+    expect(fonte).toContain('.from("contacts")');
+    expect(buscaDeContato.slice(0, 400)).toContain('.eq("organization_id", org)');
+  });
+
+  it("resolve o canal DENTRO da organização do compromisso", () => {
+    const buscaDeCanal = fonte.slice(fonte.indexOf('.from("channel_sessions")'));
+    expect(fonte).toContain('.from("channel_sessions")');
+    expect(buscaDeCanal.slice(0, 400)).toContain('.eq("organization_id", org)');
+  });
+
+  it("carimba o compromisso DENTRO da organização dele", () => {
+    const carimbo = fonte.slice(fonte.indexOf("reminder_sent_at: new Date()"));
+    expect(carimbo.slice(0, 400)).toContain('.eq("organization_id", org)');
+  });
+
+  it("a organização vem da linha do compromisso, nunca de parâmetro", () => {
+    expect(fonte).toContain("const org = linha.organization_id");
+    // controle: se alguém trocar por leitura de query string, isto reprova.
+    expect(fonte).not.toContain("searchParams.get(\"organization_id\")");
+  });
+});

--- a/app/api/v1/cron/agenda-reminder/route.ts
+++ b/app/api/v1/cron/agenda-reminder/route.ts
@@ -1,0 +1,309 @@
+/**
+ * O LEMBRETE DO COMPROMISSO — o consumidor que faltava.
+ *
+ * A migration 0177 declarou que `calendar_appointments.contact_id` é "quem
+ * recebe o LEMBRETE", `calendar_event_types` ganhou `reminder_enabled` e
+ * `reminder_minutes_before`, a tela oferece os dois — e nada nunca leu
+ * `reminder_sent_at`. O comentário de `app/api/v1/agenda/agendamentos/_handler.ts`
+ * fala desta rota no futuro do pretérito: "no dia em que o worker de lembrete
+ * nascer". Este é o dia.
+ *
+ * Enquanto ele não existia, ligar o lembrete no tipo de agendamento não fazia
+ * nada — e não fazia nada EM SILÊNCIO, que é o caro: quem configurou acreditou
+ * que o paciente seria avisado. Coluna sem consumidor é o anti-pattern nº 3 do
+ * CLAUDE.md deste repo, e este era um deles.
+ *
+ * ═══ O QUE ESTA ROTA DECIDE, E POR QUÊ ═══
+ *
+ * **Lembrete é transacional, não marketing.** Quem recusou receber campanha
+ * continua recebendo aviso do próprio compromisso. `consent.marketing.declined_at`
+ * NÃO barra: esconder de alguém que o pedido dele está pronto não é respeitar a
+ * recusa, é perder a entrega. Bloqueio de contato (`is_blocked`) e ausência de
+ * telefone barram, porque aí não há para onde mandar.
+ *
+ * **A janela de envio vale.** Um lembrete que chega às 6h da manhã é o tipo de
+ * mensagem que faz o número ser denunciado. Fora da janela do canal a rodada
+ * simplesmente não marca `reminder_sent_at`, e a próxima tenta de novo — o
+ * adiamento é o silêncio, não uma fila nova.
+ *
+ * **O carimbo é da TENTATIVA, não da entrega.** `sendMessageHandler` marca
+ * `failed`/`queued` na própria mensagem e devolve normalmente; o estado da
+ * entrega vive lá. Se este carimbo esperasse a entrega, um contato com número
+ * permanentemente inválido receberia uma tentativa a cada 5 minutos até a hora
+ * do compromisso.
+ *
+ * **Compromisso que já começou não gera lembrete.** Avisar às 15h de uma
+ * retirada das 14h não é lembrete, é ruído — e o carimbo some com a linha da
+ * varredura seguinte de qualquer jeito.
+ *
+ * ⚠️ **O contato é resolvido DENTRO da organização do compromisso.** É a
+ * preocupação literal do handler de agendamentos: "esta linha vira a organização
+ * A mandando WhatsApp para o cliente da B". Aqui `organization_id` sai sempre da
+ * linha do compromisso e filtra a busca do contato, da conversa e do canal —
+ * nunca de parâmetro. `tests/unit/agenda-reminder-nao-cruza-tenant.test.ts`
+ * prende isso.
+ */
+import { randomUUID } from "node:crypto";
+
+import type { NextRequest } from "next/server";
+
+import { sendMessageHandler } from "@/app/api/v1/messages/_handler";
+import { ok, fail } from "@/lib/api/wrappers";
+import { audit } from "@/lib/audit";
+import { ensureConversation } from "@/lib/automation/start-conversation";
+import { adiarAteAJanelaAbrir } from "@/lib/automation/janela-do-canal";
+import { espacarEnvio } from "@/lib/automation/throttle";
+import { env } from "@/lib/env";
+import { logger } from "@/lib/logger";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const dynamic = "force-dynamic";
+
+/** Teto de compromissos examinados por rodada — a varredura roda a cada 5 min. */
+const LIMITE_DA_VARREDURA = 200;
+
+/** Maior antecedência aceita pela coluna (43200 min = 30 dias). */
+const MAIOR_ANTECEDENCIA_MS = 43_200 * 60_000;
+
+interface TipoDoCompromisso {
+  name: string;
+  reminder_enabled: boolean;
+  reminder_minutes_before: number;
+  reminder_template_name: string | null;
+  location_details: string | null;
+}
+
+interface CompromissoAVencer {
+  id: string;
+  organization_id: string;
+  contact_id: string;
+  title: string;
+  starts_at: string;
+  location_details: string | null;
+  calendar_event_types: TipoDoCompromisso | TipoDoCompromisso[] | null;
+}
+
+/** O join do PostgREST devolve objeto ou array conforme a cardinalidade inferida. */
+function tipoDe(linha: CompromissoAVencer): TipoDoCompromisso | null {
+  const t = linha.calendar_event_types;
+  if (!t) return null;
+  return Array.isArray(t) ? (t[0] ?? null) : t;
+}
+
+/**
+ * O texto do lembrete.
+ *
+ * `reminder_template_name` é a outra coluna que a 0177 criou e ninguém leu.
+ * Quando ela aponta para um modelo de mensagem da organização, ele vence; sem
+ * ela, sai o texto abaixo, que diz as três coisas que a pessoa precisa saber:
+ * o que é, quando, e onde.
+ */
+export function montarLembrete(input: {
+  nomeDoContato: string | null;
+  titulo: string;
+  quando: Date;
+  timezone: string;
+  local: string | null;
+}): string {
+  const dia = new Intl.DateTimeFormat("pt-BR", {
+    timeZone: input.timezone,
+    weekday: "long",
+    day: "2-digit",
+    month: "2-digit",
+  }).format(input.quando);
+  const hora = new Intl.DateTimeFormat("pt-BR", {
+    timeZone: input.timezone,
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).format(input.quando);
+
+  const saudacao = input.nomeDoContato ? `Oi, ${input.nomeDoContato}!` : "Oi!";
+  const onde = input.local ? ` Endereço: ${input.local}.` : "";
+  return `${saudacao} Passando pra lembrar do seu compromisso: ${input.titulo}, ${dia} às ${hora}.${onde}`;
+}
+
+/**
+ * Está na hora de lembrar?
+ *
+ * Pura, e exportada, porque é a regra que o teste precisa exercitar sem banco:
+ * cedo demais não manda, tarde demais (já começou) também não.
+ */
+export function estaNaHora(agora: Date, comeca: Date, antecedenciaMin: number): boolean {
+  if (comeca.getTime() <= agora.getTime()) return false;
+  return comeca.getTime() - antecedenciaMin * 60_000 <= agora.getTime();
+}
+
+async function handle(req: NextRequest): Promise<Response> {
+  const requestId = randomUUID();
+
+  const auth = req.headers.get("authorization") ?? "";
+  const fornecido = auth.startsWith("Bearer ") ? auth.slice("Bearer ".length).trim() : "";
+  const aceitos = [env.INTERNAL_CRON_SECRET, env.INTERNAL_SECRET].filter(Boolean);
+  if (aceitos.length === 0 || !fornecido || !aceitos.includes(fornecido)) {
+    return fail("forbidden", "Cron secret missing or invalid.", 403, { requestId });
+  }
+
+  const admin = createAdminClient();
+  const agora = new Date();
+
+  // `!inner` no tipo: só interessa compromisso cujo TIPO pede lembrete. O corte
+  // por `starts_at` usa a maior antecedência possível — o corte fino, que depende
+  // do `reminder_minutes_before` de cada linha, é `estaNaHora` logo abaixo.
+  const { data, error } = await admin
+    .from("calendar_appointments")
+    .select(
+      "id, organization_id, contact_id, title, starts_at, location_details, " +
+        "calendar_event_types!inner(name, reminder_enabled, reminder_minutes_before, reminder_template_name, location_details)",
+    )
+    .eq("status", "confirmed")
+    .eq("calendar_event_types.reminder_enabled", true)
+    .not("contact_id", "is", null)
+    .is("reminder_sent_at", null)
+    .gt("starts_at", agora.toISOString())
+    .lte("starts_at", new Date(agora.getTime() + MAIOR_ANTECEDENCIA_MS).toISOString())
+    .order("starts_at", { ascending: true })
+    .limit(LIMITE_DA_VARREDURA);
+
+  if (error) {
+    logger.error("[agenda-reminder] consulta falhou", { error: error.message, requestId });
+    return fail("internal_error", "Falha ao buscar compromissos.", 500, { requestId });
+  }
+
+  const linhas = (data ?? []) as unknown as CompromissoAVencer[];
+  let enviados = 0;
+  let pulados = 0;
+  const motivos: Record<string, number> = {};
+  const pular = (motivo: string) => {
+    pulados += 1;
+    motivos[motivo] = (motivos[motivo] ?? 0) + 1;
+  };
+
+  for (const linha of linhas) {
+    const tipo = tipoDe(linha);
+    if (!tipo) {
+      pular("sem_tipo");
+      continue;
+    }
+    if (!estaNaHora(agora, new Date(linha.starts_at), tipo.reminder_minutes_before)) {
+      pular("ainda_nao");
+      continue;
+    }
+
+    // ⚠️ organization_id SEMPRE da linha do compromisso — ver o cabeçalho.
+    const org = linha.organization_id;
+
+    const { data: contato } = await admin
+      .from("contacts")
+      .select("id, name, display_name, phone_number, is_blocked")
+      .eq("id", linha.contact_id)
+      .eq("organization_id", org)
+      .maybeSingle();
+
+    if (!contato) {
+      pular("contato_fora_da_org");
+      continue;
+    }
+    if (contato.is_blocked) {
+      pular("contato_bloqueado");
+      continue;
+    }
+    if (!contato.phone_number) {
+      pular("sem_telefone");
+      continue;
+    }
+
+    const { data: canal } = await admin
+      .from("channel_sessions")
+      .select("id")
+      .eq("organization_id", org)
+      .eq("status", "WORKING")
+      .limit(1)
+      .maybeSingle();
+
+    if (!canal) {
+      pular("sem_canal");
+      continue;
+    }
+
+    const foraDaJanela = await adiarAteAJanelaAbrir(admin, org, canal.id);
+    if (foraDaJanela) {
+      pular("fora_da_janela");
+      continue;
+    }
+
+    const { data: organizacao } = await admin
+      .from("organizations")
+      .select("timezone")
+      .eq("id", org)
+      .maybeSingle();
+
+    let corpo = montarLembrete({
+      nomeDoContato: contato.display_name ?? contato.name ?? null,
+      titulo: linha.title,
+      quando: new Date(linha.starts_at),
+      timezone: organizacao?.timezone ?? "America/Sao_Paulo",
+      local: linha.location_details ?? tipo.location_details ?? null,
+    });
+
+    if (tipo.reminder_template_name) {
+      const { data: modelo } = await admin
+        .from("message_templates")
+        .select("body")
+        .eq("organization_id", org)
+        .or(`shortcut.eq.${tipo.reminder_template_name},title.eq.${tipo.reminder_template_name}`)
+        .limit(1)
+        .maybeSingle();
+      if (modelo?.body) corpo = modelo.body;
+    }
+
+    await espacarEnvio(canal.id);
+
+    try {
+      const conversaId = await ensureConversation(admin, org, contato.id, canal.id);
+      // `webhook_source` é o ator que esta base dá a envio nascido de worker —
+      // o mesmo que `lib/followup/enviar-texto-fixo.ts` usa. O `id` é o
+      // compromisso, para o audit da mensagem correlacionar com a linha que a
+      // originou.
+      await sendMessageHandler(
+        admin,
+        {
+          organization_id: org,
+          actor: { type: "webhook_source", id: linha.id },
+          requestId: `agenda-reminder:${linha.id}`,
+        },
+        { conversation_id: conversaId, type: "text", body: corpo } as Parameters<
+          typeof sendMessageHandler
+        >[2],
+      );
+      // Carimba a TENTATIVA — o desfecho da entrega vive na mensagem.
+      await admin
+        .from("calendar_appointments")
+        .update({ reminder_sent_at: new Date().toISOString() })
+        .eq("id", linha.id)
+        .eq("organization_id", org);
+      enviados += 1;
+    } catch (err) {
+      const mensagem = err instanceof Error ? err.message : String(err);
+      logger.error("[agenda-reminder] envio falhou", { appointmentId: linha.id, error: mensagem, requestId });
+      pular("erro_no_envio");
+    }
+  }
+
+  // Rodada que não avisou ninguém NÃO é mutação, e não audita — a lei está no
+  // CLAUDE.md §Audit log, e `tests/unit/cron-audita-so-quando-ha-efeito.test.ts`
+  // varre o AST de toda rota deste diretório atrás de `audit` incondicional.
+  if (enviados > 0) {
+    await audit({
+      action: "agenda.lembrete_enviado",
+      resourceType: "calendar_appointment",
+      requestId,
+      metadata: { enviados, pulados, motivos },
+    });
+  }
+
+  return ok({ examinados: linhas.length, enviados, pulados, motivos }, { requestId });
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/docker/scheduler/entrypoint.sh
+++ b/docker/scheduler/entrypoint.sh
@@ -75,6 +75,11 @@ CRONS="
 # manda o que mudou). A volta é cara — varre calendário inteiro — e por isso
 # roda a cada 15.
 */5 * * * *|60|api/v1/cron/agenda-google-push
+# O LEMBRETE. A cada 5 minutos porque a antecedência é escolhida pelo dono no
+# tipo de agendamento; uma varredura mais lenta transformaria avisar 30 minutos
+# antes em avisar entre 30 e 45 minutos antes. Barato: só olha compromisso
+# confirmado, futuro e ainda não avisado.
+*/5 * * * *|45|api/v1/cron/agenda-reminder
 */15 * * * *|60|api/v1/cron/risk-watcher
 */30 * * * *|60|api/v1/cron/contact-phones
 17 * * * *|60|api/v1/cron/contact-proposals-watcher

--- a/lib/audit/actions.ts
+++ b/lib/audit/actions.ts
@@ -367,6 +367,10 @@ export const AUDIT_ACTIONS = [
   "agenda.tipo_criado",
   "agenda.tipo_alterado",
   "agenda.tipo_desativado",
+  // A rodada que AVISOU alguém do próprio compromisso. Mensagem que saiu para o
+  // telefone de um cliente é efeito, e efeito audita — mas só a rodada que
+  // enviou: a que varreu e não achou ninguém a avisar não é mutação.
+  "agenda.lembrete_enviado",
   // A rodada de renovação — e ela só audita quando FEZ algo, como manda a regra
   // do cron desta base. Uma linha por rodada com efeito, carregando a contagem:
   // é o que permite responder "quantas agendas precisaram reconectar esta


### PR DESCRIPTION
## O buraco

A migration **0177** declarou que `calendar_appointments.contact_id` é *"quem recebe o LEMBRETE"*, `calendar_event_types` ganhou `reminder_enabled` e `reminder_minutes_before`, a tela oferece os dois — e **nada nunca leu `reminder_sent_at`**.

O comentário de `app/api/v1/agenda/agendamentos/_handler.ts:118` fala desta rota no futuro:

> *"o cabeçalho da migration 0177 diz que `contact_id` é 'quem recebe o LEMBRETE'. **No dia em que o worker de lembrete nascer**, esta linha vira a organização A mandando WhatsApp para o cliente da B"*

Enquanto ele não existia, ligar o lembrete no tipo de agendamento **não fazia nada — em silêncio**. Quem configurou acreditou que o paciente seria avisado. Coluna sem consumidor é o anti-pattern nº 3 do `CLAUDE.md`, e esta era uma delas.

## O que entra

`app/api/v1/cron/agenda-reminder` — varredura a cada 5 min, agendada no `entrypoint.sh`.

## Três decisões, e o porquê de cada uma

**Lembrete é transacional, não marketing.** Quem recusou campanha continua recebendo aviso do próprio compromisso: esconder de alguém que o pedido dele está pronto não é respeitar a recusa, é perder a entrega. `is_blocked` e ausência de telefone seguem barrando, porque aí não há para onde mandar.

**A janela do canal vale.** Lembrete às 6h da manhã é o tipo de mensagem que faz o número ser denunciado. Fora da janela a rodada não carimba `reminder_sent_at`, e a próxima tenta — o adiamento é o silêncio, não uma fila nova.

**O carimbo é da tentativa, não da entrega.** `sendMessageHandler` marca `failed`/`queued` na própria mensagem e devolve normalmente. Se o carimbo esperasse a entrega, um número permanentemente inválido receberia uma tentativa a cada 5 minutos até a hora do compromisso.

E compromisso que já começou não gera lembrete — avisar às 15h de uma retirada das 14h é ruído.

## O isolamento entre organizações

É o medo literal do handler que criou a coluna. Aqui `organization_id` sai **sempre** da linha do compromisso e filtra a busca do contato, a do canal e o carimbo — nunca de parâmetro.

O teste prende isso lendo a fonte (o encadeamento da consulta não vive numa função pura; montar um dublê de Supabase testaria o dublê). **Sabotado:** removendo `.eq("organization_id", org)` da busca do contato, exatamente 1 caso falha e 13 passam.

## `reminder_template_name` também deixa de ser decorativa

A outra coluna que a 0177 criou e ninguém leu. Quando aponta para um modelo de mensagem da organização, ele vence o texto padrão.

## Verificação

| | |
|---|---|
| `pnpm typecheck` | 0 erros |
| `pnpm exec eslint` nos arquivos novos | 0 problemas |
| Teste novo | 14 casos |
| `cron-audita-so-quando-ha-efeito` | ✅ — a rota só audita quando `enviados > 0` |
| `cron-routes-scheduled` | ✅ |
| `tests/shell/scheduler-entrypoint.test.sh` | ✅ — **22 rotas, 22 encontradas** |
| `pnpm release:conferir` | `1.10.1 + minor = 1.11.0` |

Sobre o shell test: ele me pegou duas vezes antes de passar. O comentário que escrevi no `CRONS="..."` tinha crase e depois aspas duplas — a primeira vira substituição de comando, a segunda fecha a string. A cerca da linha 56 do `entrypoint.sh` existe exatamente para isso, e funcionou.

## De onde veio

Farmácia de manipulação usando agendamento para retirada de fórmula. Ligou o lembrete no tipo, marcou a retirada, e o paciente nunca foi avisado — sem erro em lugar nenhum.
