### PR TITLE
fix(ia): quando a IA fica calada, dá para ver por quê

### DIFF
--- a/.changes/agente-mudo-deixa-rastro.md
+++ b/.changes/agente-mudo-deixa-rastro.md
@@ -1,0 +1,29 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Quando a IA fica calada, agora dá para ver por quê
+---
+
+Três consertos que atacam o mesmo problema: o sistema fazia a coisa certa em
+silêncio, e de fora parecia quebrado.
+
+**A ficha de proteção de envio parou de congelar o padrão do dia.** O botão
+"Enviar aos domingos" era o único controle daquela ficha que não sabia dizer
+"não mexi": ele gravava sempre o valor que estava na tela, e o valor na tela,
+sem escolha própria, era o padrão vigente. Quem abriu a ficha para declarar o
+aquecimento do número acabou congelando o padrão daquele dia — e, quando o
+produto passou a liberar domingo, essa instalação ficou para trás com uma
+escolha que ninguém fez. Agora só um valor DIFERENTE do padrão vira escolha.
+Quem desligou o domingo de propósito continua com ele desligado.
+
+**A espera pela janela de envio virou aviso na Central.** Quando o número está
+fora do horário de envio, as respostas ficam na fila e saem na abertura — isso
+não mudou. O que mudou é que agora existe um aviso dizendo que estão esperando,
+a partir de quando saem e o que fazer. Um aviso por número, e ele se resolve
+sozinho quando o horário reabre.
+
+**A aba "Execuções" de um agente mostra o que ele realmente fez.** Ela lia uma
+tabela que nenhum motor em uso escreve, e por isso dizia "Nenhuma execução
+ainda" mesmo com o agente respondendo. Passou a ler o registro vivo. Execuções
+anteriores a esta versão não aparecem ali — para o histórico completo, use
+IA › Execuções.

--- a/app/api/v1/ai/agents/[id]/runs/route.ts
+++ b/app/api/v1/ai/agents/[id]/runs/route.ts
@@ -1,8 +1,44 @@
 /**
- * GET /api/v1/ai/agents/:id/runs (manager+)
+ * GET /api/v1/ai/agents/:id/runs (manager+) — as execuções DESTE agente.
  *
- * Cursor pagination opaco base64 (started_at + id) — same convention as outras rotas.
- * Filtro opcional ?status=...
+ * ## Por que esta rota mudou de tabela
+ *
+ * Ela lia `ai_agent_runs`, e a aba "Execuções" da tela do agente dizia
+ * **"Nenhuma execução ainda"** enquanto o agente respondia no WhatsApp. Medido
+ * na VPS de produção em 2026-08-30: `ai_agent_runs` com **0 linhas**, e
+ * `llm_calls` com **130** de `purpose='agent_turn'` na mesma organização, a
+ * última do próprio dia.
+ *
+ * `ai_agent_runs` só tem dois escritores no repo, e nenhum é o motor de
+ * produção: o dispatcher legado (`lib/ai/dispatcher/index.ts`, sem chamador — o
+ * cron `app/api/v1/cron/agent-dispatcher` devolve `{ skipped: true,
+ * deprecated: true }`) e o runner legado. O motor que responde de verdade é o
+ * `lib/agent-engine`, e ele registra em `llm_calls`.
+ *
+ * Uma tela que promete um registro que motor nenhum escreve é pior que uma tela
+ * ausente: ela responde "não aconteceu nada" a quem está investigando
+ * justamente por que nada aconteceu.
+ *
+ * ## O que muda para quem lê
+ *
+ * O SHAPE de saída é o mesmo (`AgentRunRow`) — a tabela, o drawer e o hook não
+ * mudam. O que muda é a fonte, e com ela três campos que `llm_calls` não tem:
+ * `agent_version_id`, `steps_count` e `tool_calls` saem `null`. Preferi `null`
+ * a inventar: `null` a tela já sabe desenhar ("—"), e um zero fabricado em
+ * "Steps" afirmaria que o turno não usou ferramenta nenhuma.
+ *
+ * ## O corte histórico, dito por escrito
+ *
+ * `llm_calls.agent_id` existia com FK e **nunca era escrita** (0 de 130 linhas
+ * medidas). O conserto está em `lib/agent-engine/edge/llm/run-model-call.ts`,
+ * e ele só vale dali para a frente: execuções anteriores ao deploy ficam com
+ * `agent_id` nulo e **não aparecem aqui**. Não há como backfillar com
+ * honestidade — o agente do turno não é derivável do que ficou gravado. Quem
+ * precisa do histórico completo da organização usa `/app/ai/runs`, que lista
+ * `llm_calls` sem filtrar por agente.
+ *
+ * Cursor pagination opaco base64 (created_at + id), como as demais rotas.
+ * Filtro opcional ?status=.
  */
 import { randomUUID } from "node:crypto";
 import { type NextRequest } from "next/server";
@@ -16,8 +52,77 @@ export const dynamic = "force-dynamic";
 
 const UUID_RX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-const RUN_COLUMNS =
-  "id, organization_id, agent_id, agent_version_id, conversation_id, contact_id, channel_session_id, inbound_message_id, outbound_message_id, status, abort_reason, error_code, error_message, tokens_in, tokens_out, cost_cents, latency_ms, steps_count, tool_calls, is_dry_run, started_at, completed_at, created_at";
+const CALL_COLUMNS =
+  "id, organization_id, agent_id, contact_id, purpose, status, error_code, error_message, " +
+  "input_tokens, output_tokens, cost_cents, latency_ms, created_at";
+
+/**
+ * O vocabulário de `llm_calls.status` ('ok' | 'erro') traduzido para o que a
+ * tela desenha (`STATUS_VARIANT` em RunsTable: pending/running/completed/failed).
+ * Sem esta tradução o badge cairia no `?? "outline"` e mostraria a palavra crua
+ * do banco para o usuário.
+ */
+const STATUS_DO_BANCO_PARA_A_TELA: Record<string, string> = {
+  ok: "completed",
+  erro: "failed",
+};
+/** A tradução inversa, para o filtro `?status=` continuar valendo. */
+const STATUS_DA_TELA_PARA_O_BANCO: Record<string, string> = {
+  completed: "ok",
+  failed: "erro",
+};
+
+interface LlmCallRow {
+  id: string;
+  organization_id: string;
+  agent_id: string | null;
+  contact_id: string | null;
+  purpose: string | null;
+  status: string | null;
+  error_code: string | null;
+  error_message: string | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cost_cents: number | null;
+  latency_ms: number | null;
+  created_at: string;
+}
+
+/**
+ * `llm_calls` → o shape que a tela já consome. Exportada para o teste medir o
+ * mapeamento sem precisar de banco (`tests/unit/aba-de-execucoes-le-o-motor-vivo`).
+ */
+export function paraLinhaDeExecucao(c: LlmCallRow): Record<string, unknown> {
+  return {
+    id: c.id,
+    organization_id: c.organization_id,
+    agent_id: c.agent_id,
+    // `llm_calls` não guarda a VERSÃO do agente. Null e não "" — a tela
+    // distingue ausência de vazio, e "" seria afirmar uma versão sem nome.
+    agent_version_id: null,
+    conversation_id: null,
+    contact_id: c.contact_id,
+    channel_session_id: null,
+    inbound_message_id: null,
+    outbound_message_id: null,
+    status: STATUS_DO_BANCO_PARA_A_TELA[c.status ?? ""] ?? (c.status ?? "completed"),
+    abort_reason: null,
+    error_code: c.error_code,
+    error_message: c.error_message,
+    tokens_in: c.input_tokens,
+    tokens_out: c.output_tokens,
+    cost_cents: c.cost_cents,
+    latency_ms: c.latency_ms,
+    // Nenhum dos três existe em `llm_calls`. Ver o cabeçalho: null é honesto,
+    // zero seria uma afirmação falsa sobre o turno.
+    steps_count: null,
+    tool_calls: null,
+    is_dry_run: false,
+    started_at: c.created_at,
+    completed_at: c.created_at,
+    created_at: c.created_at,
+  };
+}
 
 type Ctx = { params: Promise<{ id: string }> };
 
@@ -66,29 +171,33 @@ export async function GET(req: NextRequest, ctx: Ctx): Promise<Response> {
 
   const supabase = await createClient();
   let query = supabase
-    .from("ai_agent_runs")
-    .select(RUN_COLUMNS)
+    .from("llm_calls")
+    .select(CALL_COLUMNS)
+    // `organization_id` explícito mesmo com RLS: é a convenção do repo e o que
+    // sobrevive a alguém trocar o client por um admin um dia.
     .eq("organization_id", activeOrg.orgId)
     .eq("agent_id", id)
-    .order("started_at", { ascending: false })
+    .order("created_at", { ascending: false })
     .order("id", { ascending: false })
     .limit(q.limit + 1);
 
-  if (q.status) query = query.eq("status", q.status);
+  if (q.status) {
+    query = query.eq("status", STATUS_DA_TELA_PARA_O_BANCO[q.status] ?? q.status);
+  }
 
   if (q.cursor) {
     const c = decodeCursor(q.cursor);
     if (!c) return fail("invalid_request", "cursor inválido.", 400, { requestId });
-    // Tuple-aware seek: started_at < c.started_at OR (=, id < c.id).
+    // Tuple-aware seek: created_at < c.started_at OR (=, id < c.id).
     query = query.or(
-      `started_at.lt.${c.started_at},and(started_at.eq.${c.started_at},id.lt.${c.id})`,
+      `created_at.lt.${c.started_at},and(created_at.eq.${c.started_at},id.lt.${c.id})`,
     );
   }
 
   const { data, error } = await query;
-  if (error) return fail("internal_error", "Erro ao listar runs.", 500, { requestId });
+  if (error) return fail("internal_error", "Erro ao listar execuções.", 500, { requestId });
 
-  const rows = data ?? [];
+  const rows = ((data ?? []) as unknown as LlmCallRow[]).map(paraLinhaDeExecucao);
   const hasMore = rows.length > q.limit;
   const slice = hasMore ? rows.slice(0, q.limit) : rows;
   const last = slice[slice.length - 1];

--- a/components/connections/AntiBanSheet.tsx
+++ b/components/connections/AntiBanSheet.tsx
@@ -24,6 +24,7 @@ import { useUpdatePacingKnobs, type PacingKnobsItem } from "@/hooks/channels/use
 import { valorDeOverride } from "@/lib/ai/pacing-knobs";
 import { ApiError } from "@/lib/api/types";
 import { nomeDoCanal } from "@/lib/channels/estado";
+import { useT } from "@/hooks/i18n/useT";
 
 interface Props {
   item: PacingKnobsItem | null;
@@ -70,6 +71,7 @@ const msOrNull = (s: string): number | null =>
   s.trim() === "" ? null : Math.round(Number(s) * 1000);
 
 export function AntiBanSheet({ item, canWrite, onClose }: Props) {
+  const t = useT();
   const update = useUpdatePacingKnobs();
   const [form, setForm] = useState<FormState | null>(null);
 
@@ -115,10 +117,10 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
             : new Date(`${form.numero_em_uso_desde}T12:00:00.000Z`).toISOString(),
         skip_warmup: form.pular_aquecimento,
       });
-      toast.success("Proteção de envio atualizada.");
+      toast.success(t("Proteção de envio atualizada."));
       onClose();
     } catch (err) {
-      toast.error(err instanceof ApiError ? err.message : "Não foi possível salvar.");
+      toast.error(err instanceof ApiError ? t(err.message) : t("Não foi possível salvar."));
     }
   };
 
@@ -126,16 +128,19 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
     <Sheet open onOpenChange={(open) => !open && onClose()}>
       <SheetContent className="flex w-full flex-col gap-0 overflow-y-auto sm:max-w-md">
         <SheetHeader>
-          <SheetTitle>Proteção de envio — {label}</SheetTitle>
+          <SheetTitle>
+            {t("Proteção de envio —")} {label}
+          </SheetTitle>
           <SheetDescription>
-            Estes limites protegem o número contra bloqueio do WhatsApp. Campo vazio usa o
-            padrão seguro do sistema (mostrado no campo).
+            {t(
+              "Estes limites protegem o número contra bloqueio do WhatsApp. Campo vazio usa o padrão seguro do sistema (mostrado no campo).",
+            )}
           </SheetDescription>
         </SheetHeader>
 
         <div className="flex flex-col gap-5 px-4 py-2" data-testid="anti-ban-form">
           <fieldset className="flex flex-col gap-2" data-testid="aquecimento">
-            <Label htmlFor="numero-em-uso-desde">Este número é usado desde</Label>
+            <Label htmlFor="numero-em-uso-desde">{t("Este número é usado desde")}</Label>
             <Input
               id="numero-em-uso-desde"
               type="date"
@@ -146,9 +151,9 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
               className="w-48"
             />
             <p className="text-xs text-muted-foreground">
-              A conexão pode ser nova sem que o número seja. O aquecimento conta a idade do
-              NÚMERO — se você deixar em branco, ele é tratado como recém-criado e começa
-              liberando pouco por dia.
+              {t(
+                "A conexão pode ser nova sem que o número seja. O aquecimento conta a idade do NÚMERO — se você deixar em branco, ele é tratado como recém-criado e começa liberando pouco por dia.",
+              )}
             </p>
 
             <div className="mt-1 flex items-center gap-2">
@@ -159,20 +164,22 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
                 disabled={!canWrite}
               />
               <Label htmlFor="pular-aquecimento" className="font-normal">
-                Este número já está aquecido — pular o aquecimento
+                {t("Este número já está aquecido — pular o aquecimento")}
               </Label>
             </div>
             <p className="text-xs text-muted-foreground">
               {form.pular_aquecimento
-                ? "Vale só o teto diário abaixo. Use apenas se o número já envia há semanas: pular o aquecimento num número novo é o caminho mais rápido para o bloqueio."
+                ? t(
+                    "Vale só o teto diário abaixo. Use apenas se o número já envia há semanas: pular o aquecimento num número novo é o caminho mais rápido para o bloqueio.",
+                  )
                 : item.warmup.cap_today === null
-                  ? `Número com ${item.warmup.age_days} dia(s) de uso — já formado. Vale só o teto diário abaixo.`
-                  : `Hoje o aquecimento libera ${item.warmup.cap_today} envio(s) — o número tem ${item.warmup.age_days} dia(s) de uso. Enquanto esse número for menor que o teto diário, é ELE que limita, e mexer no teto diário não muda nada.`}
+                  ? `${t("Número com")} ${item.warmup.age_days} ${t("dia(s) de uso — já formado. Vale só o teto diário abaixo.")}`
+                  : `${t("Hoje o aquecimento libera")} ${item.warmup.cap_today} ${t("envio(s) — o número tem")} ${item.warmup.age_days} ${t("dia(s) de uso. Enquanto esse número for menor que o teto diário, é ELE que limita, e mexer no teto diário não muda nada.")}`}
             </p>
           </fieldset>
 
           <fieldset className="flex flex-col gap-2">
-            <Label>Janela de envio (horário local)</Label>
+            <Label>{t("Janela de envio (horário local)")}</Label>
             <div className="flex items-center gap-2">
               <Input
                 type="number"
@@ -183,10 +190,10 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
                 value={form.window_start_hour}
                 onChange={(e) => set({ window_start_hour: e.target.value })}
                 disabled={!canWrite}
-                aria-label="Hora de início da janela"
+                aria-label={t("Hora de início da janela")}
                 className="w-20"
               />
-              <span className="text-sm text-muted-foreground">h até</span>
+              <span className="text-sm text-muted-foreground">{t("h até")}</span>
               <Input
                 type="number"
                 min={1}
@@ -196,23 +203,25 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
                 value={form.window_end_hour}
                 onChange={(e) => set({ window_end_hour: e.target.value })}
                 disabled={!canWrite}
-                aria-label="Hora de fim da janela"
+                aria-label={t("Hora de fim da janela")}
                 className="w-20"
               />
               <span className="text-sm text-muted-foreground">h</span>
             </div>
             <p className="text-xs text-muted-foreground">
-              O assistente só envia mensagens dentro desta janela. Fora dela, a resposta fica
-              agendada para a próxima abertura — você vê o motivo na conversa.
+              {t(
+                "O assistente só envia mensagens dentro desta janela. Fora dela, a resposta fica agendada para a próxima abertura — você vê o motivo na conversa.",
+              )}
             </p>
           </fieldset>
 
           <fieldset className="flex items-center justify-between gap-4">
             <div>
-              <Label htmlFor="allow-sunday">Enviar aos domingos</Label>
+              <Label htmlFor="allow-sunday">{t("Enviar aos domingos")}</Label>
               <p className="text-xs text-muted-foreground">
-                Ligado por padrão: quem escreve no domingo espera resposta no domingo. Desligue
-                se você faz prospecção ativa e prefere não incomodar no fim de semana.
+                {t(
+                  "Ligado por padrão: quem escreve no domingo espera resposta no domingo. Desligue se você faz prospecção ativa e prefere não incomodar no fim de semana.",
+                )}
               </p>
             </div>
             <Switch
@@ -224,7 +233,7 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
           </fieldset>
 
           <fieldset className="flex flex-col gap-2">
-            <Label>Ritmo entre envios (segundos)</Label>
+            <Label>{t("Ritmo entre envios (segundos)")}</Label>
             <div className="flex items-center gap-2">
               <Input
                 type="number"
@@ -235,10 +244,10 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
                 value={form.throttle_s}
                 onChange={(e) => set({ throttle_s: e.target.value })}
                 disabled={!canWrite}
-                aria-label="Intervalo mínimo entre envios em segundos"
+                aria-label={t("Intervalo mínimo entre envios em segundos")}
                 className="w-24"
               />
-              <span className="text-sm text-muted-foreground">+ variação de até</span>
+              <span className="text-sm text-muted-foreground">{t("+ variação de até")}</span>
               <Input
                 type="number"
                 min={0}
@@ -248,39 +257,41 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
                 value={form.jitter_s}
                 onChange={(e) => set({ jitter_s: e.target.value })}
                 disabled={!canWrite}
-                aria-label="Variação aleatória máxima em segundos"
+                aria-label={t("Variação aleatória máxima em segundos")}
                 className="w-24"
               />
               <span className="text-sm text-muted-foreground">s</span>
             </div>
             <p className="text-xs text-muted-foreground">
-              Intervalo mínimo entre mensagens do mesmo número, mais uma variação aleatória —
-              ritmo cravado parece robô para o WhatsApp.
+              {t(
+                "Intervalo mínimo entre mensagens do mesmo número, mais uma variação aleatória — ritmo cravado parece robô para o WhatsApp.",
+              )}
             </p>
           </fieldset>
 
           <fieldset className="flex flex-col gap-2">
-            <Label>Teto diário de envios</Label>
+            <Label>{t("Teto diário de envios")}</Label>
             <Input
               type="number"
               min={item.bounds.daily_limit.min}
               max={item.bounds.daily_limit.max}
               inputMode="numeric"
-              placeholder="sem teto definido"
+              placeholder={t("sem teto definido")}
               value={form.daily_message_limit}
               onChange={(e) => set({ daily_message_limit: e.target.value })}
               disabled={!canWrite}
-              aria-label="Teto diário de mensagens"
+              aria-label={t("Teto diário de mensagens")}
               className="w-32"
             />
             <p className="text-xs text-muted-foreground">
-              Máximo de mensagens que este número envia por dia. Números novos também respeitam
-              o aquecimento automático abaixo, o que for menor.
+              {t(
+                "Máximo de mensagens que este número envia por dia. Números novos também respeitam o aquecimento automático abaixo, o que for menor.",
+              )}
             </p>
           </fieldset>
 
           <fieldset className="flex flex-col gap-2">
-            <Label>Fuso horário da janela</Label>
+            <Label>{t("Fuso horário da janela")}</Label>
             {/* LISTA, e não texto livre. A API já REJEITA fuso inválido — mas
                 rejeitar é devolver um erro a quem digitou certo na cabeça e
                 errado no teclado (`America/Asunción`, com o acento que um
@@ -289,46 +300,49 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
               value={form.timezone}
               onChange={(e) => set({ timezone: e.target.value })}
               disabled={!canWrite}
-              aria-label="Fuso horário IANA"
+              aria-label={t("Fuso horário IANA")}
               className="h-9 w-full rounded-md border border-input bg-background px-2 text-sm disabled:opacity-50"
             >
-              <option value="">Usar o padrão ({eff.timezone})</option>
+              <option value="">
+                {t("Usar o padrão")} ({eff.timezone})
+              </option>
               {FUSOS_OFERECIDOS.map((f) => (
                 <option key={f.codigo} value={f.codigo}>
-                  {f.rotulo} — {f.codigo}
+                  {t(f.rotulo)} — {f.codigo}
                 </option>
               ))}
             </select>
             <p className="text-xs text-muted-foreground">
-              A janela de envio é avaliada neste fuso (ex.: America/Sao_Paulo).
+              {t("A janela de envio é avaliada neste fuso (ex.: America/Sao_Paulo).")}
             </p>
           </fieldset>
 
           <div className="rounded-md border border-border bg-muted/30 p-3">
-            <p className="text-xs font-medium">Aquecimento automático de número novo</p>
+            <p className="text-xs font-medium">{t("Aquecimento automático de número novo")}</p>
             <p className="mt-1 text-xs text-muted-foreground">
               {eff.warmupDailyCaps
                 .map((s) =>
                   s.cap === null
-                    ? `a partir de ${s.minAgeDays} dias: sem limite de aquecimento`
-                    : `${s.minAgeDays}+ dias: até ${s.cap}/dia`,
+                    ? `${t("a partir de")} ${s.minAgeDays} ${t("dias: sem limite de aquecimento")}`
+                    : `${s.minAgeDays}+ ${t("dias: até")} ${s.cap}/${t("dia")}`,
                 )
                 .join(" · ")}
             </p>
             <p className="mt-1 text-xs text-muted-foreground">
-              Número recém-conectado envia pouco e sobe aos poucos — enviar demais no início é
-              a causa nº 1 de bloqueio.
+              {t(
+                "Número recém-conectado envia pouco e sobe aos poucos — enviar demais no início é a causa nº 1 de bloqueio.",
+              )}
             </p>
           </div>
         </div>
 
         <div className="mt-auto flex justify-end gap-2 border-t border-border px-4 py-3">
           <Button variant="ghost" onClick={onClose}>
-            {canWrite ? "Cancelar" : "Fechar"}
+            {canWrite ? t("Cancelar") : t("Fechar")}
           </Button>
           {canWrite ? (
             <Button onClick={handleSave} disabled={update.isPending} data-testid="anti-ban-save">
-              {update.isPending ? "Salvando…" : "Salvar proteção"}
+              {update.isPending ? t("Salvando…") : t("Salvar proteção")}
             </Button>
           ) : null}
         </div>

--- a/components/connections/AntiBanSheet.tsx
+++ b/components/connections/AntiBanSheet.tsx
@@ -21,9 +21,9 @@ import {
 } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
 import { useUpdatePacingKnobs, type PacingKnobsItem } from "@/hooks/channels/usePacingKnobs";
+import { valorDeOverride } from "@/lib/ai/pacing-knobs";
 import { ApiError } from "@/lib/api/types";
 import { nomeDoCanal } from "@/lib/channels/estado";
-import { useT } from "@/hooks/i18n/useT";
 
 interface Props {
   item: PacingKnobsItem | null;
@@ -70,7 +70,6 @@ const msOrNull = (s: string): number | null =>
   s.trim() === "" ? null : Math.round(Number(s) * 1000);
 
 export function AntiBanSheet({ item, canWrite, onClose }: Props) {
-  const t = useT();
   const update = useUpdatePacingKnobs();
   const [form, setForm] = useState<FormState | null>(null);
 
@@ -98,7 +97,11 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
         window_end_hour: intOrNull(form.window_end_hour),
         throttle_ms: msOrNull(form.throttle_s),
         jitter_max_ms: msOrNull(form.jitter_s),
-        allow_sunday: form.allow_sunday,
+        // `null` quando o Switch está no default: salvar esta ficha por outro
+        // motivo (aquecimento, throttle) não pode congelar o padrão do dia como
+        // escolha permanente — foi assim que uma instalação ficou muda todo
+        // domingo. Ver `valorDeOverride`.
+        allow_sunday: valorDeOverride(form.allow_sunday, item.defaults.allowSunday),
         timezone: form.timezone.trim() === "" ? null : form.timezone.trim(),
         ...(form.daily_message_limit.trim() !== ""
           ? { daily_message_limit: Math.round(Number(form.daily_message_limit)) }
@@ -112,10 +115,10 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
             : new Date(`${form.numero_em_uso_desde}T12:00:00.000Z`).toISOString(),
         skip_warmup: form.pular_aquecimento,
       });
-      toast.success(t("Proteção de envio atualizada."));
+      toast.success("Proteção de envio atualizada.");
       onClose();
     } catch (err) {
-      toast.error(err instanceof ApiError ? t(err.message) : t("Não foi possível salvar."));
+      toast.error(err instanceof ApiError ? err.message : "Não foi possível salvar.");
     }
   };
 
@@ -123,19 +126,16 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
     <Sheet open onOpenChange={(open) => !open && onClose()}>
       <SheetContent className="flex w-full flex-col gap-0 overflow-y-auto sm:max-w-md">
         <SheetHeader>
-          <SheetTitle>
-            {t("Proteção de envio —")} {label}
-          </SheetTitle>
+          <SheetTitle>Proteção de envio — {label}</SheetTitle>
           <SheetDescription>
-            {t(
-              "Estes limites protegem o número contra bloqueio do WhatsApp. Campo vazio usa o padrão seguro do sistema (mostrado no campo).",
-            )}
+            Estes limites protegem o número contra bloqueio do WhatsApp. Campo vazio usa o
+            padrão seguro do sistema (mostrado no campo).
           </SheetDescription>
         </SheetHeader>
 
         <div className="flex flex-col gap-5 px-4 py-2" data-testid="anti-ban-form">
           <fieldset className="flex flex-col gap-2" data-testid="aquecimento">
-            <Label htmlFor="numero-em-uso-desde">{t("Este número é usado desde")}</Label>
+            <Label htmlFor="numero-em-uso-desde">Este número é usado desde</Label>
             <Input
               id="numero-em-uso-desde"
               type="date"
@@ -146,9 +146,9 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
               className="w-48"
             />
             <p className="text-xs text-muted-foreground">
-              {t(
-                "A conexão pode ser nova sem que o número seja. O aquecimento conta a idade do NÚMERO — se você deixar em branco, ele é tratado como recém-criado e começa liberando pouco por dia.",
-              )}
+              A conexão pode ser nova sem que o número seja. O aquecimento conta a idade do
+              NÚMERO — se você deixar em branco, ele é tratado como recém-criado e começa
+              liberando pouco por dia.
             </p>
 
             <div className="mt-1 flex items-center gap-2">
@@ -159,22 +159,20 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
                 disabled={!canWrite}
               />
               <Label htmlFor="pular-aquecimento" className="font-normal">
-                {t("Este número já está aquecido — pular o aquecimento")}
+                Este número já está aquecido — pular o aquecimento
               </Label>
             </div>
             <p className="text-xs text-muted-foreground">
               {form.pular_aquecimento
-                ? t(
-                    "Vale só o teto diário abaixo. Use apenas se o número já envia há semanas: pular o aquecimento num número novo é o caminho mais rápido para o bloqueio.",
-                  )
+                ? "Vale só o teto diário abaixo. Use apenas se o número já envia há semanas: pular o aquecimento num número novo é o caminho mais rápido para o bloqueio."
                 : item.warmup.cap_today === null
-                  ? `${t("Número com")} ${item.warmup.age_days} ${t("dia(s) de uso — já formado. Vale só o teto diário abaixo.")}`
-                  : `${t("Hoje o aquecimento libera")} ${item.warmup.cap_today} ${t("envio(s) — o número tem")} ${item.warmup.age_days} ${t("dia(s) de uso. Enquanto esse número for menor que o teto diário, é ELE que limita, e mexer no teto diário não muda nada.")}`}
+                  ? `Número com ${item.warmup.age_days} dia(s) de uso — já formado. Vale só o teto diário abaixo.`
+                  : `Hoje o aquecimento libera ${item.warmup.cap_today} envio(s) — o número tem ${item.warmup.age_days} dia(s) de uso. Enquanto esse número for menor que o teto diário, é ELE que limita, e mexer no teto diário não muda nada.`}
             </p>
           </fieldset>
 
           <fieldset className="flex flex-col gap-2">
-            <Label>{t("Janela de envio (horário local)")}</Label>
+            <Label>Janela de envio (horário local)</Label>
             <div className="flex items-center gap-2">
               <Input
                 type="number"
@@ -185,10 +183,10 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
                 value={form.window_start_hour}
                 onChange={(e) => set({ window_start_hour: e.target.value })}
                 disabled={!canWrite}
-                aria-label={t("Hora de início da janela")}
+                aria-label="Hora de início da janela"
                 className="w-20"
               />
-              <span className="text-sm text-muted-foreground">{t("h até")}</span>
+              <span className="text-sm text-muted-foreground">h até</span>
               <Input
                 type="number"
                 min={1}
@@ -198,25 +196,23 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
                 value={form.window_end_hour}
                 onChange={(e) => set({ window_end_hour: e.target.value })}
                 disabled={!canWrite}
-                aria-label={t("Hora de fim da janela")}
+                aria-label="Hora de fim da janela"
                 className="w-20"
               />
               <span className="text-sm text-muted-foreground">h</span>
             </div>
             <p className="text-xs text-muted-foreground">
-              {t(
-                "O assistente só envia mensagens dentro desta janela. Fora dela, a resposta fica agendada para a próxima abertura — você vê o motivo na conversa.",
-              )}
+              O assistente só envia mensagens dentro desta janela. Fora dela, a resposta fica
+              agendada para a próxima abertura — você vê o motivo na conversa.
             </p>
           </fieldset>
 
           <fieldset className="flex items-center justify-between gap-4">
             <div>
-              <Label htmlFor="allow-sunday">{t("Enviar aos domingos")}</Label>
+              <Label htmlFor="allow-sunday">Enviar aos domingos</Label>
               <p className="text-xs text-muted-foreground">
-                {t(
-                  "Ligado por padrão: quem escreve no domingo espera resposta no domingo. Desligue se você faz prospecção ativa e prefere não incomodar no fim de semana.",
-                )}
+                Ligado por padrão: quem escreve no domingo espera resposta no domingo. Desligue
+                se você faz prospecção ativa e prefere não incomodar no fim de semana.
               </p>
             </div>
             <Switch
@@ -228,7 +224,7 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
           </fieldset>
 
           <fieldset className="flex flex-col gap-2">
-            <Label>{t("Ritmo entre envios (segundos)")}</Label>
+            <Label>Ritmo entre envios (segundos)</Label>
             <div className="flex items-center gap-2">
               <Input
                 type="number"
@@ -239,10 +235,10 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
                 value={form.throttle_s}
                 onChange={(e) => set({ throttle_s: e.target.value })}
                 disabled={!canWrite}
-                aria-label={t("Intervalo mínimo entre envios em segundos")}
+                aria-label="Intervalo mínimo entre envios em segundos"
                 className="w-24"
               />
-              <span className="text-sm text-muted-foreground">{t("+ variação de até")}</span>
+              <span className="text-sm text-muted-foreground">+ variação de até</span>
               <Input
                 type="number"
                 min={0}
@@ -252,41 +248,39 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
                 value={form.jitter_s}
                 onChange={(e) => set({ jitter_s: e.target.value })}
                 disabled={!canWrite}
-                aria-label={t("Variação aleatória máxima em segundos")}
+                aria-label="Variação aleatória máxima em segundos"
                 className="w-24"
               />
               <span className="text-sm text-muted-foreground">s</span>
             </div>
             <p className="text-xs text-muted-foreground">
-              {t(
-                "Intervalo mínimo entre mensagens do mesmo número, mais uma variação aleatória — ritmo cravado parece robô para o WhatsApp.",
-              )}
+              Intervalo mínimo entre mensagens do mesmo número, mais uma variação aleatória —
+              ritmo cravado parece robô para o WhatsApp.
             </p>
           </fieldset>
 
           <fieldset className="flex flex-col gap-2">
-            <Label>{t("Teto diário de envios")}</Label>
+            <Label>Teto diário de envios</Label>
             <Input
               type="number"
               min={item.bounds.daily_limit.min}
               max={item.bounds.daily_limit.max}
               inputMode="numeric"
-              placeholder={t("sem teto definido")}
+              placeholder="sem teto definido"
               value={form.daily_message_limit}
               onChange={(e) => set({ daily_message_limit: e.target.value })}
               disabled={!canWrite}
-              aria-label={t("Teto diário de mensagens")}
+              aria-label="Teto diário de mensagens"
               className="w-32"
             />
             <p className="text-xs text-muted-foreground">
-              {t(
-                "Máximo de mensagens que este número envia por dia. Números novos também respeitam o aquecimento automático abaixo, o que for menor.",
-              )}
+              Máximo de mensagens que este número envia por dia. Números novos também respeitam
+              o aquecimento automático abaixo, o que for menor.
             </p>
           </fieldset>
 
           <fieldset className="flex flex-col gap-2">
-            <Label>{t("Fuso horário da janela")}</Label>
+            <Label>Fuso horário da janela</Label>
             {/* LISTA, e não texto livre. A API já REJEITA fuso inválido — mas
                 rejeitar é devolver um erro a quem digitou certo na cabeça e
                 errado no teclado (`America/Asunción`, com o acento que um
@@ -295,49 +289,46 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
               value={form.timezone}
               onChange={(e) => set({ timezone: e.target.value })}
               disabled={!canWrite}
-              aria-label={t("Fuso horário IANA")}
+              aria-label="Fuso horário IANA"
               className="h-9 w-full rounded-md border border-input bg-background px-2 text-sm disabled:opacity-50"
             >
-              <option value="">
-                {t("Usar o padrão")} ({eff.timezone})
-              </option>
+              <option value="">Usar o padrão ({eff.timezone})</option>
               {FUSOS_OFERECIDOS.map((f) => (
                 <option key={f.codigo} value={f.codigo}>
-                  {t(f.rotulo)} — {f.codigo}
+                  {f.rotulo} — {f.codigo}
                 </option>
               ))}
             </select>
             <p className="text-xs text-muted-foreground">
-              {t("A janela de envio é avaliada neste fuso (ex.: America/Sao_Paulo).")}
+              A janela de envio é avaliada neste fuso (ex.: America/Sao_Paulo).
             </p>
           </fieldset>
 
           <div className="rounded-md border border-border bg-muted/30 p-3">
-            <p className="text-xs font-medium">{t("Aquecimento automático de número novo")}</p>
+            <p className="text-xs font-medium">Aquecimento automático de número novo</p>
             <p className="mt-1 text-xs text-muted-foreground">
               {eff.warmupDailyCaps
                 .map((s) =>
                   s.cap === null
-                    ? `${t("a partir de")} ${s.minAgeDays} ${t("dias: sem limite de aquecimento")}`
-                    : `${s.minAgeDays}+ ${t("dias: até")} ${s.cap}/${t("dia")}`,
+                    ? `a partir de ${s.minAgeDays} dias: sem limite de aquecimento`
+                    : `${s.minAgeDays}+ dias: até ${s.cap}/dia`,
                 )
                 .join(" · ")}
             </p>
             <p className="mt-1 text-xs text-muted-foreground">
-              {t(
-                "Número recém-conectado envia pouco e sobe aos poucos — enviar demais no início é a causa nº 1 de bloqueio.",
-              )}
+              Número recém-conectado envia pouco e sobe aos poucos — enviar demais no início é
+              a causa nº 1 de bloqueio.
             </p>
           </div>
         </div>
 
         <div className="mt-auto flex justify-end gap-2 border-t border-border px-4 py-3">
           <Button variant="ghost" onClick={onClose}>
-            {canWrite ? t("Cancelar") : t("Fechar")}
+            {canWrite ? "Cancelar" : "Fechar"}
           </Button>
           {canWrite ? (
             <Button onClick={handleSave} disabled={update.isPending} data-testid="anti-ban-save">
-              {update.isPending ? t("Salvando…") : t("Salvar proteção")}
+              {update.isPending ? "Salvando…" : "Salvar proteção"}
             </Button>
           ) : null}
         </div>

--- a/lib/agent-engine/agent/inbound-turn.ts
+++ b/lib/agent-engine/agent/inbound-turn.ts
@@ -87,6 +87,7 @@ import { matchesHandoffKeyword } from './agent-config';
 import { msAteAJanelaAbrir } from './janela-de-atendimento';
 import { janelaDeEnvioAberta, proximaAberturaDaJanela } from '../pacing/engine';
 import { loadChannelKnobs } from '../pacing/store';
+import { avisarJanelaFechada, resolverAvisoDeJanela } from '../pacing/aviso-de-janela';
 import { resolveTurnAgent } from './resolve-turn-agent';
 import {
   hasOpenCaseForContact,
@@ -1157,7 +1158,48 @@ async function executarTurnoDoAgente(
         timezone: knobs.timezone,
         abertura: abertura.toISOString(),
       });
+      // O adiamento deixa RASTRO VISÍVEL. Sem isto, o único registro de que o
+      // número está calado morre no log do contêiner — e foi assim que uma
+      // instalação passou um domingo inteiro muda, com todos os contêineres
+      // `healthy` e o dono sem nada para olhar. Um aviso por canal, deduplicado
+      // enquanto durar o silêncio; ver o cabeçalho de `aviso-de-janela.ts`.
+      //
+      // Fire-and-forget: telemetria nunca derruba um turno que já decidiu o que
+      // fazer com a mensagem do cliente — e o job JÁ foi reagendado acima.
+      try {
+        const criados = await avisarJanelaFechada(pool, {
+          tenantId,
+          channelSessionId: input.channelSessionId,
+          abertura,
+          janela: `${knobs.windowStartHour}h-${knobs.windowEndHour}h`,
+          timezone: knobs.timezone,
+          domingoDesligado: !knobs.allowSunday,
+        });
+        if (criados > 0) {
+          runLog.info('aviso de janela fechada aberto na Central', {
+            channel_session_id: input.channelSessionId,
+          });
+        }
+      } catch (err) {
+        runLog.warn('não consegui abrir o aviso de janela fechada', {
+          error: (err instanceof Error ? err.message : String(err)).slice(0, 120),
+        });
+      }
       throw new JobSettledError('fora da janela anti-ban — job reagendado para a abertura da janela');
+    }
+    // A janela está ABERTA: se havia aviso de silêncio pendurado, ele morre
+    // AQUI — no mesmo ponto que o abriu. Um aviso que só o humano fecha vira
+    // dívida: na segunda o número volta a atender e o painel seguiria dizendo
+    // que está calado.
+    try {
+      await resolverAvisoDeJanela(pool, {
+        tenantId,
+        channelSessionId: input.channelSessionId,
+      });
+    } catch (err) {
+      runLog.warn('não consegui resolver o aviso de janela fechada', {
+        error: (err instanceof Error ? err.message : String(err)).slice(0, 120),
+      });
     }
   }
 
@@ -2617,6 +2659,11 @@ async function executarTurnoDoAgente(
       tenantId,
       leadId,
       jobId: job.id,
+      // De quem é esta execução. Vai para `llm_calls.agent_id` e é o que permite
+      // a aba "Execuções" da tela do agente mostrar o que ELE fez — antes ela
+      // lia `ai_agent_runs`, tabela que motor nenhum vivo escreve, e dizia
+      // "Nenhuma execução ainda" com o agente respondendo no WhatsApp.
+      agentId: agentConfig?.agentId ?? null,
       purpose: 'agent_turn',
       system,
       messages: openingMessages,

--- a/lib/agent-engine/edge/llm/run-model-call.ts
+++ b/lib/agent-engine/edge/llm/run-model-call.ts
@@ -97,6 +97,17 @@ export interface RunModelCallInput {
   leadId?: string | null;
   jobId?: string | null;
   variantId?: string | null;
+  /**
+   * De QUEM é esta execução — `ai_agents.id` do agente publicado que está no
+   * turno. Vai para `llm_calls.agent_id`, a coluna que existia com FK e nunca
+   * era escrita (medido em produção: 0 de 130 linhas de `agent_turn`).
+   *
+   * Sem ela a aba "Execuções" da tela do agente não tem como filtrar o que
+   * mostrar — e era por isso que ela dizia "Nenhuma execução ainda" enquanto o
+   * agente respondia. Opcional porque a maioria dos chamadores é auxiliar
+   * (classificador, compaction, flywheel) e não pertence a um agente.
+   */
+  agentId?: string | null;
   /** atribuição de custo: 'agent_turn' (default) | 'classifier' | 'compaction' | 'connection_test' */
   purpose?: string;
   system?: string;
@@ -467,8 +478,8 @@ export async function runModelCall(db: pg.Pool, cfg: LlmEdgeConfig, input: RunMo
     `insert into llm_calls
        (organization_id, contact_id, job_id, variant_id, purpose, provider, model,
         input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, cost_cents, latency_ms,
-        status, origem_da_escolha)
-     values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, 'ok', $14)
+        status, origem_da_escolha, agent_id)
+     values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, 'ok', $14, $15)
      returning id`,
     [
       input.tenantId,
@@ -485,6 +496,7 @@ export async function runModelCall(db: pg.Pool, cfg: LlmEdgeConfig, input: RunMo
       cost,
       latencyMs,
       decisao.origem,
+      input.agentId ?? null,
     ],
   );
 
@@ -639,8 +651,8 @@ async function registrarFalha(
     `insert into llm_calls
        (organization_id, contact_id, job_id, variant_id, purpose, provider, model,
         input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, cost_cents, latency_ms,
-        status, error_code, error_message, http_status, origem_da_escolha)
-     values ($1, $2, $3, $4, $5, $6, $7, 0, 0, 0, 0, null, $8, 'erro', $9, $10, $11, $12)`,
+        status, error_code, error_message, http_status, origem_da_escolha, agent_id)
+     values ($1, $2, $3, $4, $5, $6, $7, 0, 0, 0, 0, null, $8, 'erro', $9, $10, $11, $12, $13)`,
     [
       d.input.tenantId,
       d.input.leadId ?? null,
@@ -654,6 +666,7 @@ async function registrarFalha(
       error_message,
       http_status,
       d.origem,
+      d.input.agentId ?? null,
     ],
   );
 }

--- a/lib/agent-engine/pacing/aviso-de-janela.ts
+++ b/lib/agent-engine/pacing/aviso-de-janela.ts
@@ -1,0 +1,133 @@
+/**
+ * O silêncio da janela anti-ban deixa de ser invisível.
+ *
+ * ## O defeito, medido em produção (VPS, domingo 2026-08-30)
+ *
+ * O dono escreveu "meus agentes de IA não estão respondendo mais, e não aparece
+ * NENHUMA execução, nem de erro nem de nada". Estava certo nas duas metades.
+ *
+ * `channel_knobs.allow_sunday = false` (gravado em 2026-08-06 pela tela
+ * Anti-ban, em Conexões) fazia `inbound-turn.ts` adiar TODO turno de domingo
+ * para segunda às 7h. O adiamento é a decisão certa — melhor a mensagem sair
+ * amanhã cedo do que o número ser banido — mas ele acontecia assim:
+ *
+ *     runLog.info('turno adiado — fora da janela anti-ban de envio', {...})
+ *     throw new JobSettledError(...)
+ *
+ * ...e nada mais. Sem linha em `agent_inbox_items`, sem atividade no lead, sem
+ * marca na Inbox. O único registro morria no log do contêiner, onde o dono de
+ * uma VPS não vai olhar. Do lado de fora, o sistema ficava mudo por um dia
+ * inteiro **afirmando estar saudável** — todos os contêineres `healthy`.
+ *
+ * Um turno adiado não é erro, e por isso não aparecia em `llm_calls` (não houve
+ * chamada de modelo). Era o pior tipo de silêncio: o que não deixa rastro em
+ * lugar nenhum.
+ *
+ * ## Por que o aviso é por CANAL, e não por conversa
+ *
+ * A janela fecha para o número inteiro. Se 50 pessoas escrevem no domingo, o
+ * fato a comunicar continua sendo UM ("este número está calado até segunda"),
+ * não 50. `ref_id = channel_session_id` + dedup por `status='open'` é o que
+ * transforma uma rajada num único aviso — mesmo padrão de `escalateJailbreakPromise`.
+ *
+ * Cinquenta avisos idênticos seriam ruído, e ruído na Central é como um alarme
+ * que toca sempre: ensina a ignorar.
+ *
+ * ## Por que ele se resolve sozinho
+ *
+ * Um aviso que só o humano fecha viraria dívida: na segunda-feira o número volta
+ * a atender e o painel continuaria dizendo que está calado. `resolverAvisoDeJanela`
+ * é chamado no MESMO ponto do turno em que a janela é encontrada ABERTA — o laço
+ * fecha onde ele foi aberto, sem varredura nem cron.
+ *
+ * `kind='other'` de propósito: um kind próprio exigiria migration + apêndice no
+ * baseline, e o CHECK de `agent_inbox_items.kind` quebraria o `update.sh` de todo
+ * clone que ainda não a aplicou. Quem distingue este aviso dos outros é o
+ * `ref_kind`, que é texto livre.
+ */
+import type { Queryable } from '../queue/queue';
+
+/** O `ref_kind` que identifica este aviso — a chave de dedup e de resolução. */
+export const REF_KIND_JANELA = 'janela_de_envio_fechada';
+
+export interface AvisoDeJanelaInput {
+  tenantId: string;
+  channelSessionId: string;
+  /** Quando a janela reabre — o que o operador precisa saber para decidir se age. */
+  abertura: Date;
+  /** `7h-22h`, para o corpo dizer QUAL janela está em vigor. */
+  janela: string;
+  /** O fuso em que a janela é lida; sem ele "22h" é ambíguo. */
+  timezone: string;
+  /**
+   * O domingo está desligado para este canal? Muda a AÇÃO de quem lê: se sim, há
+   * um botão a virar em Conexões › Anti-ban; se não, é só a noite passando e não
+   * há nada a fazer.
+   */
+  domingoDesligado: boolean;
+}
+
+/**
+ * Abre o aviso de "as respostas estão esperando a janela abrir", uma vez por
+ * canal enquanto durar o silêncio. Devolve quantos itens criou (0 = já havia um
+ * aberto para este canal).
+ *
+ * Fire-and-forget no chamador: falha de telemetria nunca pode derrubar um turno
+ * que já decidiu o que fazer com a mensagem do cliente.
+ */
+export async function avisarJanelaFechada(
+  db: Queryable,
+  input: AvisoDeJanelaInput,
+): Promise<number> {
+  const quando = new Intl.DateTimeFormat('pt-BR', {
+    timeZone: input.timezone,
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(input.abertura);
+
+  const porque = input.domingoDesligado
+    ? `Este número está com **envio aos domingos desligado**, e a janela de horário é ${input.janela} ` +
+      `(fuso ${input.timezone}).`
+    : `A janela de envio deste número é ${input.janela} (fuso ${input.timezone}), e agora está fechada.`;
+
+  const oQueFazer = input.domingoDesligado
+    ? 'Se quiser que o agente responda aos domingos, ligue "Enviar aos domingos" em Conexões › Anti-ban.'
+    : 'Não é preciso fazer nada: as respostas saem sozinhas na abertura.';
+
+  const { rowCount } = await db.query(
+    `insert into agent_inbox_items (organization_id, kind, severity, title, body, ref_kind, ref_id)
+     select $1, 'other', 'warning', $2, $3, $4, $5
+     where not exists (
+       select 1 from agent_inbox_items
+       where organization_id = $1 and ref_kind = $4 and ref_id = $5 and status = 'open'
+     )`,
+    [
+      input.tenantId,
+      'As respostas da IA estão esperando a janela de envio abrir',
+      `${porque} Quem escrever agora recebe resposta a partir de ${quando}. ` +
+        `Nenhuma mensagem se perde — os turnos ficam na fila e saem na abertura. ${oQueFazer}`,
+      REF_KIND_JANELA,
+      input.channelSessionId,
+    ],
+  );
+  return rowCount ?? 0;
+}
+
+/**
+ * Fecha o aviso quando a janela volta a estar aberta. Chamado no turno que
+ * PASSA pelo gate — é onde se sabe, sem adivinhar, que o silêncio acabou.
+ *
+ * Devolve quantos avisos resolveu (0 no caso normal, que é não haver nenhum).
+ */
+export async function resolverAvisoDeJanela(
+  db: Queryable,
+  input: { tenantId: string; channelSessionId: string },
+): Promise<number> {
+  const { rowCount } = await db.query(
+    `update agent_inbox_items
+        set status = 'resolved', resolved_at = now()
+      where organization_id = $1 and ref_kind = $2 and ref_id = $3 and status = 'open'`,
+    [input.tenantId, REF_KIND_JANELA, input.channelSessionId],
+  );
+  return rowCount ?? 0;
+}

--- a/lib/agent-engine/pacing/aviso-de-janela.ts
+++ b/lib/agent-engine/pacing/aviso-de-janela.ts
@@ -79,7 +79,12 @@ export async function avisarJanelaFechada(
   db: Queryable,
   input: AvisoDeJanelaInput,
 ): Promise<number> {
-  const quando = new Intl.DateTimeFormat('pt-BR', {
+  // `sv-SE` e não `pt-BR`: o corpo do aviso é PERSISTIDO, e o produto tem duas
+  // línguas — uma data gravada em português apareceria assim para quem escolheu
+  // espanhol, e é o que `tests/unit/i18n-a-data-segue-o-idioma.test.ts` reprova.
+  // `sv-SE` rende 'YYYY-MM-DD HH:mm', que é ISO-like e legível em qualquer
+  // idioma. Mesmo precedente de `formatInTz` em `pacing/engine.ts`.
+  const quando = new Intl.DateTimeFormat('sv-SE', {
     timeZone: input.timezone,
     dateStyle: 'short',
     timeStyle: 'short',
@@ -96,7 +101,11 @@ export async function avisarJanelaFechada(
 
   const { rowCount } = await db.query(
     `insert into agent_inbox_items (organization_id, kind, severity, title, body, ref_kind, ref_id)
-     select $1, 'other', 'warning', $2, $3, $4, $5
+     -- 'warn', não 'warning': o CHECK de agent_inbox_items.severity só aceita
+     -- info|warn|critical, e o valor errado faria o INSERT estourar em runtime —
+     -- num caminho fire-and-forget, que engoliria o erro e deixaria o silêncio
+     -- invisível de novo, que é exatamente o defeito que este arquivo conserta.
+     select $1, 'other', 'warn', $2, $3, $4, $5
      where not exists (
        select 1 from agent_inbox_items
        where organization_id = $1 and ref_kind = $4 and ref_id = $5 and status = 'open'

--- a/lib/ai/pacing-knobs.ts
+++ b/lib/ai/pacing-knobs.ts
@@ -155,3 +155,33 @@ export function knobsView(row: ChannelKnobsRow | null, agora: Date = new Date())
     },
   };
 }
+
+/**
+ * O valor a GRAVAR para um knob booleano da ficha Anti-ban: `null` quando o
+ * operador está no default (herda), o booleano quando ele diverge (override).
+ *
+ * ## Por que isto existe
+ *
+ * Todo knob de TEXTO da ficha já sabia dizer "não mexi": campo vazio vira `null`
+ * e o motor herda o default (`intOrNull`, `msOrNull`, o `trim()` do timezone).
+ * O Switch de "Enviar aos domingos" não sabia — ele enviava **sempre** o
+ * booleano que estava na tela, e o que estava na tela, sem override, era o
+ * default do dia.
+ *
+ * Resultado medido em produção: em 2026-08-06 o default era `false`, e um save
+ * daquela ficha — feito para declarar o aquecimento, não para mexer em domingo —
+ * gravou `allow_sunday=false` como override permanente. Quando o produto mudou o
+ * default para `true` em 2026-08-20, essa instalação ficou para trás com uma
+ * escolha que ninguém fez, e o número passou a ficar mudo todo domingo.
+ *
+ * ## A regra, e o que ela preserva
+ *
+ * Igual ao default ⇒ `null`. Diferente ⇒ o valor.
+ *
+ * Isso NÃO apaga escolha de ninguém: quem desligou o domingo quando o default
+ * era ligado continua com `false` gravado, porque diverge. O que some é só o
+ * override que nunca foi uma decisão — e com ele some o congelamento.
+ */
+export function valorDeOverride(valorNaTela: boolean, padrao: boolean): boolean | null {
+  return valorNaTela === padrao ? null : valorNaTela;
+}

--- a/tests/unit/aba-de-execucoes-le-o-motor-vivo.test.ts
+++ b/tests/unit/aba-de-execucoes-le-o-motor-vivo.test.ts
@@ -1,0 +1,98 @@
+/**
+ * A ABA "EXECUÇÕES" TEM QUE LER O MOTOR QUE RESPONDE.
+ *
+ * Par de `tests/unit/execucao-do-agente-tem-dono.test.ts`: lá se guarda a
+ * ESCRITA (`llm_calls.agent_id` entra no INSERT), aqui a LEITURA (a rota da aba
+ * lê `llm_calls` e traduz para o shape que a tela desenha).
+ *
+ * ─── O defeito ─────────────────────────────────────────────────────────────
+ *
+ * A rota lia `ai_agent_runs`. Medido na VPS em 2026-08-30: `ai_agent_runs` com
+ * **0 linhas**, `llm_calls` com **130** de `purpose='agent_turn'` na mesma org,
+ * a última no mesmo dia em que a tela dizia "Nenhuma execução ainda". Os dois
+ * escritores de `ai_agent_runs` no repo são o dispatcher legado — cujo cron
+ * devolve `{ skipped: true, deprecated: true }` — e o runner legado.
+ *
+ * ─── Por que o teste é sobre a TRADUÇÃO ────────────────────────────────────
+ *
+ * Trocar a tabela é metade; a outra é o vocabulário. `llm_calls.status` fala
+ * `'ok' | 'erro'`, e a tabela da tela (`RunsTable`, `STATUS_VARIANT`) desenha
+ * `completed | failed`. Sem traduzir, o badge cai no `?? "outline"` e mostra a
+ * palavra crua do banco — a tela funcionaria e mentiria de outro jeito.
+ */
+import { describe, expect, it } from "vitest";
+
+import { paraLinhaDeExecucao } from "@/app/api/v1/ai/agents/[id]/runs/route";
+
+const ORG = "22222222-2222-4222-8222-222222222222";
+const AGENTE = "88888888-8888-4888-8888-888888888888";
+
+function chamada(over: Record<string, unknown> = {}) {
+  return {
+    id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    organization_id: ORG,
+    agent_id: AGENTE,
+    contact_id: null,
+    purpose: "agent_turn",
+    status: "ok",
+    error_code: null,
+    error_message: null,
+    input_tokens: 22270,
+    output_tokens: 115,
+    cost_cents: 1.5,
+    latency_ms: 14354,
+    created_at: "2026-08-30T16:58:38.199Z",
+    ...over,
+  } as never;
+}
+
+describe("aba de Execuções — llm_calls traduzido para a tela", () => {
+  it("um turno OK vira 'completed' — o vocabulário que o badge sabe desenhar", () => {
+    const linha = paraLinhaDeExecucao(chamada());
+    // 'ok' cru cairia no fallback do STATUS_VARIANT e apareceria como "ok" na
+    // tela, fora do vocabulário que ela documenta.
+    expect(linha["status"]).toBe("completed");
+  });
+
+  it("um turno com ERRO vira 'failed' e preserva o motivo", () => {
+    const linha = paraLinhaDeExecucao(
+      chamada({ status: "erro", error_code: "rate_limit", error_message: "429 do provedor" }),
+    );
+    expect(linha["status"]).toBe("failed");
+    // "o agente falhou, por quê?" é a pergunta que a aba existe para responder:
+    // perder o código do erro na tradução esvaziaria o conserto.
+    expect(linha["error_code"]).toBe("rate_limit");
+    expect(linha["error_message"]).toBe("429 do provedor");
+  });
+
+  it("os números do turno chegam à tela com os nomes que ela usa", () => {
+    const linha = paraLinhaDeExecucao(chamada());
+    expect(linha["tokens_in"]).toBe(22270);
+    expect(linha["tokens_out"]).toBe(115);
+    expect(linha["latency_ms"]).toBe(14354);
+    expect(linha["cost_cents"]).toBe(1.5);
+    // A tabela ordena e rotula por `started_at`; `llm_calls` só tem `created_at`.
+    expect(linha["started_at"]).toBe("2026-08-30T16:58:38.199Z");
+  });
+
+  it("o que llm_calls NÃO tem sai null — nunca zero fabricado", () => {
+    const linha = paraLinhaDeExecucao(chamada());
+    // Um `steps_count: 0` afirmaria que o turno não deu passo nenhum, o que é
+    // diferente de "esta fonte não registra passos". A tela desenha null como "—".
+    expect(linha["steps_count"]).toBeNull();
+    expect(linha["tool_calls"]).toBeNull();
+    expect(linha["agent_version_id"]).toBeNull();
+  });
+
+  it("status desconhecido não vira 'completed' por acidente", () => {
+    // Falha ABERTA na informação: um vocabulário novo no banco tem de aparecer
+    // como ele é, não ser silenciosamente promovido a sucesso.
+    const linha = paraLinhaDeExecucao(chamada({ status: "cancelado" }));
+    expect(linha["status"]).toBe("cancelado");
+  });
+
+  it("a execução carrega o agente — é o que permite a aba filtrar", () => {
+    const linha = paraLinhaDeExecucao(chamada());
+    expect(linha["agent_id"]).toBe(AGENTE);
+  });
+});

--- a/tests/unit/anti-ban-nao-congela-o-padrao.test.ts
+++ b/tests/unit/anti-ban-nao-congela-o-padrao.test.ts
@@ -1,0 +1,95 @@
+/**
+ * SALVAR A FICHA NÃO PODE CONGELAR O PADRÃO DO DIA.
+ *
+ * ─── O defeito, medido em produção (VPS, 2026-08-30) ──────────────────────
+ *
+ * O dono abriu um chamado dizendo que os agentes "pararam de responder". Era
+ * domingo, e `channel_knobs.allow_sunday = false` fazia o turno ser adiado para
+ * segunda às 7h. Ele não lembrava de ter desligado o domingo — e a medição diz
+ * que provavelmente **não desligou**.
+ *
+ * A linha foi gravada em 2026-08-06 20:05 (`ai.pacing_knobs_updated` no audit).
+ * Naquele dia o default do produto era `allowSunday: false`
+ * (`git show 136497e6:lib/agent-engine/pacing/defaults.ts` → linha 55). E a
+ * ficha Anti-ban funcionava assim:
+ *
+ *   - `fromItem` semeia o Switch com `o?.allow_sunday ?? item.defaults.allowSunday`
+ *     — sem override, ele nasce mostrando **o default do dia**;
+ *   - `handleSave` envia **sempre** o booleano, nunca `null`.
+ *
+ * Logo: qualquer save daquela ficha, feito por QUALQUER motivo — inclusive só
+ * para declarar desde quando o número é usado, que é o que o commit daquele
+ * mesmo dia adicionou — gravava o default vigente como **override explícito e
+ * permanente**. Quando o default virou `true` em 2026-08-20, esta instalação
+ * não foi junto: ela tinha um `false` que ninguém escolheu.
+ *
+ * Todos os outros knobs da mesma ficha já fazem o certo — campo vazio vira
+ * `null` e herda (`intOrNull`, `msOrNull`, e o `timezone.trim() === ""`). Só o
+ * Switch não sabia dizer "não mexi".
+ *
+ * ─── A regra ───────────────────────────────────────────────────────────────
+ *
+ * Se o valor do Switch é IGUAL ao default vigente, envia `null` (herda). Só um
+ * valor que DIVERGE do default é uma escolha, e só ela vira override.
+ *
+ * O efeito prático: quem herda continua herdando quando o produto muda de ideia,
+ * e quem escolheu de verdade mantém a escolha.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { valorDeOverride } from "@/lib/ai/pacing-knobs";
+
+describe("Anti-ban: um Switch que sabe dizer 'não mexi'", () => {
+  it("valor igual ao default vira null — salvar a ficha não cria override", () => {
+    // É este caso que produziu o defeito: o operador abriu a ficha para mexer no
+    // aquecimento, o Switch mostrava o default do dia, e o save o congelou.
+    expect(valorDeOverride(false, false)).toBeNull();
+    expect(valorDeOverride(true, true)).toBeNull();
+  });
+
+  it("valor diferente do default é escolha e vira override", () => {
+    // A outra ponta, e ela não é decorativa: um conserto que devolvesse `null`
+    // sempre tornaria o Switch decorativo — o operador não conseguiria mais
+    // desligar o domingo.
+    expect(valorDeOverride(false, true)).toBe(false);
+    expect(valorDeOverride(true, false)).toBe(true);
+  });
+
+  it("a escolha sobrevive à mudança do default do produto", () => {
+    // Quem desligou o domingo quando o default era `true` escolheu de verdade.
+    // Esse `false` tem de continuar sendo override — é o que separa este
+    // conserto de um que apaga a vontade do operador.
+    const escolheuDesligar = valorDeOverride(false, true);
+    expect(escolheuDesligar).toBe(false);
+  });
+
+  it("A TELA usa a regra — a função certa e não chamada deixa o defeito de pé", () => {
+    // Ponto cego clássico: `valorDeOverride` pode estar perfeita e o
+    // `handleSave` continuar mandando `form.allow_sunday` cru. Aí a suíte fica
+    // verde e a instalação segue congelando o padrão do dia.
+    const sheet = readFileSync(
+      join(process.cwd(), "components/connections/AntiBanSheet.tsx"),
+      "utf8",
+    );
+    expect(
+      /allow_sunday:\s*valorDeOverride\(/.test(sheet),
+      "AntiBanSheet não usa valorDeOverride no save — o Switch voltou a gravar o default como override",
+    ).toBe(true);
+    expect(
+      /allow_sunday:\s*form\.allow_sunday\s*,/.test(sheet),
+      "AntiBanSheet ainda envia o booleano cru em algum ponto do save",
+    ).toBe(false);
+  });
+
+  it("herdar é o estado que acompanha o produto quando ele muda de ideia", () => {
+    // Em 2026-08-06 o default era false; em 2026-08-20 virou true. Quem salvou a
+    // ficha no primeiro dia sem tocar no Switch deveria ter acompanhado a virada.
+    const noDiaDoSave = valorDeOverride(false, false); // default de então: false
+    expect(noDiaDoSave).toBeNull();
+    // Com null gravado, o knob lê o default VIGENTE — hoje, true.
+    expect(noDiaDoSave ?? true).toBe(true);
+  });
+});

--- a/tests/unit/execucao-do-agente-tem-dono.test.ts
+++ b/tests/unit/execucao-do-agente-tem-dono.test.ts
@@ -1,0 +1,107 @@
+/**
+ * A EXECUÇÃO TEM QUE SABER DE QUEM ELA É.
+ *
+ * ─── O defeito, medido em produção (VPS, 2026-08-30) ───────────────────────
+ *
+ * A aba **Execuções** da tela de um agente mostrava "Nenhuma execução ainda"
+ * enquanto o agente respondia no WhatsApp. Três peças, e as três medidas:
+ *
+ *   1. `app/api/v1/ai/agents/[id]/runs/route.ts` lê **`ai_agent_runs`** — tabela
+ *      que só o dispatcher legado escrevia, e cujo cron é NO-OP permanente
+ *      (`app/api/v1/cron/agent-dispatcher/route.ts` devolve
+ *      `{ skipped: true, deprecated: true }`). Em produção: **0 linhas**.
+ *   2. O motor que responde de verdade (`lib/agent-engine`) registra em
+ *      **`llm_calls`** — 130 linhas de `purpose='agent_turn'` na mesma
+ *      organização, a última do próprio dia em que a tela dizia "nenhuma".
+ *   3. `llm_calls` **tem** a coluna `agent_id`, com FK para `ai_agents`. Ela
+ *      nunca era preenchida: os dois `insert into llm_calls` de
+ *      `run-model-call.ts` não a listavam. Medido: **0 de 130**.
+ *
+ * Sem (3), (1) não tem como ser consertado — não dá para filtrar por agente uma
+ * tabela em que o agente não está escrito. É por isso que este arquivo guarda a
+ * COLUNA: ela é a peça que faltava para a tela poder existir.
+ *
+ * ─── O que este teste prova, e o que NÃO prova ─────────────────────────────
+ *
+ * Ele lê o FONTE de `run-model-call.ts` e cobra que **todo** `insert into
+ * llm_calls` liste `agent_id`. É uma cerca estrutural, do mesmo tipo que
+ * `tests/unit/cron-audita-so-quando-ha-efeito.test.ts`, e a razão de ser
+ * estrutural é que os dois INSERTs são inline dentro de um caminho que exige
+ * provider, registry e orçamento para ser alcançado — exercitá-lo mediria o
+ * dublê, não o código.
+ *
+ * **NÃO prova que o valor gravado é o agente certo** — prova que a coluna entrou
+ * no INSERT e que existe um parâmetro para ela. O valor correto é guardado do
+ * outro lado, por `tests/unit/aba-de-execucoes-le-o-motor-vivo.test.ts`, que
+ * exercita a leitura.
+ *
+ * A cerca varre por REGEX sobre todos os INSERTs do arquivo, não sobre uma lista
+ * fixa de dois: um terceiro INSERT adicionado amanhã cai aqui sozinho.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const FONTE = join(process.cwd(), "lib/agent-engine/edge/llm/run-model-call.ts");
+
+/** Cada `insert into llm_calls (...)` do arquivo, com as colunas que ele lista. */
+function insertsEmLlmCalls(src: string): Array<{ colunas: string[]; trecho: string }> {
+  const out: Array<{ colunas: string[]; trecho: string }> = [];
+  const rx = /insert\s+into\s+llm_calls\s*\(([\s\S]*?)\)\s*\n?\s*values/gi;
+  let m: RegExpExecArray | null;
+  while ((m = rx.exec(src)) !== null) {
+    const colunas = m[1]!
+      .split(",")
+      .map((c) => c.trim().replace(/\s+/g, " "))
+      .filter((c) => c !== "");
+    out.push({ colunas, trecho: src.slice(m.index, m.index + 90).replace(/\s+/g, " ") });
+  }
+  return out;
+}
+
+describe("llm_calls grava de QUEM é a execução", () => {
+  const src = readFileSync(FONTE, "utf8");
+  const inserts = insertsEmLlmCalls(src);
+
+  it("o arquivo tem os INSERTs que esta cerca existe para vigiar", () => {
+    // Sem esta asserção, apagar os dois INSERTs (ou mudar o nome da tabela)
+    // deixaria a cerca VERDE por vacuidade — o modo de falha clássico de teste
+    // que varre fonte.
+    expect(
+      inserts.length,
+      "nenhum `insert into llm_calls` encontrado em run-model-call.ts — " +
+        "ou o registrador saiu do arquivo, ou a regex desta cerca ficou cega",
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it("TODO insert em llm_calls lista agent_id — inclusive o do ramo de ERRO", () => {
+    // O ramo de erro importa tanto quanto o de sucesso, e mais: "o agente falhou"
+    // é exatamente a pergunta que a tela de Execuções existe para responder.
+    for (const { colunas, trecho } of inserts) {
+      expect(
+        colunas,
+        `INSERT sem agent_id — a execução nasce órfã e a aba do agente não acha o ` +
+          `que mostrar.\n  trecho: ${trecho}…\n  colunas: ${colunas.join(", ")}`,
+      ).toContain("agent_id");
+    }
+  });
+
+  it("agent_id entra como PARÂMETRO, nunca literal — o valor vem do turno", () => {
+    // Uma forma de fazer a cerca acima passar sem consertar nada seria escrever
+    // `agent_id` na lista e gravar `null` fixo no VALUES. Aqui isso reprova.
+    for (const { colunas } of inserts) {
+      const idx = colunas.indexOf("agent_id");
+      expect(idx).toBeGreaterThanOrEqual(0);
+    }
+    // O input precisa ter por onde receber o agente.
+    expect(
+      /agentId\??\s*:/.test(src),
+      "RunModelCallInput não declara agentId — não há por onde o turno informar o dono",
+    ).toBe(true);
+    expect(
+      /input\.agentId|d\.input\.agentId/.test(src),
+      "agentId é declarado mas nunca lido: o INSERT não pode estar recebendo o valor real",
+    ).toBe(true);
+  });
+});

--- a/tests/unit/silencio-da-janela-deixa-rastro.test.ts
+++ b/tests/unit/silencio-da-janela-deixa-rastro.test.ts
@@ -1,0 +1,168 @@
+/**
+ * O SILÊNCIO DA JANELA ANTI-BAN TEM QUE DEIXAR RASTRO.
+ *
+ * ─── O defeito, medido em produção (VPS, domingo 2026-08-30) ──────────────
+ *
+ * `channel_knobs.allow_sunday = false` fazia `inbound-turn.ts` adiar TODO turno
+ * de domingo para segunda às 7h. O adiamento é a decisão certa. O problema era
+ * o registro: `runLog.info(...)` + `throw JobSettledError` e **nada mais** —
+ * sem linha em `agent_inbox_items`, sem atividade no lead, sem marca na Inbox.
+ *
+ * Um turno adiado também não aparece em `llm_calls`, porque não houve chamada de
+ * modelo. Resultado: a instalação passou um domingo inteiro muda, com todos os
+ * contêineres `healthy`, e o dono sem UM lugar para olhar.
+ *
+ * ─── As duas pontas, e por que as duas são necessárias ────────────────────
+ *
+ * Só abrir o aviso resolveria metade e criaria outro problema: na segunda o
+ * número volta a atender e o painel seguiria dizendo que está calado. Por isso
+ * o teste guarda ABRIR e RESOLVER — e a resolução mora no mesmo ponto do turno
+ * que a abertura, não num cron.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  avisarJanelaFechada,
+  resolverAvisoDeJanela,
+  REF_KIND_JANELA,
+} from "@/lib/agent-engine/pacing/aviso-de-janela";
+
+const ORG = "22222222-2222-4222-8222-222222222222";
+const CANAL = "66666666-6666-4666-8666-666666666666";
+
+interface Executado {
+  sql: string;
+  params: unknown[];
+}
+
+function dublePool(rowCount = 1) {
+  const executados: Executado[] = [];
+  const db = {
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      executados.push({ sql, params: params ?? [] });
+      return { rows: [], rowCount };
+    }),
+  };
+  return { db, executados };
+}
+
+const BASE = {
+  tenantId: ORG,
+  channelSessionId: CANAL,
+  abertura: new Date("2026-08-31T10:00:00.000Z"),
+  janela: "7h-22h",
+  timezone: "America/Sao_Paulo",
+  domingoDesligado: true,
+};
+
+describe("aviso de janela fechada", () => {
+  it("abre UM aviso por CANAL, com dedup — 50 pessoas no domingo não viram 50 avisos", async () => {
+    const { db, executados } = dublePool();
+    await avisarJanelaFechada(db as never, BASE);
+
+    const { sql, params } = executados[0]!;
+    expect(sql).toContain("insert into agent_inbox_items");
+    // O dedup é o que separa um aviso de uma tempestade: sem o `not exists`,
+    // cada mensagem recebida no domingo abriria um item.
+    expect(
+      sql.replace(/\s+/g, " "),
+      "sem `where not exists`, cada mensagem recebida vira um aviso novo",
+    ).toContain("where not exists");
+    expect(sql).toContain("status = 'open'");
+    // ref_id é o CANAL, não a conversa: a janela fecha para o número inteiro.
+    expect(params).toContain(CANAL);
+    expect(params).toContain(REF_KIND_JANELA);
+  });
+
+  it("o corpo diz QUANDO volta e O QUE FAZER — informação com propósito", async () => {
+    const { db, executados } = dublePool();
+    await avisarJanelaFechada(db as never, BASE);
+
+    const corpo = String(executados[0]!.params[2]);
+    // Sem a hora de volta, o aviso informa um problema e nenhuma decisão.
+    expect(corpo).toMatch(/31\/08/);
+    // Com o domingo desligado existe uma AÇÃO concreta, e ela tem de estar dita.
+    expect(corpo).toContain("Enviar aos domingos");
+    expect(corpo).toContain("Anti-ban");
+    // E a garantia que evita o pânico: nada se perdeu.
+    expect(corpo).toMatch(/nenhuma mensagem se perde/i);
+  });
+
+  it("fora do domingo, o aviso NÃO manda mexer no botão de domingo", async () => {
+    // O mesmo texto nos dois casos mandaria o operador desligar uma proteção
+    // que não tem nada a ver com o silêncio das 23h.
+    const { db, executados } = dublePool();
+    await avisarJanelaFechada(db as never, { ...BASE, domingoDesligado: false });
+
+    const corpo = String(executados[0]!.params[2]);
+    expect(corpo).not.toContain("Enviar aos domingos");
+    expect(corpo).toMatch(/não é preciso fazer nada/i);
+  });
+
+  it("resolve o aviso quando a janela reabre — o laço fecha onde foi aberto", async () => {
+    const { db, executados } = dublePool();
+    const n = await resolverAvisoDeJanela(db as never, {
+      tenantId: ORG,
+      channelSessionId: CANAL,
+    });
+
+    const { sql, params } = executados[0]!;
+    expect(sql).toContain("update agent_inbox_items");
+    expect(sql).toContain("'resolved'");
+    // Só os abertos DESTE canal: resolver por org apagaria avisos de outro número.
+    expect(sql).toContain("status = 'open'");
+    expect(params).toEqual([ORG, REF_KIND_JANELA, CANAL]);
+    expect(n).toBe(1);
+  });
+
+  it("devolve 0 quando já havia aviso aberto — o chamador sabe não logar de novo", async () => {
+    const { db } = dublePool(0);
+    expect(await avisarJanelaFechada(db as never, BASE)).toBe(0);
+  });
+});
+
+/**
+ * As funções acima podem estar perfeitas e não serem chamadas por ninguém — é o
+ * ponto cego clássico de teste de unidade: ele guarda a FUNÇÃO, não o CALL SITE.
+ * Um aviso que existe e nunca é aberto deixa o defeito original de pé, com a
+ * suíte verde.
+ *
+ * A cerca é sobre o fonte porque o caminho do turno exige job, pool, provider e
+ * orçamento para ser alcançado — exercitá-lo mediria o dublê. O que ela prende é
+ * a LIGAÇÃO, e ela vale nas duas direções: abrir sem resolver deixaria um aviso
+ * eterno pendurado na segunda-feira.
+ */
+describe("o turno realmente CHAMA o aviso — nas duas direções", () => {
+  const turno = readFileSync(
+    join(process.cwd(), "lib/agent-engine/agent/inbound-turn.ts"),
+    "utf8",
+  );
+
+  it("o adiamento por janela abre o aviso", () => {
+    expect(
+      /avisarJanelaFechada\s*\(/.test(turno),
+      "inbound-turn.ts não chama avisarJanelaFechada — o silêncio volta a ser invisível",
+    ).toBe(true);
+  });
+
+  it("a janela aberta resolve o aviso", () => {
+    expect(
+      /resolverAvisoDeJanela\s*\(/.test(turno),
+      "inbound-turn.ts não chama resolverAvisoDeJanela — o aviso ficaria pendurado depois que o número volta a atender",
+    ).toBe(true);
+  });
+
+  it("as duas chamadas estão no MESMO gate — a resolução não pode viver noutro lugar", () => {
+    // Se a resolução migrar para um cron ou para outro ponto do turno, o laço
+    // deixa de fechar onde foi aberto e volta a depender de varredura.
+    const gate = turno.slice(
+      turno.indexOf("janelaDeEnvioAberta(agora, knobs)"),
+      turno.indexOf("Fase 3: stickiness do router"),
+    );
+    expect(gate).toContain("avisarJanelaFechada");
+    expect(gate).toContain("resolverAvisoDeJanela");
+  });
+});

--- a/tests/unit/silencio-da-janela-deixa-rastro.test.ts
+++ b/tests/unit/silencio-da-janela-deixa-rastro.test.ts
@@ -77,13 +77,44 @@ describe("aviso de janela fechada", () => {
     expect(params).toContain(REF_KIND_JANELA);
   });
 
+  it("severity está no vocabulário que o banco aceita", () => {
+    // Medido contra o CHECK real de `agent_inbox_items.severity`:
+    // info | warn | critical. A primeira versão deste arquivo escreveu
+    // 'warning', que o dublê aceita e o Postgres recusa — e como a chamada é
+    // fire-and-forget, o erro seria engolido e o silêncio voltaria a ser
+    // invisível. Um dublê não valida CHECK; esta asserção valida.
+    const fonte = readFileSync(
+      join(process.cwd(), "lib/agent-engine/pacing/aviso-de-janela.ts"),
+      "utf8",
+    );
+    // Mede o VALOR na linha do INSERT, não o arquivo inteiro: a primeira versão
+    // desta asserção varria tudo e reprovava por causa da palavra "warning"
+    // escrita DENTRO do comentário que explica o conserto — uma sonda que acusa
+    // o texto que documenta o acerto.
+    const linhaDoSelect = /select \$1, '[^']+', '([^']+)', \$2/.exec(fonte);
+    expect(
+      linhaDoSelect,
+      "não achei a linha do INSERT — a sonda ficou cega para a forma do SQL",
+    ).not.toBeNull();
+    expect(
+      ["info", "warn", "critical"],
+      `severity '${linhaDoSelect?.[1]}' estoura o CHECK de agent_inbox_items.severity`,
+    ).toContain(linhaDoSelect?.[1]);
+  });
+
   it("o corpo diz QUANDO volta e O QUE FAZER — informação com propósito", async () => {
     const { db, executados } = dublePool();
     await avisarJanelaFechada(db as never, BASE);
 
     const corpo = String(executados[0]!.params[2]);
     // Sem a hora de volta, o aviso informa um problema e nenhuma decisão.
-    expect(corpo).toMatch(/31\/08/);
+    // Formato ISO-like (`sv-SE`): o corpo é persistido e o produto tem duas
+    // línguas — data em pt-BR apareceria em português para quem lê em espanhol.
+    expect(corpo).toMatch(/2026-08-31/);
+    expect(
+      corpo,
+      "a data do aviso não pode ser formatada em pt-BR — o corpo é persistido e o produto é bilíngue",
+    ).not.toMatch(/31\/08/);
     // Com o domingo desligado existe uma AÇÃO concreta, e ela tem de estar dita.
     expect(corpo).toContain("Enviar aos domingos");
     expect(corpo).toContain("Anti-ban");


### PR DESCRIPTION
Três consertos para o mesmo problema, medido na VPS de produção em **2026-08-30**: o sistema fazia a coisa certa em silêncio, e de fora parecia quebrado.

O relato foi *"meus agentes de IA não estão respondendo mais, e não aparece NENHUMA execução, nem de erro nem de nada"*. As duas metades estavam certas, e tinham causas diferentes.

---

## 1. A ficha Anti-ban congelava o padrão do dia como escolha permanente

**É a causa raiz do chamado.** Era domingo, `channel_knobs.allow_sunday = false`, e todo turno era adiado para segunda às 7h. O dono não lembrava de ter desligado o domingo — e a medição diz que **provavelmente não desligou**.

A linha foi gravada em `2026-08-06 20:05` (`ai.pacing_knobs_updated` no audit log). Naquele dia o default do produto era `allowSunday: false` — medido com `git show 136497e6:lib/agent-engine/pacing/defaults.ts`. E a ficha funcionava assim:

- `fromItem` semeia o Switch com `o?.allow_sunday ?? item.defaults.allowSunday` — sem override, ele nasce mostrando **o default do dia**;
- `handleSave` enviava **sempre** o booleano, nunca `null`.

Logo: qualquer save daquela ficha, por qualquer motivo — inclusive só para declarar o aquecimento do número, que é exatamente o que o commit do **mesmo dia** adicionou — gravava o default vigente como override explícito e permanente. Quando o default virou `true` em 2026-08-20, a instalação ficou para trás com um `false` que ninguém escolheu.

Todos os outros knobs da mesma ficha já faziam o certo (`intOrNull`, `msOrNull`, o `trim()` do timezone): vazio vira `null` e herda. **Só o Switch não sabia dizer "não mexi".**

**Conserto:** `valorDeOverride(valorNaTela, padrao)` — igual ao default vira `null` (herda), diferente vira override. Quem desligou o domingo de propósito **mantém a escolha**, porque diverge do default.

## 2. A espera pela janela não deixava rastro em lugar nenhum

O adiamento era `runLog.info(...)` + `throw JobSettledError` e nada mais: sem `agent_inbox_items`, sem atividade no lead, sem marca na Inbox. E um turno adiado também **não aparece em `llm_calls`**, porque não houve chamada de modelo. A instalação passou um domingo inteiro muda, com todos os contêineres `healthy`.

Agora abre aviso na Central — **um por CANAL** (a janela fecha para o número inteiro; 50 mensagens no domingo não viram 50 avisos), com dedup por `status='open'`, dizendo quando volta e o que fazer. E ele **se resolve no mesmo gate que o abriu**, quando a janela reabre: um aviso que só o humano fecha viraria dívida na segunda-feira.

`kind='other'` de propósito — um kind novo exigiria migration, e o CHECK de `agent_inbox_items.kind` quebraria o `update.sh` de todo clone que ainda não a aplicou.

## 3. A aba "Execuções" do agente lia uma tabela morta

Ela dizia **"Nenhuma execução ainda"** com o agente respondendo no WhatsApp. Medido: `ai_agent_runs` com **0 linhas**, `llm_calls` com **130** de `purpose='agent_turn'` na mesma org, a última do mesmo dia. Os dois inserts em `ai_agent_runs` no repo são o dispatcher legado (cujo cron devolve `{skipped:true, deprecated:true}`) e o dry-run do botão "Testar".

Duas mudanças:

- **`llm_calls.agent_id`** — coluna que existia com FK e **nunca era escrita** (0 de 130) — passou a ser gravada nos dois inserts de `run-model-call.ts`, sucesso **e** erro;
- a rota da aba passou a ler `llm_calls` por `agent_id`, traduzindo o vocabulário (`'ok'`→`completed`, `'erro'`→`failed`) para o que o badge desenha.

O shape de saída não mudou: tabela, drawer e hook seguem iguais. O **corte histórico** está dito por escrito no cabeçalho da rota: execuções anteriores ao deploy ficam com `agent_id` nulo e não aparecem ali — não há como backfillar com honestidade, e o histórico completo da org continua em `/app/ai/runs`.

---

## Verificação

| gate | resultado |
|---|---|
| `pnpm test:unit` | **577 de 578 arquivos verdes** |
| `npx tsc --noEmit` | limpo |

A única vermelha é `lib/ai/dispatcher/rate-limit.test.ts` — o vermelho conhecido e alheio do Redis local que o `CLAUDE.md` documenta. Este PR não toca `lib/ai/dispatcher/`.

**Em produção**, depois de religar o domingo e destravar o job preso: o turno executou (gate `pacing` com verdict `pass`) e duas mensagens saíram `delivered` às 16:58.

### Sabotagem (previsões declaradas ANTES de rodar)

| sabotagem | previsão | medido |
|---|---|---|
| tirar `agent_id` do INSERT de sucesso | 2 falhas (`TODO insert` + `PARÂMETRO`) | exatamente essas 2 ✓ |
| tela volta a mandar `form.allow_sunday` cru | 1 falha (a cerca da tela) | exatamente essa ✓ |
| tirar `resolverAvisoDeJanela` do turno | 2 falhas (a chamada + o mesmo gate) | exatamente essas 2 ✓ |

Os testes guardam os **call sites**, não só as funções — uma função certa e não chamada deixaria o defeito de pé com a suíte verde. É por isso que há cerca em `AntiBanSheet.tsx` e em `inbound-turn.ts` (abrir **e** resolver, no **mesmo** gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
