### PR TITLE
fix(ia): o uuid que o modelo inventa deixa de virar filtro

### DIFF
--- a/.changes/uuid-inventado-pela-ia-nao-vira-filtro.md
+++ b/.changes/uuid-inventado-pela-ia-nao-vira-filtro.md
@@ -1,0 +1,24 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O atendente de IA volta a achar horário quando consulta a agenda
+---
+
+Numa clínica, o atendente de IA tentou marcar um procedimento e não conseguiu —
+duas vezes seguidas. Ele fez tudo certo: descobriu o tipo de atendimento,
+resolveu a data que a pessoa pediu e foi consultar os horários. Mesmo assim
+respondeu que a equipe precisava confirmar, e abriu um chamado interno.
+
+A causa não era a agenda nem o atendente. Quando a IA não tem um dado opcional
+para preencher — no caso, qual profissional atenderia —, alguns modelos escrevem
+um código vazio em vez de simplesmente não mandar o campo. O sistema aceitava
+esse código como se fosse um profissional de verdade, procurava a agenda de
+alguém que não existe, e concluía que não havia horário publicado. Nenhum erro
+aparecia em lugar nenhum: a consulta era registrada como bem-sucedida.
+
+O sistema agora reconhece esses códigos vazios e os ignora, voltando a usar o
+profissional configurado no tipo de atendimento. Isso valia para dezenas de
+lugares além da agenda — inclusive a busca no acervo de conhecimento, em que o
+efeito era o atendente responder "não sei" com o material publicado ao lado, e o
+cadastro de negócios, em que um responsável inexistente ficava gravado e sumia
+dos filtros por dono.

--- a/lib/ai/runtime/tools.ts
+++ b/lib/ai/runtime/tools.ts
@@ -21,6 +21,7 @@ import type { McpAuthResult } from "@/lib/mcp/auth";
 import { logger } from "@/lib/logger";
 import { allTools, getToolByName } from "@/lib/mcp/tools";
 import { catalogEntry } from "@/lib/mcp/tools/catalog";
+import { higienizarUuidsDeAterro } from "@/lib/mcp/uuid-de-aterro";
 import { recusaDeCapacidadeParaOModelo } from "@/lib/mcp/recusa-para-o-modelo";
 import type { McpContext, McpToolDefinition } from "@/lib/mcp/types";
 import { resolveActiveLeadForContact, type LeadCandidate } from "@/lib/leads/active-lead";
@@ -68,7 +69,31 @@ function wrapMcpTool(
     inputSchema,
     execute: async (args: unknown) => {
       const startedAt = Date.now();
-      const argsRecord = (args ?? {}) as Record<string, unknown>;
+      // ── O UUID QUE O MODELO INVENTA PARA "NÃO SEI" ────────────────────────
+      //
+      // Aqui, na fronteira, e não em cada handler. Medido em produção: um
+      // agente mandou `owner_user_id: "00000000-…"` num campo OPCIONAL, o
+      // `?? tipo.default_owner_user_id` do outro lado não caiu no default
+      // porque o valor não era `undefined`, e a agenda de um usuário que não
+      // existe voltou vazia. A paciente ficou sem consulta e a chamada está no
+      // audit com `success: true` — não havia erro para investigar.
+      //
+      // O catálogo tem 28 campos de uuid que aceitam ausência, e todos vazavam
+      // a mesma sentinela. Consertar por handler seria consertar por instância:
+      // o 29º nasceria fora. Ver `lib/mcp/uuid-de-aterro.ts`.
+      const higiene = higienizarUuidsDeAterro(
+        def.inputSchema as Record<string, z.ZodTypeAny>,
+        (args ?? {}) as Record<string, unknown>,
+      );
+      const argsRecord = higiene.limpos;
+      if (higiene.descartados.length > 0) {
+        // Não é cosmético: sem esta linha o defeito passa a se curar em
+        // silêncio e ninguém descobre que um modelo faz isso o tempo todo.
+        logger.info("uuid de aterro descartado do payload da tool", {
+          tool: def.name,
+          campos: higiene.descartados.join(","),
+        });
+      }
       try {
         ensureScope(input.auth.scopes, def.requiresScope);
         ensureRole(input.auth.role, def.requiresRole);

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -10,11 +10,13 @@
  *     MCP fica no metadata, nao no JSON-RPC error envelope).
  */
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { z } from "zod";
 
 import { createAdminClient } from "@/lib/supabase/admin";
 import { auditMcpToolCall } from "./audit";
 import { ensureRole, ensureScope, type McpAuthResult } from "./auth";
 import { allTools } from "./tools";
+import { higienizarUuidsDeAterro } from "./uuid-de-aterro";
 import type { McpContext } from "./types";
 
 const SERVER_NAME = "deskcomm-crm";
@@ -47,7 +49,17 @@ export function createMcpServer(auth: McpAuthResult, requestId: string): McpServ
       },
       async (rawArgs) => {
         const startedAt = Date.now();
-        const args = (rawArgs ?? {}) as Record<string, unknown>;
+        // A MESMA higiene do outro ingresso (`lib/ai/runtime/tools.ts`), pela
+        // mesma razão: um uuid de aterro em campo opcional vira filtro por um
+        // id que não existe, e o resultado vazio é lido como "não há". Aqui é o
+        // caminho do MCP externo; lá é o do agente. Os dois entram no mesmo
+        // handler, então os dois higienizam — deixar um de fora seria fechar a
+        // porta e esquecer a janela. Ver `lib/mcp/uuid-de-aterro.ts`.
+        const higiene = higienizarUuidsDeAterro(
+          tool.inputSchema as Record<string, z.ZodTypeAny>,
+          (rawArgs ?? {}) as Record<string, unknown>,
+        );
+        const args = higiene.limpos;
         const ctx: McpContext = {
           organizationId: auth.organizationId,
           role: auth.role,

--- a/lib/mcp/uuid-de-aterro.ts
+++ b/lib/mcp/uuid-de-aterro.ts
@@ -1,0 +1,120 @@
+/**
+ * O UUID QUE O MODELO INVENTA PARA "NÃO SEI" — e por que ele não pode virar filtro.
+ *
+ * ─── O defeito, medido em produção ──────────────────────────────────────────
+ *
+ * Um agente de clínica tentou marcar Botox para uma quinta-feira. Ele fez tudo
+ * certo: descobriu os tipos de atendimento, achou o slug `hof-e-botox`,
+ * consultou os horários livres. Duas tentativas seguidas falharam, e o audit
+ * mostra por quê — o argumento que ele mandou:
+ *
+ *     crm_find_free_slots { event_type_slug: "hof-e-botox",
+ *                           owner_user_id: "00000000-0000-0000-0000-000000000000" }
+ *
+ * O campo é OPCIONAL. O modelo, em vez de omiti-lo, preencheu com o uuid nil —
+ * o jeito dele de dizer "não tenho esse dado". E `input.owner_user_id ?? null`
+ * só trata `undefined`: o nil passou, virou o dono da agenda em
+ * `params.ownerUserId ?? tipo.default_owner_user_id`, a jornada de um usuário
+ * que não existe veio vazia, e o produto concluiu que a agenda não estava
+ * publicada. O agente então fez o que deve fazer quando não há horário: não
+ * inventou nenhum, avisou que a equipe confirmaria, e abriu um caso para um
+ * humano. Comportamento certo sobre um dado envenenado.
+ *
+ * A paciente ficou sem consulta, e não havia erro em lugar nenhum para
+ * investigar — as duas chamadas estão no audit com `success: true`.
+ *
+ * ─── Por que o Zod não pega, e por que isso é bom ───────────────────────────
+ *
+ * `z.string().uuid()` ACEITA a nil e a max de propósito: as duas são UUIDs
+ * válidos pela RFC 9562, e o regex do zod as allowlista em letra, ao lado da
+ * forma v1–v8. Não é falha da validação — é a especificação.
+ *
+ * A consequência é boa para nós: o conjunto do que passa é FECHADO e tem dois
+ * elementos. Todo o resto do lixo que um modelo poderia inventar (`""`,
+ * `"null"`, `"none"`, `"0"`) já é recusado pelo `safeParse`. Medido no zod
+ * deste repo.
+ *
+ * ⚠️ E um uuid v4 ALUCINADO, bem formado, NÃO entra aqui e não deve entrar: ele
+ * é indistinguível de um id legítimo nesta fronteira. Quem trata aquele caso é
+ * o desfecho nomeado lá embaixo — "não encontrei esse compromisso" —, que já
+ * existe e ensina o modelo. Ampliar este predicado para "id que não resolve"
+ * seria mover uma decisão de negócio para dentro de um utilitário de borda.
+ */
+
+/** As duas formas que o Zod deixa passar, e as únicas. */
+const NIL = "00000000-0000-0000-0000-000000000000";
+const MAX = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+
+/**
+ * ⚠️ A nil COM MÁSCARA DE VERSÃO também entra.
+ *
+ * Um modelo que "sabe" que uuid v4 tem um `4` e um `8` produz
+ * `00000000-0000-4000-8000-000000000000` — todos os dígitos significativos em
+ * zero, com os nibbles de versão e variante preenchidos para parecer legítimo.
+ * Pela RFC não é a nil; pela intenção é a mesma coisa, e pelo efeito também:
+ * não casa com linha nenhuma. Por isso o teste abaixo é sobre os HEX
+ * SIGNIFICATIVOS, e não uma comparação com duas constantes.
+ */
+function todosOsHexIguais(valor: string, digito: string): boolean {
+  const hex = valor.toLowerCase().replace(/-/g, "");
+  if (hex.length !== 32) return false;
+  // Posição 12 é a versão e 16 é a variante: os dois nibbles que um modelo
+  // preenche para o valor "parecer" um uuid. Ignorá-los é o que faz este
+  // predicado pegar a nil mascarada sem deixar de pegar a nil crua.
+  return hex
+    .split("")
+    .every((c, i) => i === 12 || i === 16 || c === digito);
+}
+
+/**
+ * Este uuid é a forma que um modelo usa para dizer "não sei"?
+ *
+ * Só isso — não responde se o id EXISTE. Um id inexistente mas bem formado
+ * segue caminho normal e recebe a recusa nomeada de quem sabe respondê-la.
+ */
+export function ehUuidDeAterro(valor: unknown): boolean {
+  if (typeof valor !== "string") return false;
+  const v = valor.trim().toLowerCase();
+  if (v === NIL || v === MAX) return true;
+  return todosOsHexIguais(v, "0") || todosOsHexIguais(v, "f");
+}
+
+/**
+ * Apaga do payload as chaves em que o modelo pôs um uuid de aterro — e SÓ as
+ * que o schema permite estarem ausentes.
+ *
+ * ⚠️ APAGA A CHAVE, não escreve `null`. É a diferença entre consertar e trocar
+ * de defeito: os call sites fazem `input.owner_user_id ?? tipo.default_owner_user_id`
+ * e `input.assistente_id ?? ctx.actor.id`. Com a chave ausente, o `??` cai no
+ * lado certo e TODOS eles voltam a funcionar sem que nenhum precise mudar.
+ * Escrever `null` faria o `??` cair igual, mas quebraria os que testam
+ * `if (params.x)` esperando `undefined` — e, pior, um campo com
+ * `.nullable().default(null)` passaria a receber uma decisão em vez do default
+ * dele. Ausência é o único valor que significa "o modelo não disse".
+ *
+ * ⚠️ E SÓ PARA O OPCIONAL. Num campo obrigatório — `appointment_id` — apagar a
+ * chave trocaria uma recusa que ENSINA ("não encontrei esse compromisso,
+ * confirme com `crm_list_appointments`") por um erro de validação de protocolo,
+ * que o modelo lê pior e que não diz o que fazer em seguida. Quem decide não é
+ * uma lista de nomes: é o próprio schema, perguntado se aceita a ausência.
+ */
+export function higienizarUuidsDeAterro(
+  shape: Record<string, { safeParse: (v: unknown) => { success: boolean } }>,
+  args: Record<string, unknown>,
+): { limpos: Record<string, unknown>; descartados: string[] } {
+  const limpos: Record<string, unknown> = { ...args };
+  const descartados: string[] = [];
+
+  for (const [campo, valor] of Object.entries(args)) {
+    if (!ehUuidDeAterro(valor)) continue;
+    const schemaDoCampo = shape[campo];
+    // Campo que o schema não conhece: o Zod vai recusá-lo de qualquer forma.
+    if (schemaDoCampo === undefined) continue;
+    // A pergunta que decide, e ela é feita ao SCHEMA: este campo pode faltar?
+    if (!schemaDoCampo.safeParse(undefined).success) continue;
+    delete limpos[campo];
+    descartados.push(campo);
+  }
+
+  return { limpos, descartados };
+}

--- a/tests/unit/o-seam-higieniza-o-uuid-do-modelo.test.ts
+++ b/tests/unit/o-seam-higieniza-o-uuid-do-modelo.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * O SEAM HIGIENIZA — não basta a função saber.
+ *
+ * ═══ Por que este arquivo existe, separado do irmão ═════════════════════════
+ *
+ * `uuid-de-modelo-nao-vira-filtro.test.ts` prova uma propriedade de
+ * `higienizarUuidsDeAterro`: dado o schema e o payload, ela apaga a chave certa.
+ * Isso é verdade e é insuficiente — porque uma função correta que ninguém chama
+ * não protege nada.
+ *
+ * Medido, não suposto: sabotei o ingresso (`lib/ai/runtime/tools.ts`, trocando
+ * `higiene.limpos` de volta pelos args crus) e os SETE casos do arquivo irmão
+ * ficaram verdes. É o modo de falha que o repo já catalogou — guarda que mede a
+ * função e não o call site.
+ *
+ * Aqui a asserção é sobre a CADEIA INTEIRA: monta a ferramenta como o turno do
+ * agente a monta (`pickToolsFromMcp`), executa com a sentinela que o modelo
+ * mandou em produção, e lê o que chegou lá no fim — na COLETA, que é quem faz a
+ * consulta. Se qualquer elo do caminho parar de higienizar, este caso cai.
+ *
+ * ═══ O caso real que ele reproduz ═══════════════════════════════════════════
+ *
+ *     crm_find_free_slots { event_type_slug: "hof-e-botox",
+ *                           owner_user_id: "00000000-0000-0000-0000-000000000000" }
+ *
+ * Com o zerado passando, `params.ownerUserId ?? tipo.default_owner_user_id`
+ * escolhe o zerado, a jornada de um usuário que não existe volta vazia, e o
+ * agente conclui que a agenda não foi publicada. A paciente ficou sem consulta.
+ */
+
+const NIL = "00000000-0000-0000-0000-000000000000";
+const BOM = "fb8061a5-27c0-4b13-9728-833b8f06828a";
+
+// A coleta é o FIM da cadeia: é ela quem recebe o `ownerUserId` e consulta a
+// jornada. Espiá-la aqui é o que torna a asserção sobre o caminho, e não sobre
+// a função de higiene.
+vi.mock("@/lib/agenda/consulta", async (original) => {
+  const real = await original<typeof import("@/lib/agenda/consulta")>();
+  return { ...real, horariosLivresDaOrg: vi.fn() };
+});
+// O audit escreve no Supabase e não é o objeto desta medição.
+vi.mock("@/lib/mcp/audit", () => ({ auditMcpToolCall: vi.fn().mockResolvedValue(undefined) }));
+
+const { horariosLivresDaOrg } = await import("@/lib/agenda/consulta");
+const { pickToolsFromMcp } = await import("@/lib/ai/runtime/tools");
+
+function montarTurno() {
+  return pickToolsFromMcp({
+    toolIds: ["crm_find_free_slots"],
+    auth: {
+      organizationId: "org-1",
+      role: "ai_operator",
+      scopes: ["mcp:read", "mcp:write"],
+      actor: { type: "ai_agent", id: "ag-1", role: "ai_operator" },
+      apiTokenId: "tok-1",
+    },
+    ctx: {
+      organizationId: "org-1",
+      role: "ai_operator",
+      actor: { type: "ai_agent", id: "ag-1", role: "ai_operator" },
+      apiTokenId: "tok-1",
+      requestId: "req-1",
+    },
+    supabase: {} as never,
+    pipelineIds: null,
+    handoffToolEnabled: false,
+  } as never);
+}
+
+async function executarComOwner(owner: string): Promise<Record<string, unknown> | undefined> {
+  vi.mocked(horariosLivresDaOrg).mockResolvedValue({
+    ok: true,
+    slots: [],
+    fusoDaRegra: "America/Sao_Paulo",
+    publicouHorarios: true,
+    fusoSuposto: false,
+    fontesDefasadas: [],
+    agendaExternaNuncaLida: false,
+  } as never);
+
+  const tools = montarTurno();
+  const alvo = tools["crm_find_free_slots"] as unknown as {
+    execute: (a: unknown) => Promise<unknown>;
+  };
+  expect(alvo, "pickToolsFromMcp não montou crm_find_free_slots").toBeTruthy();
+
+  await alvo.execute({ event_type_slug: "hof-e-botox", dias_a_frente: 7, owner_user_id: owner });
+
+  // O 3º argumento da coleta é o objeto de parâmetros — é lá que o dono chega.
+  return vi.mocked(horariosLivresDaOrg).mock.calls[0]?.[2] as Record<string, unknown> | undefined;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("o seam do agente higieniza o uuid inventado pelo modelo", () => {
+  it("o uuid de aterro NÃO chega à consulta — o dono do tipo volta a valer", async () => {
+    const params = await executarComOwner(NIL);
+
+    expect(params, "a coleta não chegou a ser chamada").toBeTruthy();
+    // `null` é o que o handler passa quando a chave não veio, e é o que faz
+    // `?? tipo.default_owner_user_id` escolher o dono real do atendimento.
+    expect(params?.ownerUserId).toBeNull();
+    expect(params?.ownerUserId).not.toBe(NIL);
+  });
+
+  it("um dono LEGÍTIMO atravessa intacto — a higiene não come dado bom", async () => {
+    // O controle. Sem ele, uma higiene que apagasse `owner_user_id` sempre
+    // satisfaria o caso acima e quebraria o agendamento com dono escolhido.
+    const params = await executarComOwner(BOM);
+
+    expect(params?.ownerUserId).toBe(BOM);
+  });
+});

--- a/tests/unit/uuid-de-modelo-nao-vira-filtro.test.ts
+++ b/tests/unit/uuid-de-modelo-nao-vira-filtro.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { allTools } from "@/lib/mcp/tools";
+import { ehUuidDeAterro, higienizarUuidsDeAterro } from "@/lib/mcp/uuid-de-aterro";
+
+/**
+ * O UUID QUE O MODELO INVENTA NÃO PODE VIRAR FILTRO — a guarda da CLASSE.
+ *
+ * ═══ O defeito, medido em produção ═══════════════════════════════════════════
+ *
+ * Um agente de clínica tentou marcar Botox numa quinta-feira e não conseguiu,
+ * duas vezes. Ele tinha feito tudo certo — descobriu os tipos de atendimento,
+ * achou o slug, foi consultar horário. O audit mostra o argumento:
+ *
+ *     crm_find_free_slots { event_type_slug: "hof-e-botox",
+ *                           owner_user_id: "00000000-0000-0000-0000-000000000000" }
+ *
+ * Campo OPCIONAL, preenchido com o uuid nil em vez de omitido. Do outro lado,
+ * `input.owner_user_id ?? tipo.default_owner_user_id` não caiu no default,
+ * porque o valor não era `undefined`. A agenda de um usuário que não existe
+ * voltou vazia, o produto concluiu "ninguém publicou horário", e o agente fez o
+ * certo sobre o dado errado: não inventou horário e abriu caso para um humano.
+ *
+ * A paciente ficou sem consulta. As duas chamadas estão no audit com
+ * `success: true` — não havia erro em lugar nenhum para investigar.
+ *
+ * ═══ Por que a guarda é da CLASSE, e não daquele campo ═══════════════════════
+ *
+ * Porque o campo não tem nada de especial. Medido no catálogo inteiro: são 60+
+ * ferramentas e dezenas de campos de uuid que aceitam ausência, e ANTES do
+ * conserto todos vazavam a mesma sentinela. Entre eles, dois que fazem pior que
+ * a agenda:
+ *
+ *   - `crm_search_knowledge.assistente_id` — o nil sobrescreve a identidade do
+ *     próprio agente (`?? ctx.actor.id`), e ele conclui que não tem acervo. O
+ *     sintoma é a IA responder "não sei" com a base publicada ao lado.
+ *   - `crm_create_lead` / `crm_update_lead.owner_user_id` — a coluna não tem FK,
+ *     então o dono fantasma PERSISTE: o negócio some do filtro por dono e das
+ *     métricas. A leitura errada morre no próximo turno; esta fica no banco.
+ *
+ * Consertar por instância deixaria o próximo campo nascer fora. Esta guarda
+ * pergunta a propriedade a TODO o catálogo, e a pergunta é feita ao SCHEMA.
+ *
+ * ═══ Por que só a nil e a max, e não "id que não existe" ════════════════════
+ *
+ * Porque o conjunto do que o Zod deixa passar é FECHADO e tem essas duas
+ * formas: `z.string().uuid()` as allowlista em letra, por serem UUIDs válidos
+ * pela RFC 9562. Todo o resto do lixo (`""`, `"null"`, `"none"`) já é recusado
+ * no `safeParse`.
+ *
+ * Um uuid v4 ALUCINADO, bem formado, fica de fora de propósito: nesta fronteira
+ * ele é indistinguível de um id legítimo, e quem trata aquele caso é a recusa
+ * nomeada lá embaixo ("não encontrei esse compromisso"), que já existe e ensina
+ * o modelo. Guarda de borda não decide negócio.
+ */
+
+/** As sentinelas — o que um modelo escreve quando quer dizer "não sei". */
+const NIL = "00000000-0000-0000-0000-000000000000";
+const MAX = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+/** A nil vestida de v4, que um modelo "caprichoso" produz. */
+const NIL_MASCARADA = "00000000-0000-4000-8000-000000000000";
+/** Um uuid legítimo — o controle que separa "sentinela" de "uuid qualquer". */
+const BOM = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+
+type Shape = Record<string, z.ZodTypeAny>;
+
+/** O campo é um uuid? Perguntado ao schema, com controle negativo. */
+function ehCampoUuid(s: z.ZodTypeAny): boolean {
+  return (
+    s.safeParse(BOM).success &&
+    !s.safeParse("nao-e-uuid").success &&
+    !s.safeParse("zzzzzzzz-zzzz-4zzz-8zzz-zzzzzzzzzzzz").success
+  );
+}
+
+/** O campo aceita ausência? É isto que separa opcional de obrigatório. */
+function aceitaAusencia(s: z.ZodTypeAny): { sim: boolean; valor: unknown } {
+  const r = s.safeParse(undefined);
+  return { sim: r.success, valor: r.success ? r.data : undefined };
+}
+
+interface CampoUuid {
+  tool: string;
+  campo: string;
+  schema: z.ZodTypeAny;
+}
+
+function camposDeUuid(): { opcionais: CampoUuid[]; obrigatorios: CampoUuid[] } {
+  const opcionais: CampoUuid[] = [];
+  const obrigatorios: CampoUuid[] = [];
+  for (const t of allTools) {
+    for (const [campo, schema] of Object.entries((t.inputSchema ?? {}) as Shape)) {
+      if (typeof schema?.safeParse !== "function") continue;
+      if (!ehCampoUuid(schema)) continue;
+      (aceitaAusencia(schema).sim ? opcionais : obrigatorios).push({ tool: t.name, campo, schema });
+    }
+  }
+  return { opcionais, obrigatorios };
+}
+
+describe("o uuid que o modelo inventa não vira filtro", () => {
+  it("a varredura ENCONTRA campos — uma lista vazia passaria por vacuidade", () => {
+    // O controle. Sem ele, quebrar `ehCampoUuid` deixa a guarda VERDE sobre um
+    // conjunto vazio — a forma mais silenciosa de uma guarda morrer. Os pisos
+    // são folgados de propósito: o que importa é não ser zero.
+    const { opcionais, obrigatorios } = camposDeUuid();
+    expect(opcionais.length).toBeGreaterThanOrEqual(20);
+    expect(obrigatorios.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("TODO campo de uuid opcional colapsa a sentinela para a ausência", () => {
+    // A régua. Não é "vira undefined": um campo `.nullable().default(null)` tem
+    // `null` como ausência, e exigir `undefined` dele seria falso positivo. A
+    // âncora é o que o PRÓPRIO campo devolve quando o modelo não o manda.
+    const vazam: string[] = [];
+    for (const { tool, campo, schema } of camposDeUuid().opcionais) {
+      const ausente = aceitaAusencia(schema).valor;
+      for (const sentinela of [NIL, MAX, NIL_MASCARADA]) {
+        const { limpos } = higienizarUuidsDeAterro({ [campo]: schema }, { [campo]: sentinela });
+        const depois = schema.safeParse(limpos[campo]);
+        if (depois.success && depois.data !== ausente) vazam.push(`${tool}.${campo}`);
+      }
+    }
+
+    expect(
+      [...new Set(vazam)].sort(),
+      "estes campos deixam o uuid inventado pelo modelo virar filtro. O efeito não é " +
+        "erro: é consulta que casa zero linhas e volta vazia, e o modelo lê o vazio como " +
+        '"não existe". Foi assim que uma paciente ficou sem consulta com a agenda livre.',
+    ).toEqual([]);
+  });
+
+  it("campo OBRIGATÓRIO não é tocado — a recusa que ensina vale mais que o silêncio", () => {
+    // Apagar a chave de um campo obrigatório trocaria "não encontrei esse
+    // compromisso, confirme com crm_list_appointments" por um erro de protocolo,
+    // que o modelo lê pior e que não diz o que fazer em seguida.
+    const { obrigatorios } = camposDeUuid();
+    for (const { campo, schema } of obrigatorios) {
+      const { limpos, descartados } = higienizarUuidsDeAterro({ [campo]: schema }, { [campo]: NIL });
+      expect(descartados).toEqual([]);
+      expect(limpos[campo]).toBe(NIL);
+    }
+  });
+
+  it("uuid LEGÍTIMO atravessa intacto — a guarda não pode comer dado bom", () => {
+    // O controle positivo do predicado. Sem ele, um `ehUuidDeAterro` que
+    // devolvesse `true` para tudo faria os dois casos acima passarem.
+    for (const { campo, schema } of camposDeUuid().opcionais) {
+      const { limpos, descartados } = higienizarUuidsDeAterro({ [campo]: schema }, { [campo]: BOM });
+      expect(descartados).toEqual([]);
+      expect(limpos[campo]).toBe(BOM);
+    }
+  });
+});
+
+describe("ehUuidDeAterro — o predicado", () => {
+  it("reconhece as formas que o Zod deixa passar", () => {
+    expect(ehUuidDeAterro(NIL)).toBe(true);
+    expect(ehUuidDeAterro(MAX)).toBe(true);
+    expect(ehUuidDeAterro(NIL_MASCARADA)).toBe(true);
+    expect(ehUuidDeAterro(MAX.toUpperCase())).toBe(true);
+  });
+
+  it("NÃO reconhece uuid legítimo, nem id inexistente bem formado", () => {
+    // A fronteira do predicado, e ela é deliberada: "não resolve" é pergunta de
+    // negócio, respondida lá embaixo com um desfecho que ensina o modelo.
+    expect(ehUuidDeAterro(BOM)).toBe(false);
+    expect(ehUuidDeAterro("11111111-1111-4111-8111-111111111111")).toBe(false);
+    expect(ehUuidDeAterro("")).toBe(false);
+    expect(ehUuidDeAterro(undefined)).toBe(false);
+    expect(ehUuidDeAterro(42)).toBe(false);
+  });
+
+  it("o Zod REALMENTE aceita as sentinelas — é por isso que esta guarda existe", () => {
+    // Se um dia o zod passar a recusá-las, este caso cai e a guarda inteira
+    // vira redundante. Melhor descobrir por um teste vermelho do que mantendo
+    // código que não protege mais nada.
+    const uuid = z.string().uuid();
+    expect(uuid.safeParse(NIL).success).toBe(true);
+    expect(uuid.safeParse(MAX).success).toBe(true);
+    expect(uuid.safeParse("").success).toBe(false);
+    expect(uuid.safeParse("null").success).toBe(false);
+  });
+});


### PR DESCRIPTION
## O defeito, medido em produção hoje

Um agente de clínica tentou marcar Botox numa quinta-feira e **falhou duas
vezes**. Ele tinha feito tudo certo — descobriu os tipos de atendimento, achou o
slug `hof-e-botox`, resolveu a data que a paciente pediu, foi consultar horário.
O audit mostra o argumento que ele mandou:

```
crm_find_free_slots { event_type_slug: "hof-e-botox",
                      owner_user_id: "00000000-0000-0000-0000-000000000000" }
```

Campo **opcional**, preenchido com o uuid nil em vez de omitido — o jeito que o
modelo tem de dizer *"não sei"*. Do outro lado, `input.owner_user_id ?? null` só
trata `undefined`: o nil passou, venceu `?? tipo.default_owner_user_id`, a
jornada de um usuário inexistente voltou vazia, e o produto concluiu que ninguém
publicou horário.

O agente então fez **o certo sobre o dado errado**: não inventou horário, avisou
que a equipe confirmaria, abriu caso para um humano. A paciente ficou sem
consulta — e as duas chamadas estão no audit com `success: true`. Não havia erro
em lugar nenhum para investigar.

## A classe é maior que o caso

A varredura do catálogo achou dezenas de campos de uuid que aceitam ausência, e
**todos** vazavam a mesma sentinela. Dois piores que a agenda:

| Campo | Efeito |
|---|---|
| `crm_search_knowledge.assistente_id` | o nil sobrescreve a identidade do próprio agente (`?? ctx.actor.id`); ele conclui que não tem acervo e responde **"não sei" com a base publicada ao lado** |
| `crm_create_lead` / `crm_update_lead.owner_user_id` | a coluna **não tem FK**, então o dono fantasma **persiste**: o negócio some do filtro por dono e das métricas |

A diferença importa: leitura errada morre no próximo turno; escrita errada fica
no banco.

## O conserto é na fronteira

Nos **dois ingressos** (o seam do agente e o servidor MCP), não em cada handler
— conserto por instância deixaria o próximo campo nascer fora, que é exatamente
como esta classe chegou até aqui.

**Apaga a chave, não escreve `null`.** É a ausência que faz
`?? tipo.default_owner_user_id` e `?? ctx.actor.id` caírem no lado certo, sem
que nenhum call site precise mudar. Escrever `null` funcionaria para o `??` e
quebraria quem testa `if (params.x)` — e um campo `.nullable().default(null)`
passaria a receber uma decisão em vez do default dele.

**E só no opcional.** Num campo obrigatório, apagar a chave trocaria uma recusa
que **ensina** ("não encontrei esse compromisso, confirme com
`crm_list_appointments`") por um erro de protocolo, que o modelo lê pior. Quem
decide não é uma lista de nomes: é o **próprio schema**, perguntado se aceita a
ausência — o que também cobre corretamente `.nullable().default(null)`, cuja
ausência é `null` e não `undefined`.

## O predicado NÃO é "id que não existe"

O conjunto que o zod deixa passar é **fechado**: nil e max são UUIDs válidos pela
RFC 9562 e o regex os allowlista em letra; todo o resto do lixo (`""`, `"null"`,
`"none"`) já é recusado no `safeParse`. Também entra a nil **vestida de v4**
(`00000000-0000-4000-8000-000000000000`), que um modelo "caprichoso" produz.

Um uuid v4 **alucinado** fica de fora **de propósito**: nesta fronteira ele é
indistinguível de um id legítimo, e quem trata aquele caso é o desfecho nomeado
lá embaixo, que já existe e ensina o modelo. Guarda de borda não decide negócio.

## Duas guardas — e a segunda existe por medição, não por zelo

1. **`uuid-de-modelo-nao-vira-filtro`** varre o catálogo inteiro e cobra a
   propriedade de todo campo opcional. Com controle de vacuidade, controle de
   uuid legítimo (a higiene não pode comer dado bom), e um caso que prova que o
   zod **realmente** aceita as sentinelas — se um dia recusar, ele cai e a guarda
   vira redundante em vez de ficar decorativa.

2. **`o-seam-higieniza-o-uuid-do-modelo`** mede a **cadeia**: monta a ferramenta
   por `pickToolsFromMcp` e lê o que chegou à coleta.

A segunda existe porque a primeira tem ponto cego **medido**: sabotei o ingresso
(trocando `higiene.limpos` pelos args crus) e os **7 casos da guarda 1 ficaram
verdes**. Função correta que ninguém chama não protege nada.

| Sabotagem | Guarda 1 | Guarda 2 |
|---|---|---|
| ingresso ignora a higiene | 7/7 verde ⚠️ | **1 reprovado** ✅ |

## Medições

| Verificação | Resultado |
|---|---|
| `pnpm typecheck` | exit=0 |
| `pnpm exec eslint` (5 arquivos) | 0 erros, 0 avisos |
| guardas novas + agenda + retenção + escopo de funil | **90 casos verdes**, 6 arquivos |

## O que este PR não faz

- **Não valida `owner_user_id` contra a organização.** `crm_leads.owner_user_id`
  não tem FK e `ownerPatchOrThrow` não o checa — a higiene tira o caso do modelo,
  mas um id errado bem formado ainda persiste um dono fantasma. Estender o check
  que `owner_agent_id` já tem é uma linha e merece commit próprio.
- **Não mexe no early return de `listaAgendamentos`**, que descarta em silêncio
  um `contact_id` válido quando o `lead_id` não tem vínculo. Com a higiene o caso
  do modelo some, mas a precedência lead→contato continua a mesma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F37LqMkUyGYaVYgYemsY3x
