### PR TITLE
test(ia): a varredura do resolver quebrava para quem tem color.ui=always

### DIFF
--- a/tests/unit/openrouter-alcance.test.ts
+++ b/tests/unit/openrouter-alcance.test.ts
@@ -48,7 +48,15 @@ const RAIZ = resolve(__dirname, "../..");
 function chamadoresDoResolver(): string[] {
   const saida = execFileSync(
     "git",
-    ["grep", "-l", "resolveLanguageModel", "--", "lib", "workers", "app", "scripts"],
+    // `--color=never` não é decoração: `git grep` não colore quando não há TTY,
+    // MAS colore assim mesmo se o dev tiver `color.ui=always` no ~/.gitconfig — e
+    // aí cada caminho volta embrulhado em ANSI, o `split("\n")` devolve
+    // "\u001b[35mlib/ai/...\u001b[m", e nenhum `readFileSync` acha o arquivo.
+    // Medido nas três combinações:
+    //   sem config            -> ANSI: false
+    //   -c color.ui=always    -> ANSI: true   <- o teste quebra aqui
+    //   + --color=never       -> ANSI: false
+    ["grep", "--color=never", "-l", "resolveLanguageModel", "--", "lib", "workers", "app", "scripts"],
     { cwd: RAIZ, encoding: "utf8" },
   );
   return saida


### PR DESCRIPTION
Uma linha, extraida do PR #465 de @prevprocesso-maker (que nao pode ser mergeado inteiro - ver o veredito la).

`tests/unit/openrouter-alcance.test.ts` roda `git grep -l` por `execFileSync` e trata a saida como lista de caminhos. O git **nao** colore sem TTY, entao no CI e na maquina da maioria isso passa. Quem tem `color.ui=always` no `~/.gitconfig` recebe cada caminho embrulhado em ANSI, e o `readFileSync` seguinte procura um arquivo cujo nome comeca com o escape.

## Medicao, nas tres pontas

Config injetada por env (`GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`) para nao tocar o gitconfig de ninguem:

```
original, sem config                  -> Tests  6 passed (6)
original, color.ui=always             -> Tests  1 failed | 5 passed (6)
    Error: ENOENT: no such file or directory,
      open '/Users/.../wt/tri465c/<ESC>[35mlib/ai/gateway-binding.ts<ESC>[m'
com --color=never, color.ui=always    -> Tests  6 passed (6)
```

(`<ESC>` e o byte 0x1b literal na saida real.)

O terceiro caso e o que sustenta o conserto: a flag de linha de comando vence a config.

## Por que isso importa mais do que uma linha

E um defeito que o CI **nunca** pega e que morde exatamente quem esta tentando contribuir. O teste some verde na maquina de quem tem cor ligada, e a pessoa nao tem como saber que o problema e o gitconfig dela.

Sem fragmento em `.changes/`: nada muda para quem opera uma VPS.

Credito do achado a @prevprocesso-maker.

Generated with [Claude Code](https://claude.com/claude-code)
