### PR TITLE
fix(ia): o atendente de IA passa a marcar consulta de verdade

### DIFF
--- a/.changes/o-atendente-de-ia-marca-consulta.md
+++ b/.changes/o-atendente-de-ia-marca-consulta.md
@@ -1,0 +1,34 @@
+---
+impacto: capacidade_nova
+secao: adicionado
+titulo: O atendente de IA passa a marcar consulta pela conversa
+---
+
+Quem instalou e ligou a agenda tinha um atendente de IA que consultava horário e
+não fechava nada: o paciente pedia "quinta às 14h" e a resposta era sempre "vou
+confirmar com a equipe". Faltavam duas coisas, e nenhuma delas era o modelo.
+
+A primeira: ele não sabia que dia era hoje. Nenhuma informação sobre a data
+chegava até ele, então não tinha como transformar "quinta que vem" ou "amanhã de
+manhã" num horário de verdade. Agora todo atendimento começa sabendo a data, a
+hora e o dia da semana, no fuso que você escolheu nas configurações da empresa.
+
+A segunda: ele não tinha como descobrir o que a sua empresa atende. Consulta,
+retorno, avaliação, procedimento — a lista está no sistema, e ele não conseguia
+lê-la; tinha que adivinhar o nome exato e errava. Agora existe uma capacidade
+nova, "Ver o que a empresa atende", que mostra a ele os tipos de atendimento com
+a duração de cada um.
+
+Junto vieram outras duas: confirmar um horário quando a pessoa avisa que vem, e
+registrar depois se ela foi atendida ou não apareceu. E a lista de horários
+livres passou a sair em português — "sexta-feira 04/09 às 14:00" em vez de um
+código de data —, com um número menor de opções por vez, o que também deixa a
+resposta mais rápida.
+
+O sistema também passou a recusar um registro que antes aceitava calado: marcar
+"faltou" num compromisso que ainda nem começou. Isso devolvia o horário para
+outra pessoa enquanto o cliente original ainda estava contando com ele.
+
+**As capacidades novas não entram sozinhas nos agentes que já existem.** Para o
+seu atendente usá-las, abra *O que o agente pode fazer*, ligue o pacote
+**Vender** de novo e publique. Agente criado a partir de agora já nasce com elas.

--- a/app/api/v1/agenda/agendamentos/_handler.ts
+++ b/app/api/v1/agenda/agendamentos/_handler.ts
@@ -271,6 +271,39 @@ export async function alterarAgendamentoHandler(
   }
 
   if (input.status && input.status !== atual.status) {
+    // ⚠️ DESFECHO É SOBRE O PASSADO. `completed` e `no_show` respondem "o que
+    // aconteceu?", e num compromisso que ainda não começou não aconteceu nada.
+    //
+    // Isto não era guardado, e o buraco ficou barato enquanto só gente marcava
+    // pela tela — os botões Realizado/Faltou vivem no histórico. Deixa de ser
+    // barato agora que `crm_set_appointment_outcome` põe a mesma escrita na mão
+    // de um modelo, que decide por texto e não por onde clicou.
+    //
+    // O dano do `no_show` prematuro é concreto e não é só um registro errado:
+    // `no_show` está em `LIBERAM_O_HORARIO` (`lib/agenda/ocupados.ts`), então
+    // ele DEVOLVE ao pool um horário que o cliente ainda espera. Outro cliente
+    // pega, e os dois aparecem na mesma hora.
+    //
+    // O `completed` prematuro tem outro dano: grava `appointment_completed` na
+    // timeline e some com os botões da tela, tirando de quem atendeu a chance de
+    // registrar o que de fato aconteceu.
+    //
+    // A guarda é AQUI, no handler, e não na ferramenta: a regra não é sobre quem
+    // chama. Recusa de negócio com o código do repo — a tool a traduz em resposta
+    // ao modelo, sem derrubar o turno.
+    if (
+      (input.status === "completed" || input.status === "no_show") &&
+      new Date(atual.starts_at as string).getTime() > Date.now()
+    ) {
+      throw new ApiError(
+        422,
+        "agenda_ainda_nao_aconteceu",
+        undefined,
+        ctx.requestId,
+        "Este compromisso ainda não começou — não dá para registrar se a pessoa veio ou faltou. " +
+          "Se ela avisou que não vem, desmarque em vez de registrar falta.",
+      );
+    }
     mudanca.status = input.status;
     // Remarcar vence: se vieram os dois, a notícia da timeline é a remarcação.
     transicao = transicao ?? input.status;

--- a/app/api/v1/agenda/tipos/route.ts
+++ b/app/api/v1/agenda/tipos/route.ts
@@ -25,6 +25,7 @@ import { fail, ok } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { listaTiposDeAtendimento } from "@/lib/agenda/consulta";
 
 export const dynamic = "force-dynamic";
 
@@ -88,18 +89,39 @@ export async function GET(req: NextRequest): Promise<Response> {
   const autorizado = await requireRole("viewer", { requestId, resource: "calendar_event_types" });
   if (!autorizado.ok) return autorizado.response;
 
-  const admin = createAdminClient();
-  const { data, error } = await admin
-    .from("calendar_event_types")
-    .select(
-      "id, name, slug, description, category, duration_minutes, location_kind, location_details, default_owner_user_id, requires_confirmation, is_active, buffer_before_minutes, buffer_after_minutes, minimum_notice_minutes, booking_window_days",
-    )
-    .eq("organization_id", autorizado.org.orgId)
-    .order("is_active", { ascending: false })
-    .order("name");
-
-  if (error) return fail("internal_error", error.message, 500, { requestId });
-  return ok(data ?? [], { requestId });
+  // A MESMA coleta que a ferramenta MCP usa. Esta query era inline aqui, e havia
+  // outras três iguais no repo — a tela e a IA respondendo por recortes
+  // diferentes sobre o que a organização atende. Ver `listaTiposDeAtendimento`.
+  //
+  // `incluirInativos: true` porque quem chama esta rota administra o cadastro:
+  // esconder o tipo desativado tiraria dele a única porta para reativá-lo.
+  const r = await listaTiposDeAtendimento(createAdminClient(), autorizado.org.orgId, {
+    incluirInativos: true,
+  });
+  if (!r.ok) return fail("internal_error", r.motivoParaOperador, 500, { requestId });
+  // O wire desta rota é snake_case e a tela já o consome assim; o coletor fala a
+  // língua do domínio. A tradução é aqui, na borda, e não no coletor — que
+  // também serve a IA, cujo vocabulário é outro.
+  return ok(
+    r.tipos.map((t) => ({
+      id: t.id,
+      name: t.nome,
+      slug: t.slug,
+      description: t.descricao,
+      category: t.categoria,
+      duration_minutes: t.duracaoMin,
+      location_kind: t.localKind,
+      location_details: t.localDetalhes,
+      default_owner_user_id: t.donoPadraoId,
+      requires_confirmation: t.precisaConfirmacao,
+      is_active: t.ativo,
+      buffer_before_minutes: t.bufferAntesMin,
+      buffer_after_minutes: t.bufferDepoisMin,
+      minimum_notice_minutes: t.antecedenciaMinimaMin,
+      booking_window_days: t.janelaDeAgendamentoDias,
+    })),
+    { requestId },
+  );
 }
 
 export async function POST(req: NextRequest): Promise<Response> {

--- a/lib/agenda/consulta.ts
+++ b/lib/agenda/consulta.ts
@@ -524,3 +524,118 @@ export async function idDoTipoPorSlug(
     .maybeSingle();
   return data ? { id: String(data.id), nome: String(data.name) } : null;
 }
+
+
+/**
+ * O que uma organização OFERECE para marcar.
+ *
+ * ⚠️ ESTE COLETOR NASCEU DE QUATRO CÓPIAS. `calendar_event_types` era lida em
+ * quatro lugares independentes, cada um com o seu recorte de colunas: o `GET`
+ * de `/api/v1/agenda/tipos`, a tela de configuração, a tela que marca e o
+ * `marcarAgendamentoHandler`. Nenhuma chamava a outra. É a mesma situação que
+ * o cabeçalho deste arquivo descreve para os horários — e o desfecho seria o
+ * mesmo: a tela e a IA respondendo por regras diferentes sobre o que a clínica
+ * atende.
+ *
+ * ⚠️ `incluirInativos` NÃO é conveniência, é a diferença entre duas perguntas.
+ * *"O que existe de cadastro?"* (tela de configuração, que precisa mostrar o
+ * desativado para alguém poder reativá-lo) e *"o que dá para marcar agora?"*
+ * (a IA e a tela que marca). Oferecer um tipo inativo ao modelo é beco sem
+ * saída garantido: `horariosLivresDaOrg` o encontra e recusa com
+ * `tipo_desativado`. Por isso o default é SÓ ATIVOS — quem quer o outro pede.
+ */
+export interface TipoDeAtendimento {
+  /** Chave de lista e alvo de PATCH/DELETE na TELA. Nunca vai ao modelo (ver a tool). */
+  id: string;
+  nome: string;
+  /** O handle estável que as ferramentas de agenda aceitam em `event_type_slug`. */
+  slug: string;
+  descricao: string | null;
+  categoria: string;
+  duracaoMin: number;
+  localKind: string;
+  localDetalhes: string | null;
+  /** true = o compromisso nasce aguardando o cliente confirmar (`pending`). */
+  precisaConfirmacao: boolean;
+  ativo: boolean;
+  /** Sem dono não há jornada, e sem jornada não há horário (`sem_responsavel`). */
+  donoPadraoId: string | null;
+  /**
+   * Os quatro números da grade. Eles NÃO vão ao modelo — `horariosLivresDaOrg`
+   * já os aplicou antes de devolver os horários, e repassá-los convidaria a IA a
+   * recalcular o que a máquina calculou. Estão aqui porque a rota de
+   * configuração os publica desde antes deste coletor existir, e campo que some
+   * de uma rota `/api/v1/` é quebra de contrato.
+   */
+  bufferAntesMin: number;
+  bufferDepoisMin: number;
+  antecedenciaMinimaMin: number;
+  janelaDeAgendamentoDias: number;
+}
+
+export type ResultadoDosTipos =
+  | { ok: true; tipos: TipoDeAtendimento[] }
+  | {
+      ok: false;
+      codigo: "erro_interno";
+      motivoParaOperador: string;
+      motivoParaCliente: string;
+    };
+
+/**
+ * Os tipos de atendimento da organização.
+ *
+ * ⚠️ Erro de leitura NUNCA vira lista vazia. As duas leituras são
+ * indistinguíveis para quem recebe, e significam o oposto: lista vazia diz "a
+ * organização não cadastrou nada" e faria o modelo anunciar ao paciente que a
+ * clínica não atende. A recusa nomeada é o que leva alguém a corrigir.
+ */
+export async function listaTiposDeAtendimento(
+  supabase: SupabaseClient,
+  organizationId: string,
+  opcoes?: { incluirInativos?: boolean },
+): Promise<ResultadoDosTipos> {
+  const incluirInativos = opcoes?.incluirInativos ?? false;
+
+  let q = supabase
+    .from("calendar_event_types")
+    .select(
+      "id, name, slug, description, category, duration_minutes, location_kind, location_details, requires_confirmation, is_active, default_owner_user_id, buffer_before_minutes, buffer_after_minutes, minimum_notice_minutes, booking_window_days",
+    )
+    // Service role bypassa a RLS: este filtro é a única proteção no caminho da
+    // ferramenta MCP (ver o cabeçalho do arquivo).
+    .eq("organization_id", organizationId);
+  if (!incluirInativos) q = q.eq("is_active", true);
+
+  const { data, error } = await q.order("is_active", { ascending: false }).order("name");
+
+  if (error) {
+    return {
+      ok: false,
+      codigo: "erro_interno",
+      motivoParaOperador: error.message,
+      motivoParaCliente: `Não consegui ver o que a agenda oferece agora. ${NAO_OFERECA}`,
+    };
+  }
+
+  return {
+    ok: true,
+    tipos: (data ?? []).map((t) => ({
+      id: String(t.id),
+      nome: String(t.name),
+      slug: String(t.slug),
+      descricao: t.description === null ? null : String(t.description),
+      categoria: String(t.category),
+      duracaoMin: Number(t.duration_minutes),
+      localKind: String(t.location_kind),
+      localDetalhes: t.location_details === null ? null : String(t.location_details),
+      precisaConfirmacao: Boolean(t.requires_confirmation),
+      ativo: Boolean(t.is_active),
+      donoPadraoId: t.default_owner_user_id === null ? null : String(t.default_owner_user_id),
+      bufferAntesMin: Number(t.buffer_before_minutes),
+      bufferDepoisMin: Number(t.buffer_after_minutes),
+      antecedenciaMinimaMin: Number(t.minimum_notice_minutes),
+      janelaDeAgendamentoDias: Number(t.booking_window_days),
+    })),
+  };
+}

--- a/lib/agent-engine/agent/followup-flow-classify.ts
+++ b/lib/agent-engine/agent/followup-flow-classify.ts
@@ -15,6 +15,8 @@ import type { Logger } from '../obs/logger';
 import type { ProviderRegistry } from '../edge/llm/providers';
 import { runModelCall, type LlmEdgeConfig } from '../edge/llm/run-model-call';
 import type { LeadContext } from '../edge/crm/get-lead-context';
+import { fusoDaOrganizacao } from './fuso-da-org';
+import { renderAgora } from '@/lib/tempo/agora';
 
 const CLASSIFY_INSTRUCTION =
   'Você é um classificador auxiliar de follow-up (NÃO responde ao lead). Classifique a ' +
@@ -117,12 +119,21 @@ export interface PropostaDeEsperaBruta {
   motivo: string;
 }
 
-function buildPlanMessage(context: LeadContext, now: Date, esperas: EsperaParaPlanejar[]): string {
+function buildPlanMessage(
+  context: LeadContext,
+  now: Date,
+  esperas: EsperaParaPlanejar[],
+  fuso: string,
+): string {
   return [
     PLAN_INSTRUCTION,
     '',
-    '## Agora',
-    now.toISOString(),
+    // Este bloco era `'## Agora'` seguido de `now.toISOString()` cru — o único
+    // relógio que o motor tinha, e meio relógio: sem dia da semana e sem fuso,
+    // ele não responde a pergunta que ESTE planejador faz, que é quando é
+    // aceitável falar com alguém. Passou a ser o mesmo `renderAgora` do turno,
+    // porque dois formatos de "## Agora" no mesmo motor viram dois vocabulários.
+    renderAgora(now, fuso),
     '',
     '## Esperas do fluxo, na ordem',
     ...esperas.map((e, i) =>
@@ -213,7 +224,17 @@ export async function planFollowupTiming(
       jobId: ids.jobId,
       purpose: 'followup_decide_timing',
       ...(args.model !== undefined ? { model: args.model } : {}),
-      messages: [{ role: 'user', content: buildPlanMessage(args.context, now, args.esperas) }],
+      messages: [
+        {
+          role: 'user',
+          content: buildPlanMessage(
+            args.context,
+            now,
+            args.esperas,
+            await fusoDaOrganizacao(db, ids.tenantId, deps.log),
+          ),
+        },
+      ],
     },
     { registry: deps.registry, log: deps.log },
   );

--- a/lib/agent-engine/agent/fuso-da-org.ts
+++ b/lib/agent-engine/agent/fuso-da-org.ts
@@ -1,0 +1,76 @@
+/**
+ * O FUSO DA ORGANIZAÇÃO — de onde o turno tira "que horas são aqui".
+ *
+ * ⚠️ A FONTE É `organizations.timezone`, E NÃO `channel_knobs.timezone`.
+ *
+ * As duas colunas guardam um IANA e hoje guardam o MESMO texto
+ * (`America/Sao_Paulo`) numa instalação brasileira — o que faz a escolha
+ * parecer indiferente. Não é, e o defeito só aparece no cliente que não é de
+ * São Paulo:
+ *
+ *   - `organizations.timezone` é o fuso que a PESSOA escolheu, no wizard de
+ *     boas-vindas (`app/actions/onboarding/acceptWelcome.ts`) e em
+ *     Configurações › Empresa (`app/actions/settings/updateTenant.ts`).
+ *   - `channel_knobs.timezone` é knob ANTI-BAN por canal, e NADA no repo o
+ *     semeia a partir da org: o PUT de `/api/v1/ai/pacing` grava só o que vem
+ *     no body e trata linha ausente como `null`, que cai em
+ *     `PACING_DEFAULTS.timezone`. Numa clínica de Manaus que nunca abriu o
+ *     painel anti-ban, ele é o literal de São Paulo — uma hora de erro, calada,
+ *     em toda consulta marcada.
+ *
+ * Ler o fuso do pacing seria de graça (o turno já o carrega) e é exatamente por
+ * isso que a armadilha existe.
+ *
+ * ⚠️ FALHA ABERTA, e isso é decisão, não descuido. A leitura pode estourar num
+ * clone cujo schema está atrás do código, e o valor pode ser um fuso que o
+ * `Intl` recusa — `organizations.timezone` não é validado por escritor nenhum
+ * (`tenantSchema` e o schema do onboarding são `z.string().max(64)` sem
+ * `refine`, e a coluna não tem CHECK). Nos dois casos o turno segue com o
+ * padrão do produto: derrubar o atendimento de um cliente por causa de um
+ * acento no campo de configuração seria pior que uma hora de diferença.
+ */
+
+import { FUSO_PADRAO, fusoValido } from '@/lib/tempo/fusos';
+
+import type { Queryable } from '../queue/queue';
+import type { Logger } from '../obs/logger';
+
+/**
+ * O fuso IANA da organização, sempre utilizável.
+ *
+ * Nunca lança e nunca devolve string vazia — quem chama pode passar direto ao
+ * `Intl`. Quando degrada, o motivo vai ao log com o valor recusado: sem isso, a
+ * organização de Manaus que digitou o fuso errado veria horários de São Paulo
+ * para sempre, sem nada explicando.
+ */
+export async function fusoDaOrganizacao(
+  db: Queryable,
+  organizationId: string,
+  log?: Logger,
+): Promise<string> {
+  let bruto: string | null = null;
+  try {
+    const { rows } = await db.query<{ timezone: string | null }>(
+      'select timezone from organizations where id = $1',
+      [organizationId],
+    );
+    bruto = rows[0]?.timezone ?? null;
+  } catch (err) {
+    log?.warn('não consegui ler o fuso da organização — o turno segue no padrão', {
+      fuso_padrao: FUSO_PADRAO,
+      error: (err instanceof Error ? err.message : String(err)).slice(0, 120),
+    });
+    return FUSO_PADRAO;
+  }
+
+  const tz = bruto?.trim() ?? '';
+  if (tz !== '' && fusoValido(tz)) return tz;
+
+  log?.warn('fuso da organização inutilizável — o turno segue no padrão', {
+    // O valor recusado vai ao log porque é ele que diz o que corrigir na tela.
+    // Não é PII: é um código IANA de configuração, não dado de pessoa.
+    fuso_recusado: tz,
+    fuso_padrao: FUSO_PADRAO,
+  });
+  return FUSO_PADRAO;
+}

--- a/lib/agent-engine/agent/inbound-turn.ts
+++ b/lib/agent-engine/agent/inbound-turn.ts
@@ -130,6 +130,8 @@ import {
   type JailbreakLevel,
 } from '../guardrails/jailbreak/classifier';
 import { camadaLigada, lerCamadasDaOrg } from '../guardrails/camadas-da-org';
+import { fusoDaOrganizacao } from './fuso-da-org';
+import { renderAgora } from '@/lib/tempo/agora';
 
 /**
  * Superfície ESTÁTICA das tools do agente (description + inputSchema) — parte do
@@ -1116,6 +1118,11 @@ async function executarTurnoDoAgente(
   // linhas de distância um do outro, e duas queries para a mesma pergunta viram,
   // com o tempo, duas respostas.
   const camadas = await lerCamadasDaOrg(pool, tenantId);
+  // O fuso da ORGANIZAÇÃO — o que o bloco `## Agora` usa lá embaixo, na montagem
+  // da abertura. Lido aqui pela mesma razão da linha acima: uma query por turno,
+  // longe do ponto de uso, para não virar duas respostas para a mesma pergunta.
+  // Nunca lança e nunca vem vazio (ver `fuso-da-org.ts`).
+  const fusoDaOrg = await fusoDaOrganizacao(pool, tenantId, runLog);
 
   // F4-06 (acceptance 2): lead em handoff humano → NO-OP no INÍCIO do turno, antes de
   // qualquer chamada de modelo/CRM. O bot silenciou (bot_silenced_until='infinity', cache
@@ -2583,9 +2590,29 @@ async function executarTurnoDoAgente(
         `Se a mensagem dele responde a isso, chame provide_case_update com este case_id e a informação recebida — ` +
         `NÃO diga que já repassou/avisou o responsável sem chamar a tool.`
       : '';
-  const openingSuffixes = [matchedSkillsBlock, stageHintBlock, splitHint, caseAwaitingLeadBlock].filter(
-    (b) => b !== '',
-  );
+  // ── O RELÓGIO DO TURNO ────────────────────────────────────────────────────
+  //
+  // Entra AQUI, e o lugar é a metade do conserto.
+  //
+  // No `system` (o prefixo estável org-wide, F2-17) ele invalidaria o cache de
+  // prompt de TODOS os leads a cada turno, porque muda a cada segundo — é o que
+  // `stable-prefix.ts` proíbe em letra. No sufixo por-lead ele é volátil entre
+  // iguais, e custa os ~50 tokens dele.
+  //
+  // PRIMEIRO da lista de propósito: a âncora temporal precede o material que o
+  // modelo vai usar para decidir data — corpo de skill, hint do classificador,
+  // caso pendente. E `executarTurnoDoAgente` é o ponto por onde passam os TRÊS
+  // turnos conversacionais (inbound, follow-up e resposta a caso), então um
+  // ponto só cobre os três — e alcança de carona a chamada de fechamento, que
+  // reusa `openingTextOnly` e é onde nasce o `prazo` ISO da declaração.
+  const agoraBlock = renderAgora(clock(), fusoDaOrg);
+  const openingSuffixes = [
+    agoraBlock,
+    matchedSkillsBlock,
+    stageHintBlock,
+    splitHint,
+    caseAwaitingLeadBlock,
+  ].filter((b) => b !== '');
   const openingText =
     openingSuffixes.length === 0 ? openingBase : `${openingBase}\n\n${openingSuffixes.join('\n\n')}`;
   // Onda 3 (aprimoramento): mídia inbound recente vira part nativa (image/file) SÓ para

--- a/lib/agent-engine/agent/operator-turn.ts
+++ b/lib/agent-engine/agent/operator-turn.ts
@@ -43,6 +43,8 @@ import { checkpointDoJob } from './inbound-turn';
 import { declaracaoDoTurnoSchema, promessasEmAberto, type DeclaracaoDoTurno } from './declaracao';
 import { loadPublishedAgentConfigById } from './agent-config';
 import { isLeadInHandoff } from './human-handoff';
+import { fusoDaOrganizacao } from './fuso-da-org';
+import { renderAgora } from '@/lib/tempo/agora';
 import { insertInboxItem } from '../db/repository';
 import { buildMcpTurnTools } from '../edge/crm/mcp-tools';
 import { runModelCall } from '../edge/llm/run-model-call';
@@ -85,20 +87,36 @@ export const SYSTEM_DO_OPERADOR =
   'Use apenas o que a conversa sustenta. Não invente avanço, não registre o que ninguém disse. ' +
   'Se não houver nada a fazer, não faça nada — um turno sem ação é uma resposta válida.';
 
-/** O briefing do turno: o que o Conversador declarou, em linguagem de negócio. */
+/**
+ * O briefing do turno: o que o Conversador declarou, em linguagem de negócio.
+ *
+ * `agoraBlock` é o relógio (`renderAgora`), e ele não é enfeite aqui: o
+ * Operador é quem EXECUTA a promessa com prazo — o briefing abaixo já ecoa
+ * `— até ${p.prazo}` em ISO —, e `crm_schedule_followup` pode estar entregue só
+ * a ele (`entrega-de-capacidade.ts`), o que faz dele o único papel do turno com
+ * a ferramenta que precisa de data. Cobrar um prazo sem saber que dia é hoje é
+ * o mesmo buraco que a abertura do Conversador tinha.
+ *
+ * Opcional com default vazio de propósito: os chamadores de teste montam o
+ * briefing sem relógio, e o que este parâmetro não pode fazer é obrigar quem já
+ * chamava a mudar.
+ */
 export function renderBriefingDoOperador(
   declaracao: DeclaracaoDoTurno | null,
   promessas: ReturnType<typeof promessasEmAberto>,
+  agoraBlock = '',
 ): string {
+  const comAgora = (linhas: string[]): string =>
+    (agoraBlock === '' ? linhas : [agoraBlock, '', ...linhas]).join('\n');
   if (declaracao === null) {
     // Ausente ≠ vazia, de novo — e aqui a diferença vira instrução. Dizer ao
     // modelo "não houve declaração" e pedir que ele olhe o estado é diferente de
     // deixá-lo achar que o turno foi vazio.
-    return [
+    return comAgora([
       'O turno anterior NÃO deixou declaração do que aconteceu (fechamento incompleto).',
       'Verifique o estado do lead e registre o que estiver claramente pendente.',
       'Na dúvida, não faça nada.',
-    ].join('\n');
+    ]);
   }
   const linhas = ['Foi isto que aconteceu na conversa que acabou:'];
   if (declaracao.intencoes.length > 0) {
@@ -112,7 +130,7 @@ export function renderBriefingDoOperador(
     }
   }
   linhas.push('', 'Deixe o sistema refletindo isso. O que já estiver registrado, não repita.');
-  return linhas.join('\n');
+  return comAgora(linhas);
 }
 
 /** O que o Operador decidiu neste turno — vai a `event_log` e, quando muda o que
@@ -420,7 +438,19 @@ export function createOperatorTurnHandler(deps: InboundTurnDeps) {
             // pergunta que o dono do negócio vai fazer — não teria resposta.
             purpose: 'operator_turn',
             system: SYSTEM_DO_OPERADOR,
-            messages: [{ role: 'user', content: renderBriefingDoOperador(declaracao, promessas) }],
+            messages: [
+              {
+                role: 'user',
+                content: renderBriefingDoOperador(
+                  declaracao,
+                  promessas,
+                  renderAgora(
+                    deps.clock?.() ?? new Date(),
+                    await fusoDaOrganizacao(pool, tenantId, log),
+                  ),
+                ),
+              },
+            ],
             tools: mcp.tools,
             maxSteps: agentConfig.maxSteps,
             // O modelo E o provider/credencial, sempre juntos — a regra do PR

--- a/lib/leads/escopo-de-funil.ts
+++ b/lib/leads/escopo-de-funil.ts
@@ -103,6 +103,12 @@ export const ALVO_DE_FUNIL: Record<string, AlvoDeFunil> = {
   crm_book_appointment: "funil_vem_do_contato",
   crm_reschedule_appointment: "sem_funil",
   crm_cancel_appointment: "sem_funil",
+  // Mesmo argumento das duas acima, e pela mesma razão: operam por
+  // `appointment_id` e nunca recebem `lead_id`. Classificá-las
+  // `funil_vem_do_lead` seria teatro — o gate procuraria um argumento que não
+  // vem e liberaria 100% das vezes, com aparência de escopado.
+  crm_confirm_appointment: "sem_funil",
+  crm_set_appointment_outcome: "sem_funil",
 
   // ---- não têm funil, e isso é declarado ----
   crm_send_whatsapp_message: "sem_funil",

--- a/lib/mcp/tools/agendamento.ts
+++ b/lib/mcp/tools/agendamento.ts
@@ -23,8 +23,11 @@ import {
   horariosLivresDaOrg,
   idDoTipoPorSlug,
   listaAgendamentos,
+  listaTiposDeAtendimento,
   MAXIMO_DE_DIAS,
 } from "@/lib/agenda/consulta";
+import { rotuloDoLocal } from "@/lib/agenda/locais";
+import { rotuloLocal } from "@/lib/tempo/agora";
 import {
   alterarAgendamentoHandler,
   cancelarAgendamentoHandler,
@@ -36,6 +39,105 @@ import type { McpToolDefinition } from "@/lib/mcp/types";
 
 /** Teto do horizonte pedido — espelha o da rota, e o excesso é erro de chamada. */
 const DIAS_PADRAO = 14;
+
+/**
+ * Quantos horários voltam ao modelo, e por que existe um teto.
+ *
+ * ⚠️ NÃO HAVIA NENHUM. Medido no formato atual, a chamada PADRÃO de 14 dias
+ * devolve 177 horários — cerca de 3.600 tokens de lista, todos entrando inteiros
+ * no contexto do turno; no teto de 62 dias são 788. Isso é caro e é pior que
+ * caro: um modelo que recebe 177 opções escolhe mal, e a lista empurra para fora
+ * do contexto o que a pessoa disse.
+ *
+ * A irmã `crm_list_appointments` já tinha teto (`limite`, máx. 50). Esta não —
+ * a assimetria era descuido, não decisão.
+ */
+const HORARIOS_PADRAO = 24;
+const HORARIOS_MAX = 50;
+
+/**
+ * ⚠️ CORTAR PELA CABEÇA ENVIESA. 24 horários numa grade de 30 minutos sobre um
+ * expediente de 9h são um dia e meio: um pedido de "semana que vem" voltaria só
+ * com amanhã, e o modelo concluiria que não há vaga na semana que vem.
+ *
+ * Espalhar pega os primeiros de CADA dia até o teto, o que preserva a forma da
+ * janela pedida — a pessoa vê opções ao longo do período que ela citou.
+ */
+function espalhaPorDia(
+  slots: readonly { inicio: Date; fim: Date }[],
+  fuso: string,
+  teto: number,
+): { inicio: Date; fim: Date }[] {
+  const porDia = new Map<string, { inicio: Date; fim: Date }[]>();
+  for (const s of slots) {
+    const dia = rotuloLocal(s.inicio, fuso).slice(0, 20);
+    const lista = porDia.get(dia);
+    if (lista) lista.push(s);
+    else porDia.set(dia, [s]);
+  }
+  const escolhidos: { inicio: Date; fim: Date }[] = [];
+  // Rodadas: um de cada dia por vez, na ordem em que os dias aparecem.
+  for (let rodada = 0; escolhidos.length < teto; rodada += 1) {
+    let achouAlgum = false;
+    for (const lista of porDia.values()) {
+      const s = lista[rodada];
+      if (s === undefined) continue;
+      achouAlgum = true;
+      escolhidos.push(s);
+      if (escolhidos.length >= teto) break;
+    }
+    if (!achouAlgum) break;
+  }
+  return escolhidos.sort((a, b) => a.inicio.getTime() - b.inicio.getTime());
+}
+
+/**
+ * ⚠️ SEM INPUT, e o precedente é `crm_list_team_members` (`operacao.ts`). Um
+ * filtro aqui só criaria como errar: o modelo passaria o nome que o paciente
+ * disse ("botox") e receberia lista vazia de uma organização que atende
+ * exatamente isso sob outro nome ("HOF e Botox").
+ */
+const tiposShape = {};
+
+export const crmListEventTypes: McpToolDefinition<typeof tiposShape> = {
+  name: "crm_list_event_types",
+  description:
+    "Lista o que esta organização atende — os tipos de atendimento que dá para marcar, quanto cada " +
+    "um dura e como é feito. " +
+    "CHAME ANTES de oferecer horário ou marcar qualquer coisa: `crm_find_free_slots` e " +
+    "`crm_book_appointment` exigem `event_type_slug`, e ele tem de ser um `slug` que voltou daqui. " +
+    "NUNCA invente um slug nem traduza o que a pessoa disse por conta própria: ela fala 'botox' e o " +
+    "atendimento pode se chamar outra coisa — é você que faz a ponte, olhando esta lista. " +
+    "Lista vazia significa que ninguém cadastrou o que a organização atende: não invente atendimento, " +
+    "avise que alguém da equipe confirma. " +
+    "`precisa_confirmacao: true` muda o que você diz depois de marcar — o horário fica reservado " +
+    "AGUARDANDO a pessoa confirmar, não confirmado.",
+  inputSchema: tiposShape,
+  category: "read",
+  requiresRole: "agent",
+  requiresScope: "mcp:read",
+  handler: async (_input, ctx) => {
+    const r = await listaTiposDeAtendimento(ctx.supabase, ctx.organizationId);
+    if (!r.ok) {
+      return { tipos: [], motivo: r.codigo, mensagem: r.motivoParaCliente };
+    }
+    return {
+      tipos: r.tipos.map((t) => ({
+        // O SLUG vem primeiro, e o `id` NÃO vem: o slug existe para dar à IA um
+        // handle que ela não alucina, e devolver o uuid ao lado convidaria o
+        // modelo a mandá-lo onde slug é esperado.
+        slug: t.slug,
+        nome: t.nome,
+        descricao: t.descricao,
+        duracao_minutos: t.duracaoMin,
+        // Traduzido: `in_person` é vocabulário de banco e o modelo repassa o que
+        // recebe. `rotuloDoLocal` é o MESMO tradutor que a tela usa.
+        onde: rotuloDoLocal(t.localKind, t.localDetalhes) ?? null,
+        precisa_confirmacao: t.precisaConfirmacao,
+      })),
+    };
+  },
+};
 
 const horariosLivresShape = {
   event_type_slug: z
@@ -58,6 +160,13 @@ const horariosLivresShape = {
   de: z.string().datetime({ offset: true }).optional(),
   ate: z.string().datetime({ offset: true }).optional(),
   owner_user_id: z.string().uuid().optional(),
+  limite: z
+    .number()
+    .int()
+    .min(1)
+    .max(HORARIOS_MAX)
+    .optional()
+    .describe(`quantos horários no máximo (padrão ${HORARIOS_PADRAO})`),
 };
 
 export const crmFindFreeSlots: McpToolDefinition<typeof horariosLivresShape> = {
@@ -67,6 +176,11 @@ export const crmFindFreeSlots: McpToolDefinition<typeof horariosLivresShape> = {
     "do atendente, folgas, o que ele já tem marcado e a agenda externa dele. " +
     "Use ANTES de oferecer horário ao cliente: oferecer um horário que não existe e depois voltar " +
     "atrás é pior do que demorar um instante a mais para responder. " +
+    "Cada horário vem em dois formatos: `inicio` é o instante que você COPIA para `starts_at` de " +
+    "`crm_book_appointment`, sem reescrever; `quando` já está na hora local da agenda e é o que você " +
+    "fala com a pessoa. " +
+    "A lista vem cortada no `limite` e espalhada ao longo do período: `total_de_horarios` diz quantos " +
+    "existem e `ha_mais` avisa que sobraram — lista cortada NÃO é agenda cheia. " +
     "QUANDO: informe `dias_a_frente` (a partir de agora — ex.: 7 para a próxima semana). " +
     "SE VOCÊ NÃO SABE QUE DIA É HOJE, USE `dias_a_frente` — não tente montar `de`/`ate`. " +
     "Lista vazia NÃO é erro e NÃO significa que a agenda está cheia: leia `publicou_horarios`. " +
@@ -120,11 +234,30 @@ export const crmFindFreeSlots: McpToolDefinition<typeof horariosLivresShape> = {
       };
     }
 
+    // O fuso é o DA REGRA (a jornada do atendente), nunca o da organização: é
+    // nele que os horários foram calculados, e é o que esta resposta já publica.
+    // Rotular com outro faria `quando` discordar de `fuso_da_regra` na mesma
+    // resposta.
+    const escolhidos = espalhaPorDia(
+      consulta.slots,
+      consulta.fusoDaRegra,
+      input.limite ?? HORARIOS_PADRAO,
+    );
+
     return {
-      horarios: consulta.slots.map((s) => ({
+      horarios: escolhidos.map((s) => ({
+        // `inicio` é o que volta em `starts_at` — copie, não reescreva.
         inicio: s.inicio.toISOString(),
         fim: s.fim.toISOString(),
+        // `quando` é para FALAR com a pessoa. Um só, e do início: o fim não
+        // responde pergunta nenhuma (a duração é do tipo) e dobraria o custo.
+        quando: rotuloLocal(s.inicio, consulta.fusoDaRegra),
       })),
+      // Sem estes dois, uma lista cortada é indistinguível de uma agenda que
+      // acabou — o mesmo modo de falha que `publicou_horarios` existe para
+      // evitar.
+      total_de_horarios: consulta.slots.length,
+      ha_mais: consulta.slots.length > escolhidos.length,
       fuso_da_regra: consulta.fusoDaRegra,
       /** false = o atendente NÃO publicou jornada. Diferente de "sem vaga" (DECISÃO 1.1). */
       publicou_horarios: consulta.publicouHorarios,
@@ -230,6 +363,9 @@ const ENSINO_POR_CODIGO: Record<string, string> = {
     "não consigo ler a agenda desse atendente agora. Não ofereça horários e não diga que está sem vaga — avise que alguém da equipe confirma.",
   agenda_ja_cancelado:
     "esse compromisso já estava desmarcado. Não é erro: siga sem desmarcar de novo.",
+  agenda_ainda_nao_aconteceu:
+    "esse compromisso ainda não começou, então não há desfecho a registrar. Se a pessoa avisou que " +
+    "não vem, use `crm_cancel_appointment`; se ela quer outro dia, `crm_reschedule_appointment`.",
   not_found: "não encontrei esse compromisso. Confirme com `crm_list_appointments` antes de tentar de novo.",
   internal_error: "não consegui completar agora. Avise que alguém da equipe confirma, e não repita a tentativa.",
 };
@@ -370,5 +506,76 @@ export const crmCancelAppointment: McpToolDefinition<typeof cancelarShape> = {
         { id: input.appointment_id, reason: input.reason },
       );
       return { cancelado: true, compromisso: r };
+    }),
+};
+
+const confirmarShape = {
+  appointment_id: z.string().uuid().describe("o compromisso, vindo de `crm_list_appointments`"),
+  notes: z.string().max(2000).optional(),
+};
+
+export const crmConfirmAppointment: McpToolDefinition<typeof confirmarShape> = {
+  name: "crm_confirm_appointment",
+  description:
+    "Confirma que o cliente VAI COMPARECER a um compromisso que estava aguardando a resposta dele. " +
+    "Use quando ele disser que vem — 'confirmado', 'pode marcar', 'estarei lá'. " +
+    "Serve só para compromisso na situação `pending`: chame `crm_list_appointments` antes e veja a " +
+    "situação. Confirmar o que já estava confirmado devolve `ja_estava: true` — não é erro, e não é " +
+    "motivo para avisar a pessoa de novo. " +
+    "NÃO use para dizer que o atendimento ACONTECEU: isso é `crm_set_appointment_outcome`, e é depois " +
+    "da hora.",
+  inputSchema: confirmarShape,
+  category: "write",
+  requiresRole: "ai_operator",
+  requiresScope: "mcp:write",
+  handler: async (input, ctx) =>
+    semDerrubarOTurno("confirmado", async () => {
+      const r = await alterarAgendamentoHandler(
+        ctx.supabase,
+        { organization_id: ctx.organizationId, actor: ctx.actor, requestId: ctx.requestId },
+        {
+          id: input.appointment_id,
+          status: "confirmed",
+          ...(input.notes ? { notes: input.notes } : {}),
+        },
+      );
+      return { confirmado: true, compromisso: r };
+    }),
+};
+
+const desfechoShape = {
+  appointment_id: z.string().uuid().describe("o compromisso, vindo de `crm_list_appointments`"),
+  outcome: z
+    .enum(["completed", "no_show"])
+    .describe("`completed` = a pessoa foi atendida; `no_show` = ela não apareceu e não avisou"),
+  notes: z.string().max(2000).optional(),
+};
+
+export const crmSetAppointmentOutcome: McpToolDefinition<typeof desfechoShape> = {
+  name: "crm_set_appointment_outcome",
+  description:
+    "Registra o que ACONTECEU num compromisso que JÁ PASSOU: a pessoa foi atendida (`completed`) ou " +
+    "não apareceu (`no_show`). " +
+    "SÓ DEPOIS DA HORA — compromisso futuro é recusado, porque você não sabe o que ainda vai " +
+    "acontecer. Veja a hora do compromisso em `crm_list_appointments` e compare com a data de hoje. " +
+    "NÃO use para quem AVISOU que não vem: isso é `crm_cancel_appointment`, que desmarca com o motivo " +
+    "registrado e libera o horário para outra pessoa. `no_show` é para quem não avisou e não veio — " +
+    "é um registro sobre o passado, e a equipe lê isso como falta.",
+  inputSchema: desfechoShape,
+  category: "write",
+  requiresRole: "ai_operator",
+  requiresScope: "mcp:write",
+  handler: async (input, ctx) =>
+    semDerrubarOTurno("registrado", async () => {
+      const r = await alterarAgendamentoHandler(
+        ctx.supabase,
+        { organization_id: ctx.organizationId, actor: ctx.actor, requestId: ctx.requestId },
+        {
+          id: input.appointment_id,
+          status: input.outcome,
+          ...(input.notes ? { notes: input.notes } : {}),
+        },
+      );
+      return { registrado: true, compromisso: r };
     }),
 };

--- a/lib/mcp/tools/catalogo/agendamento.ts
+++ b/lib/mcp/tools/catalogo/agendamento.ts
@@ -162,6 +162,20 @@ import { declararTools } from "./tipos";
 
 export const TOOLS_AGENDAMENTO = declararTools([
   {
+    // A PRIMEIRA da lista porque é o primeiro passo do fluxo — e porque a
+    // ausência dela era o defeito. As outras quatro exigem o identificador do
+    // tipo de atendimento, e nenhuma capacidade do catálogo dizia quais existem:
+    // o agente chutava o nome e ouvia "não existe atendimento chamado assim".
+    name: "crm_list_event_types",
+    category: "read",
+    rotulo: "Ver o que a empresa atende",
+    explicacao:
+      "Mostra os tipos de atendimento que dá para marcar, quanto cada um dura e como é feito, para o atendente de IA falar do que existe de verdade.",
+    oQueToca: "Agenda da equipe",
+    risco: "seguro",
+    pacotes: ["vender"],
+  },
+  {
     name: "crm_find_free_slots",
     category: "read",
     rotulo: "Ver horários livres na agenda",
@@ -199,6 +213,29 @@ export const TOOLS_AGENDAMENTO = declararTools([
     explicacao:
       "Move um compromisso já marcado para outro horário, mantendo o mesmo cliente e o mesmo tipo de atendimento.",
     oQueToca: "Agenda da equipe",
+    risco: "atencao",
+    pacotes: ["vender"],
+  },
+  {
+    name: "crm_confirm_appointment",
+    category: "write",
+    rotulo: "Confirmar um horário combinado",
+    explicacao:
+      "Confirma o horário que estava esperando a resposta da pessoa, para a equipe saber que ela vem mesmo.",
+    oQueToca: "Agenda da equipe",
+    // `atencao` e não `critico`: confirmar errado se desfaz — remarca ou desmarca.
+    risco: "atencao",
+    pacotes: ["vender"],
+  },
+  {
+    name: "crm_set_appointment_outcome",
+    category: "write",
+    rotulo: "Registrar se a pessoa veio ou faltou",
+    explicacao:
+      "Anota o que aconteceu num horário que já passou: a pessoa foi atendida, ou não apareceu.",
+    oQueToca: "Agenda da equipe",
+    // `atencao`: registrar falta devolve o horário para outra pessoa, mas o
+    // sistema recusa fazer isso antes da hora — a guarda mora no handler.
     risco: "atencao",
     pacotes: ["vender"],
   },

--- a/lib/mcp/tools/index.ts
+++ b/lib/mcp/tools/index.ts
@@ -66,9 +66,12 @@ import {
 import {
   crmBookAppointment,
   crmCancelAppointment,
+  crmConfirmAppointment,
   crmFindFreeSlots,
   crmListAppointments,
+  crmListEventTypes,
   crmRescheduleAppointment,
+  crmSetAppointmentOutcome,
 } from "./agendamento";
 import {
   crmScheduleFollowup,
@@ -86,6 +89,7 @@ import {
 // unknown>` e cada handler valida no Zod do registerTool.
 export const allTools: ReadonlyArray<McpToolDefinition> = [
   // read
+  crmListEventTypes,
   crmFindFreeSlots,
   crmListAppointments,
   crmSearchContacts,
@@ -125,6 +129,8 @@ export const allTools: ReadonlyArray<McpToolDefinition> = [
   crmBookAppointment,
   crmRescheduleAppointment,
   crmCancelAppointment,
+  crmConfirmAppointment,
+  crmSetAppointmentOutcome,
   crmCreateLead,
   crmUpdateLead,
   crmMoveLeadStage,

--- a/lib/tempo/agora.ts
+++ b/lib/tempo/agora.ts
@@ -1,0 +1,92 @@
+/**
+ * O BLOCO QUE DIZ AO MODELO QUE HORAS SÃO.
+ *
+ * ─── O defeito, medido ─────────────────────────────────────────────────────
+ *
+ * O modelo do agente NUNCA soube a data. O ritual de abertura do turno
+ * (`inbound-turn.ts`) entrega checkpoint, funil, notas e histórico — e nenhum
+ * relógio. O follow-up entrega um DELTA ("passaram 3 horas"), que responde "há
+ * quanto tempo" e não "que dia é hoje".
+ *
+ * Quem paga é o agendamento. `crm_book_appointment` exige `starts_at` como
+ * instante absoluto e `crm_schedule_followup` exige `promised_at` no mesmo
+ * formato; sem relógio, o modelo não tem de onde tirar nenhum dos dois, e
+ * "quinta às 14h" não vira nada. A prova de que isso dói em produção não é
+ * teórica: o system prompt de um agente real desta instalação tem um parágrafo
+ * chamado "Você não tem relógio, mas tem carimbo", ensinando a IA a inferir a
+ * data pelo timestamp da última mensagem do histórico. Contorno de prompt para
+ * um buraco de runtime — e um contorno que cada tenant teria de reinventar.
+ *
+ * ─── Por que as duas formas, e não uma ─────────────────────────────────────
+ *
+ * A linha humana ("sexta-feira, 04/09/2026, 14:32") é a que responde ao que a
+ * PESSOA disse: "quinta que vem", "amanhã de manhã", "depois do fim de semana".
+ * Sem o dia da semana por extenso o modelo teria de derivá-lo de uma data, que
+ * é exatamente o cálculo que ele erra.
+ *
+ * O `instante_absoluto` é a string que as ferramentas EXIGEM de volta —
+ * `z.string().datetime({ offset: true })` em `lib/mcp/tools/agendamento.ts`.
+ * Dar ao modelo o formato exato que ele terá de produzir remove um passo de
+ * conversão, que é onde ele erra o segundo.
+ *
+ * ─── Falha ABERTA, sempre ──────────────────────────────────────────────────
+ *
+ * `Intl.DateTimeFormat({ timeZone })` LANÇA `RangeError` num fuso que não
+ * existe, e `organizations.timezone` não é validado por escritor nenhum
+ * (`lib/schemas/settings.ts` e `lib/schemas/onboarding.ts` são `z.string()` sem
+ * `refine`, e a coluna não tem CHECK). Este bloco roda na montagem do prompt,
+ * ANTES da chamada de modelo: um throw aqui mata o turno inteiro e o sintoma
+ * chega ao dono como agente mudo, sem erro nenhum para investigar. Por isso o
+ * fuso torto degrada para o padrão e o turno segue.
+ */
+
+import { partesNoFuso, diaDaSemanaLocal } from "@/lib/agenda/fuso";
+import { FUSO_PADRAO, fusoValido } from "@/lib/tempo/fusos";
+
+/**
+ * Domingo = 0, a mesma régua de `diaDaSemanaLocal` e do `dow` da jornada.
+ *
+ * Tabela nossa, e não `Intl.DateTimeFormat('pt-BR', { weekday: 'long' })`, por
+ * uma razão de instrumento: a saída do `Intl` depende dos dados de locale do
+ * ICU compilado no runtime, e um Node `small-icu` devolve o nome em inglês sem
+ * lançar. O bloco passaria a dizer "friday" para o cliente brasileiro, e nenhum
+ * teste que rode no runtime completo veria isso.
+ */
+const DIAS_DA_SEMANA = [
+  "domingo",
+  "segunda-feira",
+  "terça-feira",
+  "quarta-feira",
+  "quinta-feira",
+  "sexta-feira",
+  "sábado",
+] as const;
+
+const doisDigitos = (n: number): string => String(n).padStart(2, "0");
+
+/**
+ * O bloco `## Agora`, pronto para entrar no sufixo por-lead da abertura.
+ *
+ * `agora` é PARÂMETRO e nunca `new Date()` interno: o turno tem relógio
+ * injetável (`deps.clock`), e um segundo relógio aqui dentro faria o teste com
+ * clock fixo medir uma coisa e a produção outra. O repo já pagou esse defeito
+ * uma vez, no invariante da janela de envio.
+ *
+ * Fuso ausente, vazio ou inválido cai em {@link FUSO_PADRAO} — nunca lança.
+ */
+export function renderAgora(agora: Date, fuso: string): string {
+  const fusoEmVigor = fusoValido(fuso) ? fuso : FUSO_PADRAO;
+  const p = partesNoFuso(agora, fusoEmVigor);
+  const diaDaSemana = DIAS_DA_SEMANA[diaDaSemanaLocal(agora, fusoEmVigor)] ?? "";
+
+  return [
+    "## Agora",
+    `${diaDaSemana}, ${doisDigitos(p.dia)}/${doisDigitos(p.mes)}/${p.ano}, ` +
+      `${doisDigitos(p.hora)}:${doisDigitos(p.minuto)} (${fusoEmVigor})`,
+    `instante_absoluto: ${agora.toISOString()}`,
+    "É daqui que sai toda data: o que a pessoa disser em palavras (\"amanhã\", \"quinta\", " +
+      "\"semana que vem\") você resolve a partir desta data, nunca de memória. " +
+      "Ferramenta que pede um instante recebe o formato de `instante_absoluto`; " +
+      "com a pessoa você fala como gente (\"quinta às 14h\").",
+  ].join("\n");
+}

--- a/lib/tempo/agora.ts
+++ b/lib/tempo/agora.ts
@@ -90,3 +90,29 @@ export function renderAgora(agora: Date, fuso: string): string {
       "com a pessoa você fala como gente (\"quinta às 14h\").",
   ].join("\n");
 }
+
+/**
+ * "quinta-feira 04/09 às 14:00" — um instante na parede daquele fuso.
+ *
+ * Existe para os HORÁRIOS LIVRES. `crm_find_free_slots` devolvia só o ISO em
+ * UTC, e pedir ao modelo que converta cada um para o fuso da clínica antes de
+ * dizer "quinta às 14h" é pedir exatamente o cálculo que ele erra — o mesmo que
+ * `renderAgora` existe para eliminar no turno.
+ *
+ * ⚠️ NÃO É `renderAgora` com outro formato, e a diferença não é cosmética: aqui
+ * não entra o ano nem o `instante_absoluto`, porque isto se repete uma vez por
+ * horário oferecido e o ISO já vai no campo ao lado. As duas compartilham as
+ * constantes, não o corpo.
+ *
+ * ⚠️ O dia da semana sai da data JÁ LIDA, e não de uma segunda consulta ao
+ * `Intl`: `partesNoFuso` reusa um formatador em cache por fuso, enquanto
+ * `diaDaSemanaLocal` constrói um formatador novo a cada chamada — o que numa
+ * lista de horários vira um por linha. Uma data civil não tem horário de verão,
+ * então derivar o dia dela é exato.
+ */
+export function rotuloLocal(instante: Date, fuso: string): string {
+  const fusoEmVigor = fusoValido(fuso) ? fuso : FUSO_PADRAO;
+  const p = partesNoFuso(instante, fusoEmVigor);
+  const diaDaSemana = DIAS_DA_SEMANA[new Date(Date.UTC(p.ano, p.mes - 1, p.dia)).getUTCDay()] ?? "";
+  return `${diaDaSemana} ${doisDigitos(p.dia)}/${doisDigitos(p.mes)} às ${doisDigitos(p.hora)}:${doisDigitos(p.minuto)}`;
+}

--- a/lib/tempo/fusos.ts
+++ b/lib/tempo/fusos.ts
@@ -48,6 +48,23 @@ export const FUSOS_OFERECIDOS: { codigo: string; rotulo: string }[] = [
 ];
 
 /**
+ * O fuso de quem ainda não escolheu — e o mesmo valor das outras duas pontas:
+ * o DEFAULT da coluna `organizations.timezone` (baseline.sql) e o
+ * `availabilityScheduleSchema` da jornada (`lib/schemas/routing.ts`).
+ *
+ * Existe para quem precisa DEGRADAR: leitor que encontra a coluna com um valor
+ * que o `Intl` recusa não pode lançar nem inventar UTC — UTC daria três horas
+ * de erro numa instalação brasileira, calado. Cair no mesmo valor que o banco
+ * já usa como padrão mantém uma verdade só.
+ *
+ * ⚠️ NÃO é o fuso do pacing. `PACING_DEFAULTS.timezone` tem o mesmo texto e
+ * responde a outra pergunta (a janela anti-ban daquele CANAL, override por
+ * linha em `channel_knobs`). Coincidem hoje; unificar os dois faria uma
+ * decisão de anti-ban mudar o relógio do agente.
+ */
+export const FUSO_PADRAO = "America/Sao_Paulo";
+
+/**
  * O runtime consegue usar este fuso?
  *
  * Pergunta ao `Intl`, e não a uma lista: é o `Intl` que o motor da janela usa, e

--- a/tests/invariants/o-turno-diz-ao-modelo-que-dia-e-hoje.test.ts
+++ b/tests/invariants/o-turno-diz-ao-modelo-que-dia-e-hoje.test.ts
@@ -1,0 +1,292 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import pg from "pg";
+
+import type * as InboundTurn from "@/lib/agent-engine/agent/inbound-turn";
+import type * as Providers from "@/lib/agent-engine/edge/llm/providers";
+import type * as Queue from "@/lib/agent-engine/queue/queue";
+import type * as ObsLogger from "@/lib/agent-engine/obs/logger";
+
+/**
+ * O PROMPT DO TURNO CARREGA A DATA DE HOJE, NO FUSO DA ORGANIZAÇÃO.
+ *
+ * ─── O defeito que este arquivo existe para impedir ─────────────────────────
+ *
+ * O ritual de abertura entregava checkpoint, funil, notas e histórico — e
+ * nenhum relógio. `crm_book_appointment` exige `starts_at` como instante
+ * absoluto; sem saber que dia é hoje, o modelo não tem de onde tirá-lo, e
+ * "quinta às 14h" não vira agendamento nenhum. O sintoma no cliente não é erro:
+ * é o agente respondendo "vou confirmar com a equipe" para sempre.
+ *
+ * O teste unitário irmão (`tests/unit/o-turno-sabe-que-horas-sao.test.ts`)
+ * prova que `renderAgora` formata certo. Ele NÃO prova que o bloco chega ao
+ * modelo: apagar a linha que o põe em `openingSuffixes` o deixa inteiramente
+ * verde. Quem guarda o call site é este arquivo — ele roda o handler REAL e lê
+ * o prompt que de fato saiu.
+ *
+ * ─── Por que Manaus, e não São Paulo ────────────────────────────────────────
+ *
+ * Este é o caso de controle, e ele separa duas colunas que guardam a MESMA
+ * string em toda instalação brasileira:
+ *
+ *   organizations.timezone   → o fuso que a PESSOA escolheu no onboarding.
+ *   channel_knobs.timezone   → knob ANTI-BAN por canal. Nada no repo o semeia
+ *                              a partir da org: linha ausente cai em
+ *                              `PACING_DEFAULTS.timezone`, o literal de
+ *                              São Paulo.
+ *
+ * A segunda estava à mão dentro do turno, o que faz dela a escolha tentadora —
+ * e errada por uma hora inteira em Manaus, calada, porque numa org paulista as
+ * duas coincidem e nenhum teste vê diferença. Aqui a org é de Manaus e o canal
+ * não tem knob: se alguém trocar a fonte pelo fuso do pacing, o bloco dirá
+ * 14:30 e este arquivo reprova.
+ *
+ * ─── O instante ─────────────────────────────────────────────────────────────
+ *
+ * `2026-09-04T17:30:00Z` = sexta, 14:30 em São Paulo e 13:30 em Manaus. Escolhi
+ * o meio da tarde de propósito: precisa estar DENTRO da janela anti-ban (7h-22h,
+ * avaliada no fuso do pacing) nos dois fusos, senão o turno é adiado antes de
+ * montar prompt nenhum e o arquivo mediria outra coisa.
+ *
+ * Harness copiado de `janela-usa-o-relogio-injetado.test.ts` (handler real,
+ * modelo fake, canal que captura, `sleep` no-op), com ids próprios: o banco é
+ * recriado por arquivo, mas ids distintos mantêm o log legível quando os dois
+ * rodam na mesma corrida.
+ */
+
+const container = process.env.TEST_DB_CONTAINER;
+if (!container) {
+  throw new Error("TEST_DB_CONTAINER not set — rode via `pnpm test:db` (scripts/test-db.sh)");
+}
+
+process.env.NEXT_PUBLIC_SUPABASE_URL ??= "https://placeholder.supabase.co";
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??= "placeholder-anon";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "placeholder-service";
+
+const PORT = Number(process.env.TEST_DB_PORT ?? 54329);
+const pool = new pg.Pool({
+  connectionString: `postgresql://postgres:postgres@127.0.0.1:${PORT}/postgres`,
+  max: 2,
+});
+
+const ORG = "dddddddd-0000-4000-8000-0000000000b1";
+const CONTACT = "dddddddd-0000-4000-8000-0000000000b2";
+const SESSION = "dddddddd-0000-4000-8000-0000000000b3";
+const CONV = "dddddddd-0000-4000-8000-0000000000b4";
+const MSG = "dddddddd-0000-4000-8000-0000000000b5";
+const CRM_EVENT = "dddddddd-0000-4000-8000-0000000000b6";
+
+/** Sexta, 14:30 em São Paulo — e 13:30 em Manaus, que é o fuso desta org. */
+const INSTANTE = new Date("2026-09-04T17:30:00Z");
+
+/** O que o bloco tem de dizer. Se sair a hora de São Paulo, a fonte está errada. */
+const ESPERADO_MANAUS = "sexta-feira, 04/09/2026, 13:30 (America/Manaus)";
+/** O que ele NÃO pode dizer — é a hora que `channel_knobs`/pacing daria. */
+const HORA_DO_PACING = "14:30";
+
+interface EnvioCapturado {
+  body: string;
+}
+
+type Modules = {
+  createInboundTurnHandler: typeof InboundTurn.createInboundTurnHandler;
+  queue: typeof Queue;
+  createLogger: typeof ObsLogger.createLogger;
+  createFakeRegistry: typeof Providers.createFakeRegistry;
+};
+let m: Modules;
+
+let enviados: EnvioCapturado[] = [];
+/** Todo prompt que chegou ao modelo neste turno, já serializado. */
+let promptsVistos: string[] = [];
+
+const CHECKPOINT = JSON.stringify({
+  commitments: [],
+  objections: [],
+  next_action: null,
+  rolling_summary: "turno de teste",
+});
+
+const USO = {
+  inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 1, text: 1, reasoning: 0 },
+};
+
+/** Modelo fake que GRAVA o prompt recebido, manda uma mensagem e encerra. */
+function modeloQueGravaOPrompt() {
+  let mandou = false;
+  return async (options: { prompt: unknown }) => {
+    promptsVistos.push(JSON.stringify(options.prompt));
+    if (!mandou) {
+      mandou = true;
+      return {
+        content: [
+          {
+            type: "tool-call" as const,
+            toolCallId: "c1",
+            toolName: "send_message",
+            input: JSON.stringify({ body: "oi, consigo te encaixar sim" }),
+          },
+        ],
+        finishReason: { unified: "tool-calls" as const, raw: undefined },
+        usage: USO,
+        warnings: [],
+      };
+    }
+    return {
+      content: [{ type: "text" as const, text: CHECKPOINT }],
+      finishReason: { unified: "stop" as const, raw: undefined },
+      usage: USO,
+      warnings: [],
+    };
+  };
+}
+
+function montaHandler(doGenerate: unknown, instante: Date) {
+  return m.createInboundTurnHandler({
+    crmCfg: { supabase: {} as never },
+    llmCfg: { anthropicApiKey: "fake" } as never,
+    knobs: {
+      historyLimit: 10,
+      maxContextTokens: 1000,
+      notesIndexMaxTokens: 500,
+      maxSteps: 12,
+      queuedRetryDelayMs: 1000,
+      breaker: {
+        exactFailureWarn: 2,
+        exactFailureBlock: 5,
+        sameToolFailureWarn: 3,
+        sameToolFailureHalt: 8,
+        noProgressWarn: 3,
+        noProgressBlock: 5,
+      },
+    },
+    log: m.createLogger(),
+    registry: m.createFakeRegistry(doGenerate as never),
+    channel: () =>
+      ({
+        channel: "captura",
+        send: async (i: EnvioCapturado) => {
+          enviados.push(i);
+          return {
+            kind: "sent" as const,
+            idempotencyKey: `k${enviados.length}`,
+            messageId: `m${enviados.length}`,
+          };
+        },
+        sessionHealth: async () => ({ healthy: true, status: "WORKING" }),
+        capabilities: () => ({ freeform: true, media: true, audio: true }),
+        costPerMessage: () => ({ currency: "BRL", cents: 0 }),
+      }) as never,
+    clock: () => instante,
+    sleep: async () => {},
+  });
+}
+
+async function rodaTurno(handler: ReturnType<typeof montaHandler>): Promise<Error | null> {
+  await pool.query("update job_queue set status = 'done' where status = 'pending'");
+  const { job } = await m.queue.enqueueJob(pool, ORG, {
+    kind: "inbound_turn",
+    leadId: CONTACT,
+    payload: {
+      conversation_id: CONV,
+      contact_id: CONTACT,
+      channel_session_id: SESSION,
+      inbound_message_id: MSG,
+      crm_event_id: CRM_EVENT,
+    },
+    maxAttempts: 1,
+  });
+  const [claimed] = await m.queue.claimJobs(pool, { workerId: "relogio", maxConcurrency: 1 });
+  expect(claimed?.id).toBe(job.id);
+  try {
+    await handler(claimed!, pool, { workerId: "relogio" });
+    await m.queue.completeJob(pool, claimed!.id, "relogio");
+    return null;
+  } catch (err) {
+    await m.queue.failJob(pool, claimed!.id, "relogio", err);
+    return err as Error;
+  }
+}
+
+beforeAll(async () => {
+  m = {
+    createInboundTurnHandler: (await import("@/lib/agent-engine/agent/inbound-turn"))
+      .createInboundTurnHandler,
+    queue: await import("@/lib/agent-engine/queue/queue"),
+    createLogger: (await import("@/lib/agent-engine/obs/logger")).createLogger,
+    createFakeRegistry: (await import("@/lib/agent-engine/edge/llm/providers")).createFakeRegistry,
+  };
+
+  // O fuso da org é MANAUS — é o que separa esta coluna do knob de pacing.
+  await pool.query(
+    `insert into organizations (id, slug, legal_name, display_name, timezone)
+     values ($1,'relogio-do-turno','Relogio do Turno','Relogio do Turno','America/Manaus')
+     on conflict (id) do update set timezone = excluded.timezone`,
+    [ORG],
+  );
+  await pool.query(
+    `insert into contacts (id, organization_id, name, phone_number)
+     values ($1,$2,'Lead do Relogio','+5592900000777') on conflict (id) do nothing`,
+    [CONTACT, ORG],
+  );
+  await pool.query(
+    `insert into channel_sessions (id, organization_id, waha_session_name, status, webhook_secret_encrypted)
+     values ($1,$2,'relogio-do-turno-session','WORKING','\\x00'::bytea) on conflict (id) do nothing`,
+    [SESSION, ORG],
+  );
+  await pool.query(
+    `insert into conversations (id, organization_id, contact_id, channel_session_id, status, is_group)
+     values ($1,$2,$3,$4,'ai_handling',false) on conflict (id) do nothing`,
+    [CONV, ORG, CONTACT, SESSION],
+  );
+  await pool.query(
+    `insert into messages (id, organization_id, conversation_id, channel_session_id, contact_id,
+       type, direction, status, body, sent_via, sent_at)
+     values ($1,$2,$3,$4,$5,'text','inbound','delivered','oi, dá pra marcar quinta?','external_device', now())
+     on conflict (id) do nothing`,
+    [MSG, ORG, CONV, SESSION, CONTACT],
+  );
+  await pool.query(
+    `with v as (
+       insert into playbook_versions (organization_id, layer, content)
+       select null, 'platform', E'## Identidade\nAssistente de teste.'
+       where not exists (select 1 from playbook_pointers where organization_id is null and layer = 'platform')
+       returning id)
+     insert into playbook_pointers (organization_id, layer, version_id)
+     select null, 'platform', id from v`,
+  );
+});
+
+beforeEach(() => {
+  enviados = [];
+  promptsVistos = [];
+});
+
+describe("o prompt do turno carrega a data de hoje", () => {
+  it("a abertura leva dia da semana, data e hora — no fuso da ORGANIZAÇÃO", async () => {
+    const erro = await rodaTurno(montaHandler(modeloQueGravaOPrompt(), INSTANTE));
+
+    expect(erro).toBeNull();
+    expect(enviados).toHaveLength(1);
+    // O turno chama o modelo duas vezes (resposta + checkpoint); o bloco tem de
+    // estar na PRIMEIRA, que é a que decide o que fazer com o pedido do lead.
+    expect(promptsVistos.length).toBeGreaterThan(0);
+    expect(promptsVistos[0]).toContain("## Agora");
+    expect(promptsVistos[0]).toContain(ESPERADO_MANAUS);
+  });
+
+  it("NÃO usa o fuso do pacing — a org é de Manaus e o canal não tem knob", async () => {
+    // Com a fonte trocada por `channel_knobs.timezone`, o bloco diria 14:30
+    // (São Paulo, o default do pacing) e este caso é o único que reprova.
+    await rodaTurno(montaHandler(modeloQueGravaOPrompt(), INSTANTE));
+
+    expect(promptsVistos[0]).not.toContain(HORA_DO_PACING);
+    expect(promptsVistos[0]).not.toContain("America/Sao_Paulo");
+  });
+
+  it("o instante absoluto vai junto — é o formato que as ferramentas de agenda exigem", async () => {
+    await rodaTurno(montaHandler(modeloQueGravaOPrompt(), INSTANTE));
+
+    expect(promptsVistos[0]).toContain("instante_absoluto: 2026-09-04T17:30:00.000Z");
+  });
+});

--- a/tests/unit/a-ia-sabe-o-que-a-clinica-atende.test.ts
+++ b/tests/unit/a-ia-sabe-o-que-a-clinica-atende.test.ts
@@ -1,0 +1,297 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { ResultadoDaConsulta, ResultadoDosTipos, TipoDeAtendimento } from "@/lib/agenda/consulta";
+import type { McpContext } from "@/lib/mcp/types";
+
+/**
+ * AS CAPACIDADES QUE FALTAVAM PARA A IA AGENDAR SOZINHA.
+ *
+ * ─── O defeito, medido numa instalação real ────────────────────────────────
+ *
+ * O agente TINHA as cinco ferramentas de agenda montadas no turno — está no log
+ * do worker — e não marcava consulta nenhuma. A causa não era o modelo: quatro
+ * das cinco exigem `event_type_slug`, e NENHUMA capacidade do catálogo dizia
+ * quais slugs existem. Na organização medida eram `atendimento`,
+ * `call-estrategica`, `consulta`, `hof-e-botox` e `reuniao` — a IA teria de
+ * adivinhar a string. Errava, recebia `tipo_desconhecido`, e caía no "vou
+ * confirmar com a equipe" para sempre.
+ *
+ * A recusa daquele caminho até ensinava o certo — "use um dos tipos que a
+ * organização oferece" —, e era uma instrução impossível de cumprir.
+ *
+ * ─── O que este arquivo cobre, e o que não ─────────────────────────────────
+ *
+ * A camada que a TOOL acrescenta: o que ela mostra ao modelo, o que ela esconde
+ * dele, e como a recusa chega. A coleta (`listaTiposDeAtendimento`) e o handler
+ * de escrita têm donos próprios; mockar os dois é o que mantém cada suíte
+ * medindo uma coisa. Mesma fronteira de `mcp-agendamento-tools.test.ts`.
+ */
+vi.mock("@/app/api/v1/agenda/agendamentos/_handler", () => ({
+  marcarAgendamentoHandler: vi.fn(),
+  alterarAgendamentoHandler: vi.fn(),
+  cancelarAgendamentoHandler: vi.fn(),
+}));
+
+vi.mock("@/lib/agenda/consulta", async (original) => {
+  const real = await original<typeof import("@/lib/agenda/consulta")>();
+  return {
+    ...real,
+    listaTiposDeAtendimento: vi.fn(),
+    horariosLivresDaOrg: vi.fn(),
+    listaAgendamentos: vi.fn(),
+    idDoTipoPorSlug: vi.fn(),
+  };
+});
+
+const { listaTiposDeAtendimento, horariosLivresDaOrg } = await import("@/lib/agenda/consulta");
+const { crmListEventTypes, crmConfirmAppointment, crmSetAppointmentOutcome, crmFindFreeSlots } =
+  await import("@/lib/mcp/tools/agendamento");
+const handlers = await import("@/app/api/v1/agenda/agendamentos/_handler");
+const { ApiError } = await import("@/lib/api/types");
+
+const ctx: McpContext = {
+  organizationId: "org-1",
+  role: "agent",
+  actor: { type: "ai_agent", id: "ag-1", role: "ai_operator" },
+  apiTokenId: "tok-1",
+  requestId: "req-1",
+  supabase: {} as unknown as SupabaseClient,
+};
+
+/** Um tipo como o banco devolve — os cinco da clínica medida são deste feitio. */
+function tipo(over: Partial<TipoDeAtendimento> = {}): TipoDeAtendimento {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    nome: "HOF e Botox",
+    slug: "hof-e-botox",
+    descricao: null,
+    categoria: "procedimento",
+    duracaoMin: 45,
+    localKind: "in_person",
+    localDetalhes: "Sala 2",
+    precisaConfirmacao: false,
+    ativo: true,
+    donoPadraoId: "22222222-2222-4222-8222-222222222222",
+    bufferAntesMin: 0,
+    bufferDepoisMin: 0,
+    antecedenciaMinimaMin: 120,
+    janelaDeAgendamentoDias: 60,
+    ...over,
+  };
+}
+
+function tiposRespondem(r: ResultadoDosTipos): void {
+  vi.mocked(listaTiposDeAtendimento).mockResolvedValue(r);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("crm_list_event_types — a capacidade que faltava", () => {
+  it("entrega o SLUG, que é o handle que as outras ferramentas exigem", async () => {
+    tiposRespondem({ ok: true, tipos: [tipo()] });
+
+    const r = (await crmListEventTypes.handler({}, ctx)) as { tipos: { slug: string }[] };
+
+    expect(r.tipos[0]?.slug).toBe("hof-e-botox");
+  });
+
+  it("NÃO entrega o id interno — o slug existe para o modelo não alucinar uuid", async () => {
+    // Devolver o uuid ao lado do slug convida o modelo a mandá-lo em
+    // `event_type_slug`, onde ele nunca casa. O campo simplesmente não sai.
+    tiposRespondem({ ok: true, tipos: [tipo()] });
+
+    const r = (await crmListEventTypes.handler({}, ctx)) as { tipos: Record<string, unknown>[] };
+
+    expect(r.tipos[0]).not.toHaveProperty("id");
+    expect(JSON.stringify(r.tipos)).not.toContain("11111111-1111-4111-8111-111111111111");
+  });
+
+  it("traduz o local em vez de vazar o vocabulário do banco", async () => {
+    // `in_person` é palavra de coluna, e o modelo repassa o que recebe. Quem
+    // traduz é o MESMO tradutor da tela.
+    tiposRespondem({ ok: true, tipos: [tipo()] });
+
+    const r = (await crmListEventTypes.handler({}, ctx)) as { tipos: { onde: string | null }[] };
+
+    expect(r.tipos[0]?.onde).toBe("Presencial · Sala 2");
+    expect(JSON.stringify(r.tipos)).not.toContain("in_person");
+  });
+
+  it("pede SÓ os ativos à coleta — tipo desativado é beco sem saída", async () => {
+    // Não é filtro de estética: `horariosLivresDaOrg` acha o tipo inativo e
+    // recusa com `tipo_desativado`. Oferecê-lo ao modelo é garantir que ele
+    // ofereça à pessoa algo que não dá para marcar.
+    tiposRespondem({ ok: true, tipos: [] });
+
+    await crmListEventTypes.handler({}, ctx);
+
+    const chamada = vi.mocked(listaTiposDeAtendimento).mock.calls[0];
+    expect(chamada?.[1]).toBe("org-1");
+    // Sem opções, ou com `incluirInativos` falso — o que não pode é pedir os inativos.
+    expect(chamada?.[2]?.incluirInativos ?? false).toBe(false);
+  });
+
+  it("diz que precisa de confirmação — muda o que o agente fala depois de marcar", async () => {
+    tiposRespondem({ ok: true, tipos: [tipo({ precisaConfirmacao: true })] });
+
+    const r = (await crmListEventTypes.handler({}, ctx)) as {
+      tipos: { precisa_confirmacao: boolean }[];
+    };
+
+    expect(r.tipos[0]?.precisa_confirmacao).toBe(true);
+  });
+
+  it("erro de leitura vira recusa NOMEADA, nunca lista vazia", async () => {
+    // As duas chegam ao modelo iguais e significam o oposto: lista vazia diz "a
+    // clínica não atende nada", e ele anunciaria isso ao paciente.
+    tiposRespondem({
+      ok: false,
+      codigo: "erro_interno",
+      motivoParaOperador: 'relation "calendar_event_types" does not exist',
+      motivoParaCliente: "Não consegui ver o que a agenda oferece agora.",
+    });
+
+    const r = (await crmListEventTypes.handler({}, ctx)) as { motivo: string; mensagem: string };
+
+    expect(r.motivo).toBe("erro_interno");
+    // A face do CLIENTE, nunca a do operador: o texto do banco não pode chegar
+    // a quem está do outro lado do WhatsApp.
+    expect(r.mensagem).not.toContain("relation");
+  });
+});
+
+describe("crm_set_appointment_outcome — desfecho é sobre o passado", () => {
+  it("compromisso que ainda não começou é RECUSADO, e a recusa ensina o caminho certo", async () => {
+    // A guarda mora no handler; aqui prova-se que a tool a traduz em resposta ao
+    // modelo em vez de deixar a exceção matar o turno.
+    vi.mocked(handlers.alterarAgendamentoHandler).mockRejectedValue(
+      new ApiError(422, "agenda_ainda_nao_aconteceu", undefined, "req-1", "não começou"),
+    );
+
+    const r = (await crmSetAppointmentOutcome.handler(
+      { appointment_id: "33333333-3333-4333-8333-333333333333", outcome: "no_show" },
+      ctx,
+    )) as { registrado: boolean; motivo: string; mensagem: string };
+
+    expect(r.registrado).toBe(false);
+    expect(r.motivo).toBe("agenda_ainda_nao_aconteceu");
+    // O ensino importa tanto quanto a recusa: sem ele o modelo tenta de novo igual.
+    expect(r.mensagem).toContain("crm_cancel_appointment");
+  });
+
+  it("passa o desfecho pedido ao handler, sem inventar transição", async () => {
+    vi.mocked(handlers.alterarAgendamentoHandler).mockResolvedValue({ id: "a1", status: "completed" });
+
+    await crmSetAppointmentOutcome.handler(
+      { appointment_id: "33333333-3333-4333-8333-333333333333", outcome: "completed" },
+      ctx,
+    );
+
+    expect(vi.mocked(handlers.alterarAgendamentoHandler).mock.calls[0]?.[2]).toMatchObject({
+      id: "33333333-3333-4333-8333-333333333333",
+      status: "completed",
+    });
+  });
+});
+
+describe("crm_confirm_appointment", () => {
+  it("confirma o que estava aguardando a pessoa", async () => {
+    vi.mocked(handlers.alterarAgendamentoHandler).mockResolvedValue({ id: "a1", status: "confirmed" });
+
+    const r = (await crmConfirmAppointment.handler(
+      { appointment_id: "33333333-3333-4333-8333-333333333333" },
+      ctx,
+    )) as { confirmado: boolean };
+
+    expect(r.confirmado).toBe(true);
+    expect(vi.mocked(handlers.alterarAgendamentoHandler).mock.calls[0]?.[2]).toMatchObject({
+      status: "confirmed",
+    });
+  });
+});
+
+/** Uma grade real: 4 dias úteis, 10 horários de 30min em cada — 40 no total. */
+function gradeDeQuatroDias(): { inicio: Date; fim: Date }[] {
+  const slots: { inicio: Date; fim: Date }[] = [];
+  for (const dia of ["01", "02", "03", "04"]) {
+    for (let i = 0; i < 10; i += 1) {
+      const h = String(12 + Math.floor(i / 2)).padStart(2, "0");
+      const m = i % 2 === 0 ? "00" : "30";
+      slots.push({
+        inicio: new Date(`2026-09-${dia}T${h}:${m}:00Z`),
+        fim: new Date(`2026-09-${dia}T${h}:${m}:00Z`),
+      });
+    }
+  }
+  return slots;
+}
+
+function horariosRespondem(slots: { inicio: Date; fim: Date }[]): void {
+  vi.mocked(horariosLivresDaOrg).mockResolvedValue({
+    ok: true,
+    slots,
+    fusoDaRegra: "America/Sao_Paulo",
+    publicouHorarios: true,
+    fusoSuposto: false,
+    fontesDefasadas: [],
+    agendaExternaNuncaLida: false,
+  } as ResultadoDaConsulta);
+}
+
+describe("crm_find_free_slots — o que o modelo consegue ler e escolher", () => {
+  it("cada horário vem com o rótulo local ao lado do instante de máquina", async () => {
+    horariosRespondem([
+      { inicio: new Date("2026-09-04T17:00:00Z"), fim: new Date("2026-09-04T17:30:00Z") },
+    ]);
+
+    const r = (await crmFindFreeSlots.handler(
+      { event_type_slug: "consulta", dias_a_frente: 7 },
+      ctx,
+    )) as { horarios: { inicio: string; quando: string }[] };
+
+    // 17:00Z = 14:00 em São Paulo, numa sexta-feira.
+    expect(r.horarios[0]?.quando).toBe("sexta-feira 04/09 às 14:00");
+    // E o ISO continua lá: é ele que volta em `starts_at`.
+    expect(r.horarios[0]?.inicio).toBe("2026-09-04T17:00:00.000Z");
+  });
+
+  it("corta no teto, mas ESPALHA pelos dias — cortar pela cabeça esconderia a semana", async () => {
+    // 40 horários em 4 dias, teto de 8. Cortar pela cabeça devolveria os 8
+    // primeiros, todos do dia 01 — e um pedido de "essa semana" voltaria só com
+    // o primeiro dia, fazendo o modelo concluir que os outros estão cheios.
+    horariosRespondem(gradeDeQuatroDias());
+
+    const r = (await crmFindFreeSlots.handler(
+      { event_type_slug: "consulta", dias_a_frente: 7, limite: 8 },
+      ctx,
+    )) as { horarios: { quando: string }[]; total_de_horarios: number; ha_mais: boolean };
+
+    expect(r.horarios).toHaveLength(8);
+    const diasOferecidos = new Set(r.horarios.map((h) => h.quando.split(" às ")[0]));
+    expect(diasOferecidos.size).toBe(4);
+    // E o modelo fica sabendo que a lista foi cortada — senão ele leria 8 como
+    // "só há 8", que é o mesmo modo de falha que `publicou_horarios` evita.
+    expect(r.total_de_horarios).toBe(40);
+    expect(r.ha_mais).toBe(true);
+  });
+
+  it("lista inteira devolvida: `ha_mais` é falso e o total bate", async () => {
+    // O controle do caso acima. Sem ele, um `ha_mais` cravado em `true` passaria.
+    horariosRespondem([
+      { inicio: new Date("2026-09-04T17:00:00Z"), fim: new Date("2026-09-04T17:30:00Z") },
+    ]);
+
+    const r = (await crmFindFreeSlots.handler(
+      { event_type_slug: "consulta", dias_a_frente: 7 },
+      ctx,
+    )) as { horarios: unknown[]; total_de_horarios: number; ha_mais: boolean };
+
+    expect(r.horarios).toHaveLength(1);
+    expect(r.total_de_horarios).toBe(1);
+    expect(r.ha_mais).toBe(false);
+  });
+});

--- a/tests/unit/desfecho-de-agenda-e-sobre-o-passado.test.ts
+++ b/tests/unit/desfecho-de-agenda-e-sobre-o-passado.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { HandlerCtx } from "@/lib/api/handlers/types";
+
+/**
+ * NÃO SE REGISTRA O DESFECHO DE UM COMPROMISSO QUE AINDA NÃO ACONTECEU.
+ *
+ * ─── O buraco, e por que ele deixou de ser barato ──────────────────────────
+ *
+ * `alterarAgendamentoHandler` aceitava `completed` e `no_show` em qualquer
+ * compromisso vivo. Nada comparava `starts_at` com o relógio — medido: a
+ * palavra `now` não aparecia em nenhuma guarda de status do arquivo.
+ *
+ * Enquanto só gente escrevia isso pela tela o buraco custava pouco, porque os
+ * botões "Realizado" e "Faltou" moram no histórico e ninguém rola até um
+ * compromisso de terça que vem para clicar em "faltou". Deixou de custar pouco
+ * quando `crm_set_appointment_outcome` pôs a mesma escrita na mão de um modelo,
+ * que não escolhe por onde clicou — escolhe por texto, a partir de uma conversa
+ * onde o paciente disse "não vou poder ir amanhã".
+ *
+ * ─── O dano do `no_show` prematuro é físico, não é registro errado ─────────
+ *
+ * `no_show` está em `LIBERAM_O_HORARIO` (`lib/agenda/ocupados.ts`): registrar
+ * falta DEVOLVE ao pool um horário que a pessoa ainda espera. Outro paciente
+ * marca em cima, e os dois chegam na mesma hora — e o primeiro tinha razão.
+ *
+ * `completed` prematuro faz outro estrago: grava `appointment_completed` na
+ * timeline e some com os botões da tela, tirando de quem atendeu a chance de
+ * registrar o que de fato aconteceu.
+ *
+ * ─── Onde a guarda mora, e por que não é na ferramenta ─────────────────────
+ *
+ * No HANDLER. A regra não é sobre quem chama: marcar como realizado o que não
+ * começou é errado pela tela, pela API e pela IA. Uma guarda na ferramenta
+ * deixaria a rota `PATCH` aberta com a mesma aparência de protegida.
+ *
+ * ─── O relógio deste arquivo ───────────────────────────────────────────────
+ *
+ * Os instantes são RELATIVOS a `Date.now()` — "daqui a um dia", "ontem" —, e não
+ * datas fixas. Uma data fixa vira passado sozinha com o calendário, e o caso do
+ * futuro deixaria de medir o futuro sem ninguém tocar em nada.
+ */
+vi.mock("@/lib/agenda/consulta", async (original) => {
+  const real = await original<typeof import("@/lib/agenda/consulta")>();
+  return { ...real, horariosLivresDaOrg: vi.fn() };
+});
+
+const { alterarAgendamentoHandler } = await import("@/app/api/v1/agenda/agendamentos/_handler");
+const { ApiError } = await import("@/lib/api/types");
+
+const ORG = "aaaaaaaa-1111-4000-8000-00000000000a";
+const AGENDAMENTO = "ffffffff-1111-4000-8000-00000000000f";
+
+const ctx: HandlerCtx = {
+  organization_id: ORG,
+  actor: { type: "user", id: "bbbbbbbb-1111-4000-8000-00000000000b", role: "manager" },
+  requestId: "req-1",
+} as unknown as HandlerCtx;
+
+const DIA = 86_400_000;
+let atualizado: Record<string, unknown> | null;
+
+/** Dublê mínimo: só o que `exigeAgendamento` lê e o que o update grava. */
+function clienteCom(startsAt: string, status: string): SupabaseClient {
+  const linha = {
+    id: AGENDAMENTO,
+    event_type_id: "cccccccc-1111-4000-8000-00000000000c",
+    owner_user_id: "dddddddd-1111-4000-8000-00000000000d",
+    contact_id: "eeeeeeee-1111-4000-8000-00000000000e",
+    starts_at: startsAt,
+    status,
+    time_zone: "America/Sao_Paulo",
+  };
+  const leitura = () => {
+    const cadeia: Record<string, unknown> = {};
+    for (const m of ["eq", "order", "limit", "in", "is", "not"]) cadeia[m] = () => cadeia;
+    cadeia.maybeSingle = async () => ({ data: linha, error: null });
+    cadeia.single = async () => ({ data: linha, error: null });
+    return cadeia;
+  };
+  return {
+    from: () => ({
+      select: () => leitura(),
+      update: (mudanca: Record<string, unknown>) => {
+        atualizado = mudanca;
+        const cadeia: Record<string, unknown> = {};
+        for (const m of ["eq"]) cadeia[m] = () => cadeia;
+        cadeia.select = () => cadeia;
+        cadeia.single = async () => ({ data: { ...linha, ...mudanca }, error: null });
+        return cadeia;
+      },
+      insert: () => ({ select: () => ({ single: async () => ({ data: {}, error: null }) }) }),
+    }),
+    rpc: async () => ({ data: null, error: null }),
+  } as unknown as SupabaseClient;
+}
+
+beforeEach(() => {
+  atualizado = null;
+});
+
+describe("desfecho de compromisso futuro é recusado", () => {
+  for (const desfecho of ["completed", "no_show"] as const) {
+    it(`\`${desfecho}\` num compromisso de amanhã é recusado, e nada é gravado`, async () => {
+      const amanha = new Date(Date.now() + DIA).toISOString();
+
+      const erro = await alterarAgendamentoHandler(
+        clienteCom(amanha, "confirmed"),
+        ctx,
+        { id: AGENDAMENTO, status: desfecho },
+      ).catch((e: unknown) => e);
+
+      expect(erro).toBeInstanceOf(ApiError);
+      expect((erro as InstanceType<typeof ApiError>).code).toBe("agenda_ainda_nao_aconteceu");
+      // A recusa tem de ser ANTES do update: uma que só reclamasse depois de
+      // gravar teria liberado o horário do mesmo jeito.
+      expect(atualizado).toBeNull();
+    });
+  }
+
+  it("o MESMO desfecho, num compromisso de ontem, é aceito — a guarda não vira muro", async () => {
+    // O controle. Sem ele, uma guarda que recusasse SEMPRE satisfaria os casos
+    // acima e quebraria o registro de falta, que é trabalho legítimo da recepção.
+    const ontem = new Date(Date.now() - DIA).toISOString();
+
+    await alterarAgendamentoHandler(clienteCom(ontem, "confirmed"), ctx, {
+      id: AGENDAMENTO,
+      status: "no_show",
+    });
+
+    expect(atualizado).toMatchObject({ status: "no_show" });
+  });
+
+  it("CONFIRMAR um compromisso futuro segue liberado — é o caso normal", async () => {
+    // A guarda é sobre DESFECHO, não sobre status. Confirmar antes da hora é
+    // exatamente o que se espera de quem combinou com o cliente; se a guarda
+    // pegasse `confirmed` junto, ela quebraria o fluxo que veio destravar.
+    const amanha = new Date(Date.now() + DIA).toISOString();
+
+    await alterarAgendamentoHandler(clienteCom(amanha, "pending"), ctx, {
+      id: AGENDAMENTO,
+      status: "confirmed",
+    });
+
+    expect(atualizado).toMatchObject({ status: "confirmed" });
+  });
+});

--- a/tests/unit/o-turno-sabe-que-horas-sao.test.ts
+++ b/tests/unit/o-turno-sabe-que-horas-sao.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { renderAgora } from "@/lib/tempo/agora";
+import { FUSO_PADRAO } from "@/lib/tempo/fusos";
+import { fusoDaOrganizacao } from "@/lib/agent-engine/agent/fuso-da-org";
+
+/**
+ * O MODELO PRECISA SABER QUE DIA É HOJE — e no fuso de quem instalou.
+ *
+ * ─── O defeito ──────────────────────────────────────────────────────────────
+ *
+ * O ritual de abertura do turno entregava checkpoint, funil, notas e histórico,
+ * e nenhum relógio. Sem data, "quinta às 14h" não vira `starts_at`, e
+ * `crm_book_appointment` nunca é chamada — o agente cai no "vou confirmar com a
+ * equipe" e a consulta não é marcada. Medido numa instalação real: o dono do
+ * produto escreveu no system prompt do agente dele um parágrafo inteiro
+ * ensinando a IA a inferir a data pelo carimbo da última mensagem.
+ *
+ * ─── O INSTANTE DE PROVA, e por que é este ─────────────────────────────────
+ *
+ * `2026-09-04T03:30:00Z` foi escolhido porque cai em dias DIFERENTES nos dois
+ * fusos do mesmo país:
+ *
+ *   America/Sao_Paulo (-3) → sexta-feira, 04/09/2026, 00:30
+ *   America/Manaus    (-4) → quinta-feira, 03/09/2026, 23:30
+ *
+ * Um instante do meio da tarde passaria com uma implementação que ignorasse o
+ * fuso e imprimisse o UTC cru — a hora sairia errada, mas o DIA DA SEMANA
+ * bateria, e é o dia da semana que a pessoa diz ao marcar. Aqui não: com o fuso
+ * ignorado, o bloco diria "sexta" para a clínica de Manaus na quinta à noite, e
+ * o teste reprova. É o caso de controle do arquivo — sem ele, `toISOString()`
+ * cru passaria.
+ */
+
+/** Sexta em São Paulo, quinta em Manaus — ver o cabeçalho. */
+const INSTANTE = new Date("2026-09-04T03:30:00Z");
+
+describe("renderAgora — o bloco que diz ao modelo que horas são", () => {
+  it("dá o dia da semana por extenso, a data e a hora locais", () => {
+    const bloco = renderAgora(INSTANTE, "America/Sao_Paulo");
+
+    expect(bloco).toContain("## Agora");
+    expect(bloco).toContain("sexta-feira, 04/09/2026, 00:30 (America/Sao_Paulo)");
+  });
+
+  it("O FUSO MUDA O DIA — o mesmo instante é quinta em Manaus e sexta em São Paulo", () => {
+    // O caso de controle do arquivo. Com o fuso ignorado, os dois blocos seriam
+    // idênticos e este `not` é o único que reprovaria.
+    const sp = renderAgora(INSTANTE, "America/Sao_Paulo");
+    const manaus = renderAgora(INSTANTE, "America/Manaus");
+
+    expect(sp).toContain("sexta-feira, 04/09/2026, 00:30");
+    expect(manaus).toContain("quinta-feira, 03/09/2026, 23:30");
+    expect(sp).not.toEqual(manaus);
+  });
+
+  it("entrega o instante absoluto no formato que as ferramentas exigem de volta", () => {
+    // `crm_book_appointment.starts_at` e `crm_schedule_followup.promised_at` são
+    // `z.string().datetime({ offset: true })`. O modelo copia daqui em vez de
+    // montar — e montar é onde ele erra o fuso.
+    expect(renderAgora(INSTANTE, "America/Sao_Paulo")).toContain(
+      "instante_absoluto: 2026-09-04T03:30:00.000Z",
+    );
+  });
+
+  it("fuso inválido NÃO derruba o turno — degrada para o padrão", () => {
+    // `America/Asunción` com acento é o caso real que `lib/tempo/fusos.ts`
+    // documenta: `Intl.DateTimeFormat` lança `RangeError`. Este bloco é montado
+    // ANTES da chamada de modelo; um throw aqui mata o atendimento inteiro e o
+    // sintoma chega ao dono como agente mudo.
+    expect(() => renderAgora(INSTANTE, "America/Asunción")).not.toThrow();
+    expect(renderAgora(INSTANTE, "America/Asunción")).toContain(`(${FUSO_PADRAO})`);
+    expect(renderAgora(INSTANTE, "")).toContain(`(${FUSO_PADRAO})`);
+  });
+
+  it("não cita ferramenta interna — o bloco entra no prompt de todo turno", () => {
+    // A abertura já é varrida por `entrega-de-capacidade.test.ts`, que exige que
+    // o nome de uma ferramenta ENTREGUE ao Operador não sobre no texto. Um bloco
+    // novo que citasse tool furaria aquela guarda por uma porta que ela não olha.
+    const bloco = renderAgora(INSTANTE, "America/Sao_Paulo");
+    for (const nome of ["update_lead_state", "save_lead_note", "send_message", "crm_"]) {
+      expect(bloco).not.toContain(nome);
+    }
+  });
+});
+
+/** Dublê de `Queryable` — a assinatura mínima que o motor usa (pg.Pool a satisfaz). */
+function bancoQueDevolve(timezone: string | null | undefined) {
+  return {
+    query: vi.fn().mockResolvedValue({ rows: timezone === undefined ? [] : [{ timezone }] }),
+  } as never;
+}
+
+describe("fusoDaOrganizacao — de onde sai o fuso, e o que acontece quando ele não presta", () => {
+  it("usa a coluna da organização", async () => {
+    expect(await fusoDaOrganizacao(bancoQueDevolve("America/Manaus"), "org-1")).toBe(
+      "America/Manaus",
+    );
+  });
+
+  it("valor que o Intl recusa vira o padrão, e o motivo vai ao log", async () => {
+    const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    expect(await fusoDaOrganizacao(bancoQueDevolve("America/Asunción"), "org-1", log)).toBe(
+      FUSO_PADRAO,
+    );
+    // Sem o log, a organização que digitou o fuso errado veria horário de São
+    // Paulo para sempre e nada explicaria por quê.
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(log.warn.mock.calls[0]?.[1]).toMatchObject({ fuso_recusado: "America/Asunción" });
+  });
+
+  it("organização sem linha, ou com a coluna vazia, cai no padrão sem lançar", async () => {
+    expect(await fusoDaOrganizacao(bancoQueDevolve(undefined), "org-1")).toBe(FUSO_PADRAO);
+    expect(await fusoDaOrganizacao(bancoQueDevolve(null), "org-1")).toBe(FUSO_PADRAO);
+    expect(await fusoDaOrganizacao(bancoQueDevolve("   "), "org-1")).toBe(FUSO_PADRAO);
+  });
+
+  it("FALHA ABERTA: banco fora do ar não derruba o turno", async () => {
+    // Um clone que atualizou o código antes do schema, ou um instante de banco
+    // indisponível, não pode custar o atendimento de um cliente.
+    const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const bancoQuebrado = {
+      query: vi.fn().mockRejectedValue(new Error('relation "organizations" does not exist')),
+    } as never;
+
+    expect(await fusoDaOrganizacao(bancoQuebrado, "org-1", log)).toBe(FUSO_PADRAO);
+    expect(log.warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/o-turno-sabe-que-horas-sao.test.ts
+++ b/tests/unit/o-turno-sabe-que-horas-sao.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { renderAgora } from "@/lib/tempo/agora";
+import { renderAgora, rotuloLocal } from "@/lib/tempo/agora";
 import { FUSO_PADRAO } from "@/lib/tempo/fusos";
 import { fusoDaOrganizacao } from "@/lib/agent-engine/agent/fuso-da-org";
 
@@ -69,8 +69,13 @@ describe("renderAgora — o bloco que diz ao modelo que horas são", () => {
     // ANTES da chamada de modelo; um throw aqui mata o atendimento inteiro e o
     // sintoma chega ao dono como agente mudo.
     expect(() => renderAgora(INSTANTE, "America/Asunción")).not.toThrow();
-    expect(renderAgora(INSTANTE, "America/Asunción")).toContain(`(${FUSO_PADRAO})`);
-    expect(renderAgora(INSTANTE, "")).toContain(`(${FUSO_PADRAO})`);
+    // ⚠️ NÃO BASTA CONFERIR O RÓTULO ENTRE PARÊNTESES. Este caso já foi assim, e
+    // uma sabotagem o pegou passando: `renderAgora` que colasse
+    // "(America/Sao_Paulo)" no texto e formatasse a hora em UTC ficava verde.
+    // O que prova a degradação é a SAÍDA ser idêntica à do fuso padrão.
+    const comPadrao = renderAgora(INSTANTE, FUSO_PADRAO);
+    expect(renderAgora(INSTANTE, "America/Asunción")).toBe(comPadrao);
+    expect(renderAgora(INSTANTE, "")).toBe(comPadrao);
   });
 
   it("não cita ferramenta interna — o bloco entra no prompt de todo turno", () => {
@@ -126,5 +131,31 @@ describe("fusoDaOrganizacao — de onde sai o fuso, e o que acontece quando ele 
 
     expect(await fusoDaOrganizacao(bancoQuebrado, "org-1", log)).toBe(FUSO_PADRAO);
     expect(log.warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("rotuloLocal — o horário que o agente OFERECE à pessoa", () => {
+  it("põe o dia da semana e a hora da parede daquele fuso", () => {
+    // 17:00Z = 14:00 em São Paulo, sexta.
+    expect(rotuloLocal(new Date("2026-09-04T17:00:00Z"), "America/Sao_Paulo")).toBe(
+      "sexta-feira 04/09 às 14:00",
+    );
+  });
+
+  it("o FUSO MUDA O RÓTULO — é o controle que reprova o ISO cru", () => {
+    const instante = new Date("2026-09-04T03:30:00Z");
+    expect(rotuloLocal(instante, "America/Sao_Paulo")).toBe("sexta-feira 04/09 às 00:30");
+    expect(rotuloLocal(instante, "America/Manaus")).toBe("quinta-feira 03/09 às 23:30");
+  });
+
+  it("não leva ano nem instante técnico — isso é do bloco do turno, não de cada horário", () => {
+    // Ele se repete uma vez por horário oferecido; o ISO já vai no campo ao lado.
+    const r = rotuloLocal(new Date("2026-09-04T17:00:00Z"), "America/Sao_Paulo");
+    expect(r).not.toContain("2026");
+    expect(r).not.toContain("instante_absoluto");
+  });
+
+  it("fuso inválido degrada em vez de derrubar a lista de horários", () => {
+    expect(() => rotuloLocal(new Date("2026-09-04T17:00:00Z"), "America/Asunción")).not.toThrow();
   });
 });


### PR DESCRIPTION
## O defeito

O agente **tinha as cinco ferramentas de agenda montadas no turno** — está no log
do worker de uma instalação real, nos testes do dono do produto — e não marcava
nada. O paciente pedia "quinta às 14h" e a resposta era sempre "vou confirmar com
a equipe".

Eram **três** defeitos, em camadas diferentes. Nenhum deles era o modelo, e
consertar um só não resolveria:

**1. O runtime nunca dizia que dia era hoje.** O ritual de abertura entrega
checkpoint, funil, notas e histórico — e nenhum relógio; o follow-up entrega um
DELTA ("passaram 3 horas"), que responde "há quanto tempo" e não "que dia é".
`crm_book_appointment` exige `starts_at` como instante absoluto e
`crm_schedule_followup` exige `promised_at` no mesmo formato: sem data, o modelo
não tem de onde tirar nenhum dos dois.

A prova de que isso doía em produção não é teórica — o system prompt de um agente
real tinha um parágrafo chamado *"Você não tem relógio, mas tem carimbo"*,
ensinando a IA a inferir a data pelo timestamp da última mensagem. Contorno de
prompt para um buraco de runtime, que cada tenant teria de reinventar sozinho.

**2. Nenhuma capacidade do catálogo listava os tipos de atendimento.** Quatro das
cinco ferramentas exigem `event_type_slug`, e o modelo não tinha como descobrir
quais existem — na organização medida eram `atendimento`, `call-estrategica`,
`consulta`, `hof-e-botox` e `reuniao`. Ele adivinhava e recebia
`tipo_desconhecido`, cuja mensagem ainda mandava *"use um dos tipos que a
organização oferece"*: uma instrução impossível de cumprir.

**3. (fora deste PR, é configuração)** O system prompt daquele agente nunca citou
uma ferramenta de agenda. `crm_find_free_slots` e `crm_list_appointments` não
aparecem uma única vez nele, embora a última seção exija "um horário marcado"
como desfecho obrigatório.

## O que este PR faz

### O relógio do turno (`6392ef2f`)

`renderAgora(agora, fuso)` — dia da semana por extenso, data e hora locais, mais
o `instante_absoluto` em ISO, que é o formato exato que as ferramentas exigem de
volta. Entra no **sufixo por-lead**, nunca no `system`: lá é o prefixo cacheável
org-wide, e um relógio ali invalidaria o cache de prompt de todos os leads a cada
turno.

O ponto escolhido (`openingSuffixes`, em `executarTurnoDoAgente`) cobre os **três**
turnos conversacionais de uma vez e alcança de carona a chamada de fechamento,
que é onde nasce o `prazo` ISO da declaração. Junto vão o briefing do Operador —
que é quem executa a promessa com prazo — e o planejador de tempo do follow-up,
que tinha um `## Agora` cru com `toISOString()`: dois blocos com o mesmo nome e
formatos diferentes viram dois vocabulários.

**A fonte do fuso é `organizations.timezone`, não `channel_knobs.timezone`.** A
segunda está à mão dentro do turno, o que faz dela a escolha tentadora — e errada:
nada no repo a semeia a partir da organização, então numa clínica de Manaus que
nunca abriu o painel anti-ban ela é o literal de São Paulo. Uma hora de erro,
calada, em toda consulta marcada. Numa org paulista as duas coincidem e nenhum
teste veria diferença; por isso o invariante usa uma org de Manaus.

Falha **aberta** em toda borda: `Intl.DateTimeFormat` lança `RangeError` num fuso
que não existe, `organizations.timezone` não é validado por escritor nenhum, e o
bloco é montado ANTES da chamada de modelo — um throw ali mataria o atendimento e
chegaria ao dono como agente mudo.

### As capacidades que faltavam (`bc9702ee`)

- **`crm_list_event_types`** — o que destrava tudo. Devolve o **slug** e não o
  uuid: o slug existe justamente para dar à IA um handle que ela não alucina.
- **`crm_confirm_appointment`** — a régua "agendou e não confirmou" dependia de
  uma capacidade que não existia.
- **`crm_set_appointment_outcome`** — `completed` / `no_show`.

As duas escritas são fachada fina sobre `alterarAgendamentoHandler`, que já
aceitava os três status desde antes: faltava a fachada, não o domínio.

**O coletor é compartilhado.** `calendar_event_types` era lida em QUATRO lugares
independentes, cada um com o seu recorte e nenhum chamando o outro — a mesma
situação que o cabeçalho de `consulta.ts` descreve para os horários, com o mesmo
desfecho: a tela e a IA respondendo por regras diferentes sobre o que a clínica
atende. A rota `/api/v1/agenda/tipos` passou a chamar `listaTiposDeAtendimento`,
e os 15 campos que ela publicava continuam saindo — campo que some de uma rota
`/api/v1/` é quebra de contrato.

**`crm_find_free_slots`** passou a devolver `quando` ("sexta-feira 04/09 às
14:00") ao lado do ISO, com teto e espalhamento por dia. Não havia teto nenhum:
medido no formato anterior, a chamada padrão de 14 dias devolvia **177 horários**
(~3.600 tokens) e o teto de 62 dias, 788. É caro e é pior que caro — um modelo
com 177 opções escolhe mal. Cortar pela cabeça enviesaria (24 horários numa grade
de 30min são um dia e meio, e "semana que vem" voltaria só com amanhã), então o
corte espalha pelos dias, e a resposta diz `total_de_horarios` e `ha_mais`: lista
cortada não pode ser lida como agenda cheia.

### Uma guarda que não existia

Nada impedia registrar `completed`/`no_show` num compromisso **futuro** — nenhuma
comparação com o relógio em todo o handler. Enquanto só gente escrevia pela tela
isso custava pouco (os botões moram no histórico); deixa de custar pouco com um
modelo decidindo por texto, a partir de uma conversa onde o paciente disse "não
vou poder ir amanhã".

O dano do `no_show` prematuro é físico: `no_show` está em `LIBERAM_O_HORARIO`,
então ele **devolve ao pool** um horário que a pessoa ainda espera — outro cliente
marca em cima e os dois chegam na mesma hora. A guarda mora no handler, não na
ferramenta: a regra não é sobre quem chama, e uma guarda na tool deixaria a rota
`PATCH` aberta com aparência de protegida.

## Medições

| Verificação | Resultado |
|---|---|
| `pnpm typecheck` (pós-merge com a `main`) | exit=0 |
| Testes das duas mudanças + gates do catálogo | 312 casos verdes, 12 arquivos |
| `pnpm test:db` do invariante novo | 3/3, exit=0, baseline install+update ok |
| `pnpm release:conferir` | válido — 1.10.1 + minor = 1.11.0 |

**Reconciliação dos vermelhos**, medida contra a mesma base e não presumida:

- `test:unit` completo: as falhas que sobraram existem na base também; as quatro
  divergentes **passam quando rodadas sozinhas** (flaky sob carga). O único
  suspeito de verdade — `i18n-a-data-segue-o-idioma`, porque este PR mexe em data
  — **falha na `main` sem esta mudança**.
- `test:db` completo: 30 falhas na branch, **37 na `main` pura**, e as 30 e as 37
  são **todas timeout**. A base falha mais que a branch; é saturação da máquina de
  medição (load 50–85), não regressão.

## As guardas têm dentes — sabotagem medida

Cinco sabotagens, com a contagem **prevista antes** de rodar:

| Sabotagem | Previsto | Medido |
|---|---|---|
| `renderAgora` ignora o fuso | 3 | 2 |
| `renderAgora` usa `new Date()` em vez do relógio injetado | 3 | 3 |
| o bloco sai de `openingSuffixes` (o call site) | 0 no unitário | 0 |
| a guarda de tempo do handler é desligada | 2 | 2 |
| `espalhaPorDia` vira `slice(0, n)` | 1 | 1 |

A primeira errou a previsão, e o erro foi o achado mais útil: o caso do fuso
inválido conferia só o **rótulo** entre parênteses, então um `renderAgora` que
colasse `(America/Sao_Paulo)` e formatasse em UTC passava. Fechado — o caso agora
exige que a saída seja idêntica à do fuso padrão.

A terceira é o motivo de o invariante existir: com o bloco fora da abertura, o
teste unitário fica **9/9 verde**. Quem guarda o call site é
`tests/invariants/o-turno-diz-ao-modelo-que-dia-e-hoje.test.ts`, que roda o
handler real e lê o prompt que de fato saiu.

## Para quem já tem agente publicado

**As capacidades novas não entram sozinhas em agente existente** — `tool_ids` é
retrato congelado da versão publicada. Para usá-las: *O que o agente pode fazer* →
religar o pacote **Vender** → publicar. Agente criado depois já nasce com elas.
Está escrito no fragmento em `.changes/`, que é o texto que o operador lê.

## Dívidas declaradas

- **Sem mapa de arquitetura** (DoD 13 pede ≥2 arestas). Não existe mapa de agenda
  no repo e nenhum gate cobra um; criar um cobrindo só as três tools novas seria
  parcial e enganoso.
- **Sem prova pela tela** (DoD 12). O que muda é motor e ferramenta, sem UI nova —
  a prova de verdade é uma conversa real no WhatsApp, e ela só existe depois do
  deploy.
- **A família de agenda está no teto.** Com as três novas, o pacote `reter` exige
  exatamente 25 contra o teto de 25 (medido pelo objeto, não por regex). Cabe, sem
  folga: a quarta capacidade de agenda torna a decisão do pacote `agendar`
  próprio — pendente com o maestro desde antes deste PR — pré-requisito, não luxo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F37LqMkUyGYaVYgYemsY3x
