### PR TITLE
fix(e2e): a hora do CI deixa de ser entrada escondida das specs de automação

### DIFF
--- a/scripts/seed-e2e-numero-conectado.ts
+++ b/scripts/seed-e2e-numero-conectado.ts
@@ -86,6 +86,87 @@ async function main(): Promise<void> {
   creds.numero_conectado = { channel_session_id: id };
   fs.writeFileSync(CREDS_PATH, JSON.stringify(creds, null, 2));
   console.log(`[seed] número conectado (WORKING): ${id}`);
+
+  await garantirJanelaSempreAberta(admin, orgId);
+}
+
+/**
+ * A JANELA DE ENVIO É ENTRADA DO CENÁRIO, NÃO O RELÓGIO DE PAREDE.
+ *
+ * ═══ O defeito que esta função existe para fechar ════════════════════════════
+ *
+ * `automacao-diz-a-verdade` e `webhooks` reprovaram TODA branch cuja execução
+ * alcançasse ~22h BRT — inclusive a `main`, e inclusive uma branch que só
+ * mexia em documentação, que não tem como quebrar e2e por mérito próprio.
+ * Medido pelo horário em que a spec rodou, em 2026-08-30/31:
+ *
+ *     21:41 BRT -> passou   (main)
+ *     21:59 BRT -> falhou   (uma feature branch)
+ *     22:00 BRT -> falhou   (main)
+ *     22:24 BRT -> falhou   (branch SÓ DE DOCS)
+ *
+ * A causa é a janela anti-ban do produto, 7h-22h (`PACING_DEFAULTS`), com fim
+ * EXCLUSIVO (`insideWindow`: `h >= start && h < end`). Passadas as 22h,
+ * `postponeUntil` da ação de WhatsApp adia o envio, o motor grava um run com
+ * `status: 'adiado'` e a aba Atividade o rotula **"Aguardando envio"** — que
+ * não é "Sucesso" nem "Falhou". A spec então não acha o texto que procura, e o
+ * erro sai como `element(s) not found`: um sintoma que não fala de relógio
+ * nenhum, e que por isso custou horas a quem foi investigar.
+ *
+ * ═══ Por que TODAS as sessões da org, e não só a deste seed ══════════════════
+ *
+ * Porque quem paga o adiamento nem sempre é quem envia. A pré-checagem do
+ * motor é **all-or-nothing sobre o evento**: o primeiro adiamento encontrado
+ * aborta o evento INTEIRO, inclusive as regras que não mandam mensagem
+ * nenhuma. É assim que `webhooks.spec`, cuja ação é só "adicionar tag", caía
+ * junto — ela não tem como se adiar sozinha, e era derrubada por uma regra
+ * irmã de envio no mesmo gatilho.
+ *
+ * Abrir só a janela do número deste seed consertaria isso HOJE, porque hoje ele
+ * é a única sessão `WORKING` do rig. Isso é verdade por acidente, não por
+ * construção: a próxima spec que semear outra sessão reabre o buraco, e reabre
+ * contaminando terceiros. Varrer a org custa um `select` e fecha por desenho.
+ *
+ * ═══ O que isto NÃO é ════════════════════════════════════════════════════════
+ *
+ * Não é desligar o anti-ban, e não é baixar a régua de asserção nenhuma:
+ * "Falhou" continua tendo de aparecer como "Falhou". O caminho do ADIAMENTO
+ * segue coberto onde ele é determinístico — `tests/invariants/`, com relógio
+ * injetado. O que muda é só isto: a hora em que o CI roda deixa de ser uma
+ * entrada escondida do teste.
+ */
+export async function garantirJanelaSempreAberta(
+  admin: ReturnType<typeof createClient>,
+  orgId: string,
+): Promise<void> {
+  const { data: sessoes, error: erroSessoes } = await admin
+    .from("channel_sessions")
+    .select("id")
+    .eq("organization_id", orgId);
+  if (erroSessoes) throw new Error(`select channel_sessions: ${erroSessoes.message}`);
+
+  const linhas = (sessoes ?? []).map((s) => ({
+    organization_id: orgId,
+    channel_session_id: (s as { id: string }).id,
+    // 0..24 abre SEMPRE: `insideWindow` é `h >= start && h < end` sobre uma
+    // hora normalizada em 0..23. Os valores são EXPLÍCITOS porque coluna nula
+    // cai de volta no default de 7h-22h — que é justamente o que se quer sair.
+    window_start_hour: 0,
+    window_end_hour: 24,
+    // A guarda de domingo roda ANTES da faixa horária: sem ela, o buraco
+    // voltaria um dia por semana, e voltaria pior — o dia inteiro.
+    allow_sunday: true,
+  }));
+  if (linhas.length === 0) return;
+
+  const { error } = await admin
+    .from("channel_knobs")
+    .upsert(linhas as never, { onConflict: "organization_id,channel_session_id" });
+  // `throw`, nunca um aviso: um seed que falha calado devolve as specs ao
+  // regime antigo, e o vermelho volta a depender da hora — que é exatamente o
+  // modo de falha que esta função existe para matar.
+  if (error) throw new Error(`upsert channel_knobs: ${error.message}`);
+  console.log(`[seed] janela de envio fixada em 0h-24h (domingo liberado) em ${linhas.length} canal(is)`);
 }
 
 void main().catch((err) => {

--- a/tests/e2e/automacao-diz-a-verdade.spec.ts
+++ b/tests/e2e/automacao-diz-a-verdade.spec.ts
@@ -247,6 +247,17 @@ test.describe("a automação conta o que aconteceu de verdade", () => {
       // O WhatsApp está fora do ar neste ambiente, então a mensagem não saiu.
       // A tela tem que dizer isso — e NÃO pode dizer "Sucesso".
       await expect(cartao.getByText("Sucesso")).toHaveCount(0);
+      // ⚠️ E TAMBÉM NÃO PODE ESTAR ADIADO — esta linha é diagnóstico, não régua
+      // nova. Quando a janela de envio fecha, o run vira `adiado` e a tela o
+      // rotula "Aguardando envio": a asserção seguinte então falha com
+      // `element(s) not found`, um sintoma que não menciona relógio nenhum e que
+      // já custou horas de investigação. Com esta linha antes, a spec falha
+      // dizendo O QUE aconteceu. Quem garante que não acontece é o seed, que
+      // fixa a janela em 0h-24h (`garantirJanelaSempreAberta`).
+      await expect(
+        cartao.getByText("Aguardando envio"),
+        "o envio foi ADIADO (janela de envio fechada), não tentado — a janela do rig deveria estar aberta 0h-24h pelo seed",
+      ).toHaveCount(0);
       await expect(cartao.getByText("Falhou").first()).toBeVisible();
 
       // E tem que dizer o QUE conferir, em português — não `waha_error`.
@@ -254,13 +265,28 @@ test.describe("a automação conta o que aconteceu de verdade", () => {
         cartao.getByText(/serviço de WhatsApp|não está conectado/i).first(),
       ).toBeVisible();
     } finally {
+      // ⚠️ `page.request` (com os cookies do login), NUNCA o fixture `request`.
+      //
+      // O fixture é um `APIRequestContext` ANÔNIMO — não há `storageState` no
+      // `playwright.config.ts` —, e as duas rotas exigem `manager`. O DELETE
+      // voltava 401, o `.catch` engolia, e a regra de ENVIO ficava ATIVA na
+      // organização compartilhada, que nenhum passo desta suíte reseta.
+      //
+      // O estrago não ficava aqui. A pré-checagem de adiamento do motor é
+      // all-or-nothing sobre o evento: com uma regra de envio viva no gatilho
+      // "contato novo (webhook)", QUALQUER outra spec que dispare esse gatilho
+      // tem o evento inteiro abortado junto — foi assim que `webhooks.spec`,
+      // que só adiciona uma tag, passou a cair sem ter nada com WhatsApp.
+      //
+      // A própria spec já sabia da diferença: a leitura dos runs, mais acima,
+      // usa `page.request.get` justamente porque precisa estar autenticada.
       if (ruleId) {
-        await request
+        await page.request
           .delete(`${APP_URL}/api/v1/automation-rules/${ruleId}`)
           .catch(() => undefined);
       }
       if (sourceId) {
-        await request
+        await page.request
           .delete(`${APP_URL}/api/v1/webhook-sources/${sourceId}`)
           .catch(() => undefined);
       }

--- a/tests/e2e/webhooks.spec.ts
+++ b/tests/e2e/webhooks.spec.ts
@@ -100,6 +100,21 @@ test.describe("webhooks & automações — fluxo completo", () => {
   // com diagnóstico.
   test.use({ actionTimeout: 10_000 });
 
+  // ⚠️ ESTA SPEC NÃO ENVIA NADA, E MESMO ASSIM DEPENDE DA JANELA DE ENVIO.
+  //
+  // A ação dela é "adicionar tag", que nunca é adiada. Mas a pré-checagem de
+  // adiamento do motor é ALL-OR-NOTHING sobre o evento: basta uma regra irmã
+  // com ação de WhatsApp no mesmo gatilho estar fora da janela para o evento
+  // INTEIRO ser abortado — e aí a tag nunca executa, nenhum run é gravado, e a
+  // asserção de "Sucesso" mais abaixo estoura as 12 tentativas.
+  //
+  // Foi exatamente o que aconteceu a partir das 22h BRT, em toda branch, por um
+  // dia inteiro. O seed declara a janela do rig (0h-24h, `garantirJanelaSempreAberta`),
+  // e é ele que tira a hora do CI de dentro da conta deste teste.
+  test.beforeAll(() => {
+    execFileSync("npx", ["tsx", "scripts/seed-e2e-numero-conectado.ts"], { stdio: "inherit" });
+  });
+
   test("cria fonte, cria automação, dispara lead real, confere atividade e kanban; agent sem acesso", async ({
     page,
     request,

--- a/tests/unit/spec-de-envio-declara-a-janela.test.ts
+++ b/tests/unit/spec-de-envio-declara-a-janela.test.ts
@@ -1,0 +1,148 @@
+import { readdirSync, readFileSync } from "node:fs";
+import * as path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * SPEC QUE DEPENDE DE ENVIO NÃO HERDA A HORA DE PAREDE — a guarda da CLASSE.
+ *
+ * ═══ A classe, e por que ela reaparece ═══════════════════════════════════════
+ *
+ * "Teste que lê uma grandeza que ninguém declarou como ENTRADA." A guarda irmã
+ * (`agenda-spec-nao-escolhe-o-periodo-sozinha`) fechou a versão da AGENDA, onde
+ * a grandeza era *que dia é hoje*. Esta fecha a versão do ENVIO, onde a
+ * grandeza é *a janela de envio do canal está aberta?* — e ela custou um dia
+ * inteiro de CI antes de alguém desconfiar do relógio.
+ *
+ * Medido em 2026-08-30/31, pelo horário em que a spec rodou:
+ *
+ *     21:41 BRT -> passou   (main)
+ *     21:59 BRT -> falhou   (uma feature branch)
+ *     22:00 BRT -> falhou   (main)
+ *     22:24 BRT -> falhou   (branch SÓ DE DOCS)
+ *
+ * A última linha é a que fecha o diagnóstico: uma branch que só mexe em
+ * documentação não quebra e2e por mérito próprio. Mas o sintoma não dizia isso
+ * — dizia `expect(locator).toBeVisible() failed / element(s) not found` —, e um
+ * sintoma mudo faz cada pessoa que o encontra suspeitar do PRÓPRIO código
+ * primeiro. Foi o que aconteceu duas vezes em duas branches diferentes.
+ *
+ * ═══ O mecanismo ═════════════════════════════════════════════════════════════
+ *
+ * A janela anti-ban do produto é 7h-22h, com fim EXCLUSIVO. Passadas as 22h,
+ * a ação de WhatsApp adia o envio, o motor grava o run com `status: 'adiado'` e
+ * a aba Atividade o rotula "Aguardando envio" — que não é "Sucesso" nem
+ * "Falhou". A spec procura um texto que a tela, corretamente, não escreveu.
+ *
+ * E o dano não para em quem envia: a pré-checagem de adiamento é
+ * **all-or-nothing sobre o evento**, então o primeiro adiamento aborta o evento
+ * INTEIRO, inclusive as regras que não mandam mensagem nenhuma. É por isso que
+ * a régua abaixo cobre também a spec que só adiciona uma tag.
+ *
+ * ═══ A régua ═════════════════════════════════════════════════════════════════
+ *
+ * Existe UM lugar que declara a janela do rig — `garantirJanelaSempreAberta`,
+ * em `scripts/seed-e2e-numero-conectado.ts` — e toda spec que depende de uma
+ * automação executar tem de passar por ele, rodando o seed.
+ *
+ * ═══ O QUE ESTA GUARDA NÃO PEGA ══════════════════════════════════════════════
+ *
+ * Ela não lê o corpo da spec atrás de outras leituras de tempo, e não garante
+ * que o autor obedeça à regra em cada linha. Ela impede a REINCIDÊNCIA
+ * silenciosa: que a próxima spec de automação nasça herdando a hora do CI e
+ * fique verde até as 22h de algum dia. Guarda de fonte não substitui revisão.
+ *
+ * Também não cobre o caminho do ADIAMENTO em si — esse continua provado onde é
+ * determinístico, nos invariantes com relógio injetado. Fixar a janela no rig
+ * não desliga o anti-ban do produto; declara a entrada do teste.
+ */
+
+const RAIZ = process.cwd();
+const DIR_E2E = path.join(RAIZ, "tests/e2e");
+const SEED = "scripts/seed-e2e-numero-conectado.ts";
+
+/**
+ * Specs dispensadas, com o motivo escrito. Esta lista SÓ ENCOLHE — cada entrada
+ * é dívida declarada.
+ */
+const DISPENSADAS: Record<string, string> = {};
+
+/**
+ * Os sinais de que a spec depende de uma automação EXECUTAR.
+ *
+ * ⚠️ Lista ABERTA, e isso é lição paga: o detector da guarda irmã precisou
+ * crescer depois de nascer, porque uma spec dependia da mesma grandeza sem ter
+ * nenhum dos sinais escolhidos na primeira versão. Quem acrescentar um caminho
+ * novo de automação acrescenta o sinal aqui.
+ *
+ * Não procuramos `new Date()` no fonte da spec: a dependência não está no que a
+ * spec escreve, está no que o motor faz por baixo dela. Uma spec sem uma única
+ * data pode depender inteiramente da hora — as duas que originaram esta guarda
+ * eram assim.
+ */
+function dependeDeAutomacaoExecutar(fonte: string): boolean {
+  // Cria ou dispara automação, e afirma sobre o DESFECHO dela.
+  const mexeComAutomacao =
+    /automation-rules|Nova automação|Nova regra|aba-atividade|ActivityTab/.test(fonte) ||
+    /event-log-drain/.test(fonte);
+  const afirmaSobreODesfecho =
+    /getByText\("(Sucesso|Falhou|Parcial|Aguardando envio)"\)/.test(fonte) ||
+    /automation_rule_runs|status.*Sucesso na aba/.test(fonte);
+  return mexeComAutomacao && afirmaSobreODesfecho;
+}
+
+function specsDeAutomacao(): string[] {
+  return readdirSync(DIR_E2E)
+    .filter((f) => f.endsWith(".spec.ts"))
+    .filter((f) => dependeDeAutomacaoExecutar(readFileSync(path.join(DIR_E2E, f), "utf8")));
+}
+
+describe("spec que depende de envio não herda a hora de parede", () => {
+  it("a varredura ENCONTRA specs — uma lista vazia passaria por vacuidade", () => {
+    // O controle. Sem ele, quebrar o detector deixa a guarda VERDE sobre um
+    // conjunto vazio, que é a forma mais silenciosa de uma guarda morrer.
+    // O piso é 2 porque são exatamente as duas que originaram o defeito:
+    // `automacao-diz-a-verdade` e `webhooks`.
+    expect(specsDeAutomacao().length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("o módulo que declara a janela existe e abre 0h-24h, domingo incluído", () => {
+    // A régua depende de o seed de fato abrir a janela. Se alguém trocar os
+    // valores por 7-22 "para ficar igual à produção", a guarda das specs
+    // continuaria verde e o defeito voltaria inteiro.
+    const fonte = readFileSync(path.join(RAIZ, SEED), "utf8");
+    expect(fonte).toContain("export async function garantirJanelaSempreAberta");
+    expect(fonte).toMatch(/window_start_hour:\s*0/);
+    expect(fonte).toMatch(/window_end_hour:\s*24/);
+    // Domingo é avaliado ANTES da faixa horária: sem isto o buraco volta um dia
+    // por semana, e volta o dia inteiro.
+    expect(fonte).toMatch(/allow_sunday:\s*true/);
+  });
+
+  it("a janela é aberta para TODAS as sessões da org, não só para a deste seed", () => {
+    // Quem paga o adiamento nem sempre é quem envia: a pré-checagem do motor é
+    // all-or-nothing sobre o evento. Abrir só um canal conserta por acidente —
+    // enquanto ele for o único — e reabre o buraco na próxima sessão semeada.
+    const fonte = readFileSync(path.join(RAIZ, SEED), "utf8");
+    const corpo = fonte.slice(fonte.indexOf("garantirJanelaSempreAberta"));
+    expect(corpo).toContain('.from("channel_sessions")');
+    expect(corpo).toMatch(/\.eq\("organization_id", orgId\)/);
+  });
+
+  it("toda spec que depende de automação executar roda o seed que declara a janela", () => {
+    const faltando: string[] = [];
+    for (const spec of specsDeAutomacao()) {
+      if (spec in DISPENSADAS) continue;
+      const fonte = readFileSync(path.join(DIR_E2E, spec), "utf8");
+      if (!fonte.includes(SEED)) faltando.push(spec);
+    }
+
+    expect(
+      faltando,
+      `estas specs dependem de uma automação executar e não rodam \`${SEED}\`, ` +
+        "que é quem declara a janela de envio do rig. Sem ele, elas passam de dia e " +
+        "reprovam a partir das 22h — em qualquer branch, inclusive na main. " +
+        "Rode o seed no `beforeAll`, ou declare a dispensa em DISPENSADAS, com o motivo.",
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## O defeito

`automacao-diz-a-verdade` e `webhooks` reprovaram **toda branch** cuja execução
alcançasse ~22h BRT — inclusive a `main`, e inclusive uma branch que só mexia em
documentação, que não tem como quebrar e2e por mérito próprio. Medido pelo
horário em que a spec de fato rodou, em 2026-08-30/31:

| Quando a spec rodou | Resultado |
|---|---|
| 21:41 BRT | **passou** (`main`) |
| 21:59 BRT | falhou (feature branch) |
| 22:00 BRT | falhou (`main`) |
| 22:24 BRT | falhou (**branch só de docs**) |

A janela anti-ban é 7h–22h, com fim **exclusivo**. Passadas as 22h a ação de
WhatsApp adia o envio, o motor grava o run como `adiado`, e a aba Atividade o
rotula **"Aguardando envio"** — que não é "Sucesso" nem "Falhou". A spec procura
um texto que a tela, corretamente, não escreveu.

O que torna isso caro não é a falha, é o **sintoma**: `element(s) not found`, que
não menciona relógio nenhum. Duas pessoas, em duas branches diferentes, gastaram
tempo suspeitando do próprio código antes de alguém olhar o horário.

## São dois defeitos, e o segundo não é sobre hora

**1. A janela não era entrada declarada do rig.** `garantirJanelaSempreAberta`
passa a fixá-la em 0h–24h, domingo incluído — a guarda de domingo roda **antes**
da faixa horária, e deixá-la fora reabriria o buraco um dia por semana, o dia
inteiro.

Para **todas** as sessões da org, não só a deste seed. Quem paga o adiamento nem
sempre é quem envia: a pré-checagem do motor é all-or-nothing sobre o evento, e o
primeiro adiamento aborta o evento **inteiro**, inclusive as regras que não mandam
mensagem. É assim que `webhooks.spec`, cuja ação é só "adicionar tag", caía junto
— ela não tem como se adiar sozinha. Abrir só um canal consertaria hoje, porque
hoje ele é a única sessão `WORKING`; isso é verdade por acidente, não por
construção. Varrer a org custa um `select`.

**2. A limpeza da spec vazava — e era ela que ligava um defeito ao outro.** O
`request.delete` do cleanup usa o fixture **anônimo** (não há `storageState` no
config), as duas rotas exigem `manager`, e o 401 era engolido por um
`.catch(() => undefined)`. Cada execução deixava uma regra de **envio** ativa na
organização compartilhada, que nada nesta suíte reseta — e uma regra de envio viva
no gatilho "contato novo (webhook)" derruba, pela pré-checagem all-or-nothing,
qualquer outra spec que dispare o mesmo gatilho. Não só depois das 22h.

A própria spec já sabia da diferença: a leitura dos runs usa `page.request.get`
justamente por precisar de sessão.

## Nenhuma asserção foi afrouxada

Sem timeout maior, sem skip por hora, sem retry. "Falhou" continua tendo de
aparecer como "Falhou". Foi **acrescentada** uma asserção — `Aguardando envio` com
contagem zero — que não é régua nova, é diagnóstico: com ela a spec falha dizendo
*"o envio foi ADIADO (janela fechada)"* em vez de `element(s) not found`.

## A guarda, para a terceira instância não nascer

`tests/unit/spec-de-envio-declara-a-janela.test.ts` é irmã de
`agenda-spec-nao-escolhe-o-periodo-sozinha` e fecha a mesma classe — *"teste que
lê uma grandeza que ninguém declarou como entrada"* — do outro lado: lá a
grandeza era *que dia é hoje*, aqui é *a janela está aberta?*.

Ela cobra que toda spec que dependa de uma automação executar rode o seed, **e
cobra os valores do próprio seed**: trocar 0–24 por 7–22 "para ficar igual à
produção" deixaria as specs verdes e traria o defeito de volta inteiro.

O detector **não** procura `new Date()` no fonte da spec, de propósito: a
dependência não está no que a spec escreve, está no que o motor faz por baixo
dela. As duas specs que originaram este conserto não têm uma única data. Ele
também já provou seu valor antes do merge — foi ele que apontou que
`webhooks.spec` não rodava o seed.

## Medições

| Verificação | Resultado |
|---|---|
| `pnpm typecheck` | exit=0 |
| `pnpm exec eslint` (4 arquivos) | 0 erros (2 warnings `no-console`, o padrão já existente no seed) |
| guarda nova + guarda irmã + cobertura de e2e | 11 casos verdes |

**Sabotagem, com a contagem prevista antes de rodar — 1, 1 e 1, e as três bateram:**

| Sabotagem | Previsto | Medido |
|---|---|---|
| tirar o seed da `webhooks.spec` | 1 (a régua) | 1 |
| voltar a janela do seed para 7–22 | 1 (o módulo) | 1 |
| cegar o detector | 1 (o controle de vacuidade) | 1 |

## O que este PR não faz

- **Não muda o produto.** `PACING_DEFAULTS` continua 7h–22h; alargar a janela do
  produto para acalmar teste seria trocar proteção por verde.
- **Não tira cobertura do adiamento.** Ele segue provado onde é determinístico —
  nos invariantes, com relógio injetado. O que muda é só a hora em que o CI roda
  deixar de ser entrada escondida.
- **Sem fragmento em `.changes/`**: só toca teste e seed de teste, e nada muda
  para quem opera uma VPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F37LqMkUyGYaVYgYemsY3x
