### PR TITLE
fix(queue): backoff exponencial no retry de failJob

### DIFF
--- a/lib/agent-engine/queue/queue.ts
+++ b/lib/agent-engine/queue/queue.ts
@@ -258,6 +258,15 @@ export async function completeJob<T = void>(
  * Devolve o job à fila após falha (attempts já foi incrementado no claim). Excedeu
  * `max_attempts` → 'dead' + escalação humana em agent_inbox_items (kind='job_dead'), no
  * MESMO statement (atômico). Devolve null se o lease já não era deste worker.
+ *
+ * Backoff exponencial no retry (10s, 20s, 40s, 80s, capado em 120s — chave em
+ * `attempts`, já pós-incremento do claim): sem isso `run_after` fica intocado e
+ * o job cai `pending` já vencido, então o próximo `claimJobs` (poll de poucos
+ * segundos) o repega na hora. Contra um erro transitório de rate limit (TPM da
+ * OpenAI, por ex.) isso queima as 5 tentativas em menos de 1s — o rate limit não
+ * teve NENHUM tempo pra ceder entre uma tentativa e outra, e o job morre por um
+ * incidente que um minuto de espera resolveria sozinho. Caso real desta VPS,
+ * 2026-08-31: 49 jobs mortos em rajadas de poucos segundos, todos por TPM.
  */
 export async function failJob(
   db: Queryable,
@@ -269,6 +278,10 @@ export async function failJob(
     `with updated as (
        update job_queue
        set status = case when attempts >= max_attempts then 'dead' else 'pending' end,
+           run_after = case
+             when attempts >= max_attempts then run_after
+             else now() + (least(power(2, greatest(attempts - 1, 0)) * 10, 120) * interval '1 second')
+           end,
            locked_by = null, locked_at = null, last_error = $3
        where id = $1 and status = 'running' and locked_by = $2
        returning *


### PR DESCRIPTION
## Problema

Job que falha volta a `pending` sem nenhum atraso: `run_after` fica intocado
(já vencido), então o próximo `claimJobs` (poll de poucos segundos) repega o
job na hora.

Contra um erro **transitório** (rate limit de tokens/min do provedor de IA,
por exemplo) isso queima as 5 tentativas em menos de 1 segundo — sem dar
nenhum tempo pro limite ceder — e o job morre (`dead` + alerta crítico em
`agent_inbox_items`) por um incidente que um minuto de espera teria resolvido
sozinho.

Caso real (VPS de produção, 2026-08-31): 49 jobs (`inbound_turn` +
`followup_turn`, 24 contatos distintos) mortos em rajadas de poucos segundos,
todos por TPM da OpenAI estourado durante o disparo em lote de followups
(muitos followups agendados pro mesmo horário disparando juntos).

## Fix

`failJob` agora aplica backoff exponencial ao `run_after` antes de devolver o
job pra fila: 10s → 20s → 40s → 80s, capado em 120s (chave em `attempts`, já
pós-incremento do claim). ~2,5min de tolerância total antes de esgotar as 5
tentativas — o bastante pra um rate limit por minuto liberar. Quando
`attempts >= max_attempts` o job vai pra `dead` como antes, sem alterar
`run_after` (não importa mais).

## Validação

Lógica testada com uma tabela temporária (transação com rollback, sem tocar
dado real) simulando `attempts` 1 a 5 contra `max_attempts=5`:

```
 attempts | status  |  delay
----------+---------+----------
        1 | pending | 00:00:10
        2 | pending | 00:00:20
        3 | pending | 00:00:40
        4 | pending | 00:01:20
        5 | dead    | 00:00:00
```

Não achei teste existente que asserte "retry sem atraso" como invariante
(procurei em `tests/unit/handoff-por-orcamento.test.ts` e
`tests/invariants/queue-relogio.test.ts`) — a mudança não deveria quebrar
nada, mas não consegui rodar a suíte completa de invariantes nesta sessão
(o ambiente disponível tinha `docker` OU `node`, nunca os dois ao mesmo
tempo, e `test:db` precisa dos dois).

## Mitigação complementar (já aplicada na VPS, fora deste PR)

`CRON_STAGGER_WINDOW_MS` subiu de 60s (default) pra 5min nesta instalação,
pra espalhar mais o disparo de followups em lote — reduz a chance de uma
rajada estourar o TPM em primeiro lugar. Isso sozinho não bastava: uma vez
que a rajada acontece, é o backoff que evita a cascata de retries imediatos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)