### PR TITLE
fix(zernio): base da API vazia cai na produção do provedor

### DIFF
--- a/.changes/canal-zernio-volta-a-enviar.md
+++ b/.changes/canal-zernio-volta-a-enviar.md
@@ -1,0 +1,25 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O canal Zernio volta a enviar em quem configurou a partir do arquivo de exemplo
+---
+
+Quem conectou o canal Zernio numa instalação montada a partir do arquivo de
+exemplo não conseguia enviar mensagem nenhuma por ele. As duas credenciais
+estavam certas, o canal aparecia configurado, e o envio falhava assim mesmo —
+tanto para quem deixou as credenciais na configuração quanto para quem as
+cadastrou pela tela.
+
+A causa estava no endereço do provedor. O arquivo de exemplo traz essa linha
+vazia, e o comentário ao lado dela promete que vazio usa o endereço de produção
+do provedor — a linha só existe para quem precisa apontar o sistema a um
+ambiente de homologação. Não era o que acontecia: o vazio era tratado como se
+fosse um endereço de verdade, e o sistema tentava falar com um lugar que não
+existe.
+
+Agora vazio significa o que o arquivo sempre disse que significava. Quem
+preencheu a linha para apontar para homologação continua sendo respeitado, e
+espaço sobrando em volta do endereço deixa de atrapalhar.
+
+Ninguém precisa mexer em nada. Instalações que já enviavam seguem iguais, e as
+que estavam com esse envio quebrado voltam a funcionar sozinhas.

--- a/lib/channels/zernio/credentials.ts
+++ b/lib/channels/zernio/credentials.ts
@@ -52,9 +52,26 @@ export interface ZernioCredsLookup {
  * Base da API. Explícita e sobrescrevível: o próprio provider publica um
  * servidor local no OpenAPI, e um teste de integração precisa apontar para
  * outro lugar sem editar código.
+ *
+ * `||` e não `??`, e o `trim()` junto — a diferença é o bug inteiro.
+ *
+ * O `.env.example` entrega esta chave VAZIA, e o comentário ao lado dela
+ * promete: "Vazio usa a produção do provedor." O `??` não cumpria essa
+ * promessa, porque ele só cai no padrão em `null`/`undefined` — string vazia
+ * é valor, e passa. Quem fizesse `cp .env.example .env`, preenchesse as duas
+ * credenciais e deixasse este override como veio — que é o caminho NORMAL,
+ * já que o override existe só para homologação — resolvia `baseUrl` para
+ * `""`, montava `/v1/inbox/conversations` sem host, e o `fetch` do Node
+ * recusava com `TypeError: Failed to parse URL`. Todo envio pelo canal
+ * quebrava, nos DOIS caminhos de credencial (env e sessão cifrada), que
+ * chamam esta mesma função.
+ *
+ * Ausente funcionava e vazia não: por isso a doutrina de QA — que manda testar
+ * com os envs opcionais AUSENTES — passava por cima. Quem copia o exemplo não
+ * tem a var ausente, tem ela presente e vazia.
  */
 export function zernioBaseUrl(): string {
-  return process.env.ZERNIO_API_BASE_URL ?? "https://zernio.com/api";
+  return process.env.ZERNIO_API_BASE_URL?.trim() || "https://zernio.com/api";
 }
 
 /**

--- a/tests/unit/canal-zernio-base-url-vazia.test.ts
+++ b/tests/unit/canal-zernio-base-url-vazia.test.ts
@@ -1,0 +1,93 @@
+/**
+ * A BASE DA API DO CANAL INTERMEDIADO HONRA O CONTRATO DO `.env.example`.
+ *
+ * ## O defeito, e por que ele escapou de tudo
+ *
+ * `zernioBaseUrl()` resolvia com `??`. O `.env.example` entrega
+ * `ZERNIO_API_BASE_URL=` VAZIA, com esta promessa escrita ao lado:
+ *
+ *     # Só para apontar para homologação. Vazio usa a produção do provedor.
+ *
+ * `??` não cumpre essa promessa. Ele só cai no padrão em `null`/`undefined`;
+ * string vazia é valor e passa direto. Resultado medido, executando:
+ *
+ *     baseUrl resolvida: ""
+ *     URL montada      : "/v1/inbox/conversations?account_id=x"
+ *     fetch LANÇOU     : TypeError: Failed to parse URL
+ *
+ * Atingia quem fez `cp .env.example .env`, preencheu `ZERNIO_ACCOUNT_ID` e
+ * `ZERNIO_API_KEY` para conectar o canal, e deixou o override como veio — que
+ * é o caminho NORMAL, porque o próprio comentário diz que ele é só para
+ * homologação. Todo envio pelo canal quebrava.
+ *
+ * Não escapava por um caminho só: a credencial da SESSÃO (token cifrado no
+ * banco) chama esta mesma função, então configurar pela tela não salvava.
+ *
+ * ## Por que os gates existentes não pegaram
+ *
+ * A doutrina de QA deste repo manda testar com os envs opcionais **AUSENTES**,
+ * e ausente SEMPRE funcionou — o `??` pega `undefined`. O estado que quebra é
+ * **presente e vazio**, que é exatamente o que copiar o `.env.example`
+ * produz. É o vão entre os dois que este arquivo fecha.
+ *
+ * E `ZERNIO_API_BASE_URL` não aparece em `lib/env.ts`: nada a valida no boot.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { zernioBaseUrl } from "@/lib/channels/zernio/credentials";
+
+const CHAVE = "ZERNIO_API_BASE_URL";
+const PRODUCAO = "https://zernio.com/api";
+
+// O `.env.local` desta máquina entra no `process.env` via `vitest.setup.ts`,
+// então o valor real precisa sair e voltar em volta de cada caso — senão o
+// teste mede o ambiente de quem roda, não o código.
+let original: string | undefined;
+beforeEach(() => {
+  original = process.env[CHAVE];
+});
+afterEach(() => {
+  if (original === undefined) delete process.env[CHAVE];
+  else process.env[CHAVE] = original;
+});
+
+describe("zernioBaseUrl honra o que o .env.example promete", () => {
+  it("VAZIA cai na produção do provedor — a promessa escrita no .env.example", () => {
+    process.env[CHAVE] = "";
+    expect(zernioBaseUrl()).toBe(PRODUCAO);
+  });
+
+  it("AUSENTE cai na produção do provedor", () => {
+    delete process.env[CHAVE];
+    expect(zernioBaseUrl()).toBe(PRODUCAO);
+  });
+
+  it("só espaço em branco também cai na produção", () => {
+    // Uma linha `ZERNIO_API_BASE_URL= ` com um espaço sobrando não é um
+    // endereço, e montaria a mesma URL sem host.
+    process.env[CHAVE] = "   ";
+    expect(zernioBaseUrl()).toBe(PRODUCAO);
+  });
+
+  it("valor real continua vencendo — o override de homologação segue existindo", () => {
+    // O caso que dá sentido aos de cima: a correção não pode ter matado o
+    // motivo de a variável existir.
+    process.env[CHAVE] = "https://homologacao.zernio.com/api";
+    expect(zernioBaseUrl()).toBe("https://homologacao.zernio.com/api");
+  });
+
+  it("espaço em volta de um valor real é aparado, não herdado", () => {
+    process.env[CHAVE] = "  https://homologacao.zernio.com/api  ";
+    expect(zernioBaseUrl()).toBe("https://homologacao.zernio.com/api");
+  });
+
+  it("o que a função devolve monta uma URL ABSOLUTA — a falha era esta", () => {
+    // A asserção que fecha a distância entre "resolveu para string vazia" e o
+    // sintoma real. `new URL` recusa caminho relativo do mesmo jeito que o
+    // `fetch` do Node recusava.
+    process.env[CHAVE] = "";
+    const url = `${zernioBaseUrl()}/v1/inbox/conversations`;
+    expect(() => new URL(url)).not.toThrow();
+    expect(new URL(url).host).toBe("zernio.com");
+  });
+});


### PR DESCRIPTION
# O que este PR faz

`zernioBaseUrl()` resolvia com `??`, que só cai no padrão em `null`/`undefined` — string vazia é valor e passa direto. O `.env.example` entrega `ZERNIO_API_BASE_URL` **vazia**, e o comentário ao lado dela promete: *"Vazio usa a produção do provedor."* O código não cumpria a própria promessa, e todo envio pelo canal quebrava para quem instalou copiando o exemplo.

## O sintoma, medido

Executando o estado de quem fez `cp .env.example .env` e conectou o canal:

```
baseUrl resolvida: ""
URL montada      : "/v1/inbox/conversations?account_id=x"
fetch LANÇOU     : TypeError: Failed to parse URL
--- contraste ---
var AUSENTE      : "https://zernio.com/api"   <- o ?? funciona aqui
```

Atinge quem preenche `ZERNIO_ACCOUNT_ID` e `ZERNIO_API_KEY` para conectar o canal e deixa este override como veio — o caminho normal, já que o próprio comentário diz que ele existe só para apontar homologação.

Três agravantes:

- **Vale para os dois caminhos de credencial.** A da sessão (token cifrado no banco) chama o mesmo `zernioBaseUrl()`, então configurar pela tela não escapa.
- **Nada valida no boot.** `ZERNIO_API_BASE_URL` não aparece em `lib/env.ts`.
- **É o vão da doutrina de QA.** Ela manda testar com os envs opcionais **ausentes**, e ausente sempre funcionou. O que quebra é **presente-e-vazio**, que é exatamente o que copiar o `.env.example` produz.

## A correção

Uma linha: `?? ` vira `?.trim() ||`. O `trim()` entra junto porque `ZERNIO_API_BASE_URL= ` com um espaço sobrando montaria a mesma URL sem host. O docblock registra o porquê, para a próxima limpeza não devolver o `??`.

## O teste

`tests/unit/canal-zernio-base-url-vazia.test.ts` — vazia, ausente, só-espaço, valor real, valor com espaço em volta, e uma asserção de que a URL montada é absoluta (que fecha a distância entre "resolveu para string vazia" e o `TypeError`). Ele salva e restaura `process.env` em volta de cada caso, senão mediria o `.env.local` de quem roda.

**Sabotado de volta para `??`: 4 dos 6 casos reprovam.** Os 2 que sobrevivem são justamente *ausente* e *valor real* — os que já funcionavam. A falha do teste tem a forma do bug, nem mais nem menos.

## Verificação — e o que NÃO foi verificado

Rodado num clone limpo desta `main` (`26d384c6`), **em Windows**. Isso importa para ler os resultados:

| Gate | Resultado |
|---|---|
| `pnpm typecheck` | exit 0 |
| `pnpm lint` | exit 0 |
| `pnpm build` | exit 0 |
| `pnpm test:unit` | ver abaixo |
| `pnpm lint:channels` | exit 1 — **já vermelho na `main` limpa** |
| `pnpm test:shell` | exit 1 — **já vermelho na `main` limpa** |
| `pnpm test:db` | **NÃO RODADO** — não há Docker nesta máquina |

Medi cada vermelho contra a `main` sem as minhas mudanças, para não atribuir a mim o que já estava lá:

- **`lint:channels`**: 155 arquivos reportados na `main` limpa. `walk()` monta caminho com `join()`, que no Windows devolve barra invertida, enquanto `ALLOWED` (regex) e `DEBT` (Set) usam barra normal — falha nas duas pontas. No CI (Linux) passa.
- **`test:shell`**: mesma prova falha na `main` limpa — `.env continua 600 (só o dono lê)`, que NTFS não tem.
- **`test:unit`**: `main` limpa dá **9 arquivos / 20 casos** falhando no Windows (vários são a mesma classe de separador de caminho). Com este PR: 11 arquivos / 22 casos. Os 2 a mais são `namespace-das-imagens` e `telas-sem-dado-de-mentira`, **os dois por timeout de 15s**, não por asserção — e **os dois passam quando rodados isoladamente** junto com os testes deste PR (4 arquivos, 33 casos, exit 0). São varreduras de disco pesadas sob carga, não regressão.

Não tenho como afirmar nada sobre `test:db` nem sobre o comportamento em Linux; o CI é a autoridade nos dois.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam (`pnpm test:unit`) — arquivo novo, verde, sabotado nos dois sentidos
- [ ] RLS testada, se toca tabela tenant-aware — não aplicável, não toca tabela
- [ ] Audit log emitido, se há mutação relevante — não aplicável
- [ ] Zod valida todo input externo novo — não aplicável, não há input novo
- [x] Sem `console.log` esquecido
- [ ] Mudança de schema — não aplicável, não há
- [x] Fragmento em `.changes/` (`impacto: nada_mudou`, `secao: corrigido`), aceito por `pnpm release:conferir`

Não mexi em `lib/env.ts`: registrar a chave lá documentaria e validaria, mas é decisão de escopo maior e preferi deixar o PR do tamanho do defeito. Fico à disposição se preferir que ela entre por lá.
