### PR TITLE
fix(dx): os gates passam num clone Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -41,3 +41,28 @@ supabase/migrations/MANIFEST.md merge=union
 # clona no Windows vê a falha. `eol=lf` fixa LF no checkout independente do
 # `core.autocrlf` de quem clonou.
 *.sql text eol=lf
+
+# ─── Fim de linha fixo em LF para TODO arquivo de texto ──────────────────────
+#
+# A regra de `*.sql` acima resolveu um caso de um problema que é geral, e o
+# resto dele continuava de pé. Num clone feito no Windows com o padrão do
+# instalador git (`core.autocrlf=true`), TODO arquivo de texto chega ao disco
+# com CRLF — e os gates deste repo leem arquivo de texto o tempo todo: o
+# workflow YAML, o mapa de jornadas, o selo da tradução, a lista de specs do
+# e2e. Um `\r` no fim da linha derruba regex ancorada e comparação de string.
+#
+# Medido num clone limpo desta main, rodando `pnpm test:unit` em Windows:
+#
+#     core.autocrlf=true  (padrão)  ->  9 arquivos / 20 casos vermelhos
+#     core.autocrlf=false           ->  5 arquivos /  8 casos vermelhos
+#
+# Os 5 arquivos e 12 casos da diferença NÃO têm defeito nenhum: são
+# `tag-so-nasce-da-main`, `e2e-cobertura-completa`, `numero-de-jornada-e-unico`,
+# `traducao-nao-defasa` e `marca-logo-spec-ancora-a-rota` lendo `\r` que o CI
+# nunca vê, porque `ubuntu-latest` não converte. É o mesmo raciocínio que o
+# bloco de `*.sql` já escreveu — só que ele vale para o repo inteiro.
+#
+# `text=auto` deixa o git detectar binário sozinho; só o que ele já trata como
+# texto é normalizado. Os blobs JÁ estão em LF, então isto não reescreve
+# arquivo nenhum: muda apenas o que o checkout entrega.
+* text=auto eol=lf

--- a/scripts/lint-channels.ts
+++ b/scripts/lint-channels.ts
@@ -29,7 +29,7 @@
  * silenciosa — se você precisar acrescentar uma, escreva o porquê junto.
  */
 import { readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 
 // O padrão vive em módulo próprio para poder ser testado sem executar o lint —
 // ver a justificativa das duas fronteiras (issue #118) lá.
@@ -185,11 +185,21 @@ const KNOWN_DEBT: { reason: string; files: string[] }[] = [
 
 const DEBT = new Set(KNOWN_DEBT.flatMap((g) => g.files));
 
+/**
+ * Caminhos SEMPRE em barra normal.
+ *
+ * `join()` devolve barra invertida no Windows, e as duas listas contra as
+ * quais estes caminhos são comparados usam barra normal: `ALLOWED` é regex
+ * ancorada em `^lib/channels/`, e `DEBT` é um Set de strings. Falhava nas
+ * DUAS pontas — nada era permitido, e nada era reconhecido como dívida já
+ * registrada —, e o script acusava 155 arquivos numa árvore limpa. No CI
+ * (Linux) passa, então só quem contribui do Windows via.
+ */
 function walk(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
     const p = join(dir, e.name);
     if (e.isDirectory()) return e.name === "node_modules" ? [] : walk(p);
-    return /\.tsx?$/.test(e.name) ? [p] : [];
+    return /\.tsx?$/.test(e.name) ? [p.split(sep).join("/")] : [];
   });
 }
 

--- a/tests/unit/helpers/caminho.ts
+++ b/tests/unit/helpers/caminho.ts
@@ -1,0 +1,26 @@
+import path from "node:path";
+
+/**
+ * Caminho relativo à raiz, SEMPRE em barra normal — nunca a do sistema de
+ * arquivos.
+ *
+ * Todo gate deste repo que varre o disco compara o que achou contra uma lista
+ * DECLARADA: allowlist com motivo escrito, registro de telas, conjunto de
+ * esperados. Essas listas são escritas — como todo caminho neste repo — com
+ * `/`. No Windows, `path.relative` devolve `app\app\ai\page.tsx`, e aí o
+ * gate erra nas DUAS pontas ao mesmo tempo: o arquivo JUSTIFICADO é acusado de
+ * infrator, e a justificativa que o liberava é acusada de órfã. Nenhuma das
+ * duas mensagens diz "seu separador de caminho está errado" — elas dizem que
+ * há dívida nova e allowlist podre, que é ruído caro num gate cuja mensagem é
+ * a única coisa que a próxima pessoa lê.
+ *
+ * No CI (Linux) passava, então o defeito só existia na máquina de quem
+ * contribui do Windows — o pior lugar para ele estar.
+ *
+ * Vive aqui, num lugar só, pelo mesmo motivo que a varredura de
+ * `varrer-codigo.ts` vive lá: quatro cópias desta linha é a garantia de que
+ * uma delas vai divergir.
+ */
+export function relativoEmBarraNormal(raiz: string, absoluto: string): string {
+  return path.relative(raiz, absoluto).split(path.sep).join("/");
+}

--- a/tests/unit/helpers/varrer-codigo.ts
+++ b/tests/unit/helpers/varrer-codigo.ts
@@ -14,6 +14,8 @@
 import { readdirSync } from "node:fs";
 import path from "node:path";
 
+import { relativoEmBarraNormal } from "./caminho";
+
 /** Raiz do repo — o vitest roda com cwd na raiz (ver vitest.config.ts). */
 export const RAIZ_DO_REPO = process.cwd();
 
@@ -39,4 +41,15 @@ function varrer(dir: string): string[] {
  */
 export function arquivosDeCodigo(raizes: readonly string[]): string[] {
   return raizes.flatMap((r) => varrer(path.join(RAIZ_DO_REPO, r)));
+}
+
+/**
+ * O caminho de um arquivo varrido, relativo à raiz e em barra normal.
+ *
+ * A varredura devolve ABSOLUTO e os três chamadores precisam dele relativo
+ * para comparar com uma lista declarada — os três faziam o mesmo `relative`
+ * à mão, e no Windows os três erravam junto.
+ */
+export function caminhoRelativo(absoluto: string): string {
+  return relativoEmBarraNormal(RAIZ_DO_REPO, absoluto);
 }

--- a/tests/unit/import-puro-sem-env.test.ts
+++ b/tests/unit/import-puro-sem-env.test.ts
@@ -33,6 +33,30 @@ import { describe, expect, it } from "vitest";
 const RAIZ = join(__dirname, "..", "..");
 
 /**
+ * O CLI do tsx como ARQUIVO JS, chamado pelo `process.execPath` — nunca por
+ * `npx`.
+ *
+ * `execFileSync` não resolve extensão de executável, e no Windows o `npx` é
+ * `npx.cmd`: o filho morria com `spawnSync npx ENOENT` antes de importar
+ * coisa nenhuma. Chamar o `.mjs` direto dispensa PATH, dispensa `.cmd` e usa
+ * exatamente o tsx deste `node_modules`, em vez do que o PATH oferecer.
+ */
+const TSX_CLI = join(RAIZ, "node_modules", "tsx", "dist", "cli.mjs");
+
+/**
+ * O filho chegou a RODAR e responder?
+ *
+ * É a distinção que faltava, e ela é o conserto de verdade. Um filho que nunca
+ * nasceu devolvia `ok:false` — indistinguível de "o módulo falhou ao
+ * importar", que é justamente o resultado que o controle positivo ESPERA. O
+ * controle ficava VERDE com o aparato inteiramente quebrado, ao lado do caso
+ * real vermelho, afirmando que o instrumento estava bom.
+ */
+function respondeu(saida: string): boolean {
+  return saida.includes("OK") || saida.includes("ERRO:");
+}
+
+/**
  * Os módulos vigiados: os que um teste unitário importa por causa de função
  * pura. A lista é explícita porque a alternativa (varrer tudo) acusaria os
  * módulos que PRECISAM de env — e um teste que acusa o correto é pior que
@@ -41,10 +65,10 @@ const RAIZ = join(__dirname, "..", "..");
 const MODULOS_PUROS = ["@/lib/leads/timeline-query"] as const;
 
 /** Importa o módulo num processo filho SEM as variáveis do app. */
-function importaComAmbienteLimpo(modulo: string): { ok: boolean; erro: string } {
+function importaComAmbienteLimpo(modulo: string): { ok: boolean; respondeu: boolean; erro: string } {
   const script = `import(${JSON.stringify(modulo)}).then(()=>{console.log("OK")},(e)=>{console.log("ERRO:"+String(e && e.message).split("\\n")[0]);});`;
-  // Só PATH e HOME: PATH para achar o `npx`, HOME para o cache dele. Nenhuma
-  // variável do app — é justamente a ausência delas que o teste mede.
+  // Só PATH e HOME. Nenhuma variável do app — é justamente a ausência delas
+  // que o teste mede.
   // `NODE_ENV` fica de fora de propósito; o cast existe porque o tipo do Node o
   // exige e aqui a omissão é o ponto.
   const limpo = {
@@ -52,16 +76,21 @@ function importaComAmbienteLimpo(modulo: string): { ok: boolean; erro: string } 
     HOME: process.env.HOME ?? "",
   } as unknown as NodeJS.ProcessEnv;
   try {
-    const saida = execFileSync("npx", ["tsx", "--eval", script], {
+    const saida = execFileSync(process.execPath, [TSX_CLI, "--eval", script], {
       cwd: RAIZ,
       env: limpo,
       encoding: "utf8",
       timeout: 120_000,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    return { ok: saida.includes("OK"), erro: saida.trim() };
+    return { ok: saida.includes("OK"), respondeu: respondeu(saida), erro: saida.trim() };
   } catch (e) {
-    return { ok: false, erro: e instanceof Error ? e.message.slice(0, 400) : String(e) };
+    // O filho pode ter RODADO e saído com código != 0 — é assim que o
+    // `--eval` termina quando a promessa rejeita. Ali o texto dele ainda vale,
+    // e é ele que separa "importou e falhou" de "nunca nasceu".
+    const bruto = typeof e === "object" && e !== null && "stdout" in e ? String((e as { stdout?: unknown }).stdout ?? "") : "";
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, respondeu: respondeu(bruto), erro: `${bruto} ${msg}`.trim().slice(0, 400) };
   }
 }
 
@@ -79,6 +108,14 @@ describe("módulo de função pura importa sem ambiente", () => {
     // script que sempre imprime OK deixaria tudo verde medindo nada.
     // `@/lib/env` DEVE falhar sem ambiente: é literalmente o trabalho dele.
     const controle = importaComAmbienteLimpo("@/lib/env");
+    // DUAS asserções, e a primeira é a que faltava. Um filho que nunca nasceu
+    // devolve `ok:false`, que é exatamente o que a segunda espera — então o
+    // controle passava com o aparato quebrado.
+    expect(
+      controle.respondeu,
+      `o processo filho não chegou a responder — o aparato não rodou, então ` +
+        `nada foi medido. Saída: ${controle.erro}`,
+    ).toBe(true);
     expect(controle.ok, `esperava @/lib/env FALHAR sem env, veio: ${controle.erro}`).toBe(false);
   });
 

--- a/tests/unit/marca-sem-divergencia-de-hidratacao.test.tsx
+++ b/tests/unit/marca-sem-divergencia-de-hidratacao.test.tsx
@@ -47,6 +47,8 @@ import path from "node:path";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { relativoEmBarraNormal } from "./helpers/caminho";
+
 import { AdminSidebar } from "@/components/admin/AdminSidebar";
 import { Sidebar } from "@/components/shell/Sidebar";
 import type { ActiveOrg, AuthUser } from "@/lib/auth/types";
@@ -241,7 +243,7 @@ describe("catraca: `branding()` é server-only", () => {
       "app/onboarding/layout.tsx",
       "lib/legal/operador.ts",
     ];
-    const vistos = varridos.filter(chamaBranding).map((f) => path.relative(RAIZ, f));
+    const vistos = varridos.filter(chamaBranding).map((f) => relativoEmBarraNormal(RAIZ, f));
     expect(esperados.filter((e) => !vistos.includes(e))).toEqual([]);
   });
 
@@ -252,7 +254,7 @@ describe("catraca: `branding()` é server-only", () => {
     );
 
     expect(
-      infratores.map((f) => path.relative(RAIZ, f)),
+      infratores.map((f) => relativoEmBarraNormal(RAIZ, f)),
       "`branding()` lê `window.__PUBLIC_ENV__` no navegador e `process.env` no\n" +
         "servidor, e as duas fontes divergem desde que o layout raiz passou a\n" +
         "injetar a marca do BANCO. Num client component isso é hydration mismatch\n" +

--- a/tests/unit/telas-filtram-a-organizacao-ativa.test.ts
+++ b/tests/unit/telas-filtram-a-organizacao-ativa.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
+import { relativoEmBarraNormal } from "./helpers/caminho";
+
 /**
  * VARREDURA: tela de servidor que consulta tabela de inquilino filtra a
  * organização ATIVA, e não só a RLS.
@@ -100,7 +102,7 @@ function consultas(): Consulta[] {
   const out: Consulta[] = [];
   for (const arquivo of telasDeServidor(path.join(RAIZ, "app/app"))) {
     const fonte = fs.readFileSync(arquivo, "utf8");
-    const rel = path.relative(RAIZ, arquivo);
+    const rel = relativoEmBarraNormal(RAIZ, arquivo);
     for (const m of fonte.matchAll(/\.from\("([a-z_]+)"\)/g)) {
       const tabela = m[1] as string;
       if (!TENANT.has(tabela)) continue;

--- a/tests/unit/telas-sem-dado-de-mentira.test.ts
+++ b/tests/unit/telas-sem-dado-de-mentira.test.ts
@@ -65,6 +65,8 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { relativoEmBarraNormal } from "./helpers/caminho";
+
 const RAIZ = process.cwd();
 const AREA_DO_TENANT = path.join(RAIZ, "app/app");
 
@@ -153,7 +155,7 @@ function cadeiaDeImports(arquivo: string, vistos = new Set<string>()): string[] 
   }
   for (const especificador of importesDe(fonte)) {
     if (PROIBIDOS.test(especificador)) {
-      achados.push(`${path.relative(RAIZ, arquivo)} → ${especificador}`);
+      achados.push(`${relativoEmBarraNormal(RAIZ, arquivo)} → ${especificador}`);
       continue;
     }
     const local = resolverLocal(especificador, arquivo);
@@ -175,12 +177,12 @@ describe("tela alcançável não come dado de mentira", () => {
   it("nenhuma tela do tenant CHEGA a uma fixture, nem por caminho indireto", () => {
     const infratores: string[] = [];
     for (const arquivo of arquivos) {
-      const relativo = path.relative(RAIZ, arquivo);
-      if (PERMITIDOS[relativo]) continue;
+      const rel = relativoEmBarraNormal(RAIZ, arquivo);
+      if (PERMITIDOS[rel]) continue;
       // A cadeia inteira, não só o import direto: o caminho provável é a tela
       // importar um componente limpo que importa a fixture.
       const proibidos = cadeiaDeImports(arquivo);
-      if (proibidos.length > 0) infratores.push(`${relativo}: ${[...new Set(proibidos)].join(" | ")}`);
+      if (proibidos.length > 0) infratores.push(`${rel}: ${[...new Set(proibidos)].join(" | ")}`);
     }
     expect(
       infratores,

--- a/tests/unit/telemetria-tem-um-leitor-so.test.ts
+++ b/tests/unit/telemetria-tem-um-leitor-so.test.ts
@@ -26,11 +26,11 @@
  * despercebida.
  */
 import { readFileSync } from "node:fs";
-import { join, relative } from "node:path";
+import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { RAIZ_DO_REPO, arquivosDeCodigo } from "./helpers/varrer-codigo";
+import { arquivosDeCodigo, caminhoRelativo } from "./helpers/varrer-codigo";
 
 /**
  * Quem PODE mencionar `ai_invocations`, e por quê. Uma entrada aqui é uma
@@ -50,7 +50,7 @@ const CONSULTA = /\.from\(\s*["'`]ai_invocations["'`]\s*\)/;
 describe("telemetria de IA tem uma tabela só", () => {
   const arquivos = arquivosDeCodigo(["app", "lib", "workers", "components", "hooks", "scripts"]).map(
     (absoluto) => ({
-      caminho: relative(RAIZ_DO_REPO, absoluto),
+      caminho: caminhoRelativo(absoluto),
       conteudo: readFileSync(absoluto, "utf8"),
     }),
   );


### PR DESCRIPTION
# O que este PR faz

Num clone limpo desta `main`, com o padrão do instalador git pra Windows, `pnpm test:unit` dá **9 arquivos / 20 casos vermelhos** e `pnpm lint:channels` acusa **155 arquivos**. Nenhum é defeito de produto: são os próprios gates lendo o disco de um jeito que só funciona em Linux.

O custo não é o vermelho — é que quem contribui do Windows abre o repo já quebrado e **não tem como distinguir o que é seu**. Foi o que me aconteceu: cheguei aqui por outro PR e gastei a primeira hora provando que aqueles 9 não eram meus.

## Antes e depois, medido na mesma máquina

| gate | `main` | com este PR |
|---|---|---|
| `pnpm test:unit` | 9 arquivos / 20 casos | **1 arquivo / 1 caso** |
| `pnpm lint:channels` | 155 arquivos acusados | **ok (60 de dívida conhecida, nenhum novo)** |
| `pnpm typecheck` | 0 | 0 |
| `pnpm lint` | 0 | 0 |
| `pnpm build` | 0 | 0 |
| `pnpm test:shell` | 1 prova | 1 prova (**não consertado** — ver no fim) |

O "depois" foi medido num **clone novo da branch**, feito com `core.autocrlf` no padrão — não na árvore onde editei. É a experiência real de quem clona.

O 1 caso restante é `namespace-das-imagens`, e ele **não é asserção: é `Test timed out in 15000ms`**. Roda isolado, passa (13/13). É varredura de disco pesada sob carga; não mexi.

## Três causas, medidas separadamente

### 1. CRLF no checkout — 5 arquivos, 12 casos

Os blobs estão em LF, mas `core.autocrlf=true` entrega CRLF no disco, e os gates leem texto o tempo todo: workflow YAML, mapa de jornadas, selo de tradução, lista de specs do e2e. Um `\r` no fim da linha derruba regex ancorada.

Mesma `main`, mesma máquina, só mudando o modo do clone:

```
core.autocrlf=true   ->  9 arquivos / 20 casos
core.autocrlf=false  ->  5 arquivos /  8 casos
```

Os 5 arquivos da diferença — `tag-so-nasce-da-main`, `e2e-cobertura-completa`, `numero-de-jornada-e-unico`, `traducao-nao-defasa`, `marca-logo-spec-ancora-a-rota` — não têm defeito nenhum.

**O `.gitattributes` já resolvia isso para `*.sql`**, e o comentário de lá já escreve o raciocínio inteiro, inclusive que *"CI passa porque `ubuntu-latest` não converte por padrão — só quem clona no Windows vê a falha"*. Este PR estende a mesma regra ao resto do texto.

Verifiquei que isso **não reescreve arquivo nenhum**: `git add --renormalize .` altera zero arquivos além do próprio `.gitattributes`, porque os blobs já são LF. Muda só o que o checkout entrega.

### 2. Separador de caminho — 3 arquivos de teste + 1 script

`path.relative` devolve barra invertida no Windows, e as listas declaradas contra as quais o resultado é comparado usam barra normal. **Falha nas duas pontas ao mesmo tempo**: o arquivo justificado é acusado de infrator, e a justificativa que o liberava é acusada de órfã. Em `telemetria-tem-um-leitor-so` isso aparece literalmente — `scripts\qa-wave-10.ts` na lista de infratores e `scripts/qa-wave-10.ts` na de allowlist morta, o mesmo arquivo nas duas.

Novo `tests/unit/helpers/caminho.ts`, num lugar só. Quatro cópias da mesma linha é a garantia de que uma delas diverge — é o mesmo argumento que o docblock de `varrer-codigo.ts` já faz para a varredura.

Mesma causa em `scripts/lint-channels.ts`: `ALLOWED` é regex ancorada em `^lib/channels/` e `DEBT` é um Set de strings, e o `join()` do Windows não casava com nenhum dos dois — nada era permitido e nada era reconhecido como dívida já registrada.

**`telas-sem-dado-de-mentira` entra aqui como preventivo**, não como conserto: o `PERMITIDOS` dele está vazio hoje, então o gate passa. A primeira entrada que alguém adicionar é que não vai casar — e o modo de falha é o pior possível, porque a mensagem vai dizer "há dívida nova" em vez de "seu separador está errado".

### 3. `npx` não é executável no Windows — 1 arquivo

`import-puro-sem-env` chamava `execFileSync("npx", ...)`, e no Windows o `npx` é `npx.cmd`: `spawnSync npx ENOENT`. Agora chama `process.execPath` com `node_modules/tsx/dist/cli.mjs` — dispensa PATH, dispensa `.cmd`, e usa o tsx deste `node_modules` em vez do que o PATH oferecer.

**E o defeito grave que isso escondia:** o CONTROLE POSITIVO passava com o aparato quebrado. Ele espera `ok:false` para `@/lib/env`, e um filho que nunca nasceu também devolve `ok:false` — os dois estados eram indistinguíveis. O resultado era o pior arranjo possível: o controle **verde** ao lado do caso real **vermelho**, afirmando que o instrumento estava bom justamente quando ele não media nada. Exatamente o que o cabeçalho daquele arquivo existe para impedir ("a diferença entre verificar e parecer que verificou"), acontecendo dentro dele.

`respondeu` separa os dois: só conta como resposta uma saída com `OK` ou `ERRO:`. Sabotei apontando o CLI para um arquivo inexistente — **o controle positivo agora reprova**, e com o código anterior passaria.

## O que NÃO foi feito, e por quê

- **`test:shell` continua vermelho.** A prova é `.env continua 600 (só o dono lê)`, e NTFS não tem permissão Unix. Fazer isso passar exige decidir se a prova pula no Windows ou se passa a checar ACL — é decisão de vocês, não minha, e ficaria escondida dentro de um PR sobre outra coisa.
- **`namespace-das-imagens` continua flaky.** Subir o timeout é chute enquanto ninguém mediu por que aquela varredura demora; preferi deixar declarado a esconder.
- **`pnpm test:db` não rodou** — não há Docker nesta máquina. Não tenho como afirmar nada sobre ele. O `.gitattributes` mexe em fim de linha, e o comentário de `*.sql` diz que o baseline se autoconfere por `md5(body)` — a regra nova é do mesmo sinal (força LF, nunca CRLF), então não deve alcançá-lo, mas **isso é raciocínio meu, não medição**. Vale um olhar de quem tem o ambiente.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam — este PR conserta gates; a prova é o antes/depois acima, num clone novo
- [ ] RLS / audit log / Zod / schema — não aplicável, não toca produto
- [x] Sem `console.log` esquecido
- [ ] Fragmento em `.changes/` — não aplicável: nada aqui muda comportamento visível a quem opera uma VPS

Separado do #432 de propósito: aquele é bug de produto, este é ferramental. Se preferir os três blocos em PRs distintos, eu divido.
