### PR TITLE
fix(catalogo): o preço da planilha entrava dez vezes maior

### DIFF
--- a/.changes/preco-da-planilha-nao-entra-dez-vezes-maior.md
+++ b/.changes/preco-da-planilha-nao-entra-dez-vezes-maior.md
@@ -1,0 +1,31 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O preço da planilha deixa de entrar dez vezes maior no catálogo
+---
+
+O catálogo de produtos aceita uma planilha para a loja não ter de cadastrar item
+por item. A leitura do preço tinha um erro de escala nas duas formas mais comuns
+de uma planilha brasileira chegar.
+
+**Um centavo escrito com um dígito só.** Quando a célula está formatada como
+número e mostra `1.299,90`, o Excel grava `1299,9` no arquivo — ele corta o zero
+do fim. O sistema lia esse único dígito como separador de milhar e gravava
+**R$ 12.999,00** no lugar de R$ 1.299,90. Dez vezes o preço, sem recusar a linha
+e sem avisar ninguém — e é esse preço que o atendimento automático responderia ao
+cliente.
+
+**Uma observação escrita ao lado do preço.** Quem escreve `R$ 5.499,00 (promo até
+10)` na mesma célula via os dígitos da observação grudarem no valor, e o produto
+entrava a R$ 54.990.010,00.
+
+Agora um ou dois dígitos depois da vírgula são sempre centavos — grupo de milhar
+tem sempre três, então um grupo menor não pode ser outra coisa. E célula com
+qualquer texto junto do número passa a ser **recusada**, com a linha apontada no
+relatório e a instrução de como escrever, em vez de virar um número plausível que
+ninguém confere numa lista de 300 itens.
+
+Para quem opera, nada muda: nenhuma configuração nova, nenhum passo de
+atualização. E nenhum catálogo precisa ser corrigido — o conserto sai na mesma
+versão que traz a importação de planilha, então nenhuma loja chegou a importar
+com o preço errado.

--- a/lib/schemas/produtos.ts
+++ b/lib/schemas/produtos.ts
@@ -22,13 +22,42 @@ export type OrigemDoProduto = (typeof ORIGENS_DO_PRODUTO)[number];
  * sentidos: ler "5.499" como 5,499 põe um iPhone a cinco reais; ler "5,49" como
  * 549 cobra cem vezes mais.
  *
- * A regra que desfaz a ambiguidade: o ÚLTIMO separador manda. Se ele tem
- * exatamente dois dígitos depois, é decimal; caso contrário é milhar. É como a
- * pessoa escreve, e não depende de saber a localidade.
+ * A regra que desfaz a ambiguidade: o ÚLTIMO separador manda, e o critério é o
+ * TAMANHO do grupo depois dele. Um grupo de milhar tem SEMPRE três dígitos —
+ * é o que "milhar" quer dizer. Logo um ou dois dígitos depois do último
+ * separador não podem ser milhar: só podem ser centavos.
+ *
+ * ⚠️ Esta regra dizia "exatamente dois dígitos", e um dígito caía no ramo do
+ * milhar. Um dígito é justamente o que o Excel EMITE: uma célula formatada como
+ * número exibindo `1.299,90` sai no CSV como `1299,9`, porque a planilha corta
+ * o zero final. Medido no fonte que estava na main:
+ *
+ *     "1299,9"  ->  1299900  =  R$ 12.999,00     (dez vezes o preço)
+ *     "1299.9"  ->  1299900  =  R$ 12.999,00
+ *
+ * Sem recusar e sem avisar — o catálogo nascia com o preço errado e o agente
+ * respondia esse preço ao cliente, que é o desfecho que este arquivo existe
+ * para impedir. A suíte ficava verde: nenhum caso tinha um único dígito.
+ *
+ * ⚠️ E a limpeza APAGAVA as letras em vez de recusar a célula, o que colava os
+ * dígitos do que estivesse junto:
+ *
+ *     "R$ 5.499,00 (promo ate 10)"  ->  R$ 54.990.010,00
+ *     "de 89,90 por 49,90"          ->  R$ 899.049,90
+ *
+ * Agora só o símbolo da moeda e o espaço saem; qualquer outro caractere faz a
+ * função devolver `null`. Preço é o campo onde adivinhar custa caro, então ele
+ * falha FECHADO: a linha vira erro com motivo, que a pessoa lê e corrige, em
+ * vez de virar um número plausível que ninguém confere.
  */
 export function precoParaCentavos(entrada: string): number | null {
-  const limpo = entrada.replace(/[^\d.,-]/g, "").trim();
-  if (limpo === "" || limpo.includes("-")) return null;
+  // Só moeda e espaço são ruído conhecido. O `\u00A0` é o espaço não-quebrável
+  // que o Excel gera ao formatar como moeda, e ele não casa `\s` em toda engine.
+  const semRuido = entrada.replace(/\u00A0/g, " ").replace(/R\$/gi, " ").trim();
+  // Qualquer coisa fora de dígito e separador significa que não sabemos ler
+  // esta célula — e não saber é um desfecho melhor que chutar.
+  if (!/^\d[\d.,]*$/.test(semRuido)) return null;
+  const limpo = semRuido;
 
   const ultimoPonto = limpo.lastIndexOf(".");
   const ultimaVirgula = limpo.lastIndexOf(",");
@@ -38,9 +67,9 @@ export function precoParaCentavos(entrada: string): number | null {
   let decimais = "";
   if (corte !== -1) {
     const depois = limpo.slice(corte + 1);
-    // Dois dígitos depois do último separador = centavos. Qualquer outra coisa
-    // (três dígitos, nenhum) é separador de milhar.
-    if (depois.length === 2 && /^\d{2}$/.test(depois)) {
+    // Um ou dois dígitos depois do último separador = centavos, porque grupo de
+    // milhar tem sempre TRÊS. Três dígitos, ou nenhum, é separador de milhar.
+    if (/^\d{1,2}$/.test(depois)) {
       inteiros = limpo.slice(0, corte);
       decimais = depois;
     }

--- a/tests/unit/preco-de-planilha-suja.test.ts
+++ b/tests/unit/preco-de-planilha-suja.test.ts
@@ -47,6 +47,9 @@ describe("preço em texto livre vira centavos", () => {
     expect(precoParaCentavos("1299.9")).toBe(129990);
     expect(precoParaCentavos("49,9")).toBe(4990);
     expect(precoParaCentavos("0,5")).toBe(50);
+    // Milhar E um decimal na mesma célula — caminho distinto, porque existe um
+    // separador ANTES do que decide. Achado por quem mediu o conserto por fora.
+    expect(precoParaCentavos("1.299,9")).toBe(129990);
 
     // E três dígitos continuam sendo milhar, que é a outra metade da regra.
     expect(precoParaCentavos("5.499")).toBe(549900);

--- a/tests/unit/preco-de-planilha-suja.test.ts
+++ b/tests/unit/preco-de-planilha-suja.test.ts
@@ -10,8 +10,8 @@ import { precoParaCentavos } from "@/lib/schemas/produtos";
  * a cinco reais; ler "5,49" como quinhentos e quarenta e nove cobra cem vezes
  * mais. Os dois erros passam despercebidos numa importação de 300 linhas.
  *
- * A regra: o ÚLTIMO separador manda. Dois dígitos depois dele são centavos;
- * qualquer outra coisa é separador de milhar.
+ * A regra: o ÚLTIMO separador manda, e o critério é o TAMANHO do grupo depois
+ * dele. Milhar tem sempre três dígitos — logo um ou dois só podem ser centavos.
  */
 describe("preço em texto livre vira centavos", () => {
   it("lê as formas que a loja escreve", () => {
@@ -31,6 +31,49 @@ describe("preço em texto livre vira centavos", () => {
     expect(precoParaCentavos("49,90")).toBe(4990);
     expect(precoParaCentavos("0,99")).toBe(99);
     expect(precoParaCentavos("100")).toBe(10000);
+  });
+
+  it("UM dígito depois da vírgula é centavo, não milhar — é o que o Excel emite", () => {
+    // O caso que faltava, e ele não é exótico: é o padrão. Uma célula formatada
+    // como número exibindo `1.299,90` sai no CSV como `1299,9`, porque a
+    // planilha corta o zero final. Enquanto a regra exigia DOIS dígitos, esse
+    // um caía no ramo do milhar e o preço entrava dez vezes maior — sem recusa
+    // e sem aviso, que é o pior desfecho possível para um campo de preço.
+    //
+    // O argumento que sustenta a regra nova, e que é o que impede este teste de
+    // ser um remendo: grupo de milhar tem SEMPRE três dígitos. Um grupo de um
+    // ou dois dígitos não pode ser milhar em nenhuma localidade.
+    expect(precoParaCentavos("1299,9")).toBe(129990);
+    expect(precoParaCentavos("1299.9")).toBe(129990);
+    expect(precoParaCentavos("49,9")).toBe(4990);
+    expect(precoParaCentavos("0,5")).toBe(50);
+
+    // E três dígitos continuam sendo milhar, que é a outra metade da regra.
+    expect(precoParaCentavos("5.499")).toBe(549900);
+    expect(precoParaCentavos("1.299")).toBe(129900);
+  });
+
+  it("RECUSA a célula que tem qualquer outra coisa junto do número", () => {
+    // A limpeza APAGAVA as letras e colava os dígitos do que sobrasse, então a
+    // observação que a loja escreve ao lado do preço virava parte dele:
+    //     "R$ 5.499,00 (promo ate 10)"  ->  R$ 54.990.010,00
+    //     "de 89,90 por 49,90"          ->  R$ 899.049,90
+    // Números plausíveis, e ninguém confere um a um numa planilha de 300 linhas.
+    // Preço falha FECHADO: vira linha de erro com motivo, que a pessoa lê.
+    expect(precoParaCentavos("R$ 5.499,00 (promo ate 10)")).toBeNull();
+    expect(precoParaCentavos("de 89,90 por 49,90")).toBeNull();
+    expect(precoParaCentavos("5499,00 a vista")).toBeNull();
+    expect(precoParaCentavos("1e3")).toBeNull();
+  });
+
+  it("mas o símbolo da moeda e o espaço do Excel continuam sendo ruído conhecido", () => {
+    // Recusar não pode virar recusar tudo: estas formas são as que a loja
+    // realmente manda, e elas têm de continuar entrando.
+    expect(precoParaCentavos("R$ 1.234.567,89")).toBe(123456789);
+    expect(precoParaCentavos("  99,90  ")).toBe(9990);
+    // O espaço não-quebrável que o Excel gera ao formatar como moeda.
+    expect(precoParaCentavos("99,90\u00A0")).toBe(9990);
+    expect(precoParaCentavos("r$99,90")).toBe(9990);
   });
 
   it("RECUSA o que não dá para ler, em vez de chutar", () => {


### PR DESCRIPTION
Forward-fix do #475, que já está na `main` (`3b6832fa`). Achado na triagem daquele PR, medido **depois** do merge e **antes** de a 1.12.0 ser cortada — que é a diferença entre um conserto e um incidente numa VPS que a gente não alcança.

## O defeito

Reproduzido no fonte de `origin/main`:

```
precoParaCentavos("1299,9")                     -> 1299900    = R$ 12.999,00
precoParaCentavos("1299.9")                     -> 1299900    = R$ 12.999,00
precoParaCentavos("R$ 5.499,00 (promo ate 10)") -> 5499001000 = R$ 54.990.010,00
precoParaCentavos("de 89,90 por 49,90")         ->   89904990 = R$ 899.049,90
```

**O primeiro não é caso exótico — é o caso comum.** Célula formatada como número exibindo `1.299,90` sai no CSV como `1299,9`: o Excel corta o zero final. A regra dizia "exatamente dois dígitos depois do último separador = centavos", e um dígito caía no ramo do milhar.

A loja importa a planilha dela, o catálogo nasce com **dez vezes o preço**, sem recusa e sem aviso — e o agente responde esse preço ao cliente. É literalmente o desfecho que o docstring daquele arquivo diz existir para impedir.

## O conserto, e o argumento que o sustenta

> **Grupo de milhar tem sempre três dígitos.**

Logo um grupo de um ou dois dígitos depois do último separador **não pode** ser milhar em localidade nenhuma — só pode ser centavos. Isso não é ajuste de limiar; é a propriedade que desambigua. `"5.499"` (três) segue milhar; `"1299,9"` (um) passa a ser centavos.

O segundo defeito pede a decisão oposta. A limpeza **apagava** as letras (`replace(/[^\d.,-]/g,"")`) e colava os dígitos do que sobrasse, então a observação escrita ao lado do preço virava parte dele. Agora só o símbolo da moeda e o espaço saem; qualquer outro caractere devolve `null`. **Preço falha fechado** — a linha vira erro com motivo e instrução, em vez de virar um número plausível que ninguém confere numa lista de 300 itens. Provado ponta a ponta pela `lerPlanilha`:

```
OK   iPhone 15 -> R$ 1.299,90
OK   AirPods   -> R$ 1.299,00
ERRO {"linha":3,"motivo":"preço não reconhecido (\"R$ 5.499,00 (promo ate 10)\") — escreva assim: 5.499,00"}
```

## Por que não havia guarda

`preco-de-planilha-suja.test.ts` tinha 4 blocos e **nenhum caso com um único dígito decimal**. Trocar a regra pelo conserto deixava a suíte inteira verde — o comportamento não estava preso em direção nenhuma, nem a certa nem a errada.

## Medição

Sabotagem, uma metade por vez, com previsão escrita antes:

```
voltar a exigir DOIS dígitos      previu 1 vermelho -> deu 1 ("UM dígito ... é o que o Excel emite")
voltar a APAGAR as letras         previu 1 vermelho -> deu 1 ("RECUSA a célula que tem outra coisa junto")
```

Casos diferentes nas duas: as metades são guardadas independentemente.

Suíte inteira (`vitest run`, sem caminho): `Test Files 610 passed (610)` · `Tests 6772 passed | 1 expected fail`, com rodapé e `grep FAIL` batendo em 0. `tsc --noEmit` exit 0.

**NÃO MEDIDO:** `pnpm test:db` (o PR não toca schema) e `pnpm test:e2e`.

## Versão

Fragmento `nada_mudou`: o operador não faz nada, e **nenhum catálogo precisa ser corrigido** — o conserto sai na mesma versão que traz a importação, então nenhuma loja chegou a importar com o preço errado. Isso só continua verdade se a 1.12.0 **não** for cortada antes deste PR.

`pnpm release:conferir` -> `1.11.1 + minor = 1.12.0 (3 fragmentos)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)