### PR TITLE
Catraca do #432: variável vazia no .env.example não cai no default com ??

### DIFF
--- a/.changes/canal-zernio-volta-a-enviar.md
+++ b/.changes/canal-zernio-volta-a-enviar.md
@@ -1,0 +1,25 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O canal Zernio volta a enviar em quem configurou a partir do arquivo de exemplo
+---
+
+Quem conectou o canal Zernio numa instalação montada a partir do arquivo de
+exemplo não conseguia enviar mensagem nenhuma por ele. As duas credenciais
+estavam certas, o canal aparecia configurado, e o envio falhava assim mesmo —
+tanto para quem deixou as credenciais na configuração quanto para quem as
+cadastrou pela tela.
+
+A causa estava no endereço do provedor. O arquivo de exemplo traz essa linha
+vazia, e o comentário ao lado dela promete que vazio usa o endereço de produção
+do provedor — a linha só existe para quem precisa apontar o sistema a um
+ambiente de homologação. Não era o que acontecia: o vazio era tratado como se
+fosse um endereço de verdade, e o sistema tentava falar com um lugar que não
+existe.
+
+Agora vazio significa o que o arquivo sempre disse que significava. Quem
+preencheu a linha para apontar para homologação continua sendo respeitado, e
+espaço sobrando em volta do endereço deixa de atrapalhar.
+
+Ninguém precisa mexer em nada. Instalações que já enviavam seguem iguais, e as
+que estavam com esse envio quebrado voltam a funcionar sozinhas.

--- a/lib/channels/zernio/credentials.ts
+++ b/lib/channels/zernio/credentials.ts
@@ -52,9 +52,26 @@ export interface ZernioCredsLookup {
  * Base da API. Explícita e sobrescrevível: o próprio provider publica um
  * servidor local no OpenAPI, e um teste de integração precisa apontar para
  * outro lugar sem editar código.
+ *
+ * `||` e não `??`, e o `trim()` junto — a diferença é o bug inteiro.
+ *
+ * O `.env.example` entrega esta chave VAZIA, e o comentário ao lado dela
+ * promete: "Vazio usa a produção do provedor." O `??` não cumpria essa
+ * promessa, porque ele só cai no padrão em `null`/`undefined` — string vazia
+ * é valor, e passa. Quem fizesse `cp .env.example .env`, preenchesse as duas
+ * credenciais e deixasse este override como veio — que é o caminho NORMAL,
+ * já que o override existe só para homologação — resolvia `baseUrl` para
+ * `""`, montava `/v1/inbox/conversations` sem host, e o `fetch` do Node
+ * recusava com `TypeError: Failed to parse URL`. Todo envio pelo canal
+ * quebrava, nos DOIS caminhos de credencial (env e sessão cifrada), que
+ * chamam esta mesma função.
+ *
+ * Ausente funcionava e vazia não: por isso a doutrina de QA — que manda testar
+ * com os envs opcionais AUSENTES — passava por cima. Quem copia o exemplo não
+ * tem a var ausente, tem ela presente e vazia.
  */
 export function zernioBaseUrl(): string {
-  return process.env.ZERNIO_API_BASE_URL ?? "https://zernio.com/api";
+  return process.env.ZERNIO_API_BASE_URL?.trim() || "https://zernio.com/api";
 }
 
 /**

--- a/tests/unit/canal-zernio-base-url-vazia.test.ts
+++ b/tests/unit/canal-zernio-base-url-vazia.test.ts
@@ -1,0 +1,93 @@
+/**
+ * A BASE DA API DO CANAL INTERMEDIADO HONRA O CONTRATO DO `.env.example`.
+ *
+ * ## O defeito, e por que ele escapou de tudo
+ *
+ * `zernioBaseUrl()` resolvia com `??`. O `.env.example` entrega
+ * `ZERNIO_API_BASE_URL=` VAZIA, com esta promessa escrita ao lado:
+ *
+ *     # Só para apontar para homologação. Vazio usa a produção do provedor.
+ *
+ * `??` não cumpre essa promessa. Ele só cai no padrão em `null`/`undefined`;
+ * string vazia é valor e passa direto. Resultado medido, executando:
+ *
+ *     baseUrl resolvida: ""
+ *     URL montada      : "/v1/inbox/conversations?account_id=x"
+ *     fetch LANÇOU     : TypeError: Failed to parse URL
+ *
+ * Atingia quem fez `cp .env.example .env`, preencheu `ZERNIO_ACCOUNT_ID` e
+ * `ZERNIO_API_KEY` para conectar o canal, e deixou o override como veio — que
+ * é o caminho NORMAL, porque o próprio comentário diz que ele é só para
+ * homologação. Todo envio pelo canal quebrava.
+ *
+ * Não escapava por um caminho só: a credencial da SESSÃO (token cifrado no
+ * banco) chama esta mesma função, então configurar pela tela não salvava.
+ *
+ * ## Por que os gates existentes não pegaram
+ *
+ * A doutrina de QA deste repo manda testar com os envs opcionais **AUSENTES**,
+ * e ausente SEMPRE funcionou — o `??` pega `undefined`. O estado que quebra é
+ * **presente e vazio**, que é exatamente o que copiar o `.env.example`
+ * produz. É o vão entre os dois que este arquivo fecha.
+ *
+ * E `ZERNIO_API_BASE_URL` não aparece em `lib/env.ts`: nada a valida no boot.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { zernioBaseUrl } from "@/lib/channels/zernio/credentials";
+
+const CHAVE = "ZERNIO_API_BASE_URL";
+const PRODUCAO = "https://zernio.com/api";
+
+// O `.env.local` desta máquina entra no `process.env` via `vitest.setup.ts`,
+// então o valor real precisa sair e voltar em volta de cada caso — senão o
+// teste mede o ambiente de quem roda, não o código.
+let original: string | undefined;
+beforeEach(() => {
+  original = process.env[CHAVE];
+});
+afterEach(() => {
+  if (original === undefined) delete process.env[CHAVE];
+  else process.env[CHAVE] = original;
+});
+
+describe("zernioBaseUrl honra o que o .env.example promete", () => {
+  it("VAZIA cai na produção do provedor — a promessa escrita no .env.example", () => {
+    process.env[CHAVE] = "";
+    expect(zernioBaseUrl()).toBe(PRODUCAO);
+  });
+
+  it("AUSENTE cai na produção do provedor", () => {
+    delete process.env[CHAVE];
+    expect(zernioBaseUrl()).toBe(PRODUCAO);
+  });
+
+  it("só espaço em branco também cai na produção", () => {
+    // Uma linha `ZERNIO_API_BASE_URL= ` com um espaço sobrando não é um
+    // endereço, e montaria a mesma URL sem host.
+    process.env[CHAVE] = "   ";
+    expect(zernioBaseUrl()).toBe(PRODUCAO);
+  });
+
+  it("valor real continua vencendo — o override de homologação segue existindo", () => {
+    // O caso que dá sentido aos de cima: a correção não pode ter matado o
+    // motivo de a variável existir.
+    process.env[CHAVE] = "https://homologacao.zernio.com/api";
+    expect(zernioBaseUrl()).toBe("https://homologacao.zernio.com/api");
+  });
+
+  it("espaço em volta de um valor real é aparado, não herdado", () => {
+    process.env[CHAVE] = "  https://homologacao.zernio.com/api  ";
+    expect(zernioBaseUrl()).toBe("https://homologacao.zernio.com/api");
+  });
+
+  it("o que a função devolve monta uma URL ABSOLUTA — a falha era esta", () => {
+    // A asserção que fecha a distância entre "resolveu para string vazia" e o
+    // sintoma real. `new URL` recusa caminho relativo do mesmo jeito que o
+    // `fetch` do Node recusava.
+    process.env[CHAVE] = "";
+    const url = `${zernioBaseUrl()}/v1/inbox/conversations`;
+    expect(() => new URL(url)).not.toThrow();
+    expect(new URL(url).host).toBe("zernio.com");
+  });
+});

--- a/tests/unit/env-vazia-no-exemplo-nao-usa-coalescencia-nula.test.ts
+++ b/tests/unit/env-vazia-no-exemplo-nao-usa-coalescencia-nula.test.ts
@@ -1,0 +1,141 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * VARIÁVEL QUE O `.env.example` ENTREGA **VAZIA** NÃO PODE CAIR NO DEFAULT COM `??`.
+ *
+ * ═══ O defeito que esta varredura fecha (achado triando o PR #432) ═══
+ *
+ * `??` só cai no padrão em `null`/`undefined`. **String vazia é valor e passa.**
+ * Quando o `.env.example` entrega a chave vazia — e o comentário ao lado promete
+ * que "vazio usa o padrão" —, quem faz `cp .env.example .env` e não preenche
+ * aquela linha recebe `""` no lugar do default.
+ *
+ * Medido no `zernioBaseUrl()`: com a variável **ausente**, `base` resolvia para
+ * `https://zernio.com/api` e a URL era válida; com ela **presente e vazia**,
+ * `base` virava `""` e `new URL("/v1/...")` estourava `Invalid URL`. Todo envio
+ * pelo canal quebrava, nos dois caminhos de credencial.
+ *
+ * ⚠️ E repare por que nenhum gate pegou: a doutrina de QA desta casa manda testar
+ * **com os envs opcionais AUSENTES**, que é o estado de um primeiro deploy. Quem
+ * copia o `.env.example` não tem a variável ausente — tem ela **presente e
+ * vazia**, que é um terceiro estado que ninguém exercitava.
+ *
+ * ═══ A regra é estreita de propósito ═══
+ *
+ * Só reprova quando as TRÊS valem juntas: a variável aparece no `.env.example`,
+ * ela vem **vazia** lá, e o código usa `?? "<default não-vazio>"`. `?? ""` não
+ * entra — ali vazio já é o valor esperado, e exigir `||` seria trocar um
+ * comportamento correto por outro igual. Proibir `??` em toda leitura de env
+ * acusaria dezenas de casos certos, e gate que reprova o comportamento certo é
+ * desligado na terceira vez que atrapalha.
+ */
+const RAIZ = path.resolve(__dirname, "../..");
+const DIRS = ["lib", "app", "workers", "scripts"];
+
+/**
+ * Variáveis que `lib/env.ts` declara OBRIGATÓRIAS — elas saem da varredura.
+ *
+ * ⚠️ Esta exclusão nasceu de um FALSO POSITIVO do próprio gate, e o registro
+ * importa. Ele acusou `lib/auth/invite-token.ts:16`
+ * (`INVITE_TOKEN_SECRET ?? INTERNAL_SECRET ?? "dev-fallback"`), porque
+ * `INTERNAL_SECRET` vem vazia no `.env.example`. Parecia grave: segredo de
+ * assinatura virando `""`.
+ *
+ * Testei antes de exigir, e caiu. `lib/env.ts:30` define
+ * `required = isProd ? z.string().min(1) : z.string().default("")` — em
+ * produção a variável vazia **reprova na validação e o app não sobe**, com
+ * mensagem própria. O caminho do `??` é inalcançável lá, e em desenvolvimento o
+ * fallback declarado (`dev-fallback`) é a intenção escrita no cabeçalho do
+ * arquivo: *"Production deployments MUST set one of the first two."*
+ *
+ * Um gate que reprovasse isso mandaria alguém consertar um defeito que não
+ * existe — que é o que o passe 7 da triagem desta casa proíbe.
+ */
+function obrigatoriasNoEnvTs(): Set<string> {
+  const src = fs.readFileSync(path.join(RAIZ, "lib/env.ts"), "utf8");
+  const obrig = new Set<string>();
+  for (const m of src.matchAll(/([A-Z][A-Z0-9_]*)\s*:\s*required(?:Always)?\(/g)) obrig.add(m[1]!);
+  return obrig;
+}
+
+/** Variáveis que o `.env.example` entrega presentes e VAZIAS. */
+function varsVaziasNoExemplo(): Set<string> {
+  const src = fs.readFileSync(path.join(RAIZ, ".env.example"), "utf8");
+  const vazias = new Set<string>();
+  for (const linha of src.split("\n")) {
+    const m = /^([A-Z][A-Z0-9_]*)=(.*)$/.exec(linha.trim());
+    if (m && m[2]!.trim() === "") vazias.add(m[1]!);
+  }
+  return vazias;
+}
+
+/** `process.env.X ?? "algo"` — com `algo` NÃO vazio. */
+function coalescenciasComDefaultReal(): Array<{ arquivo: string; linha: number; var: string }> {
+  const achados: Array<{ arquivo: string; linha: number; var: string }> = [];
+  const varrer = (dir: string) => {
+    const abs = path.join(RAIZ, dir);
+    if (!fs.existsSync(abs)) return;
+    for (const e of fs.readdirSync(abs, { withFileTypes: true })) {
+      const p = path.join(abs, e.name);
+      if (e.isDirectory()) {
+        if (e.name === "node_modules" || e.name === ".next") continue;
+        varrer(path.relative(RAIZ, p));
+        continue;
+      }
+      if (!/\.(ts|tsx)$/.test(e.name)) continue;
+      const src = fs.readFileSync(p, "utf8");
+      src.split("\n").forEach((linha, i) => {
+        const m = /process\.env\.([A-Z][A-Z0-9_]*)\s*\?\?\s*"([^"]*)"/.exec(linha);
+        if (m && m[2] !== "") {
+          achados.push({ arquivo: path.relative(RAIZ, p), linha: i + 1, var: m[1]! });
+        }
+      });
+    }
+  };
+  for (const d of DIRS) varrer(d);
+  return achados;
+}
+
+describe("env vazia no .env.example não cai no default com `??`", () => {
+  it("CONTROLE: a varredura enxerga as leituras de env que existem", () => {
+    // Sem isto, um regex que deixasse de casar devolveria "nenhum problema" e
+    // leria como aprovação — a sonda morta que devolve zero.
+    expect(
+      coalescenciasComDefaultReal().length,
+      "a varredura não achou NENHUM `process.env.X ?? \"...\"` no repositório — " +
+        "o regex parou de casar, e o resultado abaixo não vale nada",
+    ).toBeGreaterThanOrEqual(3);
+  });
+
+  it("CONTROLE: a lista de obrigatórias não engole tudo", () => {
+    // Se `obrigatoriasNoEnvTs()` casasse demais, o cruzamento ficaria vazio por
+    // exclusão e o gate viraria verde permanente — a forma mais silenciosa de
+    // um gate morrer.
+    const obrig = obrigatoriasNoEnvTs();
+    expect(obrig.size, "nenhuma obrigatória reconhecida — o regex de lib/env.ts parou de casar").toBeGreaterThan(3);
+    expect(obrig.size, "obrigatórias demais — a exclusão está engolindo o cruzamento").toBeLessThan(60);
+  });
+
+  it("CONTROLE: o .env.example tem variáveis vazias para cruzar", () => {
+    expect(varsVaziasNoExemplo().size, "nenhuma var vazia no .env.example — cruzamento vazio").toBeGreaterThan(5);
+  });
+
+  it("nenhuma variável vazia no exemplo usa `??` com default real", () => {
+    const vazias = varsVaziasNoExemplo();
+    const obrigatorias = obrigatoriasNoEnvTs();
+    const ruins = coalescenciasComDefaultReal()
+      .filter((a) => vazias.has(a.var) && !obrigatorias.has(a.var))
+      .map((a) => `${a.arquivo}:${a.linha} — ${a.var}`);
+
+    expect(
+      ruins,
+      "Estas leem uma variável que o `.env.example` entrega VAZIA e usam `??`, que só cai no " +
+        "default em null/undefined. Quem copia o exemplo recebe string vazia no lugar do padrão " +
+        "— foi assim que todo envio pelo canal Zernio quebrou (PR #432, de @jmschmitzco). " +
+        "Use `process.env.X?.trim() || \"default\"`.",
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Passe 11 (catraca) da triagem do **#432**, de @jmschmitzco. Só teste — nenhuma linha de produção nova além do conserto dele, que a branch inclui para o gate nascer verde.

## O defeito era invisível para todo gate desta casa

`??` só cai no default em `null`/`undefined`. **String vazia é valor e passa.** Medido no `zernioBaseUrl()`:

| estado da variável | resultado |
|---|---|
| **ausente** | `https://zernio.com/api` — URL válida |
| **presente e vazia** | `""` → `new URL(...)` estoura `Invalid URL` |

E a razão de ninguém ter pego é a parte que vale: a doutrina de QA manda testar **com os envs opcionais ausentes**, que é o estado de um primeiro deploy. Quem faz `cp .env.example .env` não tem a variável ausente — tem ela **presente e vazia**, um terceiro estado que nenhum gate exercitava.

## A regra é estreita de propósito

Só reprova quando as três valem juntas: a variável está no `.env.example`, vem **vazia** lá, e o código usa `?? "<default não-vazio>"`. Casos fora disso não entram:

- `?? ""` — ali vazio já é o valor esperado; exigir `||` trocaria um comportamento correto por outro igual.
- variáveis `required()` no `lib/env.ts` — ver abaixo.

Proibir `??` em toda leitura de env acusaria dezenas de casos certos, e **gate que reprova o comportamento certo é desligado na terceira vez que atrapalha**.

## O falso positivo que virou exclusão — e a razão está no arquivo

O gate acusou `lib/auth/invite-token.ts:16` (`INVITE_TOKEN_SECRET ?? INTERNAL_SECRET ?? "dev-fallback"`), porque `INTERNAL_SECRET` vem vazia no `.env.example`. Parecia grave: segredo de assinatura virando `""`.

**Testei antes de exigir, e caiu.** `lib/env.ts:30` define `required = isProd ? z.string().min(1) : z.string().default("")` — em produção a vazia **reprova na validação e o app não sobe**, com mensagem própria. O caminho do `??` é inalcançável lá, e em desenvolvimento o `dev-fallback` é a intenção escrita no cabeçalho daquele arquivo.

Sem esse teste, este PR teria virado um pedido para consertar um defeito que não existe — que é o que o passe 7 da triagem proíbe.

## Controles

Três, porque sonda que devolve zero nos dois estados não separa nada:

1. **a varredura enxerga** — reprova se o regex parar de casar `process.env.X ?? "..."`;
2. **o `.env.example` tem vazias para cruzar** — reprova se o cruzamento ficar vazio por falta de dado;
3. **a exclusão não engole tudo** — reprova se `required()` casar demais e o gate virar verde permanente por exclusão.

**Sabotagem:** devolvendo o `??` ao `zernioBaseUrl`, o gate reprova nomeando `lib/channels/zernio/credentials.ts:74 — ZERNIO_API_BASE_URL`. Restaurado, 4 de 4 verdes.

## Nota sobre a branch

Ela inclui o commit do #432 porque o gate **depende do conserto dele** para nascer verde — gate que nasce vermelho é dívida disfarçada de rede. Se o #432 entrar primeiro, este PR reduz ao arquivo de teste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKUXpCeT28H7yPMfvEqJc6