### PR TITLE
fix(queue): o relógio do worker deixa de depender do Postgres 17

### DIFF
--- a/.changes/relogio-do-worker-aguenta-postgres-15.md
+++ b/.changes/relogio-do-worker-aguenta-postgres-15.md
@@ -1,0 +1,18 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O relógio interno do assistente deixa de depender da versão do banco
+---
+
+Quando uma conexão de WhatsApp entra em espera, o sistema marca a fila com uma
+data "infinita" — é assim que ele segura o atendimento até alguém resolver o
+aviso. O cálculo de quanto falta para a próxima tarefa fazia uma conta com essa
+data que **só funciona no Postgres 17**; em Postgres 15 ou 16 o banco recusa a
+conta e o relógio do assistente para.
+
+Isso nunca afetou quem seguiu a versão recomendada. Passa a importar agora que a
+instalação aceita bancos mais antigos — e é exatamente onde apareceria: numa
+máquina nova, com uma conexão em espera, sem nada na tela explicando.
+
+A proteção já existia, mas na ordem errada: ela limitava o resultado da conta,
+e a conta estourava antes. Agora limita a data antes de calcular.

--- a/lib/agent-engine/queue/queue.ts
+++ b/lib/agent-engine/queue/queue.ts
@@ -169,17 +169,32 @@ const CLAIM_SQL = `
  *   - o `case when` é OBRIGATÓRIO: `greatest(NULL, 0)` no Postgres devolve 0, não
  *     NULL — sem ele a fila VAZIA se disfarçaria de "job vencido" e o loop
  *     voltaria a girar no ritmo curto, que é exatamente o defeito da issue;
- *   - o `least(..., 86400000)` segura `run_after = 'infinity'`, que o hold do
- *     session-watchdog grava, e que estouraria o `int4` do cast;
+ *   - o clamp segura `run_after = 'infinity'`, que o hold do session-watchdog
+ *     grava (`session-watchdog.ts`), e que estouraria o `int4` do cast. Ele
+ *     clampa o TIMESTAMP, e não o resultado, e a ordem NÃO é estilo: em
+ *     Postgres 15 e 16 `'infinity'::timestamptz - now()` é um ERRO do servidor
+ *     (`cannot subtract infinite timestamps`), então um `least()` aplicado ao
+ *     resultado nunca chega a rodar. Medido nos dois: pg15 devolve o erro,
+ *     pg17 devolve `infinity`. Enquanto o piso declarado era pg17 isto era
+ *     latente; num Postgres 15 quebra o RELÓGIO do worker
+ *     (`workers/agent-worker/main.ts`), que é quem chama esta função.
+ *     Guardado por `tests/unit/aritmetica-de-timestamp-infinito.test.ts`;
  *   - o `::int` faz o pg devolver `number`; sem ele viria `string` de `numeric`.
  */
 export async function faltaParaOProximoJob(pool: Pool): Promise<number | null> {
   const { rows } = await pool.query<{ falta_ms: number | null }>(
     `select case
               when min(run_after) is null then null
-              else least(
-                     greatest(extract(epoch from (min(run_after) - now())) * 1000, 0),
-                     86400000
+              -- O clamp é do TIMESTAMP, não do resultado — e a ordem é o
+              -- conserto. Ver o parágrafo do 'infinity' no cabeçalho: em
+              -- Postgres 15 a SUBTRAÇÃO estoura antes de qualquer least()
+              -- ('cannot subtract infinite timestamps'), então clampar depois
+              -- protege só quem já está no 17.
+              else greatest(
+                     extract(epoch from (
+                       least(min(run_after), now() + interval '1 day') - now()
+                     )) * 1000,
+                     0
                    )::int
             end as falta_ms
        from job_queue

--- a/tests/unit/aritmetica-de-timestamp-infinito.test.ts
+++ b/tests/unit/aritmetica-de-timestamp-infinito.test.ts
@@ -1,0 +1,200 @@
+/**
+ * NENHUMA CONTA DE TEMPO SOBRE COLUNA QUE ACEITA `'infinity'`.
+ *
+ * ─── O defeito, medido em dois Postgres reais (2026-08-30) ─────────────────
+ *
+ * ```
+ * select 'infinity'::timestamptz - now()
+ *   pg15 → ERROR: cannot subtract infinite timestamps
+ *   pg17 → infinity
+ * ```
+ *
+ * Subtrair timestamp infinito só passou a funcionar a partir do Postgres 16.
+ * Enquanto o piso declarado deste projeto era pg17, isso era latente. O PR que
+ * baixa o piso para pg15 (#422) o tornou alcançável — e o que ele alcança é o
+ * **relógio do worker**: `faltaParaOProximoJob` (`lib/agent-engine/queue/queue.ts`)
+ * fazia `min(run_after) - now()`, e `session-watchdog.ts` grava
+ * `run_after = 'infinity'` no hold de sessão, que é estado real de produção.
+ *
+ * A armadilha fina: a função **já tinha** um `least(..., 86400000)`, e o
+ * comentário dela dizia que ele "segura o infinity". Segurava — em pg17. O
+ * clamp estava no RESULTADO, e em pg15 a subtração estoura antes de ele rodar.
+ * Proteção certa, ordem errada; e a ordem só aparece quando alguém roda no piso.
+ *
+ * ─── Por que um gate, e não só o conserto ──────────────────────────────────
+ *
+ * O conserto fecha a única instância que existe hoje — varri e confirmei:
+ * duas colunas recebem `'infinity'` (`run_after` e `bot_silenced_until`), e só
+ * `run_after` aparecia em aritmética. Mas nada impede a próxima. Este arquivo
+ * é a catraca: quem escrever a segunda subtração descobre aqui, e não numa VPS
+ * com Postgres 15.
+ *
+ * ─── Como ele decide ───────────────────────────────────────────────────────
+ *
+ * As colunas NÃO são uma lista fixa — elas são **derivadas por varredura** de
+ * quem recebe `'infinity'` no repo. Uma lista escrita à mão envelheceria no dia
+ * em que aparecesse a terceira coluna, e envelheceria em silêncio.
+ *
+ * A forma SEGURA é clampar o timestamp ANTES de subtrair
+ * (`least(coluna, now() + interval …) - now()`). A forma insegura é subtrair
+ * direto. O gate distingue as duas.
+ */
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const RAIZ = join(__dirname, "..", "..");
+const AREAS = ["lib", "app", "workers", "supabase/migrations", "scripts"];
+const IGNORADAS = new Set(["node_modules", ".next", "dist"]);
+
+/** Caminho relativo sempre em barra normal — as mensagens deste gate são lidas. */
+function rel(abs: string): string {
+  return relative(RAIZ, abs).split(sep).join("/");
+}
+
+function arquivos(dir: string, out: string[] = []): string[] {
+  let entradas: string[];
+  try {
+    entradas = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const nome of entradas) {
+    if (IGNORADAS.has(nome)) continue;
+    const p = join(dir, nome);
+    let st;
+    try {
+      st = statSync(p);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) arquivos(p, out);
+    else if (/\.(ts|tsx|sql)$/.test(nome) && !/\.test\.tsx?$/.test(nome)) out.push(p);
+  }
+  return out;
+}
+
+const FONTES = AREAS.flatMap((a) => arquivos(join(RAIZ, a)));
+
+/**
+ * As colunas que recebem `'infinity'` em algum lugar do código — derivadas,
+ * nunca declaradas. Reconhece `col = 'infinity'` e `col = 'infinity'::tipo`,
+ * que são as duas formas usadas no repo.
+ */
+function colunasQueAceitamInfinito(): Set<string> {
+  const achadas = new Set<string>();
+  const rx = /([a-z_][a-z0-9_]{2,})\s*=\s*'infinity'/gi;
+  for (const arquivo of FONTES) {
+    const src = readFileSync(arquivo, "utf8");
+    let m: RegExpExecArray | null;
+    while ((m = rx.exec(src)) !== null) achadas.add(m[1]!.toLowerCase());
+  }
+  return achadas;
+}
+
+/**
+ * `coluna - now()`, `now() - coluna`, `age(coluna)` — as formas que estouram.
+ *
+ * O `[\s)]*` entre a coluna e o operador NÃO é decoração: a forma que existia
+ * no repo era `min(run_after) - now()`, com um parêntese de fechamento no meio.
+ * A primeira versão desta regex exigia a coluna colada ao `-`, ficou VERDE com
+ * o defeito na frente, e só apareceu porque sabotei o conserto para ver o gate
+ * reprovar. Um gate que não morde é pior que gate nenhum: ele afirma cobertura.
+ */
+function subtracoesDe(coluna: string): RegExp {
+  return new RegExp(
+    String.raw`(?:\b${coluna}\b[\s)]*-\s*now\s*\(\s*\)` +
+      String.raw`|now\s*\(\s*\)\s*-[\s(]*\b${coluna}\b` +
+      String.raw`|\bage\s*\(\s*[^)]*\b${coluna}\b)`,
+    "i",
+  );
+}
+
+/**
+ * O clamp protetor está aplicado ao TIMESTAMP — e não ao resultado?
+ *
+ * ```
+ * least(min(run_after), now() + interval '1 day') - now()   ← SEGURO
+ * least(greatest(extract(epoch from (min(run_after) - now())) …), 86400000)  ← NÃO
+ * ```
+ *
+ * A distinção é o miolo deste gate, e a primeira versão errou: eu procurava
+ * `least(` … coluna, e o `least(` da forma INSEGURA também casa — ele só está
+ * mais longe, com `greatest(extract(` no meio. Com isso o gate ficou VERDE
+ * sobre o defeito duas vezes seguidas, e as duas só apareceram porque sabotei
+ * o conserto para vê-lo reprovar.
+ *
+ * O discriminador certo: no clamp seguro a coluna vem LOGO depois do `least(`,
+ * no máximo com um `min(` no caminho — nunca com `extract` ou `epoch`, que são
+ * a assinatura de já se estar operando sobre o RESULTADO da subtração.
+ */
+function temClampDoTimestamp(trecho: string, coluna: string): boolean {
+  const rx = new RegExp(
+    String.raw`least\s*\(\s*(?:min\s*\(\s*)?\b${coluna}\b`,
+    "i",
+  );
+  return rx.test(trecho);
+}
+
+describe("aritmética de timestamp sobre coluna que aceita 'infinity'", () => {
+  const colunas = colunasQueAceitamInfinito();
+
+  it("a varredura ACHA as colunas que aceitam infinito — senão o gate é vácuo", () => {
+    // Sem esta asserção, uma regex que parasse de casar deixaria o gate verde
+    // por não ter o que varrer. `run_after` é o caso conhecido; se ele sumir,
+    // é a sonda que quebrou, não o repo que ficou limpo.
+    expect(
+      colunas.size,
+      "nenhuma coluna com 'infinity' encontrada — a varredura ficou cega",
+    ).toBeGreaterThan(0);
+    expect(colunas).toContain("run_after");
+  });
+
+  it("varre um número de arquivos compatível com o repo", () => {
+    // Segunda guarda contra vácuo: se a caminhada de diretórios quebrar, a
+    // varredura acima também não acha nada e o teste acima já pega — mas este
+    // diz QUAL das duas falhou.
+    expect(FONTES.length, "a caminhada de arquivos não achou fontes").toBeGreaterThan(300);
+  });
+
+  it("nenhuma subtração crua — o clamp vem ANTES, no timestamp", () => {
+    const infratores: string[] = [];
+
+    for (const arquivo of FONTES) {
+      const src = readFileSync(arquivo, "utf8");
+      const linhas = src.split("\n");
+
+      for (const coluna of colunas) {
+        if (!src.includes(coluna)) continue;
+        const rx = subtracoesDe(coluna);
+
+        linhas.forEach((linha, i) => {
+          // Comentário não executa: o cabeçalho desta própria função descreve a
+          // forma insegura para explicá-la, e acusá-lo seria o gate reprovando
+          // o texto que documenta o acerto.
+          const semComentario = linha.replace(/--.*$/, "").replace(/^\s*\*.*$/, "");
+          if (!rx.test(semComentario)) return;
+
+          // A subtração pode estar quebrada em várias linhas (é SQL formatado).
+          // Olho a vizinhança para achar o clamp.
+          const vizinhanca = linhas.slice(Math.max(0, i - 3), i + 2).join(" ");
+          if (temClampDoTimestamp(vizinhanca, coluna)) return;
+
+          infratores.push(`${rel(arquivo)}:${i + 1} → ${coluna} (${semComentario.trim().slice(0, 70)})`);
+        });
+      }
+    }
+
+    expect(
+      infratores,
+      "Conta de tempo sobre coluna que aceita 'infinity'.\n" +
+        "Em Postgres 15 e 16 isso é ERRO DO SERVIDOR — `cannot subtract infinite\n" +
+        "timestamps` — e derruba o caminho inteiro, não devolve um valor estranho.\n" +
+        "Clampe o TIMESTAMP antes de subtrair:\n" +
+        "  least(<coluna>, now() + interval '1 day') - now()\n" +
+        "Clampar o RESULTADO (`least(extract(...), teto)`) NÃO serve: a subtração\n" +
+        "estoura antes de o clamp rodar. Ver lib/agent-engine/queue/queue.ts.",
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## O defeito, medido em dois bancos reais

```
select 'infinity'::timestamptz - now()
  pg15 → ERROR: cannot subtract infinite timestamps
  pg17 → infinity
```

Subtrair timestamp infinito só funciona a partir do **Postgres 16**.

`faltaParaOProximoJob` (`lib/agent-engine/queue/queue.ts`) fazia `min(run_after) - now()`. E `run_after = 'infinity'` **não é hipotético**: o hold de sessão grava esse valor (`edge/crm/session-watchdog.ts`), e o worker usa essa função como **relógio** (`workers/agent-worker/main.ts`). Em Postgres 15 ou 16, uma conexão em hold derruba o cálculo do próximo job.

## A armadilha fina: a proteção existia, na ordem errada

A função **já tinha** `least(..., 86400000)`, e o comentário dela dizia que ele *"segura o `run_after = 'infinity'`"*. Segurava — em pg17. O clamp estava no **resultado**, e em pg15 a **subtração** estoura antes de ele rodar. Proteção certa, ordem errada; e a ordem só aparece quando alguém roda no piso.

**Conserto:** clampar o *timestamp*.

```sql
least(min(run_after), now() + interval '1 day') - now()
```

Medido nas **quatro** condições que o próprio comentário da função documenta, nos **dois** bancos, com resultados idênticos:

| caso | pg15 | pg17 |
|---|---|---|
| fila vazia | `NULL` | `NULL` |
| job vencido | `0` | `0` |
| `infinity` | `86400000` | `86400000` |
| daqui a 30s | `30000` | `30000` |

O valor do `infinity` é o **mesmo** que a query antiga já devolvia em pg17 — compatível para trás, não muda comportamento de quem está no 17.

## Por que também um gate

O conserto fecha a única instância que existe hoje. Varri e confirmei: só **duas** colunas recebem `'infinity'` (`run_after` e `bot_silenced_until`), e só `run_after` aparecia em aritmética. Mas nada impede a próxima.

`tests/unit/aritmetica-de-timestamp-infinito.test.ts` deriva as colunas **por varredura**, nunca de lista fixa — lista escrita à mão envelhece em silêncio no dia em que aparecer a terceira coluna.

## O gate nasceu INÚTIL duas vezes, e as duas só apareceram na sabotagem

1. a regex exigia a coluna colada ao `-`, e a forma real é `min(run_after) - now()`, com parêntese no meio → **verde com o defeito na frente**;
2. o detector de "está protegido" também reconhecia o `least(` da forma **insegura** — a que existia antes e não funciona → **verde de novo**.

Só na terceira ele reprovou, apontando arquivo, linha e trecho. Os dois enganos estão escritos no cabeçalho do teste, porque quem for mexer nessa regex precisa saber por que ela é mais larga do que parece.

## Contexto

Isto é o que bloqueava o check `invariants` do **#422** (que baixa o piso do baseline para pg15). **O defeito é do produto, não daquele PR** — ele só tornou alcançável o que já estava latente. Com isto na `main`, aquele PR fica só com o baseline.

## Verificação

- `pnpm test:unit`: **595 arquivos, 6622 casos, zero falhas**
- sabotagem do conserto → o gate reprova `lib/agent-engine/queue/queue.ts:194 → run_after`, com o trecho

🤖 Generated with [Claude Code](https://claude.com/claude-code)
