### PR TITLE
test(e2e): a contagem do painel de segurança passa a ser derivada da lista

### DIFF
--- a/tests/e2e/agente-papeis-operador.spec.ts
+++ b/tests/e2e/agente-papeis-operador.spec.ts
@@ -25,6 +25,7 @@ import { test, expect, type Browser, type Page } from "@playwright/test";
 
 import { loginComoAdmin, lerCreds, type CredsE2E } from "./helpers/login-admin";
 
+import { CONFERENCIAS_DE_SAIDA, CONFERENCIA_DE_ENTRADA } from "@/lib/ai/guardrails/lista-de-conferencia";
 let creds: CredsE2E = lerCreds();
 
 test.use({ locale: "pt-BR" });
@@ -126,18 +127,18 @@ test.describe("A aba do papel que organiza o sistema", () => {
 
     // Todas as conferências, não uma amostra.
     //
-    // ⚠️ ESTE NÚMERO É ESPELHO DE `lib/ai/guardrails/lista-de-conferencia.ts`, e
-    // ele mora em DOIS lugares: aqui e em `tests/unit/painel-de-seguranca.test.tsx`.
-    // Quem acrescentar uma conferência precisa mexer nos dois — o unit reprova na
-    // hora, este só no `e2e`, minutos depois e noutro job, e é fácil concluir que
-    // a falha é de ambiente.
+    // O NÚMERO É DERIVADO, NÃO ESCRITO. O painel renderiza as conferências de
+    // saída MAIS a de entrada, que é uma só e mora fora do array porque roda
+    // antes das outras, sobre o que CHEGA — `PainelDeSeguranca.tsx` a monta
+    // assim, e esta é a mesma expressão que `painel-de-seguranca.test.tsx` usa.
     //
-    // Foi o que aconteceu no PR #420 (@automatikpg-ux): ele acrescentou
-    // `agenda_stall`, atualizou o unit (que ele viu reprovar) e não tinha como
-    // saber deste. A conta é `CONFERENCIAS_DE_SAIDA.length + 1` — a de entrada —,
-    // e o próprio unit prova a igualdade exata entre o DOM e a lista.
+    // Era o literal `12` até este conserto, e o literal envelheceu em uma semana:
+    // o PR #420 (@automatikpg-ux) acrescentou `agenda_stall`, atualizou o unit —
+    // que reprova na hora — e não tinha como saber deste, que só reprova no
+    // `e2e`, minutos depois e noutro job. A `main` ficou vermelha por isso.
+    // Número escrito à mão envelhece calado; a expressão acompanha a lista.
     const itens = painel.locator('[data-testid^="item-conferencia-"]');
-    await expect(itens).toHaveCount(12);
+    await expect(itens).toHaveCount([...CONFERENCIAS_DE_SAIDA, CONFERENCIA_DE_ENTRADA].length);
 
     // EXATAMENTE DOIS interruptores — um por camada que custa dinheiro. Este caso
     // já afirmou ZERO, e a mudança é deliberada: enquanto o motor lia só o `.env`,


### PR DESCRIPTION
## O defeito

O `e2e` afirmava `toHaveCount(12)` — um literal. Ele envelheceu em uma semana:
o PR #420 acrescentou `agenda_stall` à lista de conferências, atualizou o teste
unit (que reprova na hora) e **não tinha como saber deste**, que só reprova no
`e2e`, minutos depois e noutro job. A `main` ficou vermelha por isso.

O #441 consertou repondo **outro literal**, `12` — com um comentário meu avisando
que o número "mora em dois lugares". Este PR tira o literal de cena: se o número
é espelho e a fórmula é conhecida, o espelho é dívida esperando a próxima pessoa.

## O conserto

```ts
await expect(itens).toHaveCount([...CONFERENCIAS_DE_SAIDA, CONFERENCIA_DE_ENTRADA].length);
```

É a mesma expressão que `tests/unit/painel-de-seguranca.test.tsx:152` já usa, e o
conjunto exato que `PainelDeSeguranca.tsx:164` renderiza.

**Não é `length + 1`.** O `+ 1` seria ele mesmo um literal, e envelheceria no dia
em que houvesse duas conferências de entrada — trocaria um número escrito à mão
por outro menor.

## Medido antes de escrever

| O que | Como | Resultado |
|---|---|---|
| O import arrasta servidor para a spec? | `grep -c '^import' lib/ai/guardrails/lista-de-conferencia.ts` | `0` — nenhuma dependência |
| O padrão existe no e2e? | `grep -rn '^import .*from "@/lib' tests/e2e/*.spec.ts` | 3 specs (não 4 — a quarta é texto dentro de um template literal) |
| O Playwright carrega o arquivo? | `playwright --list` | chega à **linha 29** (`lerCreds`, falta credencial local) — o import da 28 resolveu |
| A expressão vale o mesmo hoje? | avaliada por `tsx` | `11 + 1 = 12`, idêntico ao literal verde na `main` |
| Ela **acompanha** a lista? | acrescentei um item fictício e reavaliei | virou **13** — o literal teria ficado em 12 |
| `pnpm typecheck` | | `0 erros` |

## NÃO MEDIDO

O `e2e` completo desta spec não roda nesta máquina (falta `.env.e2e` + Supabase
local + WAHA). A prova aqui é de **carregamento e equivalência**, não de execução
verde: a asserção avalia hoje ao mesmo número que já está verde na `main`, e o CI
deste PR é quem a executa de verdade.

## Crédito

A ideia de derivar o número é do **@Assistente e Testes**, que mediu a viabilidade
antes de propor — inclusive conferindo que `CONFERENCIAS_DE_SAIDA` é exportada.
O que acrescentei foi trocar `length + 1` pelo conjunto explícito, pelo mesmo
motivo que ele deu para não usar lista fixa.