### PR TITLE
Agenda do Google: compromisso passa a chegar lá, e a ocupação aparece na tela

### DIFF
--- a/app/api/v1/agenda/agendamentos/route.ts
+++ b/app/api/v1/agenda/agendamentos/route.ts
@@ -15,8 +15,19 @@ import { randomUUID } from "node:crypto";
 import { type NextRequest } from "next/server";
 import { z } from "zod";
 
-import { listaAgendamentos } from "@/lib/agenda/consulta";
+import { listaAgendamentos, type AgendamentoListado } from "@/lib/agenda/consulta";
 import { fail, ok } from "@/lib/api/wrappers";
+import { logger } from "@/lib/logger";
+
+/**
+ * O que ESTA ROTA devolve — o contrato da lista mais a ORIGEM.
+ *
+ * `AgendamentoListado` não tem origem de propósito: ela é o contrato que a
+ * ferramenta MCP do agente também consome, e lá só existe uma origem possível.
+ * A tela precisa distinguir, porque bloco vindo do Google não abre, não arrasta
+ * e não se clica.
+ */
+type AgendamentoDaResposta = AgendamentoListado & { origem?: "google_sync" };
 import { ApiError } from "@/lib/api/types";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
@@ -139,7 +150,71 @@ export async function GET(req: NextRequest): Promise<Response> {
     );
   }
 
-  return ok(resultado.agendamentos, { requestId });
+  // ─── A OCUPAÇÃO DO GOOGLE ENTRA AQUI, e não em `listaAgendamentos` ────────
+  //
+  // O defeito, medido em produção em 2026-09-01: 114 eventos vindos do Google no
+  // banco, 1 deles na semana desenhada, e a tela mostrando a agenda vazia.
+  //
+  // O servidor SEMEAVA os externos (`app/app/agenda/page.tsx`), e o cliente os
+  // jogava fora: `agendamentosVivos ?? semente` — assim que este GET responde,
+  // ele SUBSTITUI a semente inteira, e esta rota nunca devolveu ocupação. Em
+  // visão Mês nem a semente sobrevive, porque o recorte muda e o fallback é `[]`.
+  // Resultado: o bloco aparecia no primeiro instante da semana corrente e sumia.
+  //
+  // ⚠️ POR QUE NÃO DENTRO DE `listaAgendamentos`. Aquela função é compartilhada
+  // com a ferramenta MCP do agente de IA (`lib/mcp/tools/agendamento.ts`). Pôr
+  // "Ocupado" na resposta dela faria o agente enxergar compromisso onde há um
+  // bloco anônimo do Google — e falar sobre ele com o cliente. A tela precisa da
+  // ocupação; o agente, não. Fontes diferentes para consumidores diferentes.
+  //
+  // Falha aqui NÃO derruba a listagem: sem ocupação a grade fica pobre; sem
+  // agendamento ela fica errada. São consequências de tamanhos diferentes.
+  const externos: AgendamentoDaResposta[] = [];
+  if (parsed.data.de && parsed.data.ate) {
+    const { data: ocupacao, error: erroOcupacao } = await supabase
+      .from("calendar_external_events")
+      .select("id, starts_at, ends_at, calendar_connections!inner(user_id)")
+      .eq("organization_id", activeOrg.orgId)
+      .gte("starts_at", parsed.data.de)
+      .lt("starts_at", parsed.data.ate)
+      // `transparent` no Google é "livre": existe e não ocupa. Mesmo filtro que
+      // a semente do servidor já aplicava — a regra é uma só.
+      .neq("transparency", "transparent")
+      .neq("status", "cancelled")
+      .order("starts_at");
+
+    if (erroOcupacao) {
+      logger.warn("[agenda.agendamentos] ocupação do Google não veio", {
+        erro: erroOcupacao.message,
+        requestId,
+      });
+    }
+    for (const e of ocupacao ?? []) {
+      const conexao = e.calendar_connections as { user_id: string } | { user_id: string }[] | null;
+      const dono = Array.isArray(conexao) ? conexao[0]?.user_id : conexao?.user_id;
+      externos.push({
+        id: e.id,
+        // Rótulo, NUNCA o título do evento: a tabela guarda o `title` e esta
+        // resposta não o lê. Despejar o conteúdo da agenda pessoal na tela de
+        // trabalho é o que a consulta da semente também recusa.
+        titulo: "Ocupado",
+        donoId: dono ?? null,
+        iniciaEm: e.starts_at,
+        terminaEm: e.ends_at,
+        situacao: "confirmed",
+        // Os três abaixo existem para satisfazer o contrato da lista, e são
+        // vazios porque ocupação do Google não tem nenhum deles: o fuso vive na
+        // conexão, e contato é coisa de agendamento nosso. Preenchê-los com
+        // invenção faria a tela mostrar dado que não existe.
+        fuso: "",
+        contatoId: null,
+        contatoNome: null,
+        origem: "google_sync",
+      });
+    }
+  }
+
+  return ok([...resultado.agendamentos, ...externos], { requestId });
 }
 
 export async function POST(req: NextRequest): Promise<Response> {

--- a/app/api/v1/agenda/google/callback/route.ts
+++ b/app/api/v1/agenda/google/callback/route.ts
@@ -56,6 +56,7 @@ import { cookieSecure } from "@/lib/supabase/cookie-secure";
 import { escoposFaltando } from "@/lib/agenda/google/oauth";
 import { trocarCodigoPorToken } from "@/lib/agenda/google/token";
 import { contaDaAgendaPrimaria } from "@/lib/agenda/google/calendarios";
+import { classificarErroDoGoogle } from "@/lib/agenda/google/erros";
 import { env } from "@/lib/env";
 
 export const dynamic = "force-dynamic";
@@ -268,11 +269,39 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   // 5. De quem é a agenda, e em que fuso ela vive.
   const conta = await contaDaAgendaPrimaria(token.access_token);
   if (!conta.ok) {
+    // ─── O MOTIVO do Google era jogado fora, e a tela mandava tentar de novo ──
+    //
+    // Medido em produção em 2026-09-01: três tentativas seguidas, todas
+    // `{"reason":"conta_indisponivel","detalhe":"HTTP 403"}`. O corpo do Google
+    // — que diz `accessNotConfigured`, `PERMISSION_DENIED` ou o que for — já
+    // vinha em `conta.erro` e morria aqui: nem auditoria, nem log.
+    //
+    // O custo não é só diagnóstico. 403 por API desligada NÃO passa com o
+    // tempo, e a tela dizia "Tente de novo" — mandando a pessoa repetir para
+    // sempre um caminho que não tem como funcionar. Um conselho errado é pior
+    // que nenhum, porque ocupa o lugar do certo.
+    //
+    // `classificarErroDoGoogle` já sabia ler esse corpo e já era usada no resto
+    // do módulo. Este era o único ponto que não a chamava.
+    const classificacao = classificarErroDoGoogle(conta.erro, "listar");
     await audit({
       action: "agenda.google.conexao_falhou",
       organizationId,
-      metadata: { reason: "conta_indisponivel", detalhe: conta.detalhe, user_id: userId },
+      metadata: {
+        reason: "conta_indisponivel",
+        detalhe: conta.detalhe,
+        // O que faltava para diagnosticar sem adivinhar.
+        motivo_do_google: classificacao.motivo,
+        mensagem_do_google: classificacao.mensagem,
+        user_id: userId,
+      },
     });
+    // `sem_permissao` é o 403 que NÃO é cota — o classificador já separa os
+    // dois. Ele merece tela própria porque a ação é do dono da instalação, no
+    // Google Cloud, e não da pessoa que clicou.
+    if (classificacao.desfecho === "sem_permissao") {
+      return voltar("erro=google_recusou_o_acesso");
+    }
     return voltar("erro=conta_indisponivel");
   }
 

--- a/app/api/v1/cron/agenda-google-sync/route.ts
+++ b/app/api/v1/cron/agenda-google-sync/route.ts
@@ -59,7 +59,8 @@ import { audit } from "@/lib/audit";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { decryptWebhookSecret } from "@/lib/webhooks/secrets";
 import { classificarErroDoGoogle } from "@/lib/agenda/google/erros";
-import { doEventoDoGoogle, ehIcalUidNosso } from "@/lib/agenda/google/evento";
+import { doEventoDoGoogle } from "@/lib/agenda/google/evento";
+import { ehEventoNosso } from "@/lib/agenda/google/escrita";
 import { listarEventos } from "@/lib/agenda/google/eventos-remotos";
 import { env } from "@/lib/env";
 
@@ -211,7 +212,8 @@ export async function sincronizarAgendasDoGoogle(
       // ⚠️ O FILTRO ANTI-ECO. Ver o cabeçalho: gravar o que nós mesmos criamos
       // faz o mesmo compromisso ocupar dois horários.
 
-      if (ehIcalUidNosso(lido.evento.ical_uid)) {
+      // Pelo ID, não mais pelo iCalUID — ver `ehEventoNosso`.
+      if (ehEventoNosso(lido.evento.external_event_id)) {
         resumo.nossosIgnorados += 1;
         continue;
       }

--- a/app/app/agenda/_components/AvisoDaConexaoGoogle.tsx
+++ b/app/app/agenda/_components/AvisoDaConexaoGoogle.tsx
@@ -108,6 +108,26 @@ const DESFECHOS: Record<string, Desfecho> = {
     corpo: "A conexão foi autorizada, mas o Google não respondeu quem é a conta. Tente de novo.",
     acao: "reconectar",
   },
+  /**
+   * O 403 que NÃO passa com o tempo.
+   *
+   * Medido em produção em 2026-09-01: três tentativas seguidas de conectar, as
+   * três com `HTTP 403` na leitura da agenda — e a tela mandando "Tente de
+   * novo", porque o único desfecho disponível para esse caminho era
+   * `conta_indisponivel`. A pessoa repetiria para sempre: a autorização está
+   * certa, os escopos estão certos, e quem recusa é o projeto do Google Cloud.
+   *
+   * A ação é do DONO DA INSTALAÇÃO, no Console do Google, e não de quem clicou.
+   * Por isso o texto não oferece "tentar de novo" como primeira saída — oferecer
+   * o botão errado é o que fez três tentativas virarem zero diagnóstico.
+   */
+  google_recusou_o_acesso: {
+    formato: "aviso",
+    titulo: "O Google recusou o acesso à agenda",
+    corpo:
+      "A autorização funcionou, mas o Google negou a leitura do calendário. Quase sempre é a API do Google Agenda desligada no projeto do Google Cloud desta instalação — ligue em APIs e serviços › Biblioteca › Google Calendar API e conecte de novo. O motivo exato que o Google devolveu ficou registrado no Audit Log, na falha de conexão da agenda.",
+    acao: "reconectar",
+  },
   nao_consegui_guardar: {
     formato: "aviso",
     titulo: "A conexão funcionou, mas não consegui salvar",

--- a/hooks/agenda/useAgendamentos.ts
+++ b/hooks/agenda/useAgendamentos.ts
@@ -81,7 +81,16 @@ export function useAgendamentos(recorte: RecorteDaGrade | null) {
           responsavelId: a.donoId ?? "",
           comeca: a.iniciaEm,
           termina: a.terminaEm,
-          origem: "ui" as const,
+          // A origem vem da ROTA, e não é mais carimbada aqui.
+          //
+          // Era `"ui"` fixo, e isso apagava a única coisa que distingue um bloco
+          // de ocupação do Google de um agendamento nosso — a grade usa a origem
+          // para desabilitar o clique, tirar o arraste e dizer "ocupado na
+          // agenda do Google" no rótulo acessível.
+          //
+          // `?? "ui"` mantém o fio tolerante a servidor mais velho que o
+          // cliente, como já faz o `quemSeraAtendido` logo abaixo.
+          origem: (a as { origem?: Agendamento["origem"] }).origem ?? "ui",
           situacao: a.situacao as Agendamento["situacao"],
           // Sem esta linha, montar o hook REGREDIRIA o conserto do "com quem":
           // a prop do servidor traz o nome, e o refetch o apagaria da grade.

--- a/lib/agenda/google/escrita.ts
+++ b/lib/agenda/google/escrita.ts
@@ -189,7 +189,23 @@ export async function publicarNoGoogle(
       // CALENDÁRIO que não existe. Classificar os dois como `evento_sumiu` foi o
       // que fez a VPS registrar três vezes um diagnóstico que não descrevia nada.
       classificacao: classificarErroDoGoogle(cru, jaExisteLa ? "sincronizar" : "criar"),
-      detalhe: `HTTP ${resposta.status}`,
+      // ─── O CORPO DO GOOGLE ENTRA NO DETALHE ───────────────────────────────
+      //
+      // Era só `HTTP ${status}`, e o corpo — já parseado em `cru`, uma linha
+      // acima — era descartado. Medido em produção em 2026-09-01: o cron tentou
+      // publicar dois agendamentos a cada 5 minutos durante horas, e todo o
+      // registro que sobrou foi `HTTP 400`, repetido. Nada dizia QUAL campo o
+      // Google recusou, então não havia como consertar sem adivinhar.
+      //
+      // `detalhe` já flui para o `logger.warn` do cron E para a coluna
+      // `google_sync_error` — nenhum fio novo é preciso, só parar de jogar fora
+      // o que já está na mão.
+      //
+      // Recortado em 300 caracteres: a mensagem do Google é curta e o que
+      // interessa vem no começo; o resto encheria a coluna e o log sem
+      // acrescentar. E `JSON.stringify` não vaza credencial — `cru` é a
+      // resposta de erro, não a requisição.
+      detalhe: `HTTP ${resposta.status} — ${JSON.stringify(cru).slice(0, 300)}`,
     };
   }
   const corpo = (await resposta.json().catch(() => ({}))) as { id?: string; sequence?: number };
@@ -234,4 +250,32 @@ export async function apagarNoGoogle(
     classificacao: classificarErroDoGoogle(cru, "apagar"),
     detalhe: `HTTP ${resposta.status}`,
   };
+}
+
+/**
+ * Este evento do Google foi criado por NÓS? — o anti-eco, agora pelo id.
+ *
+ * ⚠️ SUBSTITUI `ehIcalUidNosso`, e a troca não é cosmética.
+ *
+ * O reconhecimento morava no sufixo `@deskcomm.app` do `iCalUID` que mandávamos
+ * junto do evento. Só que mandar `iCalUID` e `id` juntos é o que o Google
+ * recusava com `400 Invalid resource id value` — medido em produção em
+ * 2026-09-01, a cada 5 minutos, por horas. Tirar o uid conserta a publicação e
+ * deixaria o anti-eco cego: o Google gera `<id>@google.com`, que não termina no
+ * nosso sufixo, e todo compromisso criado aqui voltaria pela sincronização como
+ * ocupação de terceiro — bloqueando o próprio horário que ele já ocupa.
+ *
+ * O id serve melhor, e sempre serviu: ele é NOSSO por construção
+ * (`idDeEventoDoGoogle`), o Google o preserva, e a rota de sincronização já tem
+ * `external_event_id` na mão no mesmo ponto onde consultava o uid. A camada que
+ * faltava já estava debaixo do nariz.
+ *
+ * ⚠️ Migrar não custou dados: NENHUM evento nosso jamais chegou ao Google, em
+ * instalação nenhuma. Três eras de falha — filtro PostgREST inválido até a
+ * v1.7.0, `evento_sumiu` na v1.9.1, e este 400 — estão documentadas no MANIFEST
+ * e no cabeçalho deste arquivo. Não há legado com o uid antigo para reconhecer.
+ */
+export function ehEventoNosso(externalEventId: string | null | undefined): boolean {
+  if (!externalEventId) return false;
+  return externalEventId.toLowerCase().startsWith(PREFIXO);
 }

--- a/lib/agenda/google/evento.ts
+++ b/lib/agenda/google/evento.ts
@@ -160,7 +160,23 @@ export interface CorpoDeEventoDoGoogle {
   end: { dateTime: string; timeZone: string };
   status: "confirmed" | "tentative" | "cancelled";
   transparency: "opaque";
-  iCalUID: string;
+  /**
+   * ⚠️ NÃO EXISTE MAIS, e a ausência é o conserto.
+   *
+   * O `events.insert` recebia `id` E `iCalUID` juntos, e a referência do Google
+   * diz que "only one of them should be supplied at event creation time".
+   * Medido em produção em 2026-09-01, a cada 5 minutos, por horas:
+   *
+   *   HTTP 400 — {"reason":"invalid","message":"Invalid resource id value."}
+   *
+   * O `id` foi medido e é válido (43 caracteres, todos em [a-v0-9]); o que
+   * violava contrato era a COPRESENÇA. `iCalUID` é do `events.import`, não do
+   * insert.
+   *
+   * Sai dos DOIS verbos, não só do POST: depois disto o evento no Google nasce
+   * com o uid que ELE gera, e um PUT tentando trocá-lo seria candidato ao mesmo
+   * 400 por outro caminho.
+   */
   reminders: { useDefault: true };
   attendees?: ParticipanteDoGoogle[];
   extendedProperties: { private: Record<string, string> };
@@ -184,16 +200,22 @@ const STATUS_PARA_GOOGLE: Record<StatusDoAgendamento, "confirmed" | "tentative" 
   no_show: "confirmed",
 };
 
-/** A identidade estável do evento, do nosso lado. */
-export function icalUidDoAgendamento(idDoAgendamento: string): string {
-  return `${idDoAgendamento}@${SUFIXO_ICAL_UID}`;
-}
-
-/** Este evento do Google foi criado por nós? É a primeira camada anti-eco. */
-export function ehIcalUidNosso(icalUid: string | null | undefined): boolean {
-  if (!icalUid) return false;
-  return icalUid.toLowerCase().endsWith(`@${SUFIXO_ICAL_UID}`);
-}
+/**
+ * ⚠️ `icalUidDoAgendamento` e `ehIcalUidNosso` FORAM REMOVIDAS aqui.
+ *
+ * O uid ia no corpo do evento junto do `id`, e a referência do `events.insert`
+ * proíbe os dois na criação. Medido em produção em 2026-09-01: HTTP 400,
+ * `Invalid resource id value`, a cada 5 minutos, por horas — e NENHUM
+ * compromisso jamais chegou ao Google, em instalação nenhuma.
+ *
+ * O reconhecimento anti-eco migrou para `ehEventoNosso` (`./escrita`), que olha
+ * o PREFIXO DO ID — nosso por construção, preservado pelo Google, e já
+ * disponível no mesmo ponto onde o filtro consultava o uid.
+ *
+ * Migrar não custou dado nenhum: não havia legado para reconhecer. E guardar as
+ * duas "para um `events.import` futuro" seria manter função pura sem consumidor
+ * — o cheiro que o cabeçalho de `escrita.ts` já nomeia como recurso pela metade.
+ */
 
 /**
  * O que escrever no campo `location`, que é o que a pessoa lê no calendário.
@@ -269,7 +291,6 @@ export function paraEventoDoGoogle(a: AgendamentoParaGoogle): CorpoDeEventoDoGoo
     // Compromisso nosso SEMPRE ocupa. Um agendamento que não ocupasse seria um
     // horário oferecido duas vezes.
     transparency: "opaque",
-    iCalUID: a.google_ical_uid?.trim() || icalUidDoAgendamento(a.id),
     reminders: { useDefault: true },
     extendedProperties: {
       private: {

--- a/tests/unit/agenda-google-evento.test.ts
+++ b/tests/unit/agenda-google-evento.test.ts
@@ -7,14 +7,14 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { ehEventoNosso, idDeEventoDoGoogle } from "@/lib/agenda/google/escrita";
+
 import {
   type AgendamentoParaGoogle,
   type EventoDoGoogle,
   type EventoExternoLido,
   type LeituraDeEvento,
   doEventoDoGoogle,
-  ehIcalUidNosso,
-  icalUidDoAgendamento,
   paraEventoDoGoogle,
 } from "@/lib/agenda/google/evento";
 
@@ -83,13 +83,31 @@ describe("paraEventoDoGoogle", () => {
     expect(de("no_show")).toBe("confirmed");
   });
 
-  it("a identidade do evento é estável e reaproveitada, nunca regerada", () => {
-    const novo = paraEventoDoGoogle(agendamento());
-    expect(novo.iCalUID).toBe(icalUidDoAgendamento(AGENDAMENTO));
-    // Segunda escrita do MESMO agendamento tem de mandar o MESMO uid: é ele
-    // que amarra o evento de lá à linha daqui.
-    const jaGravado = paraEventoDoGoogle(agendamento({ google_ical_uid: "outro-uid@deskcomm.app" }));
-    expect(jaGravado.iCalUID).toBe("outro-uid@deskcomm.app");
+  it("⚠️ o corpo NÃO leva iCalUID — mandá-lo junto do id é o que produzia 400", () => {
+    // ─── A ASSERÇÃO INVERTIDA, e o porquê ────────────────────────────────
+    //
+    // Este caso exigia `iCalUID` no corpo. A referência do `events.insert` diz
+    // que `id` e `iCalUID` "only one of them should be supplied at event
+    // creation time" — e o push manda o `id` sempre.
+    //
+    // Medido em produção em 2026-09-01, a cada 5 minutos, por horas:
+    //
+    //   HTTP 400 — {"reason":"invalid","message":"Invalid resource id value."}
+    //
+    // O `id` foi medido e É válido (43 caracteres, todos em [a-v0-9]). O que
+    // violava contrato era a COPRESENÇA. Nenhum compromisso jamais chegou ao
+    // Google, em instalação nenhuma — e este teste passava verde o tempo todo,
+    // porque media o corpo contra si mesmo e nunca contra a API.
+    const corpo = paraEventoDoGoogle(agendamento());
+    expect(corpo, "iCalUID de volta ao corpo — o 400 volta junto").not.toHaveProperty("iCalUID");
+
+    // O que amarra o evento de lá à linha daqui passa a ser o ID, que é nosso
+    // por construção e que o Google preserva.
+    expect(idDeEventoDoGoogle(AGENDAMENTO).startsWith("deskcommapp")).toBe(true);
+    expect(ehEventoNosso(idDeEventoDoGoogle(AGENDAMENTO))).toBe(true);
+    // E o controle: evento de terceiro não é reconhecido como nosso.
+    expect(ehEventoNosso("abc123doGoogle")).toBe(false);
+    expect(ehEventoNosso(null)).toBe(false);
   });
 
   it("carrega a identidade do tenant nas propriedades privadas", () => {
@@ -165,16 +183,6 @@ describe("paraEventoDoGoogle", () => {
     expect(() =>
       paraEventoDoGoogle(agendamento({ participantes: [{ email: "  " }] })),
     ).toThrow(/participante sem e-mail/);
-  });
-});
-
-describe("ehIcalUidNosso", () => {
-  it("reconhece o que criamos e ignora o resto — é a primeira camada anti-eco", () => {
-    expect(ehIcalUidNosso(icalUidDoAgendamento(AGENDAMENTO))).toBe(true);
-    expect(ehIcalUidNosso("abc@Deskcomm.App")).toBe(true);
-    expect(ehIcalUidNosso("qualquer-coisa@google.com")).toBe(false);
-    expect(ehIcalUidNosso("")).toBe(false);
-    expect(ehIcalUidNosso(null)).toBe(false);
   });
 });
 

--- a/tests/unit/agenda-google-sync-worker.test.ts
+++ b/tests/unit/agenda-google-sync-worker.test.ts
@@ -16,7 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { audit } from "@/lib/audit";
 import { decryptWebhookSecret } from "@/lib/webhooks/secrets";
-import { icalUidDoAgendamento } from "@/lib/agenda/google/evento";
+import { idDeEventoDoGoogle } from "@/lib/agenda/google/escrita";
 import { sincronizarAgendasDoGoogle } from "@/app/api/v1/cron/agenda-google-sync/route";
 
 vi.mock("@/lib/audit", () => ({ audit: vi.fn(async () => undefined), isServiceRoleConfigured: vi.fn(() => true) }));
@@ -170,8 +170,15 @@ describe("sincronizarAgendasDoGoogle", () => {
     // agendamento continua ocupando o antigo, sem nada que os ligue.
     const nosso = {
       ...eventoDeTerceiro,
-      id: "evt-nosso",
-      iCalUID: icalUidDoAgendamento("22222222-2222-4222-8222-222222222222"),
+      // ⚠️ O anti-eco migrou do iCalUID para o ID.
+      //
+      // Mandar `iCalUID` junto do `id` no insert é o que o Google recusava com
+      // 400 (medido em produção em 2026-09-01), então o uid saiu do corpo — e o
+      // reconhecimento passou para o prefixo do id, que é nosso por construção.
+      // O uid que o evento traz agora é o que o GOOGLE gera, e ele NÃO nos
+      // identifica: é justamente por isso que o id precisa fazer esse trabalho.
+      iCalUID: "gerado-pelo-google@google.com",
+      id: idDeEventoDoGoogle("22222222-2222-4222-8222-222222222222"),
     };
     vi.mocked(fetch).mockResolvedValue(pagina({ items: [nosso, eventoDeTerceiro], nextSyncToken: "T1" }));
 
@@ -282,7 +289,7 @@ describe("sincronizarAgendasDoGoogle", () => {
   });
 
   it("a contagem do anti-eco vai para o audit — é a prova de que ele agiu", async () => {
-    const nosso = { ...eventoDeTerceiro, id: "n", iCalUID: icalUidDoAgendamento("x") };
+    const nosso = { ...eventoDeTerceiro, id: idDeEventoDoGoogle("x"), iCalUID: "gerado@google.com" };
     vi.mocked(fetch).mockResolvedValue(pagina({ items: [nosso, eventoDeTerceiro], nextSyncToken: "T1" }));
     await sincronizarAgendasDoGoogle(admin(), { agora: AGORA, calendarios: [calendario()] });
     expect(audit).toHaveBeenCalledWith(


### PR DESCRIPTION
Conserta os dois defeitos da issue #467. Branch feita a partir da `main` daqui — o diff são **9 arquivos, todos da agenda**, sem nada de fork.

## 1. `events.insert` recusado com 400

```
HTTP 400 — {"reason":"invalid","message":"Invalid resource id value."}
```

O corpo ia com **`id` e `iCalUID` juntos**. A referência do `events.insert` diz que *"only one of them should be supplied at event creation time"*.

O `id` é válido — 43 caracteres, todos em `[a-v0-9]`. O que viola contrato é a **copresença**. O `iCalUID` sai dos **dois verbos**: depois disto o evento nasce com o uid que o Google gera, e um PUT tentando trocá-lo seria candidato ao mesmo 400.

### O anti-eco precisou migrar junto — é a parte delicada

`ehIcalUidNosso` reconhecia nossos eventos pelo sufixo `@deskcomm.app`. Sem o uid ficaria **cego**, e todo compromisso criado pelo CRM voltaria pela sincronização como ocupação de terceiro — bloqueando o próprio horário que ele ocupa.

Migrado para `ehEventoNosso`, que olha o **prefixo do `id`**: nosso por construção, preservado pelo Google, e já disponível como `external_event_id` no mesmo ponto do filtro (`cron/agenda-google-sync/route.ts`).

**Custo em dados: zero.** Nenhum evento nosso jamais chegou ao Google, em instalação nenhuma — as três eras de falha estão documentadas neste repo (filtro PostgREST inválido até a v1.7.0 em `MANIFEST.md:229`; `evento_sumiu` na v1.9.1 em `escrita.ts:23-29`; este 400). Não há legado com o uid antigo. `icalUidDoAgendamento` e `ehIcalUidNosso` ficaram órfãs e foram removidas.

## 2. Ocupação do Google não era desenhada

O servidor semeava os eventos externos e o cliente descartava a semente assim que o GET respondia — e a rota de listagem nunca devolveu ocupação. Em visão Mês nem a semente sobrevivia.

A ocupação entra na **rota**, nunca em `listaAgendamentos`: aquela função é compartilhada com a tool MCP, e `"Ocupado"` na resposta dela faria o agente de IA falar sobre bloco anônimo do Google com o cliente. O hook parou de carimbar `origem: "ui"` fixo.

## 3. O erro do Google deixa de ser descartado

O corpo já era parseado e jogado fora; sobrava `HTTP 400`, repetido por horas. Foi essa mudança de **uma linha** que permitiu diagnosticar o item 1 em uma única rodada.

O callback também: 403 sem cota ganha desfecho próprio, com o motivo na auditoria, em vez de *"Tente de novo"* — conselho que nunca funcionaria para uma recusa permanente.

## Prova, com tráfego real

Primeira rodada do cron depois do deploy:

```
02/set Reunião      google=deskcommapp7f1d87a7...  erro=nenhum
09/set Atendimento  google=deskcommapp1e00a3b3...  erro=nenhum
```

Os dois no Google Agenda. E o dono do produto **remarcou um deles** — a alteração sincronizou, exercitando o `PUT` e provando que o vínculo se mantém.

## Sobre a cobertura

Os testes de unidade **passavam verdes** com o payload inválido, porque mediam o corpo contra si mesmo e nunca contra a API — inclusive um que asseverava explicitamente a presença do `iCalUID`. Reescrevi na direção inversa e sabotei nas duas metades: uid de volta ao corpo → vermelho; anti-eco desligado → 2 casos vermelhos.

## Verificado

`typecheck` zerado · `lint` zerado · suíte verde, exceto 3 arquivos de `lib/notifications` que falham nesta máquina por jsdom sem origem no Node 26 (o repo fixa Node 22) — não têm relação com este diff.

Fico à disposição para ajustar o que preferir diferente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)