### PR TITLE
O escritor real do score produzia linha que o banco recusa (CRMV5W)

### DIFF
--- a/lib/leads/score-formula.ts
+++ b/lib/leads/score-formula.ts
@@ -178,6 +178,24 @@ export function calculaScore(sinais: SinaisDoLead): ScoreCalculado {
   }
   const nBant = Math.min(camposBant, TETO_BANT);
   if (nBant > 0) {
+    // QUALIFICAÇÃO NÃO GANHA ÂNCORA, e a ausência é DECIDIDA — não esquecimento.
+    //
+    // ⚠️ Ela era acidental até 2026-08-30, e a diferença custou um defeito: no
+    // fator de recência logo abaixo a ausência sempre teve comentário; aqui não
+    // tinha nenhum, e foi justamente a não documentada que quebrou. Um negócio
+    // só-BANT montava fatores sem âncora nenhuma e morria no INSERT com 23514,
+    // sem score e sem sintoma legível (ver a guarda de lastro adiante).
+    // Observação do @Maestro (2), conferindo o conserto: no mesmo arquivo, a
+    // ausência pensada estava escrita e a acidental não.
+    //
+    // POR QUE ela não pode ganhar a âncora que está à mão: os campos BANT vêm de
+    // `lead_state.qualification`, e o formato é `{kind: "checkpoint" | "message"}`.
+    // Apontar para o checkpoint seria citar como fonte algo que não sustenta
+    // aquele número — e âncora falsa é pior que ausente, porque a âncora existe
+    // exatamente para dizer DE ONDE veio.
+    //
+    // Devolver score ao lead só-BANT exige um `kind` novo, e isso é contrato:
+    // decisão de produto, registrada e não tomada aqui.
     fatores.push({
       pontos: nBant * POR_CAMPO_BANT,
       frase: plural(nBant, "item de qualificação", "itens de qualificação"),

--- a/lib/leads/score-formula.ts
+++ b/lib/leads/score-formula.ts
@@ -194,6 +194,38 @@ export function calculaScore(sinais: SinaisDoLead): ScoreCalculado {
     .filter((f) => f.pontos !== 0)
     .sort((a, b) => Math.abs(b.pontos) - Math.abs(a.pontos));
 
+  /**
+   * LASTRO CITÁVEL É SOBRE O FATOR, NÃO SOBRE O CHECKPOINT EXISTIR.
+   *
+   * A guarda lá em cima recusa quando não há checkpoint nenhum — necessária,
+   * mas não suficiente: só os fatores de COMPROMISSO e OBJEÇÃO recebem a
+   * âncora. Um negócio cujo conteúdo é apenas qualificação (BANT) passa por
+   * aquela guarda, tem dois sinais substantivos, e produz fatores em que NENHUM
+   * tem âncora — enquanto a constraint do banco exige
+   * `evidence @? '$.factors[*].ancora'`.
+   *
+   * O desfecho, medido pelo caminho de produção (`recalculaScoreDoLead` contra
+   * o Postgres do `test:db`, invariante `score-escritor-real-satisfaz-a-constraint`):
+   * `23514` dentro do worker, e o lead fica **sem score nenhum** — tela vazia e
+   * causa só no log. O cabeçalho desta função já prometia o contrário: "melhor
+   * recusar aqui, com motivo legível, do que descobrir no INSERT". A promessa
+   * estava escrita; a verificação parou no checkpoint EXISTIR, e não em algum
+   * fator USAR a âncora dele.
+   *
+   * A conta é sobre `relevantes` e não sobre `fatores`: é `relevantes` que vai
+   * para `evidence`, e um fator de zero ponto é filtrado antes de chegar lá —
+   * checar a lista errada deixaria a mesma linha passar por outro caminho.
+   *
+   * NÃO se resolve dando âncora ao fator de qualificação: ela viria de
+   * `lead_state`, e o formato da âncora é `{kind: "checkpoint" | "message"}`.
+   * Apontar o BANT para o checkpoint seria citar como fonte algo que não o
+   * sustenta. Dar-lhe âncora própria é decisão de produto (um `kind` novo), não
+   * conserto de defeito.
+   */
+  if (!relevantes.some((f) => f.ancora)) {
+    return { score: null, reason: "", evidence: {}, band: null, semSinal: "sem_lastro_citavel" };
+  }
+
   // DELTA 4 (segunda metade) — no máximo TRÊS parcelas nomeadas, que é o que o
   // contrato promete. O resto vira UMA linha agregada em vez de sumir: truncar
   // sem dizer quebraria a reconstrução da frase, e uma razão que não soma o

--- a/tests/invariants/score-escritor-real-satisfaz-a-constraint.test.ts
+++ b/tests/invariants/score-escritor-real-satisfaz-a-constraint.test.ts
@@ -1,0 +1,177 @@
+import pg from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { recalculaScoreDoLead } from "../../lib/leads/score-writer";
+import { GOV_ORG, GOV_PIPELINE, GOV_STAGE, seedGov, sql } from "./gov-helpers";
+
+/**
+ * O ESCRITOR REAL DO SCORE SATISFAZ A CONSTRAINT — provado chamando o emissor,
+ * não montando o INSERT à mão.
+ *
+ * ═══ Por que este invariante existe (CRMV5W) ═══
+ *
+ * A wave 5 pôs no banco `crm_lead_scores_needs_reason`, que exige — quando há
+ * `ai_probability` — razão não vazia, `factors` não vazio **e pelo menos um
+ * fator com `ancora`** (`supabase/baseline.sql`, a constraint). Ela foi provada
+ * com `INSERT` à mão: o banco recusa uma linha sem evidência, e isso é verdade.
+ *
+ * O que ficou sem prova é o outro lado, e é o que o QAVivo apontou na revisão
+ * fria: **o escritor de produção sempre produz o que a constraint exige?** Se
+ * não, o sintoma NÃO é "score sem evidência" — é `23514` estourando dentro do
+ * worker e o lead ficando **sem score nenhum**, com a tela mostrando vazio e a
+ * causa só no log. Constraint boa transforma corrupção silenciosa em falha
+ * ruidosa; ela não faz o produtor estar certo.
+ *
+ * ═══ O caso que este teste prende ═══
+ *
+ * Um negócio cujo conteúdo é SÓ qualificação (BANT), sem compromisso nem
+ * objeção. Ele passa nas duas recusas de `calculaScore` — tem dois sinais
+ * substantivos e tem checkpoint —, então o cálculo devolve score. Mas os
+ * fatores com âncora são exatamente os de compromisso e objeção
+ * (`lib/leads/score-formula.ts`); o de qualificação e o de recência nascem sem
+ * âncora, e o de recência **deliberadamente** ("ela não é um ponto no tempo da
+ * conversa, é a AUSÊNCIA de pontos").
+ *
+ * Medido na fórmula pura antes de escrever isto: `score: 60`, dois fatores,
+ * **nenhum com âncora**. É a linha que a constraint recusa.
+ *
+ * ═══ Por que pelo Pool e não por `sql()` ═══
+ *
+ * `sql()` roda SQL. Ele provaria de novo o que a wave 5 já provou — que o banco
+ * recusa. A pergunta aqui é sobre o PRODUTOR, então o teste chama
+ * `recalculaScoreDoLead`, a mesma função que `lib/agent-engine/agent/inbound-turn.ts`
+ * chama em produção. Molde de `escalacao-ciclo-humano.test.ts`, inclusive o
+ * controle positivo do pool.
+ */
+
+/** O container publica em 127.0.0.1:${TEST_DB_PORT:-54329} (scripts/test-db.sh). */
+const PORTA = process.env.TEST_DB_PORT ?? "54329";
+const pool = new pg.Pool({
+  connectionString: `postgres://postgres:postgres@127.0.0.1:${PORTA}/postgres`,
+  max: 2,
+});
+
+const CONTATO_SO_BANT = "cccccccc-3333-4000-8000-0000000005a1";
+const LEAD_SO_BANT = "cccccccc-6666-4000-8000-0000000005a1";
+const CONTATO_COM_LASTRO = "cccccccc-3333-4000-8000-0000000005a2";
+const LEAD_COM_LASTRO = "cccccccc-6666-4000-8000-0000000005a2";
+
+beforeAll(async () => {
+  seedGov();
+  sql(`
+    insert into public.contacts (id, organization_id, display_name) values
+      ('${CONTATO_SO_BANT}', '${GOV_ORG}', 'So Qualificacao'),
+      ('${CONTATO_COM_LASTRO}', '${GOV_ORG}', 'Com Compromisso')
+      on conflict do nothing;
+
+    insert into public.crm_leads (id, organization_id, pipeline_id, stage_id, contact_id, title, status) values
+      ('${LEAD_SO_BANT}', '${GOV_ORG}', '${GOV_PIPELINE}', '${GOV_STAGE}', '${CONTATO_SO_BANT}', 'So qualificacao', 'open'),
+      ('${LEAD_COM_LASTRO}', '${GOV_ORG}', '${GOV_PIPELINE}', '${GOV_STAGE}', '${CONTATO_COM_LASTRO}', 'Com compromisso', 'open')
+      on conflict do nothing;
+
+    -- QUALIFICAÇÃO nos dois: quatro campos preenchidos, acima do mínimo de dois
+    -- sinais substantivos que a fórmula exige.
+    insert into public.lead_state (organization_id, contact_id, qualification) values
+      ('${GOV_ORG}', '${CONTATO_SO_BANT}', '{"budget":"10k","authority":"dono","need":"sim","timeline":"mes"}'::jsonb),
+      ('${GOV_ORG}', '${CONTATO_COM_LASTRO}', '{"budget":"10k","authority":"dono","need":"sim","timeline":"mes"}'::jsonb)
+      on conflict (organization_id, contact_id) do update set qualification = excluded.qualification;
+
+    -- CHECKPOINT nos dois. As colunas commitments/objections sao JSONB
+    -- (baseline linha 6661, comentadas la como string[]) e nao array Postgres:
+    -- semear com chaves vira "invalid input syntax for type json". Sem o
+    -- checkpoint a formula recusa
+    -- por 'sem_lastro_citavel' e o caso não chegaria a existir. A diferença entre os dois leads é APENAS o
+    -- conteúdo do checkpoint.
+    -- A coluna seq NAO entra: e identity GENERATED ALWAYS (baseline linha 6657),
+    -- e inserir valor nela morre com "cannot insert a non-DEFAULT value".
+    -- Idempotencia por "where not exists" em vez de "on conflict", porque nao ha
+    -- unique por contato aqui — o writer le o checkpoint de maior seq.
+    insert into public.lead_checkpoints (organization_id, contact_id, commitments, objections)
+    select '${GOV_ORG}', '${CONTATO_SO_BANT}', '[]'::jsonb, '[]'::jsonb
+     where not exists (select 1 from public.lead_checkpoints
+                        where organization_id = '${GOV_ORG}' and contact_id = '${CONTATO_SO_BANT}');
+    insert into public.lead_checkpoints (organization_id, contact_id, commitments, objections)
+    select '${GOV_ORG}', '${CONTATO_COM_LASTRO}', '["ligar terca","mandar proposta"]'::jsonb, '[]'::jsonb
+     where not exists (select 1 from public.lead_checkpoints
+                        where organization_id = '${GOV_ORG}' and contact_id = '${CONTATO_COM_LASTRO}');
+  `);
+
+  // Controle positivo do instrumento: um pool que não conecta faria tudo
+  // estourar, mas um pool no banco ERRADO passaria com contagens zeradas e
+  // pareceria medição.
+  const { rows } = await pool.query<{ n: string }>(
+    `select count(*)::text as n from public.crm_leads where id = $1`,
+    [LEAD_SO_BANT],
+  );
+  if (rows[0]?.n !== "1") {
+    throw new Error(
+      `o pool não está no mesmo banco que o helper psql (lead de seed não encontrado na porta ${PORTA})`,
+    );
+  }
+});
+
+afterAll(async () => {
+  await pool.end();
+});
+
+async function scoreGravado(leadId: string) {
+  const { rows } = await pool.query<{
+    ai_probability: number | null;
+    ai_probability_reason: string | null;
+    tem_ancora: boolean;
+  }>(
+    `select ai_probability, ai_probability_reason,
+            coalesce(ai_probability_evidence @? '$.factors[*].ancora', false) as tem_ancora
+       from crm_lead_scores where lead_id = $1`,
+    [leadId],
+  );
+  return rows[0] ?? null;
+}
+
+describe("o escritor real do score satisfaz a constraint (CRMV5W)", () => {
+  it("CONTROLE: com compromisso, o escritor grava e a linha entra", async () => {
+    // Sem este caso, o teste abaixo não distinguiria "o escritor está errado"
+    // de "o cenário nunca chega a gravar nada".
+    const r = await recalculaScoreDoLead(pool, GOV_ORG, LEAD_COM_LASTRO);
+    expect(r.gravou, `o escritor recusou o caso de controle: ${r.motivo ?? "sem motivo"}`).toBe(
+      true,
+    );
+    const linha = await scoreGravado(LEAD_COM_LASTRO);
+    expect(linha?.ai_probability, "score não entrou no controle").not.toBeNull();
+    expect(linha?.tem_ancora, "o controle gravou sem âncora — o cenário está errado").toBe(true);
+  });
+
+  it("só qualificação: o escritor NÃO pode estourar 23514 nem deixar o lead sem score", async () => {
+    // O desfecho aceitável é um dos dois, e os dois são silenciosos para o
+    // worker: ou grava com evidência completa, ou RECUSA com motivo legível
+    // (`semSinal`), como a própria fórmula promete no cabeçalho — "melhor
+    // recusar aqui, com motivo legível, do que descobrir no INSERT".
+    //
+    // O que NÃO é aceitável é a terceira via: tentar gravar e o banco recusar.
+    let erro: unknown = null;
+    const r = await recalculaScoreDoLead(pool, GOV_ORG, LEAD_SO_BANT).catch((e) => {
+      erro = e;
+      return null;
+    });
+
+    expect(
+      (erro as { code?: string } | null)?.code,
+      "o escritor tentou gravar score sem âncora e o BANCO recusou (23514): o lead fica sem " +
+        "score nenhum, a tela mostra vazio e a causa só aparece no log do worker",
+    ).not.toBe("23514");
+    expect(erro, `o escritor estourou: ${String(erro)}`).toBeNull();
+
+    const linha = await scoreGravado(LEAD_SO_BANT);
+    if (r?.gravou) {
+      expect(
+        linha?.tem_ancora,
+        "gravou score sem nenhum fator com âncora — a constraint deveria ter recusado, " +
+          "e se não recusou é a constraint que está frouxa",
+      ).toBe(true);
+    } else {
+      // Recusa é desfecho legítimo, desde que tenha MOTIVO — recusa muda sem
+      // razão é indistinguível de falha engolida.
+      expect(r?.motivo, "o escritor recusou sem dizer por quê").toBeTruthy();
+    }
+  });
+});

--- a/tests/unit/score-formula.test.ts
+++ b/tests/unit/score-formula.test.ts
@@ -188,7 +188,15 @@ describe("a razão é DERIVADA do cálculo, e isso é verificável", () => {
       sinais({ commitments: ["a", "b"], risco: "em_dia" }),
       sinais({ objections: ["x", "y"], risco: "em_risco" }),
       sinais({ commitments: ["a", "b"], objections: ["x"], qualification: { n: "1" }, risco: "em_risco" }),
-      sinais({ qualification: { a: "1", b: "2", c: "3" }, risco: "em_voo" }),
+      // ⚠️ ERA `qualification` SOZINHA aqui, e o caso afirmava um score que o
+      // BANCO NUNCA ACEITOU: sem compromisso nem objeção, nenhum fator recebe
+      // âncora, e `crm_lead_scores_needs_reason` exige
+      // `evidence @? '$.factors[*].ancora'`. A função devolvia 60 e o INSERT
+      // do escritor real estourava 23514 — medido pelo caminho de produção no
+      // invariante `score-escritor-real-satisfaz-a-constraint`. O teste provava
+      // a FUNÇÃO e afirmava o SISTEMA. A recusa desse cenário está fixada no
+      // caso próprio mais abaixo.
+      sinais({ objections: ["x"], qualification: { a: "1", b: "2" }, risco: "em_voo" }),
     ];
     for (const caso of casos) {
       const r = calculaScore(caso);
@@ -229,8 +237,32 @@ describe("os quatro deltas do contrato", () => {
     expect(um.score).toBeNull();
     expect(um.semSinal).toBe("sem_conteudo");
 
-    const dois = calculaScore(sinais({ qualification: { need: "automatizar", budget: "5k" } }));
+    // DOIS sinais que o sistema INTEIRO aceita: o de compromisso carrega a
+    // âncora que a constraint exige. Antes este par era `need` + `budget`, e o
+    // score que ele produzia morria no INSERT (ver o caso da recusa abaixo).
+    const dois = calculaScore(
+      sinais({ commitments: ["ligar terça"], qualification: { need: "automatizar" } }),
+    );
     expect(dois.score).not.toBeNull();
+  });
+
+  it("só qualificação recusa com motivo, em vez de produzir score que o banco rejeita", () => {
+    // ═══ O defeito que este caso prende (CRMV5W) ═══
+    //
+    // Só os fatores de COMPROMISSO e OBJEÇÃO recebem âncora; qualificação e
+    // recência nascem sem ela — a recência de propósito ("é a AUSÊNCIA de
+    // pontos"). Um negócio cujo conteúdo é apenas BANT passava nas duas
+    // recusas, produzia score, e o escritor real estourava `23514` ao gravar:
+    // o lead ficava SEM SCORE NENHUM, com a tela vazia e a causa só no log do
+    // worker. Medido pelo caminho de produção, não por leitura.
+    //
+    // A promessa já estava escrita no cabeçalho de `calculaScore` — "melhor
+    // recusar aqui, com motivo legível, do que descobrir no INSERT". A
+    // verificação é que parava no checkpoint existir, e não em algum fator
+    // USAR a âncora dele.
+    const r = calculaScore(sinais({ qualification: { need: "sim", budget: "10k", authority: "dono" } }));
+    expect(r.score, "produziu score sem nenhum fator ancorado — o banco recusa esta linha").toBeNull();
+    expect(r.semSinal).toBe("sem_lastro_citavel");
   });
 
   it("recência NÃO conta para o mínimo — vitalidade não é conteúdo", () => {


### PR DESCRIPTION
Item **CRMV5W** do plano — o gap que o QAVivo apontou na revisão fria da wave 5.

## A pergunta, e por que a wave 5 não a respondeu

A wave 5 pôs `crm_lead_scores_needs_reason` no banco e a provou com `INSERT` à mão: o banco recusa score sem evidência. **Isso é verdade e continua valendo.**

O que ficou sem prova é o outro lado: **o escritor de produção sempre produz o que a constraint exige?** Constraint boa transforma corrupção silenciosa em falha ruidosa — ela não faz o produtor estar certo.

## Não produzia

Um negócio cujo conteúdo é **só qualificação (BANT)**, sem compromisso nem objeção:

- passa nas duas recusas de `calculaScore` (tem dois sinais substantivos, tem checkpoint);
- produz `score: 60`;
- e **nenhum** dos fatores tem âncora — só os de compromisso e objeção recebem uma; qualificação e recência nascem sem ela, a recência **de propósito** (*"é a AUSÊNCIA de pontos"*).

Resultado no `INSERT`: **`23514`**. O lead fica **sem score nenhum**, a tela mostra vazio, e a causa só aparece no log do worker. Não é "score sem evidência" — é score nenhum.

## Provado pelo caminho de produção, não por leitura

`tests/invariants/score-escritor-real-satisfaz-a-constraint.test.ts` chama **`recalculaScoreDoLead`** — a mesma função que `lib/agent-engine/agent/inbound-turn.ts` chama — contra o Postgres do `test:db`. Não usa `sql()`: isso provaria de novo o que a wave 5 já provou.

| | Antes do conserto | Depois |
|---|---|---|
| caso "só BANT" | **`23514`**, com a asserção nomeando o desfecho | passa |
| controle "com compromisso" | passa (grava com âncora) | passa |

O controle existe para o teste não confundir *"o escritor está errado"* com *"o cenário nunca grava nada"*, e há também o controle positivo do pool (um pool no banco errado passaria com contagens zeradas e pareceria medição).

## O conserto é a promessa que a função já fazia

O cabeçalho de `calculaScore` diz: *"melhor recusar aqui, com motivo legível, do que descobrir no INSERT"*. A verificação parava no checkpoint **existir**; agora exige que algum fator **use** a âncora dele.

A conta é sobre `relevantes`, não sobre `fatores` — é `relevantes` que vai para `evidence`, e um fator de zero ponto é filtrado antes de chegar lá. Checar a lista errada deixaria a mesma linha passar por outro caminho.

**Dar âncora ao fator de qualificação é decisão de PRODUTO, não conserto** — ela viria de `lead_state`, e o formato é `{kind: "checkpoint" | "message"}`; apontar o BANT para o checkpoint seria citar como fonte algo que não o sustenta. Fica registrado no código.

## Os testes que afirmavam o comportamento antigo

Dois casos de `score-formula.test.ts` esperavam score para o cenário só-BANT — **um score que o banco nunca aceitou**. Eles provavam a FUNÇÃO e afirmavam o SISTEMA. Passaram a usar cenários que o sistema inteiro aceita, e a recusa ganhou caso próprio, com o porquê.

Sabotagem: removida a guarda, o caso novo reprova sozinho — **1 vermelho, os outros 20 verdes**.

## Gates

- `pnpm typecheck` limpo; `tests/unit/score-formula.test.ts` **21/21**.
- `pnpm test:db` nos dois invariantes de score (o novo e o vizinho `score-band-coerencia`): **4/4**.
- **NÃO MEDIDO**: a suíte `test:db` completa não fechou nesta máquina — o processo foi morto por sinal (exit 143) aos ~11 min, duas vezes, com a máquina saturada. Os invariantes de score rodaram isolados e passaram; o CI é quem fecha a suíte inteira.
- Três arquivos de `test:unit` falham por **timeout** nesta máquina (16s–61s). Medido nos dois sentidos: falham **igual** com o conserto guardado no stash, na mesma máquina. Não são deste PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKUXpCeT28H7yPMfvEqJc6