### PR TITLE
Aplica sobre o #420: alinhar o adaptador e vigiar a consulta de produção

### DIFF
--- a/tests/e2e/agente-papeis-operador.spec.ts
+++ b/tests/e2e/agente-papeis-operador.spec.ts
@@ -125,8 +125,19 @@ test.describe("A aba do papel que organiza o sistema", () => {
     expect(altura, "o painel está no DOM e não ocupa espaço na tela").toBeGreaterThan(100);
 
     // Todas as conferências, não uma amostra.
+    //
+    // ⚠️ ESTE NÚMERO É ESPELHO DE `lib/ai/guardrails/lista-de-conferencia.ts`, e
+    // ele mora em DOIS lugares: aqui e em `tests/unit/painel-de-seguranca.test.tsx`.
+    // Quem acrescentar uma conferência precisa mexer nos dois — o unit reprova na
+    // hora, este só no `e2e`, minutos depois e noutro job, e é fácil concluir que
+    // a falha é de ambiente.
+    //
+    // Foi o que aconteceu no PR #420 (@automatikpg-ux): ele acrescentou
+    // `agenda_stall`, atualizou o unit (que ele viu reprovar) e não tinha como
+    // saber deste. A conta é `CONFERENCIAS_DE_SAIDA.length + 1` — a de entrada —,
+    // e o próprio unit prova a igualdade exata entre o DOM e a lista.
     const itens = painel.locator('[data-testid^="item-conferencia-"]');
-    await expect(itens).toHaveCount(11);
+    await expect(itens).toHaveCount(12);
 
     // EXATAMENTE DOIS interruptores — um por camada que custa dinheiro. Este caso
     // já afirmou ZERO, e a mudança é deliberada: enquanto o motor lia só o `.env`,

--- a/tests/invariants/followup-silence-sweep.test.ts
+++ b/tests/invariants/followup-silence-sweep.test.ts
@@ -7,6 +7,7 @@ import {
   type SilencePointer,
 } from "@/lib/followup/silence-sweep";
 import { isPointerEnabledForAutomaticTrigger, type FollowupGateDb } from "@/lib/followup/agent-followup-gate";
+import { CONVERSATION_TERMINAL_STATUSES } from "@/lib/schemas";
 import type { FlowGraph } from "@/lib/followup/graph-schema";
 
 /**
@@ -63,6 +64,35 @@ beforeEach(async () => {
 
 // ---- pg-backed SilenceSweepDb (test-only; prod usa createSupabaseSilenceSweepDb) ----
 
+/**
+ * O SEGUNDO IMPLEMENTADOR DE `SilenceSweepDb` — e o primeiro é
+ * `createSupabaseSilenceSweepDb`, em `lib/followup/silence-sweep.ts`.
+ *
+ * A LÓGICA testada aqui é a real: este arquivo importa e chama
+ * `runSilenceSweep`. O que é dublê é a BORDA de acesso a dados — a produção
+ * fala com o PostgREST e o `test:db` sobe só o Postgres, então cada método
+ * abaixo traduz a consulta de lá para SQL. Dois implementadores do mesmo
+ * contrato, e eles têm de concordar.
+ *
+ * ⚠️ Eles JÁ divergiram, e o custo apareceu no PR #420 (@automatikpg-ux): a
+ * produção ganhou `.not("status","in", …)` para não cobrar quem um humano já
+ * encerrou, e esta cópia ficou sem o filtro. Os dois casos que aquele PR
+ * escreveu para provar a intenção reprovaram medindo A CÓPIA, não o original.
+ *
+ * ═══ O que a constante compartilhada garante, e o que NÃO garante ═══
+ *
+ * O filtro abaixo é montado a partir de `CONVERSATION_TERMINAL_STATUSES`, a
+ * mesma que a produção usa — e não de `'closed','archived'` escrito à mão. A
+ * diferença não é cosmética: acrescentar um status terminal passa a mudar os
+ * DOIS lados no mesmo commit, sem ninguém precisar lembrar deste arquivo.
+ *
+ * Isso prende o **valor**. Não prende a **forma**: um `.eq()` novo na produção
+ * que este SQL não tenha continua invisível daqui. Esse eixo é dívida
+ * declarada, com item de plano próprio — a pergunta dele é "como fazer os dois
+ * adaptadores passarem pela mesma bateria de contrato", e não cabe num PR de
+ * contribuidor. Escrever o escopo é o que impede esta cerca de anestesiar quem
+ * vier depois achando que ela cobre tudo.
+ */
 function silenceSweepDb(): SilenceSweepDb {
   return {
     async loadActiveSilencePointers(): Promise<SilencePointer[]> {
@@ -96,8 +126,9 @@ function silenceSweepDb(): SilenceSweepDb {
          from conversations conv
          join contacts c on c.id = conv.contact_id
          where conv.organization_id = $1 and conv.last_inbound_at is not null
+           and conv.status <> all($2::text[])
          group by conv.contact_id, c.tags, c.is_blocked`,
-        [orgId],
+        [orgId, CONVERSATION_TERMINAL_STATUSES],
       );
       const cutoff = new Date(cutoffIso).getTime();
       return rows

--- a/tests/unit/sweep-nao-cobra-conversa-encerrada.test.ts
+++ b/tests/unit/sweep-nao-cobra-conversa-encerrada.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { createSupabaseSilenceSweepDb } from "@/lib/followup/silence-sweep";
+import { CONVERSATION_TERMINAL_STATUSES } from "@/lib/schemas";
+
+/**
+ * O SWEEP DE SILÊNCIO NÃO PODE COBRAR QUEM UM HUMANO JÁ ENCERROU — e este teste
+ * vigia a CONSULTA DE PRODUÇÃO, não uma cópia dela.
+ *
+ * ═══ Por que ele existe, e por que o invariante não bastava ═══
+ *
+ * `tests/invariants/followup-silence-sweep.test.ts` prova a LÓGICA real (ele
+ * importa e chama `runSilenceSweep`), mas injeta um segundo implementador de
+ * `SilenceSweepDb` com SQL próprio — porque a produção fala com o PostgREST e o
+ * `test:db` sobe só o Postgres. Para comportamento que mora na LÓGICA
+ * (threshold, dedup, gate) aquele invariante vigia. Para comportamento que mora
+ * no FILTRO DA CONSULTA, ele não vigia — o filtro está na borda, e a borda é
+ * dublê.
+ *
+ * Medido, e é o que motivou este arquivo: com os dois casos do PR #420
+ * (@automatikpg-ux) verdes, **removi o filtro da produção** e o invariante
+ * continuou **19 de 19 verdes**. Ele estava medindo o filtro do adaptador de
+ * teste, não o do produto. Um verde sem lastro é pior que teste nenhum: ele
+ * cria segurança falsa sobre um comportamento que atinge cliente — cobrar
+ * automaticamente quem um humano encerrou de propósito.
+ *
+ * ═══ A ressalva, porque ela é estreita e importa ═══
+ *
+ * Este teste vigia a CHAMADA, não o EFEITO. Se o PostgREST mudar a semântica de
+ * `.not(coluna, "in", ...)`, ele fica verde estando errado — foi exatamente o
+ * que esta casa pagou com o `setAuth` do Realtime, que o dublê deu como chamado
+ * enquanto a biblioteca tinha mudado por baixo. O efeito continua vigiado só
+ * por produção e pelos e2e.
+ *
+ * Molde: `tests/unit/inbox-aba-minhas-sem-fechadas.test.ts`, que faz o mesmo
+ * para o filtro de status da inbox.
+ */
+
+/** Registra a cadeia do PostgREST; resolve como lista vazia no `await`. */
+function fakeSupabase() {
+  const chamadas: { metodo: string; args: unknown[] }[] = [];
+  const proxy: Record<string, unknown> = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === "then") {
+          return (ok: (v: unknown) => unknown) => ok({ data: [], error: null });
+        }
+        return (...args: unknown[]) => {
+          chamadas.push({ metodo: String(prop), args });
+          return proxy;
+        };
+      },
+    },
+  ) as Record<string, unknown>;
+  return { client: { from: () => proxy } as never, chamadas };
+}
+
+/** O `.not("status","in","(closed,archived)")` que tira as encerradas. */
+const excluiTerminais = (chamadas: { metodo: string; args: unknown[] }[]) =>
+  chamadas.some(
+    (c) =>
+      c.metodo === "not" &&
+      c.args[0] === "status" &&
+      c.args[1] === "in" &&
+      CONVERSATION_TERMINAL_STATUSES.every((s) => String(c.args[2]).includes(s)),
+  );
+
+describe("createSupabaseSilenceSweepDb — a consulta de PRODUÇÃO", () => {
+  it("CONTROLE: o dublê alcança o caminho (a consulta é montada)", async () => {
+    // Sem isto, um dublê que não fosse exercitado devolveria zero chamadas e a
+    // asserção abaixo passaria por vacuidade — o modo de falha que este arquivo
+    // inteiro existe para não repetir.
+    const { client, chamadas } = fakeSupabase();
+    await createSupabaseSilenceSweepDb(client).loadSilentContactIds(
+      "org-1",
+      new Date("2026-08-30T12:00:00Z").toISOString(),
+      [],
+    );
+    expect(chamadas.map((c) => c.metodo)).toContain("select");
+    expect(chamadas.length, "o dublê não registrou chamada nenhuma").toBeGreaterThan(2);
+  });
+
+  it("exclui conversa CLOSED/ARCHIVED no BANCO — quem um humano encerrou não é cobrado", async () => {
+    const { client, chamadas } = fakeSupabase();
+    await createSupabaseSilenceSweepDb(client).loadSilentContactIds(
+      "org-1",
+      new Date("2026-08-30T12:00:00Z").toISOString(),
+      [],
+    );
+    expect(
+      excluiTerminais(chamadas),
+      "a consulta de produção não exclui as conversas terminais: o sweep vai inscrever em " +
+        "follow-up automático quem um humano fechou de propósito. Achado no PR #420.",
+    ).toBe(true);
+  });
+
+  it("o filtro deriva da constante compartilhada, não de literais", () => {
+    // Se alguém escrever ('closed','archived') à mão aqui ou na produção, o dia
+    // em que um status terminal novo entrar em CONVERSATION_TERMINAL_STATUSES
+    // deixa os dois lados divergentes em silêncio.
+    expect(CONVERSATION_TERMINAL_STATUSES.length).toBeGreaterThan(0);
+    expect([...CONVERSATION_TERMINAL_STATUSES]).toEqual(["closed", "archived"]);
+  });
+});


### PR DESCRIPTION
⚠️ **Aplica sobre o #420 — mergear o #420 PRIMEIRO.** Sem os arquivos dele na base, estes dois commits não fazem sentido sozinhos, e é assim que tem de ser: a autoria das 2012 linhas é do @automatikpg-ux, nos 11 commits dele.

> **Correção de empacotamento.** A primeira versão desta branch carregava um commit `previa 420` **assinado por mim** com os 25 arquivos dele achatados dentro. Mergear aquilo apagaria os 11 commits do contribuidor: `git log --author` nunca mais o acharia, `git blame` apontaria para nós, e o perfil dele não registraria nada. Autoria partida um `.mailmap` conserta; **autoria achatada não tem conserto**. Apontado pelo @Maestro (2) e refeito com `git rebase --onto`.

## O problema, na ordem em que foi medido

**1.** O `invariants` reprovava em dois casos — os que **ele escreveu** para provar que conversa encerrada não entra em follow-up.

**2.** Causa: `tests/invariants/followup-silence-sweep.test.ts` injeta um segundo implementador de `SilenceSweepDb`, com SQL próprio. Ele acrescentou `.not("status","in", …)` na produção; a cópia do teste ficou sem o filtro. **Os casos dele reprovavam medindo a cópia.**

**3.** Alinhei a cópia — e a exigência de provar **nos dois sentidos** derrubou a solução: removi o filtro **da produção** e o invariante seguiu **19 de 19 verdes**. Alinhar a cópia destravava o CI e produzia um **verde sem lastro**.

## O que este PR faz

**a) O adaptador de teste deriva o filtro da MESMA constante da produção** — o contribuidor já tinha feito a coisa certa usando `CONVERSATION_TERMINAL_STATUSES` em vez de literais. Copiar o *valor* faria a divergência voltar no próximo status; derivar da *fonte* muda os dois lados no mesmo commit. Isso destrava o #420, **mas não é vendido como prova do comportamento**.

**b) Um teste que vigia a consulta de PRODUÇÃO.** Dublê de `SupabaseClient` em `createSupabaseSilenceSweepDb`, assertando que o `.not` é montado com a constante. Molde: `tests/unit/inbox-aba-minhas-sem-fechadas.test.ts`.

## Provado nos dois sentidos — agora o segundo cai

| | invariante (adaptador) | teste de construção (produção) |
|---|---|---|
| com o filtro na produção | 19 de 19 | **3 de 3** |
| **sem** o filtro na produção | 19 de 19 ⚠️ *(não vigia)* | **1 vermelho** — o caso do filtro |

Os outros dois casos do arquivo novo seguem verdes na sabotagem: a cerca **discrimina**.

## Em que grau confiar — a ressalva, nos dois arquivos

> Para casos de **filtro de consulta**, o invariante não vigia a produção: o filtro está na borda, e a borda é dublê. Para casos de **lógica** (threshold, dedup, gate), vigia.

E o teste novo tem a sua: vigia a **chamada**, não o **efeito**. Se o PostgREST mudar a semântica de `.not(coluna,"in",…)`, fica verde estando errado — foi o que esta casa pagou com o `setAuth` do Realtime. O efeito segue vigiado só por produção e e2e.

## Nota

`DESKCOMM_GOV_INVARIANTS_EDIT=1` no commit do adaptador. Não afrouxa invariante: alinha um **adaptador de teste** com a produção, e a prova de que a cerca continua vigiando está na tabela acima.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKUXpCeT28H7yPMfvEqJc6
