### PR TITLE
fix(health): o endereço interno saía pelo error da rota pública

### DIFF
--- a/.changes/health-nao-publica-o-endereco-interno.md
+++ b/.changes/health-nao-publica-o-endereco-interno.md
@@ -1,0 +1,31 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O endereço interno do seu servidor deixa de aparecer na página pública de saúde
+---
+
+O sistema tem um endereço público que responde se ele está de pé — usado por
+monitoramento e pelo suporte. Ele já era cuidadoso: escondia de quem não tem a
+chave interna o endereço da conexão do WhatsApp e do serviço de fila, porque
+esse endereço é justamente o que alguém precisaria para tentar bater na porta
+deles.
+
+O cuidado tinha um furo. Quando o arquivo de configuração ficava com o endereço
+numa forma inválida — sem o `https://` na frente, ou com aspas sobrando, que são
+os dois erros mais comuns de quem instala —, a mensagem técnica da falha vinha
+com o endereço dentro, e essa mensagem **saía por inteiro** para qualquer pessoa
+que abrisse a página. O sistema fechava a porta da frente e deixava a mesma
+informação na janela do lado.
+
+Agora quem não tem a chave interna vê apenas que a consulta falhou, e **por quê**:
+se não achou o servidor, se foi recusado, se demorou demais, se a
+credencial não passou. Isso é o que serve para monitorar. O texto técnico
+completo continua saindo inteiro para quem tem a chave, que é quem precisa dele
+para consertar.
+
+Para quem opera, nada muda: nenhuma configuração nova, nenhum passo de
+atualização. Se você tinha algum alerta lendo o texto da mensagem de erro, ele
+passa a ler o motivo em vez do texto.
+
+O achado é de @prevprocesso-maker, que percebeu o furo instalando o sistema para
+um cliente.

--- a/app/api/v1/health/route.test.ts
+++ b/app/api/v1/health/route.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+/**
+ * GET /api/v1/health — a rota é PÚBLICA e não pode publicar o endereço interno.
+ *
+ * O campo `target` (protocolo + host + porta) já era escondido de propósito: só
+ * sai com `?verbose=1` mais o segredo interno, porque o endereço dos serviços
+ * externos de uma instalação é superfície de ataque. O `error`, ao lado dele,
+ * saía cru — e carrega o MESMO endereço quando o `.env` está numa das formas
+ * erradas mais comuns do self-host.
+ *
+ * A condição de alcance existe porque, das três variáveis de endereço que a
+ * rota consulta, só a do banco é validada como URL (`lib/env.ts:69`, `.url()`);
+ * as outras duas (`lib/env.ts:140` e `155`) são `required()` puro. Um valor sem
+ * esquema, ou com as aspas do `.env` sobrando, passa pelo Zod e explode no
+ * `fetch` com o host dentro da mensagem:
+ *
+ *   "servico-interno.vps-do-cliente.com"
+ *     -> "Failed to parse URL from servico-interno.vps-do-cliente.com"
+ *
+ * ESCOPO, dito em voz alta: isto vigia a SAÍDA da rota, não a validação do env.
+ * Um endereço com esquema válido e host inalcançável devolve `"fetch failed"` e
+ * guarda o host em `e.cause`, que a rota nunca devolveu — esse caso nunca vazou,
+ * e este arquivo não o cobre porque não há o que cobrir.
+ *
+ * Um cuidado de forma: este arquivo exercita SÓ o caminho da fila, e não o do
+ * outro serviço externo, porque nomeá-lo aqui reprovaria `lint:channels`
+ * (doutrina restrição-de-canal, invariante 1 — gate obrigatório). A perda é
+ * nenhuma: o vazamento é do `error` em `semAlvo()`, que é o mesmo código para os
+ * três checks; um caminho basta para prová-lo, e a asserção é sobre o corpo
+ * inteiro, não sobre um campo.
+ *
+ * Achado por @prevprocesso-maker no PR #465.
+ */
+
+/**
+ * Sem esquema de propósito: é esta forma que faz o `fetch` do Node embutir o
+ * endereço na mensagem, e é a forma que um `.env` mal preenchido produz.
+ */
+const HOST_VAZADO = "servico-interno.vps-do-cliente.com";
+const SEGREDO = "segredo-interno-de-teste-com-tamanho-suficiente";
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    NEXT_PUBLIC_SUPABASE_URL: "https://projeto-do-cliente.supabase.co",
+    SUPABASE_SERVICE_ROLE_KEY: "chave-de-teste",
+    UPSTASH_REDIS_REST_URL: "servico-interno.vps-do-cliente.com",
+    UPSTASH_REDIS_REST_TOKEN: "token-de-teste",
+    INTERNAL_CRON_SECRET: "segredo-interno-de-teste-com-tamanho-suficiente",
+    INTERNAL_SECRET: "",
+  },
+}));
+
+function pedido(query = "", headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest(`https://crm.exemplo.com.br/api/v1/health${query}`, { headers });
+}
+
+describe("GET /api/v1/health — o endereço interno não sai para quem não tem o segredo", () => {
+  beforeEach(() => vi.resetModules());
+
+  it("não publica o host numa resposta anônima, nem pelo error", async () => {
+    const { GET } = await import("./route");
+    const corpo = JSON.stringify(await (await GET(pedido())).json());
+
+    // A asserção é sobre o CORPO INTEIRO, não sobre um campo: se amanhã alguém
+    // acrescentar outro lugar por onde o endereço saia, este caso reprova.
+    expect(corpo).not.toContain(HOST_VAZADO);
+    expect(corpo).not.toContain("Failed to parse URL");
+  });
+
+  it("mantém o diagnóstico útil — o motivo continua saindo", async () => {
+    const { GET } = await import("./route");
+    const { data } = await (await GET(pedido())).json();
+
+    // Redigir não pode virar apagar: quem monitora de fora precisa seguir
+    // distinguindo "não alcancei" de "fui barrado". Sem isto, a redação seria
+    // uma regressão de observabilidade disfarçada de conserto.
+    expect(data.checks.redis.reason).toBeTruthy();
+    expect(data.checks.redis.status).toBe("down");
+  });
+
+  it("devolve o texto original a quem tem o segredo interno", async () => {
+    const { GET } = await import("./route");
+    const req = pedido("?verbose=1", { authorization: `Bearer ${SEGREDO}` });
+    const corpo = JSON.stringify(await (await GET(req)).json());
+
+    // O outro lado da mesma moeda: se a redação passasse a valer também no modo
+    // verboso, o operador perderia o diagnóstico e ninguém notaria — o caso
+    // acima ficaria verde do mesmo jeito.
+    expect(corpo).toContain(HOST_VAZADO);
+  });
+});

--- a/app/api/v1/health/route.ts
+++ b/app/api/v1/health/route.ts
@@ -193,10 +193,42 @@ function segredoInternoConfere(req: NextRequest): boolean {
   });
 }
 
-/** Sem o segredo, o endereço não sai — o resto do diagnóstico sai igual. */
+/**
+ * Sem o segredo, o endereço não sai — nem pelo `target`, nem pelo `error`.
+ *
+ * O `target` sempre foi escondido de propósito: esta rota é PÚBLICA (o `GET` não
+ * exige nada; o segredo interno só destrava o `?verbose=1`), e o cabeçalho deste
+ * arquivo chama o endereço de WAHA e Redis do cliente de superfície de ataque.
+ * Mas o `error` saía cru ao lado dele, e ele carrega o mesmo endereço numa das
+ * formas mais comuns de configuração errada.
+ *
+ * Medido, com valores que passam pelo Zod de `lib/env.ts` — porque só
+ * `NEXT_PUBLIC_SUPABASE_URL` é `.url()` (linha 69); `WAHA_API_BASE_URL` (140) e
+ * `UPSTASH_REDIS_REST_URL` (155) são `required()` puro, sem validação de forma:
+ *
+ *   "redis-interno.hostgator-vps.com"
+ *     -> e.message = "Failed to parse URL from redis-interno.hostgator-vps.com"
+ *   `"https://redis-interno.hostgator-vps.com"`  (aspas sobrando no .env)
+ *     -> e.message = "Failed to parse URL from \"https://redis-interno...\""
+ *
+ * Ou seja: exatamente os dois serviços cujo endereço a rota esconde por decisão
+ * escrita, e exatamente a instalação self-host que erra o `.env` — o caso já
+ * catalogado nesta casa como ".env sem aspas". O `error` publicava pela porta
+ * que a redação do `target` fechou.
+ *
+ * Contra-exemplo medido, para o escopo ficar honesto: um endereço com esquema
+ * válido e host inalcançável devolve `"fetch failed"`, e o host mora em
+ * `e.cause`, que esta rota nunca devolveu. O vazamento é da forma MALFORMADA,
+ * não de toda falha — e é por isso que a troca é de redação, não de remoção.
+ *
+ * O que NÃO se perde: `reason` (`classificarFalhaDeAlcance`) continua saindo
+ * inteiro, então quem monitora de fora segue distinguindo dns, recusa, tempo
+ * esgotado e credencial recusada. E quem tem o segredo continua vendo o texto
+ * original, porque `verbose=1` não passa por aqui.
+ */
 function semAlvo(check: Check): Check {
-  const { target: _oculto, ...resto } = check;
-  return resto;
+  const { target: _oculto, error, ...resto } = check;
+  return error === undefined ? resto : { ...resto, error: "erro_ao_consultar" };
 }
 
 export async function GET(req: NextRequest) {


### PR DESCRIPTION
Quarta e última extração do PR #465 de @prevprocesso-maker — e a que esta triagem **quase descartou por medição preguiçosa minha**, o que vale contar porque é o motivo de o comentário no arquivo existir.

## O que acontecia

`/api/v1/health` é **pública**: o `GET` não exige nada, e o segredo interno só destrava o `?verbose=1`. Por isso `semAlvo()` já removia o campo `target` (protocolo + host + porta) de quem não tem o segredo — o cabeçalho da própria rota chama o endereço de WAHA e Redis do cliente de superfície de ataque.

O `error` saía cru ao lado dele, e carrega o **mesmo** endereço quando o `.env` está numa das formas erradas mais comuns do self-host.

## A condição de alcance — que eu tinha medido errado

Testei o vazamento com uma URL bem-formada, vi `"fetch failed"`, concluí que não vazava. Errado: testei o **único** dos três serviços que não pode vazar.

```
lib/env.ts:69   NEXT_PUBLIC_SUPABASE_URL: requiredAlways(...).url()   <- validado
lib/env.ts:140  WAHA_API_BASE_URL:        required(...)               <- SEM .url()
lib/env.ts:155  UPSTASH_REDIS_REST_URL:   required(...)               <- SEM .url()
```

Com valor que passa pelo Zod e não é URL, o `fetch` do Node embute o endereço na mensagem:

```
"redis-interno.hostgator-vps.com"
  -> "Failed to parse URL from redis-interno.hostgator-vps.com"       VAZA
'"https://redis-interno.hostgator-vps.com"'   (aspas sobrando no .env)
  -> 'Failed to parse URL from "https://redis-interno..."'            VAZA
"https://abcdefgh.supabase.co/rest/v1/x"
  -> "fetch failed"                                                   limpo
```

São exatamente os dois serviços cujo endereço a rota esconde por decisão escrita, e exatamente a instalação que erra o `.env` — o caso já catalogado nesta casa como ".env sem aspas". O `error` publicava pela porta que a redação do `target` fechou.

## O conserto, e por que não é o do PR original

O #465 trocava `e.message` por `"request_failed"` nos três `catch`, o que apaga o diagnóstico **também** de quem tem o segredo. Aqui a redação entra em `semAlvo()`, que é onde a decisão "isto não sai sem segredo" já mora:

| quem chama | `target` | `error` | `reason` |
|---|---|---|---|
| anônimo | oculto (como antes) | `erro_ao_consultar` | **inteiro** |
| `?verbose=1` + segredo | inteiro | inteiro | inteiro |

`reason` vem de `classificarFalhaDeAlcance` — quem monitora de fora segue distinguindo dns, recusa, tempo esgotado e credencial recusada. Redigir não podia virar apagar.

## Sabotagem: três direções, três casos diferentes, previsão escrita antes

```
reverter a redação do error       previu 1o -> deu 1o  (com o host dentro da asserção)
redigir TAMBÉM no verboso         previu 3o -> deu 3o
redigir demais (apagar o reason)  previu 2o -> deu 2o
```

A terceira impede que o conserto vire regressão de observabilidade disfarçada; a segunda impede que ele cegue o operador junto com o atacante.

**Escopo declarado no teste:** ele vigia a **saída da rota**, não a validação do env. Que `WAHA_API_BASE_URL` e `UPSTASH_REDIS_REST_URL` não sejam `.url()` continua verdade depois deste PR — e provavelmente merece issue própria, porque um endereço malformado só é descoberto quando alguém abre o `/health`.

**NÃO MEDIDO:** se algum monitoramento externo em produção lê o **texto** do `error` (o fragmento em `.changes/` traz essa ressalva em voz alta). E `pnpm test:db` — a rota não toca schema, mas eu não o rodei aqui.

Fragmento em `.changes/`, `impacto: nada_mudou`. `pnpm release:conferir` -> `1.11.1 + patch = 1.11.2 (2 fragmentos)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Uma pedra no caminho, registrada porque vai pegar o próximo

A primeira versão do teste nomeava o provedor de canal ao montar o env falso, e o `lint:channels` reprovou — gate obrigatório, e o passo se chama **"Channel provider leak"**, que não deixa óbvio que o problema é uma string dentro de um teste:

```
Nome de provider fora de lib/channels/ (doutrina restricao-de-canal, invariante 1):
  app/api/v1/health/route.test.ts
```

O arquivo passou a exercitar **só** o caminho da fila. A perda é nenhuma: o vazamento é do `error` dentro de `semAlvo()`, que é o mesmo código para os três checks, e a asserção é sobre o **corpo inteiro** da resposta, não sobre um campo. As três sabotagens foram refeitas depois da reescrita e continuam batendo caso a caso.

E antes de sair consertando documentação: fui ver se o `lint:channels` estava avisado a quem contribui, e **está** — `CONTRIBUTING.md:53` o traz no comando que manda rodar antes de abrir PR. A falha foi minha, não do projeto. Registro aqui em vez de virar issue.