### PR TITLE
fix(release): a guarda reconhece o corte por REMOVER fragmento, não por esvaziar o diretório (fecha #472)

### DIFF
--- a/.changes/a-release-volta-a-sair-quando-ha-merge-no-meio.md
+++ b/.changes/a-release-volta-a-sair-quando-ha-merge-no-meio.md
@@ -1,0 +1,26 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A atualização volta a chegar quando alguém aprova outra coisa durante o fechamento da versão
+---
+
+Uma versão do sistema é fechada em duas etapas: primeiro o time monta a lista do
+que entrou, depois aprova essa lista. Entre uma coisa e outra, qualquer outra
+melhoria aprovada no meio do caminho fazia o fechamento **desistir em silêncio**
+— a versão aparecia na lista de novidades, mas nunca era publicada de verdade.
+
+O efeito para quem tem o sistema instalado era o pior tipo: nada de errado
+aparecia em lugar nenhum. O painel não acusava, o histórico de versões mostrava
+a versão nova como se existisse, e a atualização simplesmente nunca chegava. Foi
+o que aconteceu com a versão 1.11.1: ela consta no histórico desde 31 de agosto e
+nunca existiu como pacote — nenhuma instalação a recebeu.
+
+Agora o fechamento reconhece a si mesmo por outro sinal, que não depende de o
+resto do time parar de trabalhar enquanto a versão fecha. E, se alguma coisa
+estranha acontecer nesse momento, o processo **falha alto** em vez de passar
+batido — que é o que teria feito alguém perceber a 1.11.1 no mesmo dia, e não
+duas semanas depois.
+
+Para quem opera uma instalação, nada muda no dia a dia: nenhuma configuração
+nova, nenhum passo de atualização. O que muda é que "a versão saiu" volta a
+significar que ela saiu.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,6 +189,9 @@ jobs:
                 echo "${f}"
               fi
             done
+            # Fecha a substituição com status conhecido, para que o `set -e` do
+            # passo nunca dependa de qual foi o último `grep` do laço.
+            true
           )
 
           echo "fragmentos removidos por este commit: ${removidos}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,10 +148,23 @@ jobs:
           # falhou (f6f91377): a guarda antiga via depois=1 e recusava; a
           # nova vê 3 removidos e corta.
           #
-          # E a terceira condição é o que torna esta guarda MAIS FORTE que a
-          # anterior, não mais fraca: a ponta do branch de release é assinada
-          # pelo App da release. Apagar fragmento à mão num PR comum agora não
-          # basta — seria preciso a identidade do App, que vive em secrets.
+          # ⚠️ A TERCEIRA CONDIÇÃO É CINTO DE SEGURANÇA CONTRA ENGANO, NÃO
+          # CONTRA FORJA — e a distinção precisa estar escrita aqui, porque a
+          # versão anterior deste comentário dizia que a identidade do App
+          # "vive em secrets", e isso é FALSO.
+          #
+          # `%an` é o NOME DO AUTOR: campo de texto que qualquer um define.
+          # `git -c user.name='deskcomm-release[bot]' commit` devolve exatamente
+          # a string que a comparação abaixo procura. Medido.
+          #
+          # Nem adianta trocar por conferência criptográfica: os cinco cortes
+          # reais desta main têm `%G? = N` — não há assinatura para conferir.
+          #
+          # O que ela pega é o caso COMUM: alguém apaga um fragmento sem querer
+          # e a tag nasceria sozinha. Contra isso ela faz barulho em vez de
+          # silêncio, e é por isso que fica. Contra forja deliberada ela não
+          # protege, e a proteção de verdade — conferir pela API que o PR de
+          # origem foi aberto pelo App — está na issue #478.
           versao=$(pnpm exec tsx scripts/cortar-release.ts --versao-do-changelog)
 
           # `--diff-filter=D` conta o que este commit APAGOU de `.changes/`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,34 +117,75 @@ jobs:
         run: |
           set -euo pipefail
 
-          # DUAS condições, e a segunda é a que importa. Só a primeira ("o
-          # CHANGELOG anuncia versão que não tem tag") deixaria QUALQUER PR
-          # cortar a release: bastaria escrever `## [1.7.0]` no CHANGELOG à mão
-          # e a tag nasceria no merge dele, pulando o PR de release inteiro —
-          # e com ela as três imagens e o canal `stable`.
+          # ─── O QUE IDENTIFICA UM CORTE DE RELEASE ─────────────────────────
           #
-          # Isso não é hipótese: medido em 2026-08-27, o PR #354 (RAG) já
-          # trazia uma seção de versão escrita à mão no CHANGELOG.
+          # Só a primeira condição ("o CHANGELOG anuncia versão que não tem
+          # tag") deixaria QUALQUER PR cortar a release: bastaria escrever
+          # `## [1.7.0]` no CHANGELOG à mão e a tag nasceria no merge dele,
+          # pulando o PR de release inteiro — e com ela as três imagens e o
+          # canal `stable`. Não é hipótese: medido em 2026-08-27, o PR #354
+          # (RAG) já trazia uma seção de versão escrita à mão no CHANGELOG.
           #
-          # A segunda condição é a ASSINATURA do corte, e um PR comum não a
-          # produz nem por engano: o commit CONSUMIU fragmentos — havia
-          # `.changes/*.md` antes e não há depois. PR comum ACRESCENTA
-          # fragmento; só o corte esvazia o diretório.
+          # ⚠️ A SEGUNDA CONDIÇÃO ERA "O DIRETÓRIO FICOU VAZIO", E ISSO ESTAVA
+          # ERRADO — issue #472, medido no run 33494815423:
+          #
+          #     fragmentos em .changes/: antes=4 depois=1
+          #
+          # A v1.11.1 foi anunciada no CHANGELOG e NUNCA virou tag. Sem tag,
+          # sem release, sem as três imagens, sem `stable`: nenhuma VPS a
+          # recebeu, e o workflow saiu `success` — ele só decidiu não cortar.
+          #
+          # A causa é uma CORRIDA, não uma forja: o PR #460 mergeou entre o
+          # corte e o merge da release, deixando o fragmento dele vivo. O
+          # branch de release foi cortado ANTES daquele fragmento existir,
+          # então o merge apagou os 3 que consumiu e o 4º continuou lá.
+          # "Esvaziou o diretório" é falso para todo corte que corre em
+          # paralelo com um merge comum — e merge comum é o estado normal de
+          # um repo vivo.
+          #
+          # A assinatura correta é REMOVER: PR comum ACRESCENTA fragmento e
+          # nunca apaga; só o corte apaga. Conferido no commit real que
+          # falhou (f6f91377): a guarda antiga via depois=1 e recusava; a
+          # nova vê 3 removidos e corta.
+          #
+          # E a terceira condição é o que torna esta guarda MAIS FORTE que a
+          # anterior, não mais fraca: a ponta do branch de release é assinada
+          # pelo App da release. Apagar fragmento à mão num PR comum agora não
+          # basta — seria preciso a identidade do App, que vive em secrets.
           versao=$(pnpm exec tsx scripts/cortar-release.ts --versao-do-changelog)
 
-          antes=$(git ls-tree -r --name-only HEAD^ -- .changes/ | grep -c '\.md$' || true)
-          depois=$(git ls-tree -r --name-only HEAD  -- .changes/ | grep -c '\.md$' || true)
-          echo "fragmentos em .changes/: antes=${antes} depois=${depois}"
+          # `--diff-filter=D` conta o que este commit APAGOU de `.changes/`.
+          # `|| true` porque `grep -c` sai 1 quando não casa nada, e `set -e`
+          # mataria o passo justamente no caso normal (PR comum, zero removidos).
+          removidos=$(git diff --diff-filter=D --name-only HEAD^ HEAD -- .changes/ | grep -c '\.md$' || true)
+
+          # Num merge commit, `HEAD^2` é a ponta do branch de release — o
+          # commit que o App assinou. Se o merge for squash não há segundo pai,
+          # e aí o autor do próprio HEAD é quem responde. O `|| true` evita que
+          # a ausência de `HEAD^2` derrube o passo.
+          assinante=$(git log -1 --format='%an' 'HEAD^2' 2>/dev/null || true)
+          [ -n "${assinante}" ] || assinante=$(git log -1 --format='%an' HEAD)
+
+          echo "fragmentos removidos por este commit: ${removidos}"
+          echo "assinante do corte: ${assinante}"
 
           if git rev-parse -q --verify "refs/tags/v${versao}" >/dev/null; then
             echo "v${versao} já existe — nada a cortar"
             echo "cortar=nao" >> "$GITHUB_OUTPUT"
-          elif [ "${antes}" -eq 0 ] || [ "${depois}" -ne 0 ]; then
-            echo "::notice::O CHANGELOG anuncia ${versao} sem tag, mas este push NÃO consumiu fragmentos."
+          elif [ "${removidos}" -eq 0 ]; then
+            echo "::notice::O CHANGELOG anuncia ${versao} sem tag, mas este push não apagou fragmento nenhum."
             echo "::notice::Tag não criada. Uma release sai do workflow 'release' (Run workflow), nunca de um merge comum."
             echo "cortar=nao" >> "$GITHUB_OUTPUT"
+          elif [ "${assinante}" != "deskcomm-release[bot]" ]; then
+            # Alto, e não `notice`: alguém apagou fragmento de `.changes/` num
+            # commit que não veio do workflow de release. Ou é forja, ou é
+            # engano — e o silêncio é exatamente o que fez a #472 passar dias
+            # sem ninguém ver.
+            echo "::error::Este commit apagou ${removidos} fragmento(s) de .changes/ mas não foi assinado pelo App da release (assinante: ${assinante})."
+            echo "::error::A tag v${versao} NÃO foi criada. Se isto foi um corte legítimo, ele não saiu do workflow 'release'."
+            exit 1
           else
-            echo "corte de release: ${antes} fragmento(s) consumido(s), v${versao} ainda não existe"
+            echo "corte de release: ${removidos} fragmento(s) consumido(s), v${versao} ainda não existe"
             echo "cortar=sim"       >> "$GITHUB_OUTPUT"
             echo "versao=${versao}" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,8 +166,34 @@ jobs:
           assinante=$(git log -1 --format='%an' 'HEAD^2' 2>/dev/null || true)
           [ -n "${assinante}" ] || assinante=$(git log -1 --format='%an' HEAD)
 
+          # ─── O QUE SOBROU, E POR QUE ISSO IMPORTA ─────────────────────────
+          #
+          # A guarda antiga garantia, sem dizer, uma segunda coisa: `depois==0`
+          # significava que a versão anunciada dá conta de TUDO que estava
+          # pendente na main. Trocar por "removeu" abre mão disso — e há um caso
+          # em que abrir mão FAZ DANO.
+          #
+          # O caso: um PR com `impacto: exige_acao` mergeia durante a janela da
+          # release. O fragmento dele sobrevive (vai para a próxima versão), a
+          # tag sai, e `stable` passa a apontar para uma main que EXIGE ação do
+          # operador — enquanto a seção do CHANGELOG que ele lê antes de rodar o
+          # `update.sh` diz que nada mudou. O aviso fica na gaveta e o contêiner
+          # não sobe.
+          #
+          # `nada_mudou` e `capacidade_nova` sobrevivendo são inofensivos: entram
+          # na versão seguinte e ninguém quebra no meio. `exige_acao` não é.
+          exigem_acao=$(
+            git diff --diff-filter=D --name-only HEAD^ HEAD -- .changes/ > /tmp/removidos.txt || true
+            for f in $(git ls-tree -r --name-only HEAD -- .changes/ | grep '\.md$' || true); do
+              if git show "HEAD:${f}" | head -20 | grep -q '^impacto:[[:space:]]*exige_acao'; then
+                echo "${f}"
+              fi
+            done
+          )
+
           echo "fragmentos removidos por este commit: ${removidos}"
           echo "assinante do corte: ${assinante}"
+          echo "fragmentos vivos que exigem ação: ${exigem_acao:-nenhum}"
 
           if git rev-parse -q --verify "refs/tags/v${versao}" >/dev/null; then
             echo "v${versao} já existe — nada a cortar"
@@ -183,6 +209,14 @@ jobs:
             # sem ninguém ver.
             echo "::error::Este commit apagou ${removidos} fragmento(s) de .changes/ mas não foi assinado pelo App da release (assinante: ${assinante})."
             echo "::error::A tag v${versao} NÃO foi criada. Se isto foi um corte legítimo, ele não saiu do workflow 'release'."
+            exit 1
+          elif [ -n "${exigem_acao}" ]; then
+            # Alto, e de novo não `notice`: este é o único caso em que NÃO cortar
+            # é o certo, e ele precisa de gente. Cortar publicaria `stable` sem o
+            # aviso que o operador precisa ler ANTES de atualizar.
+            echo "::error::Sobrou fragmento com 'impacto: exige_acao' em .changes/ — a v${versao} sairia sem o aviso que o operador precisa ler antes de atualizar."
+            echo "::error::Fragmentos: ${exigem_acao}"
+            echo "::error::Tag NÃO criada. Rode o workflow de release de novo, agora que ele consome também esse fragmento."
             exit 1
           else
             echo "corte de release: ${removidos} fragmento(s) consumido(s), v${versao} ainda não existe"

--- a/tests/unit/guarda-da-release-reconhece-o-corte.test.ts
+++ b/tests/unit/guarda-da-release-reconhece-o-corte.test.ts
@@ -102,21 +102,47 @@ function commit(mensagem: string, autor = "Alguém do time") {
  * `HEAD^2` viraria `<sha>^2` só pela metade.
  */
 function decisaoPara(sha: string): string {
-  const script = bashDaGuarda()
-    // A versão vem do CHANGELOG por um script de TS que não existe no repo
-    // sintético; ela é irrelevante aqui e fica num número sem tag, para não
-    // sair pelo primeiro `if`.
-    .replace(/^\s*versao=\$\(.*\)$/m, 'versao="999.999.999"')
+  const original = bashDaGuarda();
+
+  // A versão vem do CHANGELOG por um script de TS que não existe no repo
+  // sintético; ela é irrelevante aqui e fica num número sem tag, para não sair
+  // pelo primeiro `if`.
+  //
+  // ⚠️ `[^\n]*` e não `.*$`: com `$` e a flag `m`, um `\r` de fim de linha faz
+  // a âncora não casar, a substituição vira NO-OP SILENCIOSA, e o script tenta
+  // rodar `pnpm exec tsx` dentro do repositório temporário — que não tem
+  // `scripts/`. O sintoma é um `Command failed` sem explicação, e foi assim que
+  // este teste passou na minha máquina e reprovou no CI.
+  const script = original
+    .replace(/^[ \t]*versao=\$\([^\n]*\)[ \t\r]*$/m, 'versao="999.999.999"')
     .replace(/HEAD\^2/g, `${sha}^2`)
     .replace(/HEAD\^/g, `${sha}^`)
     .replace(/\bHEAD\b/g, sha);
 
-  const saida = execFileSync("bash", ["-c", script], {
-    cwd: repo,
-    encoding: "utf8",
-    env: { ...process.env, GITHUB_OUTPUT: "/dev/stdout" },
-  });
-  return /cortar=(\w+)/.exec(saida)?.[1] ?? "(nenhuma decisão)";
+  // A substituição que não acontece tem de gritar, não sumir.
+  expect(script, "a linha `versao=$(...)` não foi substituída — o script rodaria o cortar-release de verdade")
+    .not.toMatch(/cortar-release\.ts/);
+
+  try {
+    const saida = execFileSync("bash", ["-c", script], {
+      cwd: repo,
+      encoding: "utf8",
+      env: { ...process.env, GITHUB_OUTPUT: "/dev/stdout" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return /cortar=(\w+)/.exec(saida)?.[1] ?? "(nenhuma decisão)";
+  } catch (err) {
+    // `execFileSync` joga fora o stderr na mensagem padrão, e sem ele o CI
+    // devolve só "Command failed: bash -c set -euo pipefail". Diagnóstico que
+    // não chega ao log é diagnóstico que não existe.
+    const e = err as { stderr?: Buffer | string; stdout?: Buffer | string; status?: number };
+    const detalhe = [
+      `exit=${e.status ?? "?"}`,
+      `stderr: ${String(e.stderr ?? "").trim() || "(vazio)"}`,
+      `stdout: ${String(e.stdout ?? "").trim() || "(vazio)"}`,
+    ].join("\n");
+    throw new Error(`a guarda derrubou o passo para ${sha}\n${detalhe}`);
+  }
 }
 
 let mergeDaReleaseComCorrida = "";

--- a/tests/unit/guarda-da-release-reconhece-o-corte.test.ts
+++ b/tests/unit/guarda-da-release-reconhece-o-corte.test.ts
@@ -1,0 +1,165 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * A GUARDA DA RELEASE, MEDIDA CONTRA OS COMMITS QUE ELA JÁ JULGOU.
+ *
+ * ═══ O defeito que este teste existe para não ter de novo ═══════════════════
+ *
+ * A v1.11.1 foi anunciada no CHANGELOG e NUNCA virou tag (issue #472). Sem
+ * tag: sem release, sem as três imagens, sem `stable` — nenhuma VPS a recebeu.
+ * E o workflow saiu `success`: ele apenas decidiu não cortar.
+ *
+ * A guarda antiga reconhecia um corte por "o diretório `.changes/` ficou
+ * vazio". No run 33494815423 ela viu `antes=4 depois=1` e desistiu — porque o
+ * PR #460 mergeou ENTRE o corte e o merge da release, deixando o fragmento
+ * dele vivo. Um merge comum correndo em paralelo com a release é o estado
+ * normal de um repo vivo, não uma anomalia.
+ *
+ * ═══ Por que este teste EXECUTA o bash do workflow ══════════════════════════
+ *
+ * Reescrever a regra em TypeScript criaria a segunda verdade sobre o que é um
+ * corte, e a segunda envelhece sozinha: alguém ajusta o YAML, o espelho de TS
+ * segue verde, e o gate passa a medir uma regra que não roda em lugar nenhum.
+ * Aqui o bloco `run:` é EXTRAÍDO do `.github/workflows/release.yml` e
+ * executado — o que está sob teste é o arquivo que o CI usa.
+ *
+ * A única transformação é trocar `HEAD` pelo commit sob julgamento (o script
+ * fala em `HEAD`, e o teste precisa julgar cinco commits sem mexer no worktree)
+ * e fixar a versão, que viria de `cortar-release.ts` e não é o que se mede aqui.
+ */
+
+const RAIZ = process.cwd();
+
+/** O bloco `run:` do passo que decide se este push foi um corte. */
+function bashDaGuarda(): string {
+  const yml = readFileSync(join(RAIZ, ".github/workflows/release.yml"), "utf8");
+  const inicio = yml.indexOf("Este push foi um corte de release?");
+  expect(inicio, "o passo da guarda sumiu do release.yml").toBeGreaterThan(-1);
+  const run = yml.indexOf("run: |", inicio);
+  expect(run, "o passo da guarda não tem bloco run").toBeGreaterThan(-1);
+
+  const linhas = yml.slice(run + "run: |".length).split("\n").slice(1);
+  const corpo: string[] = [];
+  for (const l of linhas) {
+    // O bloco acaba na primeira linha não-vazia com indentação menor que a dele.
+    if (l.trim() !== "" && !l.startsWith("          ")) break;
+    corpo.push(l.slice(10));
+  }
+  return corpo.join("\n");
+}
+
+/**
+ * Roda a guarda como se `HEAD` fosse `sha`, e devolve o que ela decidiu.
+ *
+ * `HEAD^2` primeiro, depois `HEAD^`, depois `HEAD`: a ordem importa, senão
+ * `HEAD^2` viraria `<sha>^2` só pela metade.
+ */
+function decisaoPara(sha: string): { cortar: string; saida: string } {
+  const script = bashDaGuarda()
+    // A versão vem do CHANGELOG por um script de TS; aqui ela é irrelevante e
+    // fixada num número que não tem tag, para não pular no primeiro `if`.
+    .replace(/^\s*versao=\$\(.*\)$/m, 'versao="999.999.999"')
+    .replace(/HEAD\^2/g, `${sha}^2`)
+    .replace(/HEAD\^/g, `${sha}^`)
+    .replace(/\bHEAD\b/g, sha);
+
+  const saida = execFileSync("bash", ["-c", script], {
+    cwd: RAIZ,
+    encoding: "utf8",
+    env: { ...process.env, GITHUB_OUTPUT: "/dev/stdout" },
+  });
+
+  const m = /cortar=(\w+)/.exec(saida);
+  return { cortar: m?.[1] ?? "(nenhuma decisão)", saida };
+}
+
+/**
+ * Commits reais desta `main`, e o que a guarda TEM de decidir sobre cada um.
+ *
+ * SHAs fixos de propósito: são os fatos históricos que o defeito produziu, e a
+ * `main` deste repo não é reescrita. Um deles é o commit que falhou.
+ */
+const CASOS = [
+  {
+    sha: "1e3c724f",
+    o_que_e: "release 1.11.0 — o corte que funcionou",
+    espera: "sim",
+  },
+  {
+    sha: "f6f91377",
+    o_que_e: "release 1.11.1 — O CORTE QUE A GUARDA ANTIGA RECUSOU (issue #472)",
+    espera: "sim",
+  },
+  {
+    sha: "3b6832fa",
+    o_que_e: "PR comum que ACRESCENTA fragmento (o catálogo, #475)",
+    espera: "nao",
+  },
+  {
+    sha: "b305a47b",
+    o_que_e: "PR comum que acrescentou o fragmento da corrida (#460)",
+    espera: "nao",
+  },
+  {
+    sha: "a3ae300d",
+    o_que_e: "commit solto de feature, sem tocar em .changes/",
+    espera: "nao",
+  },
+] as const;
+
+describe("a guarda da release, contra os commits que ela já julgou", () => {
+  for (const c of CASOS) {
+    it(`${c.sha} (${c.o_que_e}) → cortar=${c.espera}`, () => {
+      expect(decisaoPara(c.sha).cortar).toBe(c.espera);
+    });
+  }
+
+  it("o caso da #472 é o ÚNICO que muda de veredito — os outros quatro seguem iguais", () => {
+    // Sem este caso, uma guarda que dissesse "sim" para tudo passaria nos dois
+    // primeiros e o teste pareceria verde por competência.
+    const vereditos = CASOS.map((c) => decisaoPara(c.sha).cortar);
+    expect(vereditos).toEqual(["sim", "sim", "nao", "nao", "nao"]);
+  });
+});
+
+describe("a guarda recusa alto, e não em silêncio, quem apaga fragmento sem ser o App", () => {
+  it("um commit que apaga fragmento sem a assinatura do App derruba o passo", () => {
+    // É o buraco que a #472 deixou à vista: o workflow saiu `success` sem tag,
+    // e ninguém viu por dias. Apagar fragmento fora do corte é o caso em que
+    // silêncio é o pior desfecho possível.
+    const script = bashDaGuarda()
+      .replace(/^\s*versao=\$\(.*\)$/m, 'versao="999.999.999"')
+      .replace(/^\s*removidos=\$\(.*\)$/m, "removidos=3")
+      .replace(/^\s*assinante=\$\(.*\)$/m, 'assinante="Fulano de Tal"')
+      .replace(/^\s*\[ -n "\$\{assinante\}" \].*$/m, ":");
+
+    expect(() =>
+      execFileSync("bash", ["-c", script], {
+        cwd: RAIZ,
+        encoding: "utf8",
+        stdio: "pipe",
+        env: { ...process.env, GITHUB_OUTPUT: "/dev/null" },
+      }),
+    ).toThrow();
+  });
+
+  it("o mesmo commit COM a assinatura do App corta (controle positivo)", () => {
+    // Sem este, "derruba sempre" satisfaria o caso acima.
+    const script = bashDaGuarda()
+      .replace(/^\s*versao=\$\(.*\)$/m, 'versao="999.999.999"')
+      .replace(/^\s*removidos=\$\(.*\)$/m, "removidos=3")
+      .replace(/^\s*assinante=\$\(.*\)$/m, 'assinante="deskcomm-release[bot]"')
+      .replace(/^\s*\[ -n "\$\{assinante\}" \].*$/m, ":");
+
+    const saida = execFileSync("bash", ["-c", script], {
+      cwd: RAIZ,
+      encoding: "utf8",
+      env: { ...process.env, GITHUB_OUTPUT: "/dev/stdout" },
+    });
+    expect(saida).toMatch(/cortar=sim/);
+  });
+});

--- a/tests/unit/guarda-da-release-reconhece-o-corte.test.ts
+++ b/tests/unit/guarda-da-release-reconhece-o-corte.test.ts
@@ -81,9 +81,12 @@ function git(args: string[], opts: { autor?: string } = {}): string {
   return execFileSync("git", args, { cwd: repo, encoding: "utf8", env }).trim();
 }
 
-function fragmento(nome: string, corpo = "fragmento") {
+function fragmento(nome: string, impacto = "nada_mudou") {
   mkdirSync(join(repo, ".changes"), { recursive: true });
-  writeFileSync(join(repo, ".changes", nome), corpo);
+  writeFileSync(
+    join(repo, ".changes", nome),
+    `---\nimpacto: ${impacto}\nsecao: corrigido\ntitulo: ${nome}\n---\n\ncorpo.\n`,
+  );
 }
 
 function commit(mensagem: string, autor = "Alguém do time") {
@@ -128,7 +131,8 @@ beforeAll(() => {
   git(["config", "commit.gpgsign", "false"]);
 
   writeFileSync(join(repo, "CHANGELOG.md"), "# Changelog\n");
-  fragmento(".gitkeep", "");
+  mkdirSync(join(repo, ".changes"), { recursive: true });
+  writeFileSync(join(repo, ".changes/.gitkeep"), "");
   commit("chore: raiz");
 
   // ── Estado antes do corte: dois fragmentos declarados ────────────────────
@@ -187,6 +191,59 @@ describe("a guarda reconhece o corte pela forma dele", () => {
 
   it("NÃO corta um commit que nem toca em .changes/", () => {
     expect(decisaoPara(commitDeFeature)).toBe("nao");
+  });
+});
+
+describe("o que SOBRA da release também decide — e foi um cético que achou isto", () => {
+  /**
+   * A guarda antiga garantia, sem dizer, uma segunda propriedade: `depois==0`
+   * significava que a versão anunciada dá conta de TUDO que estava pendente na
+   * main. Trocar "esvaziou" por "removeu" abre mão disso — e há um caso em que
+   * abrir mão FAZ DANO.
+   *
+   * O caso: um PR com `impacto: exige_acao` mergeia durante a janela da
+   * release. A tag sai, `stable` passa a apontar para uma main que EXIGE ação
+   * do operador, e a seção do CHANGELOG que ele lê antes de rodar o `update.sh`
+   * diz que nada mudou. O aviso fica na gaveta e o contêiner não sobe.
+   *
+   * Eu tinha escrito no PR que a guarda nova era "mais forte, não mais fraca".
+   * Era falso nesta dimensão, e quem mostrou foi um cético que eu mesmo pus
+   * para tentar quebrá-la.
+   */
+  it("RECUSA ALTO quando sobra fragmento que exige ação do operador", () => {
+    git(["checkout", "-q", "main"]);
+    fragmento("e-obrigatorio.md", "exige_acao");
+    const concorrenteQueQuebra = commit("feat: agora o Redis é obrigatório");
+    git(["merge", "-q", "--no-ff", "-m", "Merge PR #999", concorrenteQueQuebra]);
+
+    fragmento("f.md");
+    const antes = commit("feat: mais um fragmento para a release consumir");
+    git(["checkout", "-q", "-b", "release/8.8.8", antes]);
+    rmSync(join(repo, ".changes/f.md"));
+    const ponta = commit("release(8.8.8): montada dos fragmentos", BOT);
+    git(["checkout", "-q", "main"]);
+    git(["merge", "-q", "--no-ff", "-m", "Merge pull request #1000 from release/8.8.8", ponta]);
+
+    expect(() => decisaoPara(git(["rev-parse", "HEAD"]))).toThrow();
+  });
+
+  it("CORTA quando o que sobra é inofensivo (controle positivo)", () => {
+    // Sem este caso, "recusa sempre que sobra alguma coisa" satisfaria o
+    // anterior — e seria a guarda antiga de volta, com outro nome.
+    git(["checkout", "-q", "main"]);
+    rmSync(join(repo, ".changes/e-obrigatorio.md"));
+    commit("chore: some com o fragmento que exige ação");
+
+    fragmento("g.md", "capacidade_nova");
+    fragmento("h.md");
+    const antes = commit("feat: dois fragmentos, nenhum exige ação");
+    git(["checkout", "-q", "-b", "release/7.7.7", antes]);
+    rmSync(join(repo, ".changes/g.md"));
+    const ponta = commit("release(7.7.7): montada dos fragmentos", BOT);
+    git(["checkout", "-q", "main"]);
+    git(["merge", "-q", "--no-ff", "-m", "Merge pull request #1001 from release/7.7.7", ponta]);
+
+    expect(decisaoPara(git(["rev-parse", "HEAD"]))).toBe("sim");
   });
 });
 

--- a/tests/unit/guarda-da-release-reconhece-o-corte.test.ts
+++ b/tests/unit/guarda-da-release-reconhece-o-corte.test.ts
@@ -123,14 +123,31 @@ function decisaoPara(sha: string): string {
   expect(script, "a linha `versao=$(...)` não foi substituída — o script rodaria o cortar-release de verdade")
     .not.toMatch(/cortar-release\.ts/);
 
+  // ⚠️ `GITHUB_OUTPUT` vai para um ARQUIVO, não para `/dev/stdout`.
+  //
+  // Isto foi o que reprovou este teste no CI enquanto ele passava aqui, e a
+  // causa não era nenhuma das duas que eu e o Maestro supusemos (fim de linha,
+  // interação entre testes). O stderr, quando finalmente chegou ao log, disse
+  // em uma linha:
+  //
+  //     bash: line 109: /dev/stdout: No such device or address
+  //
+  // No runner, o stdout do processo é um pipe capturado pelo `execFileSync`, e
+  // `>> /dev/stdout` falha. No macOS funciona. O passo do workflow escreve no
+  // arquivo que o GitHub dá — então o teste faz o mesmo, que é também o que o
+  // ambiente real faz.
+  const saidaDoGithub = join(repo, `.github-output-${process.pid}`);
+  writeFileSync(saidaDoGithub, "");
+
   try {
     const saida = execFileSync("bash", ["-c", script], {
       cwd: repo,
       encoding: "utf8",
-      env: { ...process.env, GITHUB_OUTPUT: "/dev/stdout" },
+      env: { ...process.env, GITHUB_OUTPUT: saidaDoGithub },
       stdio: ["ignore", "pipe", "pipe"],
     });
-    return /cortar=(\w+)/.exec(saida)?.[1] ?? "(nenhuma decisão)";
+    const escrito = readFileSync(saidaDoGithub, "utf8");
+    return /cortar=(\w+)/.exec(`${escrito}\n${saida}`)?.[1] ?? "(nenhuma decisão)";
   } catch (err) {
     // `execFileSync` joga fora o stderr na mensagem padrão, e sem ele o CI
     // devolve só "Command failed: bash -c set -euo pipefail". Diagnóstico que

--- a/tests/unit/guarda-da-release-reconhece-o-corte.test.ts
+++ b/tests/unit/guarda-da-release-reconhece-o-corte.test.ts
@@ -1,23 +1,24 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 /**
- * A GUARDA DA RELEASE, MEDIDA CONTRA OS COMMITS QUE ELA JÁ JULGOU.
+ * A GUARDA DA RELEASE, MEDIDA CONTRA A FORMA DO CORTE.
  *
  * ═══ O defeito que este teste existe para não ter de novo ═══════════════════
  *
- * A v1.11.1 foi anunciada no CHANGELOG e NUNCA virou tag (issue #472). Sem
- * tag: sem release, sem as três imagens, sem `stable` — nenhuma VPS a recebeu.
- * E o workflow saiu `success`: ele apenas decidiu não cortar.
+ * A v1.11.1 foi anunciada no CHANGELOG e NUNCA virou tag (issue #472). Sem tag:
+ * sem release, sem as três imagens, sem `stable` — nenhuma VPS a recebeu. E o
+ * workflow saiu `success`: ele apenas decidiu não cortar.
  *
  * A guarda antiga reconhecia um corte por "o diretório `.changes/` ficou
  * vazio". No run 33494815423 ela viu `antes=4 depois=1` e desistiu — porque o
  * PR #460 mergeou ENTRE o corte e o merge da release, deixando o fragmento
- * dele vivo. Um merge comum correndo em paralelo com a release é o estado
- * normal de um repo vivo, não uma anomalia.
+ * dele vivo. Merge comum correndo em paralelo com a release é o estado normal
+ * de um repo vivo, não uma anomalia.
  *
  * ═══ Por que este teste EXECUTA o bash do workflow ══════════════════════════
  *
@@ -27,12 +28,25 @@ import { describe, expect, it } from "vitest";
  * Aqui o bloco `run:` é EXTRAÍDO do `.github/workflows/release.yml` e
  * executado — o que está sob teste é o arquivo que o CI usa.
  *
- * A única transformação é trocar `HEAD` pelo commit sob julgamento (o script
- * fala em `HEAD`, e o teste precisa julgar cinco commits sem mexer no worktree)
- * e fixar a versão, que viria de `cortar-release.ts` e não é o que se mede aqui.
+ * ═══ Por que repositório SINTÉTICO, e não os commits reais ══════════════════
+ *
+ * A primeira versão deste teste julgava SHAs desta `main` — inclusive o
+ * `f6f91377` que falhou de verdade. Era evidência melhor de ler e PIOR de
+ * confiar: o checkout do CI é raso, e lá o teste devolvia
+ *
+ *     fatal: bad revision '1e3c724f^'
+ *
+ * em todos os casos. Um gate que só mede na máquina de quem o escreveu é pior
+ * que gate nenhum, porque parece cobertura.
+ *
+ * O repositório abaixo REPRODUZ a forma do #472 em vez de depender de ela ter
+ * acontecido: dois fragmentos, um branch de release que os apaga assinado pelo
+ * bot, um PR concorrente que acrescenta um terceiro no meio, e o merge com dois
+ * pais. Roda igual em qualquer clone, raso ou completo.
  */
 
 const RAIZ = process.cwd();
+const BOT = "deskcomm-release[bot]";
 
 /** O bloco `run:` do passo que decide se este push foi um corte. */
 function bashDaGuarda(): string {
@@ -52,114 +66,150 @@ function bashDaGuarda(): string {
   return corpo.join("\n");
 }
 
+let repo: string;
+
+function git(args: string[], opts: { autor?: string } = {}): string {
+  const env = { ...process.env, GIT_TERMINAL_PROMPT: "0" };
+  if (opts.autor) {
+    Object.assign(env, {
+      GIT_AUTHOR_NAME: opts.autor,
+      GIT_COMMITTER_NAME: opts.autor,
+      GIT_AUTHOR_EMAIL: `${opts.autor}@exemplo.test`,
+      GIT_COMMITTER_EMAIL: `${opts.autor}@exemplo.test`,
+    });
+  }
+  return execFileSync("git", args, { cwd: repo, encoding: "utf8", env }).trim();
+}
+
+function fragmento(nome: string, corpo = "fragmento") {
+  mkdirSync(join(repo, ".changes"), { recursive: true });
+  writeFileSync(join(repo, ".changes", nome), corpo);
+}
+
+function commit(mensagem: string, autor = "Alguém do time") {
+  git(["add", "-A"]);
+  git(["commit", "-q", "-m", mensagem], { autor });
+  return git(["rev-parse", "HEAD"]);
+}
+
 /**
- * Roda a guarda como se `HEAD` fosse `sha`, e devolve o que ela decidiu.
+ * Roda a guarda como se `HEAD` fosse `sha`, dentro do repositório sintético.
  *
  * `HEAD^2` primeiro, depois `HEAD^`, depois `HEAD`: a ordem importa, senão
  * `HEAD^2` viraria `<sha>^2` só pela metade.
  */
-function decisaoPara(sha: string): { cortar: string; saida: string } {
+function decisaoPara(sha: string): string {
   const script = bashDaGuarda()
-    // A versão vem do CHANGELOG por um script de TS; aqui ela é irrelevante e
-    // fixada num número que não tem tag, para não pular no primeiro `if`.
+    // A versão vem do CHANGELOG por um script de TS que não existe no repo
+    // sintético; ela é irrelevante aqui e fica num número sem tag, para não
+    // sair pelo primeiro `if`.
     .replace(/^\s*versao=\$\(.*\)$/m, 'versao="999.999.999"')
     .replace(/HEAD\^2/g, `${sha}^2`)
     .replace(/HEAD\^/g, `${sha}^`)
     .replace(/\bHEAD\b/g, sha);
 
   const saida = execFileSync("bash", ["-c", script], {
-    cwd: RAIZ,
+    cwd: repo,
     encoding: "utf8",
     env: { ...process.env, GITHUB_OUTPUT: "/dev/stdout" },
   });
-
-  const m = /cortar=(\w+)/.exec(saida);
-  return { cortar: m?.[1] ?? "(nenhuma decisão)", saida };
+  return /cortar=(\w+)/.exec(saida)?.[1] ?? "(nenhuma decisão)";
 }
 
-/**
- * Commits reais desta `main`, e o que a guarda TEM de decidir sobre cada um.
- *
- * SHAs fixos de propósito: são os fatos históricos que o defeito produziu, e a
- * `main` deste repo não é reescrita. Um deles é o commit que falhou.
- */
-const CASOS = [
-  {
-    sha: "1e3c724f",
-    o_que_e: "release 1.11.0 — o corte que funcionou",
-    espera: "sim",
-  },
-  {
-    sha: "f6f91377",
-    o_que_e: "release 1.11.1 — O CORTE QUE A GUARDA ANTIGA RECUSOU (issue #472)",
-    espera: "sim",
-  },
-  {
-    sha: "3b6832fa",
-    o_que_e: "PR comum que ACRESCENTA fragmento (o catálogo, #475)",
-    espera: "nao",
-  },
-  {
-    sha: "b305a47b",
-    o_que_e: "PR comum que acrescentou o fragmento da corrida (#460)",
-    espera: "nao",
-  },
-  {
-    sha: "a3ae300d",
-    o_que_e: "commit solto de feature, sem tocar em .changes/",
-    espera: "nao",
-  },
-] as const;
+let mergeDaReleaseComCorrida = "";
+let mergeDePrComum = "";
+let commitDeFeature = "";
 
-describe("a guarda da release, contra os commits que ela já julgou", () => {
-  for (const c of CASOS) {
-    it(`${c.sha} (${c.o_que_e}) → cortar=${c.espera}`, () => {
-      expect(decisaoPara(c.sha).cortar).toBe(c.espera);
-    });
-  }
+beforeAll(() => {
+  repo = mkdtempSync(join(tmpdir(), "guarda-release-"));
+  git(["init", "-q", "-b", "main"]);
+  git(["config", "user.name", "Alguém do time"]);
+  git(["config", "user.email", "alguem@exemplo.test"]);
+  git(["config", "commit.gpgsign", "false"]);
 
-  it("o caso da #472 é o ÚNICO que muda de veredito — os outros quatro seguem iguais", () => {
-    // Sem este caso, uma guarda que dissesse "sim" para tudo passaria nos dois
-    // primeiros e o teste pareceria verde por competência.
-    const vereditos = CASOS.map((c) => decisaoPara(c.sha).cortar);
-    expect(vereditos).toEqual(["sim", "sim", "nao", "nao", "nao"]);
+  writeFileSync(join(repo, "CHANGELOG.md"), "# Changelog\n");
+  fragmento(".gitkeep", "");
+  commit("chore: raiz");
+
+  // ── Estado antes do corte: dois fragmentos declarados ────────────────────
+  fragmento("a.md");
+  fragmento("b.md");
+  const antesDoCorte = commit("feat: dois fragmentos");
+
+  // ── O branch de release: apaga o que consumiu, assinado pelo App ─────────
+  git(["checkout", "-q", "-b", "release/9.9.9", antesDoCorte]);
+  rmSync(join(repo, ".changes/a.md"));
+  rmSync(join(repo, ".changes/b.md"));
+  writeFileSync(join(repo, "CHANGELOG.md"), "# Changelog\n\n## [9.9.9]\n");
+  const pontaDaRelease = commit("release(9.9.9): a versão montada a partir dos fragmentos", BOT);
+
+  // ── A CORRIDA: um PR comum mergeia na main enquanto a release espera ─────
+  git(["checkout", "-q", "main"]);
+  fragmento("c.md");
+  const prConcorrente = commit("feat: o PR que chegou no meio");
+  git(["merge", "-q", "--no-ff", "-m", "Merge PR #460", prConcorrente]);
+  mergeDePrComum = git(["rev-parse", "HEAD"]);
+
+  // ── O merge da release, com o fragmento do concorrente ainda vivo ────────
+  git(["merge", "-q", "--no-ff", "-m", "Merge pull request #461 from release/9.9.9", pontaDaRelease]);
+  mergeDaReleaseComCorrida = git(["rev-parse", "HEAD"]);
+
+  // ── Um commit qualquer de feature, que não encosta em .changes/ ──────────
+  writeFileSync(join(repo, "README.md"), "nada a ver com release\n");
+  commitDeFeature = commit("fix: coisa nenhuma");
+});
+
+afterAll(() => {
+  if (repo) rmSync(repo, { recursive: true, force: true });
+});
+
+describe("a guarda reconhece o corte pela forma dele", () => {
+  it("CORTA o merge de release que correu junto com um PR comum — a forma exata da #472", () => {
+    // A guarda antiga via `depois=1` aqui (o fragmento do concorrente) e
+    // desistia. É o caso que a v1.11.1 encontrou, e o único que muda.
+    expect(decisaoPara(mergeDaReleaseComCorrida)).toBe("sim");
+  });
+
+  it("o diretório NÃO fica vazio nesse merge — é o que enganava a guarda antiga", () => {
+    // Sem este caso, o anterior poderia estar passando por um cenário onde a
+    // regra velha também funcionaria, e o teste não provaria nada.
+    const sobraram = git([
+      "ls-tree", "-r", "--name-only", mergeDaReleaseComCorrida, "--", ".changes/",
+    ])
+      .split("\n")
+      .filter((l) => l.endsWith(".md"));
+    expect(sobraram).toEqual([".changes/c.md"]);
+  });
+
+  it("NÃO corta um merge de PR comum, que só acrescenta fragmento", () => {
+    expect(decisaoPara(mergeDePrComum)).toBe("nao");
+  });
+
+  it("NÃO corta um commit que nem toca em .changes/", () => {
+    expect(decisaoPara(commitDeFeature)).toBe("nao");
   });
 });
 
-describe("a guarda recusa alto, e não em silêncio, quem apaga fragmento sem ser o App", () => {
-  it("um commit que apaga fragmento sem a assinatura do App derruba o passo", () => {
-    // É o buraco que a #472 deixou à vista: o workflow saiu `success` sem tag,
-    // e ninguém viu por dias. Apagar fragmento fora do corte é o caso em que
-    // silêncio é o pior desfecho possível.
-    const script = bashDaGuarda()
-      .replace(/^\s*versao=\$\(.*\)$/m, 'versao="999.999.999"')
-      .replace(/^\s*removidos=\$\(.*\)$/m, "removidos=3")
-      .replace(/^\s*assinante=\$\(.*\)$/m, 'assinante="Fulano de Tal"')
-      .replace(/^\s*\[ -n "\$\{assinante\}" \].*$/m, ":");
+describe("a guarda recusa ALTO, e não em silêncio, quem apaga fragmento sem ser o App", () => {
+  it("apagar fragmento à mão, num commit não assinado pelo App, derruba o passo", () => {
+    // A forja que a guarda antiga DEIXAVA passar: escrever a seção no CHANGELOG
+    // e esvaziar o diretório criava a tag. Agora não basta apagar — é preciso a
+    // identidade do App, que vive em secrets.
+    git(["checkout", "-q", "main"]);
+    rmSync(join(repo, ".changes/c.md"));
+    writeFileSync(join(repo, "CHANGELOG.md"), "# Changelog\n\n## [999.999.999]\n");
+    const forjado = commit("feat: parece uma release e não é", "Fulano de Tal");
 
-    expect(() =>
-      execFileSync("bash", ["-c", script], {
-        cwd: RAIZ,
-        encoding: "utf8",
-        stdio: "pipe",
-        env: { ...process.env, GITHUB_OUTPUT: "/dev/null" },
-      }),
-    ).toThrow();
+    expect(() => decisaoPara(forjado)).toThrow();
   });
 
-  it("o mesmo commit COM a assinatura do App corta (controle positivo)", () => {
+  it("o mesmo apagar, ASSINADO pelo App, corta (controle positivo)", () => {
     // Sem este, "derruba sempre" satisfaria o caso acima.
-    const script = bashDaGuarda()
-      .replace(/^\s*versao=\$\(.*\)$/m, 'versao="999.999.999"')
-      .replace(/^\s*removidos=\$\(.*\)$/m, "removidos=3")
-      .replace(/^\s*assinante=\$\(.*\)$/m, 'assinante="deskcomm-release[bot]"')
-      .replace(/^\s*\[ -n "\$\{assinante\}" \].*$/m, ":");
+    fragmento("d.md");
+    commit("feat: mais um fragmento");
+    rmSync(join(repo, ".changes/d.md"));
+    const legitimo = commit("release(999.999.999): montada dos fragmentos", BOT);
 
-    const saida = execFileSync("bash", ["-c", script], {
-      cwd: RAIZ,
-      encoding: "utf8",
-      env: { ...process.env, GITHUB_OUTPUT: "/dev/stdout" },
-    });
-    expect(saida).toMatch(/cortar=sim/);
+    expect(decisaoPara(legitimo)).toBe("sim");
   });
 });

--- a/tests/unit/guarda-da-release-reconhece-o-corte.test.ts
+++ b/tests/unit/guarda-da-release-reconhece-o-corte.test.ts
@@ -162,6 +162,26 @@ function decisaoPara(sha: string): string {
   }
 }
 
+/**
+ * Roda a guarda esperando que ela RECUSE, e devolve o que ela disse.
+ *
+ * ⚠️ Existe porque `expect(...).toThrow()` sozinho é VÁCUO: qualquer coisa que
+ * derrube o bash faz o caso passar. Foi exatamente o que aconteceu por dois
+ * runs seguidos — o `/dev/stdout` matava o script antes de a guarda decidir, e
+ * os casos de recusa passavam pelo motivo errado enquanto os de decisão
+ * falhavam. Um teste que aceita qualquer falha não distingue a guarda
+ * funcionando da guarda quebrada.
+ */
+function recusaPara(sha: string): { status: number; saida: string } {
+  try {
+    decisaoPara(sha);
+  } catch (err) {
+    const m = /exit=(\d+)/.exec(String((err as Error).message));
+    return { status: Number(m?.[1] ?? -1), saida: String((err as Error).message) };
+  }
+  throw new Error(`a guarda NÃO recusou ${sha} — ela decidiu, quando devia ter derrubado o passo`);
+}
+
 let mergeDaReleaseComCorrida = "";
 let mergeDePrComum = "";
 let commitDeFeature = "";
@@ -267,7 +287,10 @@ describe("o que SOBRA da release também decide — e foi um cético que achou i
     git(["checkout", "-q", "main"]);
     git(["merge", "-q", "--no-ff", "-m", "Merge pull request #1000 from release/8.8.8", ponta]);
 
-    expect(() => decisaoPara(git(["rev-parse", "HEAD"]))).toThrow();
+    const r = recusaPara(git(["rev-parse", "HEAD"]));
+    expect(r.status, "a guarda tem de sair com 1, e não morrer por outro motivo").toBe(1);
+    expect(r.saida).toMatch(/exige_acao/);
+    expect(r.saida).toMatch(/e-obrigatorio\.md/);
   });
 
   it("CORTA quando o que sobra é inofensivo (controle positivo)", () => {
@@ -300,7 +323,10 @@ describe("a guarda recusa ALTO, e não em silêncio, quem apaga fragmento sem se
     writeFileSync(join(repo, "CHANGELOG.md"), "# Changelog\n\n## [999.999.999]\n");
     const forjado = commit("feat: parece uma release e não é", "Fulano de Tal");
 
-    expect(() => decisaoPara(forjado)).toThrow();
+    const r = recusaPara(forjado);
+    expect(r.status, "a guarda tem de sair com 1, e não morrer por outro motivo").toBe(1);
+    expect(r.saida).toMatch(/não foi assinado pelo App/);
+    expect(r.saida).toMatch(/Fulano de Tal/);
   });
 
   it("o mesmo apagar, ASSINADO pelo App, corta (controle positivo)", () => {

--- a/tests/unit/tag-so-nasce-da-main.test.ts
+++ b/tests/unit/tag-so-nasce-da-main.test.ts
@@ -87,14 +87,19 @@ describe("a tag nasce no CI, e nunca do GITHUB_TOKEN", () => {
     // cortar a release: bastaria escrever `## [1.7.0]` à mão e a tag nasceria
     // no merge dele, levando junto as três imagens e o canal `stable`.
     // Medido em 2026-08-27: o PR #354 já trazia uma seção de versão escrita à
-    // mão. A segunda condição é a assinatura do corte — havia `.changes/*.md`
-    // antes e não há depois — e um PR comum não a produz: ele ACRESCENTA
-    // fragmento, nunca esvazia o diretório.
+    // mão. A segunda condição é a assinatura do corte: o commit REMOVEU
+    // fragmento — PR comum ACRESCENTA e nunca apaga.
     const t = job(release, "cortar-tag");
-    expect(t).toMatch(/git ls-tree[^\n]*HEAD\^[^\n]*\.changes\//);
-    expect(t).toMatch(/git ls-tree[^\n]*HEAD[^\n]*\.changes\//);
-    // O ramo que RECUSA precisa existir e cobrir os dois lados da assinatura.
-    expect(t).toMatch(/antes[^\n]*-eq 0[^\n]*depois[^\n]*-ne 0/);
+    // ⚠️ A assinatura MUDOU na migration desta guarda (issue #472): era "o
+    // diretório ficou vazio" (`antes>0 && depois==0`) e virou "este commit
+    // REMOVEU fragmento". A regra antiga recusava todo corte que corresse em
+    // paralelo com um merge comum — e merge comum é o estado normal de um repo
+    // vivo. Foi assim que a v1.11.1 nunca virou tag.
+    expect(t).toMatch(/git diff[^\n]*--diff-filter=D[^\n]*\.changes\//);
+    // O ramo que RECUSA precisa existir: zero removidos não é corte.
+    expect(t).toMatch(/removidos[^\n]*-eq 0/);
+    // E a condição que a guarda antiga NÃO tinha: só o App da release corta.
+    expect(t).toMatch(/deskcomm-release\[bot\]/);
   });
 
   it("a tag só é criada em push na main, nunca num dispatch de branch qualquer", () => {


### PR DESCRIPTION
Fecha #472.

## O buraco

A **v1.11.1 está no CHANGELOG desde 31/08 e nunca virou tag.** Sem tag: sem
release, sem as três imagens, sem `stable`. Nenhuma VPS a recebeu — e o
conserto do UUID zerado, que era o conteúdo dela, nunca chegou em produção.

O workflow `release` **rodou e saiu `success`**. Ele só decidiu não cortar.

## A causa é corrida, não forja

A guarda reconhecia um corte por **"o diretório `.changes/` ficou vazio"**. O PR
#460 mergeou entre o corte e o merge da release, deixando o fragmento dele vivo.
Run `33494815423`:

```
fragmentos em .changes/: antes=4 depois=1
```

"Esvaziou o diretório" é falso para todo corte que corre em paralelo com um
merge comum — e merge comum é o estado normal de um repo vivo. A guarda não
estava frouxa: estava medindo a coisa errada.

## O conserto, e por que ele é MAIS forte

A assinatura correta de um corte é **REMOVER**: PR comum acrescenta fragmento e
nunca apaga; só o corte apaga.

Mas "removeu ao menos um", sozinho, seria **estritamente mais fraco** que a
guarda atual — isso foi medido por um cético antes de a proposta virar código:
ele admite tudo que a atual admite, mais o cenário de apagar UM fragmento à mão.
Então entrou uma terceira condição, que a guarda antiga não tinha:

> a ponta do branch de release precisa estar **assinada pelo App da release**
> (`HEAD^2`).

⚠️ **Correção de uma afirmação minha que estava neste PR e era falsa.** Eu tinha
escrito que isso "torna a guarda mais forte contra forja, porque exigiria a
identidade do App, que vive em secrets". Não é verdade, e o Maestro mediu:
`%an` é o **nome do autor**, campo de texto que qualquer um define —
`git -c user.name='deskcomm-release[bot]' commit` devolve exatamente a string
comparada. Nem cabe conferência criptográfica: os cinco cortes reais desta
`main` têm `%G? = N`.

A condição **fica**, com o valor que de fato tem: é **cinto de segurança contra
engano**, não contra forja. Pega o caso comum — alguém apaga um fragmento sem
querer e a tag nasceria sozinha — e faz barulho em vez de silêncio. A proteção
contra forja de verdade (conferir pela API que o PR de origem foi aberto pelo
App) está na **issue #478**, e o comentário no YAML aponta para lá.

O buraco que **já existia** e continua existindo: escrever a seção no CHANGELOG
à mão e apagar todos os fragmentos **cria a tag** — medido em árvore git real
(`antes=3 depois=0 → cortar=sim`). A guarda antiga também não o fechava.

## O segundo defeito da #472 era o silêncio

Um commit que apaga fragmento sem a assinatura do App agora **derruba o passo**
com `::error::`, em vez de sair verde sem tag. Foi o silêncio que deixou a
1.11.1 passar dias sem ninguém ver — o defeito não foi só não cortar, foi não
cortar em silêncio.

## As provas

O teste **executa o bash extraído do próprio `release.yml`**. Reescrever a regra
em TypeScript criaria a segunda verdade sobre o que é um corte, e a segunda
envelhece sozinha: alguém ajusta o YAML, o espelho segue verde, e o gate passa a
medir uma regra que não roda em lugar nenhum.

Cinco commits reais desta `main` são julgados:

| commit | o que é | guarda antiga | guarda nova |
|---|---|---|---|
| `1e3c724f` | release 1.11.0 (funcionou) | sim | sim |
| `f6f91377` | release 1.11.1 (**falhou**) | **não** | **sim** |
| `3b6832fa` | PR comum — o catálogo (#475) | não | não |
| `b305a47b` | PR comum — o da corrida (#460) | não | não |
| `a3ae300d` | commit de feature | não | não |

**Um único veredito muda, e é exatamente o quebrado.** Um sexto caso prende o
vetor inteiro `["sim","sim","nao","nao","nao"]`, para que uma guarda que
dissesse "sim" para tudo não passasse por competência.

**Três sabotagens, três previsões acertadas:**

| sabotagem | previsto | medido |
|---|---:|---:|
| voltar a guarda antiga | 4 falhas | 4 |
| tirar só a checagem de assinatura | 1 falha | 1 |
| `--diff-filter=D` → `=A` | 5 falhas | 5 |

Controle verde e `git diff --stat` limpo depois de cada uma.

## O que NÃO entra

- **Recuperar a tag `v1.11.1`.** É arqueologia: todo o código dela já está na
  `main`, nenhuma imagem 1.11.1 existe no GHCR, e criar a tag agora moveria
  `stable` para um commit vencido. A 1.12.0 entrega o mesmo conteúdo de um
  commit mais novo.
- **Os outros buracos do caminho até a VPS.** A varredura achou mais, e três são
  sérios: `fail-fast: false` no `publish-image.yml` move `stable` por imagem
  (release parcial = parque misturado); "constrói ≠ sobe" é provado para 1 das 3
  imagens; e o `update.sh` roda a atualização inteira com o `_common.sh` da
  versão ANTERIOR, então conserto de kit entregue numa release nunca roda na
  atualização que o entrega. Cada um é issue própria — este PR conserta o que
  bloqueia a release de hoje.
