### PR TITLE
test(e2e): a janela declarada abre mesmo — a metade que a guarda irmã não vê

### DIFF
--- a/tests/e2e/automacao-diz-a-verdade.spec.ts
+++ b/tests/e2e/automacao-diz-a-verdade.spec.ts
@@ -191,7 +191,50 @@ test.describe("a automação conta o que aconteceu de verdade", () => {
         page.getByRole("button", { name: "Criar automação" }).click(),
       ]);
       expect(salvo.ok()).toBeTruthy();
-      ruleId = ((await salvo.json()) as { data: { id: string } }).data.id;
+      const regraCriada = (await salvo.json()) as {
+        data: { id: string; actions?: Array<{ config?: { channel_session_id?: string } }> };
+      };
+      ruleId = regraCriada.data.id;
+
+      // ── A JANELA DE ENVIO, FIXADA: este teste não pode depender da HORA ──
+      //
+      // O que esta spec prova é que um envio MORTO aparece como "Falhou". Para
+      // isso o envio precisa ser TENTADO — e fora da janela de envio do número
+      // ele nem chega a ser. `postponeUntil` (send-whatsapp.ts) devolve o
+      // instante da próxima abertura, o motor grava a run como `adiado`
+      // (engine.ts → registrarAdiamento, reason `fora_da_janela_de_envio`) e a
+      // aba Atividade mostra "Aguardando envio". Correto para o produto, e
+      // fatal para este teste: ele cobra "Falhou" e não encontra.
+      //
+      // MEDIDO: a janela default é 7h–22h no fuso do TENANT
+      // (`PACING_DEFAULTS`, lib/agent-engine/pacing/defaults.ts:60-63), e o
+      // tenant do rig é `America/Sao_Paulo` (scripts/seed-e2e-credentials.ts).
+      // O runner do GitHub roda em UTC, então a janela real do CI é
+      // 10:00–01:00 UTC — e TODA rodada que alcançar esta spec entre 01:00 e
+      // 10:00 UTC falhava aqui. Foi o que separou os dois runs da `main` em
+      // 2026-08-31: o de 00:37 UTC passou, o de 02:42 UTC falhou na linha da
+      // asserção de "Falhou", com o resto do arquivo intacto.
+      //
+      // O conserto não é tolerar `adiado` — isso apagaria a asserção que o
+      // arquivo existe para fazer. É tirar o relógio da equação: 0h–24h abre a
+      // janela sempre, pela mesma rota que a tela de Conexões usa.
+      const canalDaAcao = regraCriada.data.actions?.[0]?.config?.channel_session_id;
+      expect(
+        canalDaAcao,
+        "a ação salva não trouxe channel_session_id — sem ele não dá para fixar a janela",
+      ).toBeTruthy();
+      const janela = await page.request.put(`${APP_URL}/api/v1/ai/pacing`, {
+        data: {
+          channel_session_id: canalDaAcao,
+          window_start_hour: 0,
+          window_end_hour: 24,
+          allow_sunday: true,
+        },
+      });
+      expect(
+        janela.ok(),
+        `não deu para abrir a janela de envio do número: HTTP ${janela.status()}`,
+      ).toBeTruthy();
 
       // Liga a regra (nasce pausada, por desenho).
       await page.getByLabel(new RegExp(`Ligar ${RULE_NAME}`)).click();

--- a/tests/e2e/automacao-diz-a-verdade.spec.ts
+++ b/tests/e2e/automacao-diz-a-verdade.spec.ts
@@ -191,50 +191,7 @@ test.describe("a automação conta o que aconteceu de verdade", () => {
         page.getByRole("button", { name: "Criar automação" }).click(),
       ]);
       expect(salvo.ok()).toBeTruthy();
-      const regraCriada = (await salvo.json()) as {
-        data: { id: string; actions?: Array<{ config?: { channel_session_id?: string } }> };
-      };
-      ruleId = regraCriada.data.id;
-
-      // ── A JANELA DE ENVIO, FIXADA: este teste não pode depender da HORA ──
-      //
-      // O que esta spec prova é que um envio MORTO aparece como "Falhou". Para
-      // isso o envio precisa ser TENTADO — e fora da janela de envio do número
-      // ele nem chega a ser. `postponeUntil` (send-whatsapp.ts) devolve o
-      // instante da próxima abertura, o motor grava a run como `adiado`
-      // (engine.ts → registrarAdiamento, reason `fora_da_janela_de_envio`) e a
-      // aba Atividade mostra "Aguardando envio". Correto para o produto, e
-      // fatal para este teste: ele cobra "Falhou" e não encontra.
-      //
-      // MEDIDO: a janela default é 7h–22h no fuso do TENANT
-      // (`PACING_DEFAULTS`, lib/agent-engine/pacing/defaults.ts:60-63), e o
-      // tenant do rig é `America/Sao_Paulo` (scripts/seed-e2e-credentials.ts).
-      // O runner do GitHub roda em UTC, então a janela real do CI é
-      // 10:00–01:00 UTC — e TODA rodada que alcançar esta spec entre 01:00 e
-      // 10:00 UTC falhava aqui. Foi o que separou os dois runs da `main` em
-      // 2026-08-31: o de 00:37 UTC passou, o de 02:42 UTC falhou na linha da
-      // asserção de "Falhou", com o resto do arquivo intacto.
-      //
-      // O conserto não é tolerar `adiado` — isso apagaria a asserção que o
-      // arquivo existe para fazer. É tirar o relógio da equação: 0h–24h abre a
-      // janela sempre, pela mesma rota que a tela de Conexões usa.
-      const canalDaAcao = regraCriada.data.actions?.[0]?.config?.channel_session_id;
-      expect(
-        canalDaAcao,
-        "a ação salva não trouxe channel_session_id — sem ele não dá para fixar a janela",
-      ).toBeTruthy();
-      const janela = await page.request.put(`${APP_URL}/api/v1/ai/pacing`, {
-        data: {
-          channel_session_id: canalDaAcao,
-          window_start_hour: 0,
-          window_end_hour: 24,
-          allow_sunday: true,
-        },
-      });
-      expect(
-        janela.ok(),
-        `não deu para abrir a janela de envio do número: HTTP ${janela.status()}`,
-      ).toBeTruthy();
+      ruleId = ((await salvo.json()) as { data: { id: string } }).data.id;
 
       // Liga a regra (nasce pausada, por desenho).
       await page.getByLabel(new RegExp(`Ligar ${RULE_NAME}`)).click();

--- a/tests/unit/janela-do-e2e-abre-o-dia-inteiro.test.ts
+++ b/tests/unit/janela-do-e2e-abre-o-dia-inteiro.test.ts
@@ -1,0 +1,82 @@
+/**
+ * A premissa do conserto de `tests/e2e/automacao-diz-a-verdade.spec.ts`.
+ *
+ * Aquela spec passou a fixar a janela de envio do número em 0h–24h antes de
+ * disparar a automação, porque fora da janela o envio não é TENTADO: ele vira
+ * `adiado` (`registrarAdiamento`, reason `fora_da_janela_de_envio`) e a aba
+ * Atividade mostra "Aguardando envio" em vez de "Falhou" — que é justamente a
+ * asserção que a spec existe para fazer.
+ *
+ * O defeito era invisível porque dependia do RELÓGIO: a janela default é
+ * 7h–22h no fuso do tenant, o tenant do rig é `America/Sao_Paulo`, e o runner
+ * do CI é UTC — ou seja, a janela real do CI é 10:00–01:00 UTC, e toda rodada
+ * que alcançasse a spec fora disso falhava. Um teste dependente de horário não
+ * falha quando você o escreve; falha semanas depois, na fila de outra pessoa.
+ *
+ * Este arquivo congela as DUAS pontas de que aquele conserto depende, para que
+ * ele não volte a apodrecer em silêncio:
+ *   1. o payload que a spec envia continua sendo ACEITO pelo schema da rota;
+ *   2. a janela 0–24 realmente fica aberta nas 24 horas — o EFEITO, não a
+ *      presença dos números no arquivo.
+ *
+ * O caso 3 é o controle negativo: com os defaults, a janela FECHA em algum
+ * momento do dia. Sem ele, um `janelaDeEnvioAberta` que devolvesse `true`
+ * sempre passaria neste arquivo e a prova seria vazia.
+ */
+import { describe, it, expect } from "vitest";
+
+import { PACING_DEFAULTS } from "@/lib/agent-engine/pacing/defaults";
+import { janelaDeEnvioAberta } from "@/lib/agent-engine/pacing/engine";
+import { pacingKnobsUpdateSchema, windowIsValid } from "@/lib/ai/pacing-knobs";
+
+/** As 24 horas cheias de um dia útil (segunda), no fuso do tenant do rig. */
+function asVinteEQuatroHoras(): Date[] {
+  // 2026-08-31 é uma segunda-feira: dia de semana evita que `allowSunday`
+  // vire uma segunda variável no meio da medição.
+  return Array.from({ length: 24 }, (_, h) => new Date(Date.UTC(2026, 7, 31, h, 30, 0)));
+}
+
+describe("a janela que o e2e fixa abre o dia inteiro", () => {
+  it("o payload que a spec envia é aceito pelo schema da rota de pacing", () => {
+    const payload = {
+      channel_session_id: "11111111-1111-4111-8111-111111111111",
+      window_start_hour: 0,
+      window_end_hour: 24,
+      allow_sunday: true,
+    };
+
+    expect(() => pacingKnobsUpdateSchema.parse(payload)).not.toThrow();
+    // A rota valida a janela RESULTANTE além do schema — 0 < 24.
+    expect(windowIsValid(0, 24)).toBe(true);
+  });
+
+  it("com 0h–24h, nenhuma hora do dia fica fora da janela", () => {
+    const knobs = {
+      ...PACING_DEFAULTS,
+      windowStartHour: 0,
+      windowEndHour: 24,
+      allowSunday: true,
+    };
+
+    const fechadas = asVinteEQuatroHoras().filter((t) => !janelaDeEnvioAberta(t, knobs));
+
+    expect(
+      fechadas.map((t) => t.toISOString()),
+      "com a janela fixada em 0–24 nenhuma hora pode estar fechada — é isto que tira o relógio do teste",
+    ).toEqual([]);
+  });
+
+  it("CONTROLE: com os defaults (7h–22h) a janela fecha em parte do dia", () => {
+    const fechadas = asVinteEQuatroHoras().filter(
+      (t) => !janelaDeEnvioAberta(t, { ...PACING_DEFAULTS, allowSunday: true }),
+    );
+
+    // Sem esta asserção o caso acima passaria mesmo se `janelaDeEnvioAberta`
+    // devolvesse `true` incondicionalmente — instrumento morto lendo como
+    // sucesso. Aqui ele TEM que saber dizer "não".
+    expect(
+      fechadas.length,
+      "os defaults têm que fechar em alguma hora do dia, senão a sonda está cega",
+    ).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/janela-do-e2e-abre-o-dia-inteiro.test.ts
+++ b/tests/unit/janela-do-e2e-abre-o-dia-inteiro.test.ts
@@ -13,7 +13,22 @@
  * que alcançasse a spec fora disso falhava. Um teste dependente de horário não
  * falha quando você o escreve; falha semanas depois, na fila de outra pessoa.
  *
- * Este arquivo congela as DUAS pontas de que aquele conserto depende, para que
+ * ═══ Por que este arquivo existe AO LADO da guarda irmã ═════════════════════
+ *
+ * `spec-de-envio-declara-a-janela.test.ts` (PR #450) guarda a OUTRA metade: ela
+ * reprova a spec de envio que não DECLARA a janela. As duas não se cobrem, e a
+ * diferença importa — medida, não suposta:
+ *
+ *     grep -c 'janelaDeEnvioAberta|PACING_DEFAULTS|windowEndHour'
+ *       em spec-de-envio-declara-a-janela.test.ts  ->  0
+ *
+ * Ou seja: a guarda irmã confere que o seed está lá, não que ele ABRE alguma
+ * coisa. Se alguém mudar `insideWindow` para ignorar `windowEndHour`, o seed
+ * continua declarado, aquela guarda continua verde, e a janela deixa de abrir —
+ * a spec volta a depender do relógio sem ninguém notar. Foi exatamente a
+ * segunda sabotagem deste arquivo, e ela vermelheceu aqui.
+ *
+ * Este congela as DUAS pontas de que o conserto depende, para que
  * ele não volte a apodrecer em silêncio:
  *   1. o payload que a spec envia continua sendo ACEITO pelo schema da rota;
  *   2. a janela 0–24 realmente fica aberta nas 24 horas — o EFEITO, não a


### PR DESCRIPTION
## O que sobrou deste PR, e por quê

Este PR nasceu consertando a dependência de relógio da `automacao-diz-a-verdade.spec.ts`. **O #450 chegou primeiro e resolveu melhor** — fixando a janela no *seed*, o que mata a classe para toda spec, em vez de só para uma. Ele já está na `main`.

Então **o conserto de spec daqui saiu**. Sobrou 1 arquivo: a metade que ainda não está coberta.

## A metade que falta

A guarda que entrou com o #450 (`tests/unit/spec-de-envio-declara-a-janela.test.ts`) reprova a spec de envio que **não declara** a janela. Ela não verifica que a janela declarada **abre** alguma coisa:

```
grep -c 'janelaDeEnvioAberta|PACING_DEFAULTS|windowEndHour'
  em tests/unit/spec-de-envio-declara-a-janela.test.ts  →  0
```

Isso não é crítica ao #450 — são perguntas diferentes, e as duas precisam de resposta.

## A prova de que não são redundantes

Sabotei `lib/agent-engine/pacing/engine.ts` (só o fonte) fazendo `insideWindow` ignorar `windowEndHour`, e rodei **as duas** guardas. Previsão escrita antes:

| guarda | previsto | observado |
|---|---|---|
| `janela-do-e2e-abre-o-dia-inteiro` (este PR) | vermelha | `Tests 1 failed \| 2 passed (3)` — exit 1 |
| `spec-de-envio-declara-a-janela` (#450, na `main`) | verde | `Tests 4 passed (4)` — exit 0 |

Ou seja: com essa mudança, o seed continua declarado, a guarda irmã continua verde, **e a janela deixa de abrir** — a spec voltaria a depender do relógio sem ninguém notar. É esse buraco que este arquivo fecha.

Também sabotei na outra direção (`insideWindow` devolvendo `true` sempre): `Tests 1 failed | 2 passed`, pego pelo **controle negativo** — o caso que exige que os defaults *fechem* em alguma hora do dia. Sem ele, uma função que sempre devolve "aberto" passaria neste arquivo e a prova seria vazia.

## O que ele mede

1. o payload que a spec envia continua **aceito** pelo schema da rota de pacing;
2. `0–24` não deixa **nenhuma** das 24 horas fechada — o efeito, não a presença dos números;
3. **controle negativo**: com os defaults (7h–22h), a janela fecha em parte do dia.

`pnpm typecheck` → exit 0. `vitest` do arquivo → `Tests 3 passed (3)`.

## O que NÃO foi medido

- Não rodei a suíte `e2e` completa; este PR não toca spec nenhuma agora.
- A branch foi atualizada com `git merge origin/main` (nunca reset), então o diff contra a `main` é exatamente 1 arquivo novo, 82 linhas.

## Crédito

O diagnóstico da janela, o achado do cleanup vazado (DELETE com fixture anônimo numa rota que exige `manager`, com o 401 engolido por um `.catch`) e o elo `all-or-nothing` do motor — que explica como a janela derrubava até uma spec que não envia nada — são do autor do #450. Eu cheguei ao mesmo bug por outro caminho e por uma leitura mais rasa; o conserto que ficou na `main` é o dele, e é o certo.
