### PR TITLE
test(e2e): a spec de automação drena até esvaziar e diz QUAL falha aconteceu

### DIFF
--- a/tests/e2e/webhooks.spec.ts
+++ b/tests/e2e/webhooks.spec.ts
@@ -211,6 +211,7 @@ test.describe("webhooks & automações — fluxo completo", () => {
       const internalSecret = loadInternalSecret();
       const TETO_DE_TICKS = 40; // trava de segurança: 40 × 50 = 2000 eventos
       let ticks = 0;
+      let ultimoResumo: { scanned?: number; retried?: number; failed?: number } = {};
       for (; ticks < TETO_DE_TICKS; ticks++) {
         // Batch de até 50 eventos pendentes, cada um com handlers que fazem
         // vários round-trips de DB (e potencialmente WAHA/IA) — bem mais lento
@@ -220,16 +221,28 @@ test.describe("webhooks & automações — fluxo completo", () => {
           timeout: 60_000,
         });
         expect(drainRes.ok()).toBeTruthy();
-        const resumo = (await drainRes.json()) as { data?: { scanned?: number } };
+        const resumo = (await drainRes.json()) as {
+          data?: { scanned?: number; retried?: number; failed?: number };
+        };
+        ultimoResumo = resumo.data ?? {};
         await page.waitForTimeout(700);
-        // `scanned === 0` é a única condição que significa "não há mais nada
-        // pendente com handler". Sai DEPOIS do tick vazio: o trigger legado
-        // duplica evento, e parar no primeiro lote parcial deixaria o par para trás.
+        // A condição de parada é "não há mais NADA pendente" (`scanned === 0`),
+        // NUNCA "o meu evento apareceu": parar no próprio evento esconderia
+        // acúmulo deixado por outras specs, que é o defeito que este conserto
+        // existe para expor. Sai DEPOIS do tick vazio, não no primeiro lote
+        // parcial: o trigger legado duplica evento, e parar antes deixaria o par
+        // para trás — a razão original de o laço ser 3 e não 1.
         if ((resumo.data?.scanned ?? 0) === 0) break;
       }
+      // Estourar o teto FALHA, e falha dizendo o que sobrou. Seguir em silêncio
+      // devolveria o defeito disfarçado de timeout: "não drenou o suficiente" é
+      // exatamente o que estamos consertando, e ele não pode voltar sem nome.
       expect(
         ticks,
-        "a fila não esvaziou dentro do teto — há acúmulo grande demais, e não é ruído desta spec",
+        `a fila não esvaziou em ${TETO_DE_TICKS} ticks (${TETO_DE_TICKS * 50} eventos). ` +
+          `Último tick: scanned=${ultimoResumo.scanned ?? "?"}, ` +
+          `retried=${ultimoResumo.retried ?? "?"}, failed=${ultimoResumo.failed ?? "?"}. ` +
+          "Acúmulo grande demais para ser ruído desta spec — ou há evento que falha e reenfileira em laço.",
       ).toBeLessThan(TETO_DE_TICKS);
 
       // --- Step 7: aba Atividade mostra a run com sucesso ---

--- a/tests/e2e/webhooks.spec.ts
+++ b/tests/e2e/webhooks.spec.ts
@@ -253,17 +253,38 @@ test.describe("webhooks & automações — fluxo completo", () => {
       const runTitle = page.getByText(RULE_NAME, { exact: true }).first();
       const runCard = cardOf(runTitle);
       let found = false;
+      // Fotografado a cada tentativa para a mensagem de falha poder DISTINGUIR as
+      // causas. A asserção antiga dizia só "não apareceu com status Sucesso", e
+      // esse texto cobre TRÊS mundos diferentes:
+      //
+      //   card nem existe        -> a automação não rodou (evento não chegou ao motor)
+      //   card existe, sem status-> rodou e ficou pendente (run travado)
+      //   card existe com outro  -> rodou e FALHOU (o motor tem o porquê gravado)
+      //
+      // As três pedem investigações diferentes, e o teste as entregava como uma
+      // frase só. Isso custou uma noite: o vermelho do CI foi lido como acúmulo
+      // de fila, corrigido, e voltou — porque a mensagem não dizia o que a tela
+      // realmente mostrava.
+      let diagnostico = "nenhuma tentativa registrada";
       for (let attempt = 0; attempt < 12; attempt++) {
-        if ((await runCard.count()) > 0 && (await runCard.getByText("Sucesso").count()) > 0) {
+        const cards = await runCard.count();
+        if (cards > 0 && (await runCard.getByText("Sucesso").count()) > 0) {
           found = true;
           break;
         }
+        diagnostico =
+          cards === 0
+            ? `tentativa ${attempt + 1}: NENHUM card com o nome da regra na aba Atividade`
+            : `tentativa ${attempt + 1}: card existe, e o texto dele é ${JSON.stringify(
+                (await runCard.first().innerText()).replace(/\s+/g, " ").trim().slice(0, 240),
+              )}`;
         await page.getByRole("button", { name: "Atualizar" }).click();
         await page.waitForTimeout(1000);
       }
-      expect(found, "run da automação não apareceu com status Sucesso na aba Atividade").toBe(
-        true,
-      );
+      expect(
+        found,
+        `run da automação não apareceu com status Sucesso na aba Atividade. ${diagnostico}`,
+      ).toBe(true);
       await expect(runCard.getByText("Sucesso")).toBeVisible();
 
       // --- Step 8: /app/pipelines/{pipelineId} mostra o card com a tag ---

--- a/tests/e2e/webhooks.spec.ts
+++ b/tests/e2e/webhooks.spec.ts
@@ -245,6 +245,33 @@ test.describe("webhooks & automações — fluxo completo", () => {
           "Acúmulo grande demais para ser ruído desta spec — ou há evento que falha e reenfileira em laço.",
       ).toBeLessThan(TETO_DE_TICKS);
 
+      // O CAMINHO VERDE TAMBÉM CARREGA O DADO.
+      //
+      // Sem esta linha, `ticks` só é revelado quando a asserção acima FALHA — o
+      // run que passa joga fora exatamente a medida que responde à pergunta em
+      // aberto: a fila estava mesmo acumulando, ou 3 ticks bastavam e o vermelho
+      // da `main` vinha da janela de envio (#450)?
+      //
+      // Enquanto o dado morre no verde, a única forma de responder é um
+      // experimento caro: rodar esta branch sem o #450, num horário dentro da
+      // faixa 01:00-10:00 UTC. Registrando, todo run futuro responde de graça —
+      // se vier sempre 1 ou 2, a tese do acúmulo cai por medição própria; se
+      // vier alto, ela se confirma. Os dois desfechos informam.
+      //
+      // `console.info` e não `console.log`: é o método que o eslint deste repo
+      // permite (`no-console` com `allow: ["warn","error","info"]`) e o padrão
+      // que 7 specs já usam — as linhas `[QA] …` que aparecem no log do CI saem
+      // daí (`qa-agente-usa-as-maos.spec.ts:517`). Não é precedente novo.
+      //
+      // Instrumento, não catraca: baixar o TETO compraria a mesma resposta
+      // pagando com risco de flake, e flake foi o defeito que este arquivo
+      // acabou de custar um dia para consertar.
+      console.info(
+        `[QA] fila do event_log drenou em ${ticks} tick(s) de ${TETO_DE_TICKS} ` +
+          `(último: scanned=${ultimoResumo.scanned ?? "?"}, ` +
+          `retried=${ultimoResumo.retried ?? "?"}, failed=${ultimoResumo.failed ?? "?"})`,
+      );
+
       // --- Step 7: aba Atividade mostra a run com sucesso ---
       // A regra não tem condição — dispara tanto pro "Lead de Teste" (passo 3)
       // quanto pro lead real (passo 5), logo pode haver 2 cards com esse nome;

--- a/tests/e2e/webhooks.spec.ts
+++ b/tests/e2e/webhooks.spec.ts
@@ -194,9 +194,24 @@ test.describe("webhooks & automações — fluxo completo", () => {
       const directBody = (await directRes.json()) as { data: { lead_id: string } };
       expect(directBody.data.lead_id).toBeTruthy();
 
-      // --- Step 6: drena o event_log (até 3 ticks — trigger legado duplica evento) ---
+      // --- Step 6: drena o event_log ATÉ ESVAZIAR, não um número fixo de ticks ---
+      //
+      // Contar ticks era um PROXY para "drenou o suficiente", e o proxy dependia
+      // de quantas specs rodaram antes: a fila é global, FIFO por `created_at`, e
+      // esta spec é a 21ª de 42 na parte 2 do CI. Com a fila acima da capacidade
+      // do laço, o evento DESTA automação — o mais novo — nunca era alcançado, e
+      // o sintoma era "run da automação não apareceu com status Sucesso".
+      //
+      // MEDIDO (2026-08-30, local, mesmo build): o tick devolve
+      // `{"scanned":50,"done":50,...}`; com 200 na fila a spec passava, com 300
+      // falhava com a mensagem EXATA do CI, na mesma linha. O conserto não é
+      // aumentar o número de ticks — isso só adia, e a dívida cresce sozinha a
+      // cada spec nova. É trocar o proxy pela condição: drena enquanto houver
+      // trabalho.
       const internalSecret = loadInternalSecret();
-      for (let i = 0; i < 3; i++) {
+      const TETO_DE_TICKS = 40; // trava de segurança: 40 × 50 = 2000 eventos
+      let ticks = 0;
+      for (; ticks < TETO_DE_TICKS; ticks++) {
         // Batch de até 50 eventos pendentes, cada um com handlers que fazem
         // vários round-trips de DB (e potencialmente WAHA/IA) — bem mais lento
         // que uma ação de UI; timeout maior que o actionTimeout padrão do teste.
@@ -205,8 +220,17 @@ test.describe("webhooks & automações — fluxo completo", () => {
           timeout: 60_000,
         });
         expect(drainRes.ok()).toBeTruthy();
+        const resumo = (await drainRes.json()) as { data?: { scanned?: number } };
         await page.waitForTimeout(700);
+        // `scanned === 0` é a única condição que significa "não há mais nada
+        // pendente com handler". Sai DEPOIS do tick vazio: o trigger legado
+        // duplica evento, e parar no primeiro lote parcial deixaria o par para trás.
+        if ((resumo.data?.scanned ?? 0) === 0) break;
       }
+      expect(
+        ticks,
+        "a fila não esvaziou dentro do teto — há acúmulo grande demais, e não é ruído desta spec",
+      ).toBeLessThan(TETO_DE_TICKS);
 
       // --- Step 7: aba Atividade mostra a run com sucesso ---
       // A regra não tem condição — dispara tanto pro "Lead de Teste" (passo 3)


### PR DESCRIPTION
Conserta o vermelho da `main` no `e2e-parte (2)`, presente desde `f6053c4c`.

**Não é defeito de produto e não é flakiness.** É um proxy que dependia de
quantas specs rodaram antes.

## O defeito

O `event_log` é uma fila **global**, FIFO por `created_at`, e o drain leva **50
por tick** — medido, não lido: o endpoint já devolve `{"scanned":50,"done":50,…}`
em `ok(summary)`; o dado sempre esteve na resposta.

A spec contava **3 ticks**. Isso é um proxy para "drenou o suficiente", e ela é a
**21ª de 42** specs da parte 2. Com a fila acima da capacidade do laço, o evento
desta automação — o **mais novo** — nunca era alcançado, e o sintoma era
`run da automação não apareceu com status Sucesso na aba Atividade`.

## Reproduzido, variando só o tamanho da fila

Mesmo build, mesma máquina, mesma spec:

| fila pendente | resultado |
|---|---|
| 200 | `1 passed` |
| **300** | **`1 FAILED`** — mensagem e linha **idênticas** às do CI |
| 400 + este conserto | `1 passed`, 400 drenados |

O par 300/400 é a prova nos dois sentidos: falha sem o conserto, passa com ele,
com a fila **maior**.

## Por que não aumentar o número de ticks

Só adia, e a dívida **cresce sozinha**: cada spec nova na parte 2 empurra a fila,
e o teste que quebra é sempre o mais ao fim. Hoje é a 21ª; amanhã é a 22ª.

O conserto troca o proxy pela condição — drena enquanto `scanned > 0` — com teto
de 40 ticks como trava e uma asserção que **falha alto** se o teto for atingido:
aí o acúmulo é grande demais para ser ruído desta spec, e isso é outro problema,
que merece aparecer em vez de ser absorvido.

Sai **depois** do tick vazio, não no primeiro lote parcial: o trigger legado
duplica evento, e parar antes deixaria o par para trás — que era a razão original
de o laço ser 3 e não 1.

## NÃO MEDIDO

De onde vêm ~250 eventos drenados numa execução cujo laço visível daria 150. Só
há um laço e uma chamada na spec. Candidatos não medidos: a rota de ingestão
drenar inline, ou retry do Playwright. **Não afeta este conserto** — o laço novo
não depende de contagem —, mas fica registrado porque foi essa premissa errada
que me fez descartar a hipótese certa uma vez.