### PR TITLE
fix(crm): fechar um negócio parou de emitir lead.won duas vezes

### DIFF
--- a/.changes/negocio-fechado-nao-avisa-duas-vezes.md
+++ b/.changes/negocio-fechado-nao-avisa-duas-vezes.md
@@ -1,0 +1,30 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Fechar um negócio parou de avisar duas vezes, e o card não some mais numa coluna arquivada
+---
+
+Toda vez que alguém marcava um negócio como ganho ou perdido, o sistema
+registrava o acontecimento **duas vezes**: uma pelo banco, que já fazia isso
+sozinho, e outra pelo aplicativo, que não sabia que o banco já tinha feito.
+Enquanto ninguém escutava esse registro, a duplicata era só ruído guardado. Ela
+deixou de ser inofensiva quando as notificações no navegador passaram a escutar
+exatamente esse aviso — daí em diante, um único negócio fechado tocava duas
+vezes no celular de quem estava acompanhando.
+
+Junto vinham duas coisas menores e do mesmo tipo, do jeito silencioso que
+incomoda mais do que erro barulhento:
+
+- Um funil cujo estágio de fechamento tinha sido **arquivado** continuava sendo
+  usado. O negócio era fechado numa coluna que ninguém mais vê, sem aviso
+  nenhum. Agora o sistema recusa e diz que falta um estágio de fechamento no
+  funil, que é o que de fato está acontecendo.
+- O card fechado caía em **posição aleatória** na coluna final, em vez de ir para
+  o fim dela. Quem trabalha olhando o quadro perdia o negócio de vista.
+
+Para quem opera, nada muda no dia a dia: nenhuma configuração nova, nenhum passo
+de atualização, nenhum dado a corrigir. O que muda é que o aviso passa a sair uma
+vez, e que fechar num funil mal configurado avisa em vez de sumir.
+
+O achado é de @prevprocesso-maker, que instalou o sistema para um cliente e
+percebeu a emissão em dobro lendo o próprio código.

--- a/app/api/v1/leads/[id]/lose/route.test.ts
+++ b/app/api/v1/leads/[id]/lose/route.test.ts
@@ -1,0 +1,61 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { requireRole } from "@/lib/auth/require-role";
+import { createClient } from "@/lib/supabase/server";
+
+vi.mock("@/lib/auth/require-role", () => ({ requireRole: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("@/lib/audit", () => ({ audit: vi.fn(async () => undefined) }));
+vi.mock("@/lib/leads/activity-emitter", () => ({
+  emitLeadActivity: vi.fn(async () => ({ ok: true })),
+}));
+vi.mock("@/lib/leads/activity-write-failure", () => ({
+  registraFalhaDeAtividade: vi.fn(async () => undefined),
+}));
+
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+const ORG_ID = "22222222-2222-4222-8222-222222222222";
+const LEAD_ID = "33333333-3333-4333-8333-333333333333";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requireRole).mockResolvedValue({
+    ok: true,
+    user: { id: USER_ID },
+    org: { orgId: ORG_ID },
+  } as never);
+  vi.mocked(createClient).mockResolvedValue({ from: vi.fn() } as never);
+});
+
+function request(body: string): NextRequest {
+  return new NextRequest(`http://localhost/api/v1/leads/${LEAD_ID}/lose`, {
+    method: "POST",
+    body,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("POST /api/v1/leads/[id]/lose", () => {
+  it("retorna lost_reason_required para body sem motivo", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(request("{}"), { params: Promise.resolve({ id: LEAD_ID }) });
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "lost_reason_required" },
+    });
+  });
+
+  it("mantém body malformado como erro de JSON", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(request("{"), { params: Promise.resolve({ id: LEAD_ID }) });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "body_malformed" },
+    });
+  });
+});

--- a/app/api/v1/leads/[id]/lose/route.ts
+++ b/app/api/v1/leads/[id]/lose/route.ts
@@ -47,6 +47,10 @@ export async function POST(
     return ok(lead, { requestId });
   } catch (err) {
     if (err instanceof ApiError) {
+      const fieldErrors = (err.details as { fieldErrors?: Record<string, unknown> } | undefined)?.fieldErrors;
+      if (err.code === "validation_error" && fieldErrors && "lost_reason" in fieldErrors) {
+        return fail("lost_reason_required", "Informe o motivo da perda.", 422, { requestId });
+      }
       return fail(err.code, err.message, err.status, {
         details: err.details as Record<string, unknown> | undefined,
         requestId,

--- a/lib/leads/encerramento.test.ts
+++ b/lib/leads/encerramento.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { HandlerCtx } from "@/lib/api/handlers/types";
+vi.mock("@/lib/audit", () => ({ audit: vi.fn(async () => undefined) }));
+vi.mock("@/lib/leads/activity-emitter", () => ({
+  emitLeadActivity: vi.fn(async () => ({ ok: true })),
+}));
+vi.mock("@/lib/leads/activity-write-failure", () => ({
+  registraFalhaDeAtividade: vi.fn(async () => undefined),
+}));
+
+import { encerraDemanda } from "./encerramento";
+
+const ORG = "11111111-1111-4111-8111-111111111111";
+const OTHER_ORG = "22222222-2222-4222-8222-222222222222";
+const PIPELINE = "33333333-3333-4333-8333-333333333333";
+const LEAD = "44444444-4444-4444-8444-444444444444";
+const OPEN_STAGE = "55555555-5555-4555-8555-555555555555";
+const WON_STAGE = "66666666-6666-4666-8666-666666666666";
+const LOST_STAGE = "77777777-7777-4777-8777-777777777777";
+
+const ctx: HandlerCtx = {
+  organization_id: ORG,
+  actor: { type: "user", id: "88888888-8888-4888-8888-888888888888" },
+  requestId: "99999999-9999-4999-8999-999999999999",
+};
+
+type Row = Record<string, unknown>;
+
+function makeDb({
+  leads = [],
+  stages = [],
+}: {
+  leads?: Row[];
+  stages?: Row[];
+} = {}) {
+  const tables: Record<string, Row[]> = {
+    crm_leads: leads,
+    crm_stages: stages,
+    crm_lead_activities: [],
+  };
+  const updates: Row[] = [];
+  const rpcs: string[] = [];
+
+  function from(table: string) {
+    const filters: Array<[string, unknown]> = [];
+    const orders: Array<[string, boolean]> = [];
+    let limit: number | undefined;
+    let patch: Row | undefined;
+    let operation: "select" | "update" | "insert" = "select";
+    let insertRow: Row | undefined;
+
+    const builder = {
+      select: () => {
+        operation = "select";
+        return builder;
+      },
+      update: (value: Row) => {
+        operation = "update";
+        patch = value;
+        updates.push(value);
+        return builder;
+      },
+      insert: (value: Row) => {
+        operation = "insert";
+        insertRow = value;
+        return builder;
+      },
+      eq: (column: string, value: unknown) => {
+        filters.push([column, value]);
+        return builder;
+      },
+      order: (column: string, options?: { ascending?: boolean }) => {
+        orders.push([column, options?.ascending ?? true]);
+        return builder;
+      },
+      limit: (value: number) => {
+        limit = value;
+        return builder;
+      },
+      maybeSingle: async () => {
+        const rows = [...(tables[table] ?? [])]
+          .filter((row) => filters.every(([column, value]) => row[column] === value))
+          .sort((a, b) => {
+            for (const [column, ascending] of orders) {
+              const diff = Number(a[column] ?? 0) - Number(b[column] ?? 0);
+              if (diff !== 0) return ascending ? diff : -diff;
+            }
+            return 0;
+          })
+          .slice(0, limit);
+        return { data: rows[0] ?? null, error: null };
+      },
+      then: async (resolve: (value: unknown) => unknown) => {
+        if (operation === "update") {
+          const rows = tables[table] ?? [];
+          for (const row of rows) {
+            if (filters.every(([column, value]) => row[column] === value)) {
+              Object.assign(row, patch);
+              const stage = stages.find((candidate) => candidate.id === row.stage_id);
+              if (stage?.is_won === true) {
+                row.status = "won";
+                row.closed_at ??= "2026-08-20T00:00:00.000Z";
+              } else if (stage?.is_lost === true) {
+                row.status = "lost";
+                row.closed_at ??= "2026-08-20T00:00:00.000Z";
+              }
+            }
+          }
+        } else if (operation === "insert" && insertRow) {
+          (tables[table] ??= []).push(insertRow);
+        }
+        return resolve({ data: null, error: null });
+      },
+    };
+
+    return builder;
+  }
+
+  return {
+    client: { from, rpc: async (name: string) => (rpcs.push(name), { error: null }) },
+    tables,
+    updates,
+    rpcs,
+  };
+}
+
+function baseLead(overrides: Row = {}): Row {
+  return {
+    id: LEAD,
+    organization_id: ORG,
+    pipeline_id: PIPELINE,
+    stage_id: OPEN_STAGE,
+    status: "open",
+    position_in_stage: 1000,
+    contact_id: null,
+    closed_at: null,
+    lost_reason: null,
+    value_cents: 1000,
+    currency: "BRL",
+    ...overrides,
+  };
+}
+
+function baseStages(overrides: Row = {}) {
+  return [
+    { id: OPEN_STAGE, organization_id: ORG, pipeline_id: PIPELINE, is_won: false, is_lost: false, is_archived: false, position: 1, name: "Aberto" },
+    { id: WON_STAGE, organization_id: ORG, pipeline_id: PIPELINE, is_won: true, is_lost: false, is_archived: false, position: 2, name: "Pago", ...overrides },
+    { id: LOST_STAGE, organization_id: ORG, pipeline_id: PIPELINE, is_won: false, is_lost: true, is_archived: false, position: 3, name: "Perdido" },
+  ];
+}
+
+describe("encerraDemanda", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("retorna lost_reason_required antes de consultar o banco", async () => {
+    const db = makeDb();
+
+    await expect(
+      encerraDemanda(db.client as never, ctx, { leadId: LEAD, desfecho: "lost", motivo: "  " }),
+    ).rejects.toMatchObject({ code: "validation_failed", status: 422 });
+    expect(db.updates).toEqual([]);
+    expect(db.rpcs).toEqual([]);
+  });
+
+  it("não usa stage terminal arquivado", async () => {
+    const db = makeDb({
+      leads: [baseLead()],
+      stages: baseStages({ is_archived: true }),
+    });
+
+    await expect(
+      encerraDemanda(db.client as never, ctx, { leadId: LEAD, desfecho: "won" }),
+    ).rejects.toMatchObject({ code: "pipeline_no_won_stage", status: 422 });
+    expect(db.updates).toEqual([]);
+  });
+
+  // O `.order("position")` da consulta não tinha guarda: sabotado sozinho, os
+  // sete casos ficavam verdes. Um funil com DUAS etapas de ganho é comum de
+  // verdade — "Pago" e "Pago parcial", "Fechado" e "Fechado com desconto" —, e
+  // sem ordem determinística o Postgres devolve qualquer uma das duas, o que faz
+  // o MESMO negócio cair em etapas diferentes entre uma execução e a seguinte.
+  // As etapas entram aqui na ordem INVERSA da posição de propósito: sem o
+  // `.order`, o dublê preserva a ordem de inserção e a asserção pega a errada.
+  it("entre duas etapas de ganho, escolhe a de menor posição — e não a primeira que o banco devolver", async () => {
+    const SEGUNDA_GANHO = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const db = makeDb({
+      leads: [baseLead()],
+      stages: [
+        { id: OPEN_STAGE, organization_id: ORG, pipeline_id: PIPELINE, is_won: false, is_lost: false, is_archived: false, position: 1, name: "Aberto" },
+        { id: SEGUNDA_GANHO, organization_id: ORG, pipeline_id: PIPELINE, is_won: true, is_lost: false, is_archived: false, position: 9, name: "Pago parcial" },
+        { id: WON_STAGE, organization_id: ORG, pipeline_id: PIPELINE, is_won: true, is_lost: false, is_archived: false, position: 2, name: "Pago" },
+      ],
+    });
+
+    await encerraDemanda(db.client as never, ctx, { leadId: LEAD, desfecho: "won" });
+
+    expect(db.updates[0]).toMatchObject({ stage_id: WON_STAGE });
+  });
+
+  it("move para o fim da stage, preserva a fonte única de evento e fecha como ganho", async () => {
+    const db = makeDb({
+      leads: [
+        baseLead(),
+        baseLead({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", stage_id: WON_STAGE, position_in_stage: 4000, status: "won" }),
+      ],
+      stages: baseStages(),
+    });
+
+    const result = await encerraDemanda(db.client as never, ctx, { leadId: LEAD, desfecho: "won" });
+
+    expect(result.lead).toMatchObject({ status: "won", stage_id: WON_STAGE, position_in_stage: 5000 });
+    expect(db.updates[0]).toMatchObject({ stage_id: WON_STAGE, position_in_stage: 5000 });
+    expect(db.rpcs).toEqual([]);
+  });
+
+  it("não alcança lead de outra organização", async () => {
+    const db = makeDb({
+      leads: [baseLead({ organization_id: OTHER_ORG })],
+      stages: baseStages(),
+    });
+
+    await expect(
+      encerraDemanda(db.client as never, ctx, { leadId: LEAD, desfecho: "won" }),
+    ).rejects.toMatchObject({ code: "not_found", status: 404 });
+    expect(db.updates).toEqual([]);
+  });
+
+  it("é idempotente quando o lead já está ganho", async () => {
+    const lead = baseLead({ status: "won", stage_id: WON_STAGE, closed_at: "2026-08-19T00:00:00.000Z" });
+    const db = makeDb({ leads: [lead], stages: baseStages() });
+
+    const result = await encerraDemanda(db.client as never, ctx, { leadId: LEAD, desfecho: "won" });
+
+    expect(result).toMatchObject({ jaEstava: true, lead });
+    expect(db.updates).toEqual([]);
+    expect(db.rpcs).toEqual([]);
+  });
+});

--- a/lib/leads/encerramento.ts
+++ b/lib/leads/encerramento.ts
@@ -109,6 +109,8 @@ export async function encerraDemanda(
     .eq("organization_id", ctx.organization_id)
     .eq("pipeline_id", (lead as { pipeline_id: string }).pipeline_id)
     .eq(colunaTerminal, true)
+    .eq("is_archived", false)
+    .order("position", { ascending: true })
     .limit(1)
     .maybeSingle();
 
@@ -127,8 +129,27 @@ export async function encerraDemanda(
     );
   }
 
+  const terminalStageId = (stage as { id: string }).id;
+  const { data: maxPosition, error: maxPositionErr } = await supabase
+    .from("crm_leads")
+    .select("position_in_stage")
+    .eq("organization_id", ctx.organization_id)
+    .eq("stage_id", terminalStageId)
+    .order("position_in_stage", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (maxPositionErr) {
+    throw new ApiError(500, "internal_error", undefined, ctx.requestId, maxPositionErr.message);
+  }
+
+  const nextPosition =
+    maxPosition?.position_in_stage === null || maxPosition?.position_in_stage === undefined
+      ? 1000
+      : Number(maxPosition.position_in_stage) + 1000;
   const patch: Record<string, unknown> = {
-    stage_id: (stage as { id: string }).id,
+    stage_id: terminalStageId,
+    position_in_stage: nextPosition,
     updated_at: new Date().toISOString(),
   };
   if (input.desfecho === "lost") patch.lost_reason = input.motivo;
@@ -151,27 +172,11 @@ export async function encerraDemanda(
     .maybeSingle();
   const finalLead = (fresh ?? lead) as Record<string, unknown>;
 
+  // `fn_crm_lead_close_on_stage` atualiza o status e o trigger de eventos grava
+  // lead.won/lead.lost no event_log. Não emitir novamente via emit_event aqui:
+  // event_log não possui chave idempotente e isso duplicaria notificações.
   const a = actorAuditPayload(ctx.actor);
   const eventType = input.desfecho === "won" ? "lead.won" : "lead.lost";
-
-  await supabase
-    .rpc("emit_event", {
-      p_event_type: eventType,
-      p_entity_kind: "crm_lead",
-      p_entity_id: input.leadId,
-      p_payload: {
-        from_stage_id: (lead as { stage_id: string }).stage_id,
-        to_stage_id: (stage as { id: string }).id,
-        ...(input.desfecho === "lost"
-          ? { lost_reason: input.motivo }
-          : { value_cents: finalLead.value_cents, currency: finalLead.currency }),
-      },
-      p_metadata: { request_id: ctx.requestId, ...a.metadataActor },
-      p_organization_id: ctx.organization_id,
-    })
-    .then(({ error }) => {
-      if (error) console.error(`[${eventType}] emit_event failed`, error.message);
-    });
 
   // A LINHA NA TIMELINE — o que faltava. `reason` nomeia o desfecho e, na perda,
   // carrega o motivo, que é justamente o que muda a decisão de quem lê depois


### PR DESCRIPTION
# O que este PR faz

Extrai do PR #465 de @prevprocesso-maker a parte que dava para extrair. O PR dele é o `main` do fork inteiro (26 commits, 994 atrás da nossa `main`, 10 conflitos, mais a marca própria do cliente dele) e não pode ser mergeado — mas dentro dele havia um achado real que ninguém tinha visto. O achado é dele; o crédito, também.

## Os quatro consertos, em `encerraDemanda`

1. **`emit_event` duplicado.** O trigger `trg_emit_event_on_lead_change` do baseline já grava `lead.won`/`lead.lost` no `event_log`. O app emitia de novo, e `event_log` não tem chave idempotente: duas linhas por fechamento. Ficou mais caro **depois** que o PR dele foi aberto — `lib/notifications/push.handler.ts` entrou na `main` e consome exatamente esses dois eventos, então a duplicata virou **dois envios de push** por negócio fechado.

   Precisão, porque a primeira redação disto exagerava: as duas notificações levam `tag: lead-won:<id>` e o service worker chama `showNotification` com `renotify: true` (`public/notify-sw.js:50,53`). Tag igual **substitui** — a bandeja mostra **uma**. O que dobra é o **alerta**: `renotify` é justamente o que faz o aparelho tocar de novo na substituição. O usuário é avisado duas vezes de um único negócio, sem ver duas linhas.
2. **Etapa terminal arquivada.** Um funil cujo único estágio de ganho foi arquivado fechava o negócio numa coluna invisível, em silêncio. Agora filtra `is_archived = false` e devolve 422 `pipeline_no_won_stage` quando não sobra nenhuma.
3. **`position_in_stage` não era escrito.** O card herdava a posição da coluna de origem. Passa a ir para o fim, com `max + 1000` — o mesmo passo de `app/api/v1/leads/_handler.ts:267`.
4. **`lost_reason_required` no wire.** A rota devolvia `validation_error` genérico onde a spec 01 §7.5 nomeia `lost_reason_required`.

## O que eu acrescentei ao trabalho dele

O oitavo teste. O `.order("position")` que ele adicionou junto do filtro de arquivada **não tinha guarda**: sabotado sozinho, os sete casos dele ficavam verdes. Um funil com duas etapas de ganho ("Pago" e "Pago parcial") é comum, e sem ordem determinística o mesmo negócio cai em etapas diferentes entre execuções.

## Medição

Os **dois** arquivos de fonte que já existiam estavam **byte-idênticos** entre a base do fork (`c73c0f5c`) e a `main` (`f6f91377`) — blobs `8dd2721c` e `b9fd36dc` — e aplicaram limpos, sem conflito. (A primeira redação disto dizia *três*: os outros dois arquivos do bloco são **novos**, e arquivo novo não pode ser byte-idêntico a nada. Corrigido pelo cético da triagem.)

Sabotagem, uma variável por vez, com a previsão escrita antes de rodar:

```
tirar .eq("is_archived", false)      -> 1 vermelho (previsto 1)
tirar position_in_stage do patch     -> 1 vermelho (previsto 1)
tirar o ramo lost_reason_required    -> 1 vermelho (previsto 1)
reintroduzir o emit_event            -> 1 vermelho (previsto 1)
tirar .order("position")             -> 0 vermelhos ANTES do teste novo, 1 depois
```

Suíte inteira (`pnpm test:unit`, ou seja `vitest run` **sem caminho**):

```
Test Files  609 passed (609)
     Tests  6749 passed | 1 expected fail (6750)
rodapé: 0 failed | grep contou: 0
```

`npx tsc --noEmit` exit 0; `eslint` nos 4 arquivos exit 0.

**NÃO MEDIDO:** `pnpm test:db`. O trigger que este PR passa a considerar a única fonte de evento está no `baseline.sql` e foi lido, não exercitado — nenhum teste desta suíte sobe Postgres. Se o CI reprovar em `invariants`, é por aí que começo.

## Versão

Fragmento em `.changes/negocio-fechado-nao-avisa-duas-vezes.md`, `impacto: nada_mudou` (o operador não faz nada). `pnpm release:conferir` -> `1.11.1 + patch = 1.11.2 (2 fragmentos)`.

Closes nada — o #465 segue aberto, com o resto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Verificação da premissa (a parte mais arriscada deste PR)

Se o trigger **não** emitisse, este PR removeria a única emissão real e o evento sumiria — pior que duplicar. Então rastreei até a ponta, e o `baseline.sql` tem **três** definições de `fn_emit_event_on_lead_change` (linhas 213, 6304 e 8162): a que vale é a última, e o trigger é recriado na 6339 como `after update` (não mais `INSERT OR UPDATE`).

```sql
-- baseline.sql:8162, a definição em vigor
if tg_op = 'INSERT' then return new; end if;
if new.status is distinct from old.status then
  if new.status = 'won' then
    perform public.fn_log_event(new.organization_id, 'lead.won', ...);
```

E `fn_log_event` (baseline.sql:512) deriva `entity_kind := split_part(p_event_type,'.',1)` = **`'lead'`**, enquanto o `emit_event` do app gravava **`'crm_lead'`**. Duas linhas com `entity_kind` diferente — o que levanta a pergunta de quem filtra por isso:

| consumidor | filtra `entity_kind`? | escuta `lead.won`? |
|---|---|---|
| `lib/event-log/dispatcher.ts:83` | **não** — casa só `h.events.includes(row.event_type)` | — |
| `lib/notifications/push.handler.ts` | **não** (`grep entity_kind` -> vazio) | **sim** |
| `lib/automation/engine.ts:47` | **sim**, `=== "crm_lead"` | **não** — `engine.handler.ts:9` lista só `lead.created`, `lead.stage_changed`, `message.received`, `lead.tag_added`, `contact.tag_added` |

Ou seja: o único consumidor de `lead.won`/`lead.lost` não filtra `entity_kind`, então **processava as duas linhas**; e o motor de automação, que filtraria, **não escuta esses eventos** — logo não regride. `grep` por `lead.won|lead.lost` em `lib app workers components` (fora de teste) devolve exatamente três lugares: o catálogo de audit, o `push.handler.ts` e o `encerramento.ts` que este PR muda.
