### PR TITLE
docs(contrib): o fork não sabe que a marca dele não se edita no código

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,20 @@ Duas coisas vão parecer erro seu e não são:
   GitHub para quem nunca contribuiu antes. Um mantenedor libera; do segundo PR em diante
   roda sozinho. Se demorar, comente no PR.
 
+**Abra o PR de um ramo com nome, nunca do `main` do seu fork.** Se o `main` do fork já tem
+personalizações suas — e ele quase sempre tem, porque é dele que a sua VPS puxa —, o PR propõe
+essas personalizações ao produto inteiro. Isso não gera conflito e não acende gate nenhum: elas
+entram em silêncio para todas as instalações. Foi medido (PR #465): sete arquivos com a marca de um
+cliente, seis deles mergeando sem um único conflito. O caminho é `git checkout -b fix/o-que-voce-conserta`
+a partir da `main` **deste** repositório, com só o seu conserto dentro.
+
+**A marca da sua instalação não se troca editando código.** Não altere `DEFAULT_APP_NAME` em
+`lib/branding.ts`, nem os títulos em `app/`. O banco manda (`platform_branding`,
+`organizations.settings.branding`), `APP_NAME` no `.env` é a semente que o `install.sh` pergunta, e
+o resto é a tela **Configurações › Marca**. Receita inteira em [`docs/white-label.md`](docs/white-label.md).
+Editar a constante troca o padrão do PRODUTO — e a sua marca some no próximo `git pull`, o que é a
+razão prática de o caminho suportado ser melhor para você também.
+
 E sobre o `pnpm test:e2e` do DoD: rodar a suíte completa exige Docker, banco semeado e WAHA
 local. **Não travamos PR externo nisso** — mande o que conseguiu provar (unit + descrição do
 que testou na mão), que a prova de tela fica com o mantenedor. Exigir prova sem entregar a

--- a/tests/unit/marca-do-produto-nao-se-edita-no-codigo.test.ts
+++ b/tests/unit/marca-do-produto-nao-se-edita-no-codigo.test.ts
@@ -1,0 +1,82 @@
+/**
+ * A marca padrão do produto é UM valor, e ele não se troca editando código.
+ *
+ * POR QUE ESTE ARQUIVO EXISTE — medido no PR #465 (2026-09-01). Um contribuidor
+ * que instalou o CRM para o próprio cliente personalizou a marca do jeito que
+ * achou: trocou `DEFAULT_APP_NAME` em `lib/branding.ts`. Depois abriu um PR a
+ * partir do `main` do fork dele, e a personalização veio junto — proposta como
+ * mudança do produto, para todo mundo.
+ *
+ * O que torna essa classe cara não é a intenção (não havia nenhuma): é que ela
+ * chega em SILÊNCIO. Medido na prévia do merge daquele PR (`git merge-tree
+ * --write-tree origin/main <sha>`): dos sete arquivos que carregavam a marca de
+ * fora, SEIS entraram sem um único conflito — `lib/branding.ts` inclusive, porque
+ * a `main` não tinha tocado nele. E a suíte ficava VERDE, porque os três testes
+ * que fixavam o literal (`branding-marca-resolve`, `branding-saida` e o
+ * `prefixoDoArquivo` daqui de `branding.test.ts`) foram atualizados no mesmo PR,
+ * de boa-fé, para casar com o novo nome. Pino que mora no arquivo que o
+ * fork-sync naturalmente edita não é pino: é eco.
+ *
+ * Então este arquivo não acrescenta rigor — acrescenta um NOME e uma MENSAGEM.
+ * Quando alguém trocar a identidade do produto, em vez de três testes sem
+ * parentesco ficando vermelhos em três arquivos diferentes, fica vermelho UM,
+ * chamado pelo que protege, dizendo qual é o caminho suportado. O gargalo
+ * medido deste repositório é contribuidor esbarrando em regra que ninguém
+ * contou; um gate que ensina vale mais que um gate que só reprova.
+ *
+ * ESCOPO — o que este arquivo NÃO cobre, dito em voz alta para ninguém o ler
+ * como proteção maior do que é:
+ *
+ *  - Ele não impede a edição. Nada impede: um PR que muda o valor pode mudar
+ *    esta linha junto. O que ele garante é que a mudança seja DELIBERADA e
+ *    legível no diff, em vez de carona em 56 arquivos.
+ *  - Ele não varre marca ESTRANGEIRA. A varredura de `tests/unit/branding.test.ts`
+ *    procura `/deskcomm/i` — ela vê a marca da casa saindo, nunca a de fora
+ *    entrando. Uma marca qualquer hardcoded num `.tsx` continua invisível.
+ *  - `app/design/` é pulado por aquela varredura (`branding.test.ts`, a linha
+ *    `if (rel.startsWith("app/design")) continue`), e o showcase renderiza o
+ *    nome do produto em três títulos. Foi por ali que a marca de fora passou sem
+ *    encostar em gate nenhum. Fechar isso pede entrada na allowlist para cada
+ *    ocorrência do showcase, e é dívida com issue própria — não deste arquivo.
+ *
+ * O caminho SUPORTADO de marca própria está em `docs/white-label.md`: o banco
+ * (`platform_branding`, `organizations.settings.branding`) manda, e `APP_NAME`
+ * no `.env` é a semente que o `install.sh` pergunta. Uma imagem Docker serve
+ * todas as marcas — é por isso que a constante daqui é o PADRÃO do produto, e
+ * não o lugar de configurar a sua.
+ */
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_APP_NAME, resolveBranding } from "@/lib/branding";
+
+/**
+ * O nome do produto, escrito por extenso e uma única vez. Está aqui, e não
+ * importado de `lib/branding`, de propósito: um teste que compara a constante
+ * com ela mesma passa sempre.
+ */
+const MARCA_DO_PRODUTO = "DeskcommCRM";
+
+const COMO_PERSONALIZAR =
+  "Para personalizar a marca da SUA instalação, não edite esta constante: " +
+  "use APP_NAME no .env (o install.sh pergunta), a tela Configurações › Marca, " +
+  "ou platform_branding no banco. Ver docs/white-label.md. " +
+  "Editar lib/branding.ts troca o padrão do PRODUTO, para todas as instalações, " +
+  "e some com a sua marca no próximo `git pull`.";
+
+describe("a marca padrão do produto", () => {
+  it("é DeskcommCRM — e trocá-la aqui é mudar o produto, não a sua instalação", () => {
+    expect(DEFAULT_APP_NAME, COMO_PERSONALIZAR).toBe(MARCA_DO_PRODUTO);
+  });
+
+  it("é o que aparece quando o operador não configurou marca nenhuma", () => {
+    // O caminho que o usuário final vê: sem nada configurado, `resolveBranding`
+    // devolve o padrão, e a inicial do ícone sai dele. Fixar os dois juntos é o
+    // que impede a troca de passar por "só uma constante interna" — ela chega no
+    // manifest do PWA, no favicon, no remetente de e-mail e no issuer do MFA.
+    expect(resolveBranding(undefined, undefined), COMO_PERSONALIZAR).toEqual({
+      name: MARCA_DO_PRODUTO,
+      logoUrl: null,
+      initial: "D",
+    });
+  });
+});


### PR DESCRIPTION
# O que este PR faz

Fecha um buraco de documentação que o PR #465 revelou, e põe um nome na luz que acende quando alguém troca a identidade do produto.

## O que aconteceu

Um contribuidor instalou o CRM para o próprio cliente e personalizou a marca do único jeito que encontrou: trocando `DEFAULT_APP_NAME` em `lib/branding.ts`. Depois abriu um PR a partir do `main` do fork, e a personalização veio junto — proposta como mudança do produto, para todas as instalações.

**Nenhuma das duas coisas estava escrita em lugar nenhum.** O `CONTRIBUTING.md` tem uma seção inteira "se você está contribuindo de fora (fork)" que avisa sobre o `Vercel` vermelho e sobre o workflow parado, e não diz nem para abrir o PR de um ramo com nome, nem qual é o caminho suportado de marca própria — que existe, está em `docs/white-label.md`, e quem procura "como troco o nome" não chega lá pelo CONTRIBUTING.

## Por que a classe é cara: ela chega em silêncio

Medido na prévia do merge daquele PR (`git merge-tree --write-tree origin/main <sha>` -> tree `6ee7448f`):

```console
$ git show 6ee7448f:lib/branding.ts | sed -n '19p'
export const DEFAULT_APP_NAME = "CarlosCostaPrev – Sistema Integrado de Gestão"
$ git show 6ee7448f:lib/branding.ts | grep -c '<<<<<<<'
0                                    # entra sem conflito
$ git show 6ee7448f:lib/waha/client.ts | grep -c '<<<<<<<'
2                                    # controle: um arquivo que conflita acusa
```

Dos **sete** arquivos que carregavam a marca de fora, **seis** entraram sem um único conflito. E sabotando só a constante na `main` de hoje, **9 casos** ficam vermelhos — mas **3 deles o próprio merge silencia**, porque os arquivos que os contêm (`branding-marca-resolve`, `branding-saida`) mergeiam carregando o nome novo. Os outros 4 dependem de como alguém resolve o conflito de `tests/unit/branding.test.ts`, que conflita por motivo alheio.

## As duas peças

**`CONTRIBUTING.md`** ganha os dois avisos, escritos como serviço a quem instala e não como regra a quem contribui: a marca editada no código some no próximo `git pull`, então o caminho suportado é melhor para o contribuidor também.

**`tests/unit/marca-do-produto-nao-se-edita-no-codigo.test.ts`** não acrescenta rigor — acrescenta um **nome** e uma **mensagem**. Hoje, quem troca a identidade vê três testes sem parentesco ficando vermelhos em três arquivos diferentes, sem explicação. Passa a ver um, chamado pelo que protege, apontando para `docs/white-label.md`.

A propriedade que o torna útil e que os pinos existentes não têm: **um arquivo novo é invisível a um fork antigo.** O PR #465 não podia tê-lo adaptado, porque ele não existia na base dele.

```console
$ git cat-file -e pr465:tests/unit/marca-do-produto-nao-se-edita-no-codigo.test.ts
# ausente
```

O escopo do que ele **não** cobre está escrito no cabeçalho, em voz alta — inclusive que `app/design/` é pulado pela varredura de marca (`branding.test.ts`, `if (rel.startsWith("app/design")) continue`), que foi por onde a marca de fora passou sem encostar em gate nenhum. Fechar isso é dívida com issue própria.

## Medição

Sabotagem (trocar `DEFAULT_APP_NAME` pela marca do fork, **só o fonte**), previsão 8 casos, observados 9 — a diferença é `resolveBranding > cai no padrão`, que fixa `initial: "D"` e eu não tinha contado:

```
Test Files  4 failed (4)
     Tests  9 failed | 71 passed (80)
```

Sem sabotagem, os 4 arquivos passam.

## Versão

Sem fragmento em `.changes/`: nada muda para quem opera uma VPS (documentação + um teste).

Crédito do achado a @prevprocesso-maker (#465).

🤖 Generated with [Claude Code](https://claude.com/claude-code)