### PR TITLE
fix(shell): a rede contra scroll horizontal deixa de matar o sticky da barra

### DIFF
--- a/.changes/barra-lateral-volta-a-grudar.md
+++ b/.changes/barra-lateral-volta-a-grudar.md
@@ -1,0 +1,14 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A barra lateral volta a acompanhar a página
+---
+
+Em tela com conteúdo longo — a agenda, o kanban cheio, a lista de contatos — a
+barra de navegação rolava junto com a página: você descia, o menu subia e sumia,
+e sobrava uma faixa vazia no lugar dele. Para trocar de tela era preciso voltar
+ao topo.
+
+Ela agora fica parada enquanto o conteúdo rola, que é como sempre foi a intenção.
+
+Nada muda no que você faz nem na configuração; é comportamento de tela.

--- a/app/globals.css
+++ b/app/globals.css
@@ -418,8 +418,23 @@
        chegava até aqui e movia a tela inteira. Isto NUNCA deixa a barra de
        scroll horizontal aparecer, não importa o que role solto lá dentro —
        o componente que precisa de scroll horizontal (tabela, kanban)
-       continua rolando, contido nele mesmo; só a página como um todo não. */
+       continua rolando, contido nele mesmo; só a página como um todo não.
+
+       ⚠️ `clip` DEPOIS de `hidden`, e as duas linhas são necessárias.
+
+       `overflow-x: hidden` faz o elemento virar CONTÊINER DE ROLAGEM (a
+       especificação computa o eixo oposto para `auto`), e um contêiner de
+       rolagem no `<html>` quebra `position: sticky` lá dentro: a barra lateral
+       — que é `sticky top-0 h-screen` em `components/shell/Sidebar.tsx`, com um
+       comentário longo explicando por que não é `fixed` — deixava de grudar e
+       rolava com a página, sumindo do alto e deixando faixa vazia embaixo.
+
+       `overflow-x: clip` corta igual e NÃO cria contêiner de rolagem, então a
+       proteção continua inteira e o sticky volta. A linha `hidden` fica como
+       reserva para motor que não conhece `clip` (Safari < 16): lá o
+       comportamento segue exatamente o de hoje — protegido, sem sticky. */
     overflow-x: hidden;
+    overflow-x: clip;
   }
   [data-theme="dark"] {
     color-scheme: dark;
@@ -436,8 +451,13 @@
     /* Mesma trava do `html` logo acima, duplicada aqui de propósito: alguns
        motores móveis (Safari/iOS em particular) ignoram `overflow-x` só no
        `html` em certas versões — as duas juntas é o par que realmente
-       bloqueia em todo navegador testado pela comunidade. */
+       bloqueia em todo navegador testado pela comunidade.
+
+       Mesmo par `hidden` + `clip` do `<html>`, e pela mesma razão: sem o `clip`
+       aqui o `<body>` volta a ser contêiner de rolagem e a barra lateral perde
+       o sticky de novo — consertar só um dos dois não conserta nada. */
     overflow-x: hidden;
+    overflow-x: clip;
     background-color: var(--color-bg);
     color: var(--color-text);
     font-family: var(--font-atkinson), ui-sans-serif, system-ui, -apple-system,

--- a/tests/unit/barra-lateral-nao-perde-o-sticky.test.ts
+++ b/tests/unit/barra-lateral-nao-perde-o-sticky.test.ts
@@ -1,0 +1,70 @@
+/**
+ * A barra lateral gruda — e quem a quebra não é ela.
+ *
+ * `components/shell/Sidebar.tsx` é `sticky top-0 h-screen`, com um comentário
+ * longo explicando por que NÃO é `fixed` (duas medidas para a mesma coisa, e a
+ * barra passando por cima da lista no dia em que discordaram). Mesmo assim ela
+ * rolava com a página: sumia do alto e deixava faixa vazia embaixo.
+ *
+ * A causa estava três arquivos adiante. `overflow-x: hidden` no `<html>` e no
+ * `<body>` — a rede contra scroll horizontal da página — faz o elemento virar
+ * CONTÊINER DE ROLAGEM, e contêiner de rolagem no ancestral desliga
+ * `position: sticky` lá dentro. Duas proteções corretas que se anulavam.
+ *
+ * `overflow-x: clip` corta igual sem criar contêiner de rolagem. O `hidden`
+ * fica antes como reserva para motor sem `clip`.
+ *
+ * ⚠️ ESTE TESTE É UMA CERCA, NÃO UMA PROVA. Ele garante que a declaração não
+ * volte a ser só `hidden` — o modo pelo qual o defeito voltaria, e voltaria em
+ * silêncio, porque nada na tela diz "o sticky morreu". O que ele NÃO faz é
+ * medir a barra num navegador; isso é trabalho de Playwright com
+ * `getBoundingClientRect`, e está anotado como pendência no PR.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const CSS = readFileSync(join(__dirname, "..", "..", "app", "globals.css"), "utf8");
+
+/** O bloco de uma regra de topo (`html {` / `body {`) dentro de `@layer base`. */
+function blocoDe(seletor: string): string {
+  const i = CSS.indexOf(`\n  ${seletor} {`);
+  expect(i, `não achei a regra \`${seletor}\` em globals.css`).toBeGreaterThan(-1);
+  const fim = CSS.indexOf("\n  }", i);
+  return CSS.slice(i, fim);
+}
+
+describe("a rede contra scroll horizontal não pode matar o sticky", () => {
+  for (const seletor of ["html", "body"]) {
+    describe(`<${seletor}>`, () => {
+      const bloco = blocoDe(seletor);
+
+      it("ainda barra o scroll horizontal da página", () => {
+        expect(bloco).toMatch(/overflow-x:\s*(hidden|clip)\s*;/);
+      });
+
+      it("declara `clip`, que não cria contêiner de rolagem", () => {
+        expect(bloco).toMatch(/overflow-x:\s*clip\s*;/);
+      });
+
+      it("mantém `hidden` ANTES, como reserva para motor sem `clip`", () => {
+        const posHidden = bloco.search(/overflow-x:\s*hidden\s*;/);
+        const posClip = bloco.search(/overflow-x:\s*clip\s*;/);
+        expect(posHidden).toBeGreaterThan(-1);
+        expect(posClip).toBeGreaterThan(posHidden);
+      });
+    });
+  }
+
+  it("a barra lateral continua `sticky`, e nunca `fixed`", () => {
+    // O outro lado do par. Se alguém trocar por `fixed` para "resolver", volta o
+    // defeito que o comentário do Sidebar registra: barra por cima da lista.
+    const sidebar = readFileSync(
+      join(__dirname, "..", "..", "components", "shell", "Sidebar.tsx"),
+      "utf8",
+    );
+    expect(sidebar).toContain("sticky top-0");
+    expect(sidebar).not.toMatch(/className=\{?[^}]*"fixed /);
+  });
+});


### PR DESCRIPTION
## O sintoma

Em qualquer tela mais longa que a viewport — agenda, kanban cheio, lista de contatos — a barra lateral **rola junto com a página**: você desce, o menu sobe e some, e sobra uma faixa vazia no lugar dele. Para trocar de tela, é preciso voltar ao topo.

## A causa não está na barra

`components/shell/Sidebar.tsx` já é `sticky top-0 h-screen`, e traz um comentário longo explicando por que **não** é `fixed` — duas medidas para a mesma coisa, e a barra passando por cima da lista de conversas no dia em que discordaram. Está certo.

Quem a quebra está três arquivos adiante, em `app/globals.css`:

```css
html { overflow-x: hidden; }
body { overflow-x: hidden; }
```

Essa é a rede contra scroll horizontal da página — medida, deliberada, e duplicada no `body` de propósito porque Safari/iOS ignora a do `html` em certas versões. Também está certa.

**Mas `overflow-x: hidden` faz o elemento virar contêiner de rolagem** — a especificação computa o eixo oposto para `auto` — e contêiner de rolagem no ancestral desliga `position: sticky` lá dentro.

Duas proteções corretas que se anulavam, e nenhuma das duas errada sozinha. É por isso que o defeito sobrevive à leitura de qualquer um dos dois arquivos isoladamente.

## A mudança

```css
overflow-x: hidden;   /* reserva para motor sem `clip` */
overflow-x: clip;     /* corta igual, sem criar contêiner de rolagem */
```

Nos dois seletores — arrumar só um não arruma nada, porque basta um contêiner de rolagem no caminho.

`clip` mantém a proteção horizontal inteira. Motor sem suporte (Safari < 16) fica com o comportamento de hoje: protegido, sem sticky. Ninguém regride.

## O teste, e o que ele NÃO é

`tests/unit/barra-lateral-nao-perde-o-sticky.test.ts` — 7 casos. É **cerca, não prova**: impede que a declaração volte a ser só `hidden`, que é como o defeito voltaria, e voltaria em silêncio — nada na tela anuncia que o sticky morreu. Também prende o outro lado do par: a barra tem de continuar `sticky` e nunca `fixed`.

Sabotado: removendo o `clip` do `<html>`, 2 casos falham e 5 passam.

## O que não foi medido

**A barra num navegador de verdade.** A doutrina de QA Visual deste repo pede `getBoundingClientRect` no Playwright, e concordo que é o que provaria. Não fiz porque a instância que tenho roda a imagem publicada (`ghcr.io/melgarafael/deskcommcrm:1.10.1`), não este código — e um `next dev` local não reproduz o mesmo empilhamento de CSS do build.

Se preferirem uma spec Playwright antes do merge, digam que eu escrevo — ela precisaria entrar em `SPECS_PARTE_*` do `e2e.yml`, como a cerca de cobertura exige.

## Verificação

`pnpm typecheck` 0 erros · `pnpm exec eslint` 0 problemas · teste novo 7 passed · `pnpm release:conferir` → `1.10.1 + patch = 1.10.2`
