### PR TITLE
feat(agenda): a tela deixa dizer quem vai ser atendido

### DIFF
--- a/.changes/contato-no-agendamento-pela-tela.md
+++ b/.changes/contato-no-agendamento-pela-tela.md
@@ -1,0 +1,17 @@
+---
+impacto: capacidade_nova
+secao: adicionado
+titulo: Dá para dizer quem vai ser atendido ao marcar pela tela
+---
+
+Ao marcar um compromisso na agenda, você agora escolhe o contato — a mesma busca
+por nome e telefone que já existe no inbox. O compromisso passa a mostrar de quem
+é, e a equipe deixa de abrir a agenda com uma lista de horários sem dono.
+
+Continua opcional: bloqueio interno da equipe, inventário, reunião — nada disso
+tem alguém do outro lado, e obrigar um contato ali inventaria um. A tela diz o
+que se perde ao deixar em branco: sem contato, ninguém recebe lembrete daquele
+compromisso.
+
+Compromisso que o assistente marca sozinho já vinha com a pessoa vinculada; era
+o marcado por gente que nascia sem.

--- a/app/app/agenda/_client.tsx
+++ b/app/app/agenda/_client.tsx
@@ -14,6 +14,10 @@ import { AgendaInterativa } from "@/components/agenda/AgendaInterativa";
 import { FiltroDePessoas } from "@/components/agenda/FiltroDePessoas";
 import { HistoricoDaAgenda } from "@/components/agenda/HistoricoDaAgenda";
 import type { Agendamento, HorarioLivre, VisaoDaAgenda } from "@/components/agenda/tipos";
+import {
+  ContactPickerDialog,
+  type ContactPickPayload,
+} from "@/components/inbox/composer/ContactPickerDialog";
 import { EmptyAgenda } from "@/components/empty";
 import { rotuloDoLocal } from "@/lib/agenda/locais";
 import { Button } from "@/components/ui/button";
@@ -118,6 +122,21 @@ export function AgendaClient({
   // uma. Achado escrevendo a spec de marcar, não lendo o código.
   const [tipoId, setTipoId] = React.useState<string | null>(() => tiposIniciais[0]?.id ?? null);
   const tipo = tiposIniciais.find((t) => t.id === tipoId) ?? tiposIniciais[0] ?? null;
+  /**
+   * QUEM vai ser atendido.
+   *
+   * `NovoAgendamento.contact_id` existe desde que o hook nasceu, a rota o
+   * resolve contra a organização, e a listagem já lê `contacts(name)` para
+   * exibir. A ferramenta do agente (`crm_book_appointment`) chega a exigi-lo —
+   * "quem vai ser atendido". Só ESTA tela não perguntava, e o resultado é o
+   * inverso do esperado: a IA marcava com pessoa vinculada e o humano marcava
+   * órfão, fora do alcance de qualquer lembrete (que sai para `contact_id`).
+   *
+   * Opcional de propósito: bloqueio interno da equipe — inventário, reunião —
+   * continua podendo ser marcado sem ninguém do outro lado.
+   */
+  const [contato, setContato] = React.useState<ContactPickPayload | null>(null);
+  const [escolhendoContato, setEscolhendoContato] = React.useState(false);
   const [visao, setVisao] = React.useState<VisaoDaAgenda>("semana");
   const [isolada, setIsolada] = React.useState<string | null>(null);
   const [ancora, setAncora] = React.useState(() => new Date());
@@ -468,6 +487,52 @@ export function AgendaClient({
               </div>
             </div>
           )}
+          {/*
+            QUEM vai ser atendido. Fica FORA do `remarcandoId`: remarcar move o
+            horário de um compromisso que já tem (ou não tem) pessoa, e trocar o
+            contato ali seria outra operação — o PATCH de remarcar só manda
+            `starts_at`.
+          */}
+          {!remarcandoId && (
+            <div className="mt-4" data-testid="contato-do-agendamento">
+              <p className="mb-2 text-xs font-medium text-text-muted">{t("Quem vai ser atendido")}</p>
+              {contato ? (
+                <div className="flex items-center justify-between gap-2 rounded-md border border-border px-3 py-2">
+                  <span className="min-w-0 truncate text-sm">
+                    {contato.name}
+                    <span className="ml-2 text-text-muted tabular-nums">{contato.phone_number}</span>
+                  </span>
+                  <div className="flex shrink-0 gap-1">
+                    <Button variant="ghost" size="sm" onClick={() => setEscolhendoContato(true)}>
+                      {t("Trocar")}
+                    </Button>
+                    <Button variant="ghost" size="sm" onClick={() => setContato(null)}>
+                      {t("Remover")}
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    data-testid="escolher-contato"
+                    onClick={() => setEscolhendoContato(true)}
+                  >
+                    {t("Escolher contato")}
+                  </Button>
+                  {/*
+                    Dizer o que se perde é melhor que exigir. Bloqueio interno da
+                    equipe não tem paciente do outro lado, e obrigar um contato
+                    aqui inventaria um.
+                  */}
+                  <span className="text-xs text-text-muted">
+                    {t("Opcional — sem contato, ninguém recebe lembrete deste compromisso.")}
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
           {tipo && (
             <div className="mt-4 lg:min-h-0 lg:flex-1">
               <PainelDeMarcacao
@@ -529,7 +594,22 @@ export function AgendaClient({
                         return r;
                       });
                   }
-                  return marcar.mutateAsync({ event_type_id: tipo.id, starts_at: instante });
+                  return marcar
+                    .mutateAsync({
+                      event_type_id: tipo.id,
+                      starts_at: instante,
+                      // `undefined` e não `null`: o schema da rota trata ausência
+                      // como "sem pessoa", e um `null` explícito seria outro
+                      // caso a validar sem ganho nenhum.
+                      contact_id: contato?.contactId ?? undefined,
+                    })
+                    .then((r) => {
+                      // O contato é do compromisso que acabou de nascer, não do
+                      // painel: deixá-lo grudado faria o próximo agendamento
+                      // herdar a pessoa do anterior em silêncio.
+                      setContato(null);
+                      return r;
+                    });
                 }}
                 // "VER NA AGENDA" — o botão que não fazia nada.
                 //
@@ -555,6 +635,23 @@ export function AgendaClient({
           )}
         </SheetContent>
       </Sheet>
+
+      {/*
+        O MESMO seletor do inbox, não um segundo.
+        Ele já busca por nome e telefone sob a sessão do usuário (RLS), já
+        formata o rótulo com `rotuloDoContato` e já trata o vazio. Um seletor
+        próprio aqui seria uma segunda régua de "como se escreve o nome de um
+        contato", e no dia em que discordassem a mesma pessoa apareceria de dois
+        jeitos em duas telas.
+      */}
+      <ContactPickerDialog
+        open={escolhendoContato}
+        onOpenChange={setEscolhendoContato}
+        onPick={(escolhido) => {
+          setContato(escolhido);
+          setEscolhendoContato(false);
+        }}
+      />
 
       {/* CANCELAR pede motivo, e o motivo é OBRIGATÓRIO na rota (mínimo 3).
           Não é burocracia: é o que a equipe lê ao ver o horário vago. "Cancelado"

--- a/tests/unit/agendamento-carrega-o-contato.test.ts
+++ b/tests/unit/agendamento-carrega-o-contato.test.ts
@@ -1,0 +1,76 @@
+/**
+ * O compromisso marcado pela TELA leva quem vai ser atendido.
+ *
+ * `NovoAgendamento.contact_id` existe desde que o hook nasceu, a rota o resolve
+ * contra a organização, a listagem já lê `contacts(name)` para exibir — e
+ * `crm_book_appointment` chega a EXIGI-LO ("quem vai ser atendido"). Só a tela
+ * não perguntava, e o resultado era o inverso do esperado: a IA marcava com
+ * pessoa vinculada e o humano marcava órfão.
+ *
+ * Compromisso órfão não é só feio na lista: ele fica fora do alcance de
+ * qualquer lembrete, porque o lembrete sai para `contact_id`.
+ *
+ * ⚠️ CERCA, NÃO PROVA. O que provaria de verdade é estender
+ * `tests/e2e/agenda-marcar-pela-tela.spec.ts` — escolher um contato, marcar, e
+ * conferir que a linha nasceu com ele. Está declarado como pendência no PR:
+ * quem escreveu isto não tinha como rodar a suíte E2E, e spec não-executada
+ * gasta o CI de quem revisa.
+ *
+ * O que esta cerca pega é a regressão pela qual o defeito voltaria: alguém
+ * simplificar a chamada e o campo sumir de novo, em silêncio.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const TELA = readFileSync(
+  join(__dirname, "..", "..", "app", "app", "agenda", "_client.tsx"),
+  "utf8",
+);
+
+const HOOK = readFileSync(
+  join(__dirname, "..", "..", "hooks", "agenda", "useMarcarAgendamento.ts"),
+  "utf8",
+);
+
+describe("marcar pela tela leva o contato", () => {
+  it("o contrato do hook aceita contact_id", () => {
+    expect(HOOK).toMatch(/contact_id\?:\s*string/);
+  });
+
+  it("a chamada de marcar manda contact_id", () => {
+    // `event_type_id: tipo.id` aparece DUAS vezes — a primeira é a consulta de
+    // horários livres. A âncora tem de ser o que só a marcação tem.
+    const i = TELA.indexOf("starts_at: instante,");
+    expect(i, "não achei a chamada de marcar").toBeGreaterThan(-1);
+    expect(TELA.slice(i, i + 400)).toContain("contact_id");
+  });
+
+  it("a tela oferece como escolher o contato", () => {
+    expect(TELA).toContain("ContactPickerDialog");
+    expect(TELA).toContain('data-testid="escolher-contato"');
+  });
+
+  it("reusa o seletor do inbox em vez de um segundo", () => {
+    // Um seletor próprio seria uma segunda régua de como se escreve o nome de um
+    // contato — e no dia em que discordassem, a mesma pessoa apareceria de dois
+    // jeitos em duas telas.
+    expect(TELA).toContain("@/components/inbox/composer/ContactPickerDialog");
+  });
+
+  it("o contato é OPCIONAL, e a tela diz o que se perde sem ele", () => {
+    // Bloqueio interno da equipe não tem paciente do outro lado; obrigar um
+    // contato aqui inventaria um. Mas quem marcar sem precisa saber que ninguém
+    // será lembrado.
+    expect(TELA).toContain("Opcional");
+    expect(TELA).toMatch(/lembrete/i);
+  });
+
+  it("não gruda o contato no próximo agendamento", () => {
+    // Depois de marcar, o estado volta a nulo: herdar a pessoa do compromisso
+    // anterior em silêncio marcaria o paciente errado.
+    const depoisDeMarcar = TELA.slice(TELA.indexOf("contact_id: contato?.contactId"));
+    expect(depoisDeMarcar.slice(0, 500)).toContain("setContato(null)");
+  });
+});


### PR DESCRIPTION
## O buraco, e ele é o inverso do que se esperaria

`NovoAgendamento.contact_id` existe desde que o hook nasceu. A rota o **resolve contra a organização** (com um comentário longo explicando o risco). A listagem já lê `contacts(name)` para exibir. E `crm_book_appointment` chega a **exigi-lo**:

```ts
// lib/mcp/tools/agendamento.ts:259
contact_id: z.string().uuid().describe("quem vai ser atendido")   // obrigatório
```

**Só a tela não perguntava.** Então o assistente marcava com pessoa vinculada e o humano marcava órfão.

## Por que isso importa mais do que parece

Compromisso órfão não é só feio na lista:

- fica **fora do alcance de qualquer lembrete**, porque o lembrete sai para `contact_id`
- a equipe abre a agenda e vê horários ocupados **sem saber de quem são**

Foi assim que apareceu: farmácia de manipulação usando agendamento para retirada de fórmula, marcou pela tela, e o compromisso não dizia de quem era nem avisou ninguém.

## A mudança

Um bloco no painel de marcação, entre o tipo e o calendário, e o campo na chamada.

**Reusa o `ContactPickerDialog` do inbox** em vez de um segundo seletor — ele já busca sob a sessão do usuário (RLS), já formata com `rotuloDoContato` e já trata o vazio. Um seletor próprio seria uma segunda régua de como se escreve o nome de um contato, e no dia em que discordassem a mesma pessoa apareceria de dois jeitos em duas telas.

**Opcional de propósito.** Bloqueio interno da equipe — inventário, reunião — não tem alguém do outro lado, e obrigar um contato ali inventaria um. Mas a tela diz o que se perde: *"sem contato, ninguém recebe lembrete deste compromisso"*.

**Fica fora do remarcar.** O PATCH de remarcar só manda `starts_at`; trocar a pessoa ali seria outra operação.

**O contato volta a nulo depois de marcar.** Herdar a pessoa do compromisso anterior em silêncio marcaria o paciente errado.

## O teste, e o que ele não é

`tests/unit/agendamento-carrega-o-contato.test.ts` — 6 casos. **Cerca**: prende o campo na chamada, o seletor na tela, o texto do opcional e a limpeza do estado. Sabotado: removendo a linha do `contact_id`, 2 casos falham.

Uma armadilha que ela mesma documenta: `event_type_id: tipo.id` aparece **duas** vezes no arquivo — a primeira é a consulta de horários livres. Ancorar nela dava um teste que passava sem provar nada.

## O que NÃO foi medido

**A tela num navegador.** A prova de verdade seria estender `tests/e2e/agenda-marcar-pela-tela.spec.ts` — escolher um contato, marcar, e conferir que a linha nasceu com ele. Não fiz porque não consigo rodar a suíte E2E aqui (precisa de Supabase local, build de produção, WAHA), e **spec não-executada gasta o CI de quem revisa**.

Se quiserem antes do merge, digam que eu escrevo — a spec já existe e já está em `SPECS_PARTE_*`, então é acrescentar passos, não criar arquivo.

## Verificação

`pnpm typecheck` 0 erros · `pnpm exec eslint` 0 erros (2 warnings pré-existentes, linhas 169 e 239, código não tocado) · teste novo 6 passed · `pnpm release:conferir` → `capacidade_nova`

## Relacionado

Complementa o PR do worker de lembrete: sem este, o lembrete só alcançaria compromisso marcado pelo assistente.
