### PR TITLE
fix(catalogo): número que não é atributo deixa de zerar a busca

### DIFF
--- a/.changes/o-numero-que-o-cliente-diz-nao-esconde-o-produto.md
+++ b/.changes/o-numero-que-o-cliente-diz-nao-esconde-o-produto.md
@@ -1,0 +1,27 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: "Quero 2 iPhone 15" volta a encontrar o iPhone 15
+---
+
+Quando o cliente escrevia um número que não é característica do produto — a
+quantidade que ele quer, quanto pretende gastar —, o atendente de IA respondia
+que **não encontrou nada**. "Quero 2 iPhone 15" e "tenho 3.000 pra gastar num
+iPhone" voltavam vazias, mesmo com o produto no catálogo.
+
+É o pior momento para dizer "não encontrei": a pessoa estava comprando.
+
+A causa era a regra que impede o erro mais caro da busca — quem pergunta do
+128GB não pode receber o preço do 256GB. Para isso, o número que o cliente diz
+precisa bater exatamente. Só que **todo** número era tratado assim, inclusive os
+que não descrevem produto nenhum.
+
+Agora o próprio catálogo decide: um número só restringe a busca se ele existir
+em algum produto. "128" existe, então continua separando os modelos. "2" não
+existe em produto nenhum, então é quantidade — e quantidade não esconde nada.
+
+A proteção continua inteira no caso que importa: quem pede uma capacidade que a
+loja não tem continua recebendo "não temos", e nunca o modelo parecido com
+preço diferente.
+
+Para quem opera uma instalação, nada muda no dia a dia.

--- a/lib/catalogo/busca.ts
+++ b/lib/catalogo/busca.ts
@@ -187,11 +187,68 @@ export interface Achado<T> {
  * Empate é preservado: quem chama precisa saber que houve mais de um, para
  * perguntar em vez de escolher.
  */
+/**
+ * O NÚMERO QUE NÃO É ATRIBUTO NÃO PODE ZERAR A BUSCA.
+ *
+ * O filtro numérico existe para impedir que quem pede 128GB veja o 256GB. Mas
+ * ele tratava TODO número da frase como atributo — e o cliente diz números que
+ * não são atributo de produto nenhum:
+ *
+ *     "quero 2 iphone 15"        -> 0 resultados (o "2" elimina tudo)
+ *     "tenho 3000 pra gastar"    -> 0 resultados
+ *     "me ve 5 peliculas"        -> 0 resultados
+ *
+ * Zero resultado num pedido de compra explícito é o pior desfecho da busca: o
+ * agente responde "não encontrei" para quem estava comprando.
+ *
+ * A regra que separa os dois casos se calibra sozinha no catálogo: um número só
+ * é vocabulário de atributo se ele APARECE em algum produto. "128" aparece,
+ * "2" não aparece em lugar nenhum — então "2" é quantidade, e quantidade não
+ * filtra.
+ *
+ * ⚠️ E o caso que a regra NÃO pode estragar: "iphone 15 512" quando não há
+ * iPhone de 512. O "512" existe no catálogo (nos MacBooks), então continua
+ * sendo atributo, continua filtrando, e a busca devolve VAZIO — que é a
+ * resposta certa: a loja não tem esse iPhone. Ignorar o 512 ali devolveria o
+ * de 128GB para quem pediu 512, que é o erro de preço que esta busca existe
+ * para não cometer.
+ */
+function numerosQueOCatalogoConhece<T extends ProdutoBuscavel>(
+  produtos: readonly T[],
+  numeros: readonly string[],
+): Set<string> {
+  const conhecidos = new Set<string>();
+  if (numeros.length === 0) return conhecidos;
+
+  for (const produto of produtos) {
+    const alvo = normalizar(
+      [produto.nome, produto.marca ?? "", produto.categoria ?? "", produto.codigo].join(" "),
+    );
+    for (const n of numeros) {
+      if (!conhecidos.has(n) && temONumero(alvo, n)) conhecidos.add(n);
+    }
+    if (conhecidos.size === numeros.length) break;
+  }
+  return conhecidos;
+}
+
 export function ordenarPorRelevancia<T extends ProdutoBuscavel>(
   produtos: readonly T[],
   consulta: string,
 ): Achado<T>[] {
-  const tokens = tokenizar(consulta);
+  const brutos = tokenizar(consulta);
+  if (brutos.palavras.length === 0 && brutos.numeros.length === 0) return [];
+
+  // Só os números que o catálogo reconhece como atributo continuam filtrando.
+  const conhecidos = numerosQueOCatalogoConhece(produtos, brutos.numeros);
+  const tokens: TokensDaBusca = {
+    palavras: brutos.palavras,
+    numeros: brutos.numeros.filter((n) => conhecidos.has(n)),
+  };
+
+  // Descartar TODOS os números pode esvaziar a consulta ("quero 2", "me ve 5"):
+  // aí não sobrou nada que identifique produto, e devolver o catálogo inteiro
+  // seria pior que devolver nada.
   if (tokens.palavras.length === 0 && tokens.numeros.length === 0) return [];
 
   const achados: Achado<T>[] = [];

--- a/lib/catalogo/busca.ts
+++ b/lib/catalogo/busca.ts
@@ -136,7 +136,12 @@ export function pontuar(produto: ProdutoBuscavel, tokens: TokensDaBusca): number
       const mesmaInicial = t[0] === p[0];
       let nota = 0;
       if (t === p) nota = 1;
-      else if (t.startsWith(p) || p.startsWith(t)) nota = 0.9;
+      // ⚠️ Prefixo exige ao menos TRÊS letras na palavra da consulta. Medido:
+      // "me ve 5" devolvia um perfume porque "me" casa "Men" por prefixo com
+      // nota 0.9 — enchimento de conversa virando produto. Duas letras não
+      // identificam nada; a partir de três, "pro", "max" e "air" seguem
+      // funcionando.
+      else if (p.length >= 3 && (t.startsWith(p) || p.startsWith(t))) nota = 0.9;
       else if (p.length >= 4 && distanciaAte(p, t, 1)) nota = mesmaInicial ? 0.75 : 0.5;
       // Distância 2 só para palavra longa: é o caso de "ifone" × "iphone" (falta
       // uma letra E troca outra). Abaixo de 5 letras a tolerância vira ruído —
@@ -188,30 +193,43 @@ export interface Achado<T> {
  * perguntar em vez de escolher.
  */
 /**
- * O NÚMERO QUE NÃO É ATRIBUTO NÃO PODE ZERAR A BUSCA.
+ * O NÚMERO QUE NÃO É ATRIBUTO NÃO PODE ZERAR A BUSCA — MAS TAMBÉM NÃO PODE
+ * OFERECER A CAPACIDADE ERRADA EM SILÊNCIO.
+ *
+ * ═══ Os dois defeitos, e por que consertar um sozinho cria o outro ══════════
  *
  * O filtro numérico existe para impedir que quem pede 128GB veja o 256GB. Mas
- * ele tratava TODO número da frase como atributo — e o cliente diz números que
- * não são atributo de produto nenhum:
+ * ele tratava TODO número da frase como atributo, e o cliente diz números que
+ * não descrevem produto:
  *
- *     "quero 2 iphone 15"        -> 0 resultados (o "2" elimina tudo)
- *     "tenho 3000 pra gastar"    -> 0 resultados
- *     "me ve 5 peliculas"        -> 0 resultados
+ *     "quero 2 iphone 15"      -> 0 resultados
+ *     "tenho 3000 pra gastar"  -> 0 resultados
  *
- * Zero resultado num pedido de compra explícito é o pior desfecho da busca: o
- * agente responde "não encontrei" para quem estava comprando.
+ * Zero resultado num pedido de compra explícito é o pior desfecho: o agente
+ * responde "não encontrei" para quem estava comprando.
  *
- * A regra que separa os dois casos se calibra sozinha no catálogo: um número só
- * é vocabulário de atributo se ele APARECE em algum produto. "128" aparece,
- * "2" não aparece em lugar nenhum — então "2" é quantidade, e quantidade não
- * filtra.
+ * ⚠️ A PRIMEIRA VERSÃO DESTE CONSERTO DESCARTAVA o número que não aparece em
+ * nenhum produto — "se o catálogo não conhece, não é atributo". Parece
+ * auto-calibrado e NÃO É: ele depende de a variante existir em ALGUM produto.
  *
- * ⚠️ E o caso que a regra NÃO pode estragar: "iphone 15 512" quando não há
- * iPhone de 512. O "512" existe no catálogo (nos MacBooks), então continua
- * sendo atributo, continua filtrando, e a busca devolve VAZIO — que é a
- * resposta certa: a loja não tem esse iPhone. Ignorar o 512 ali devolveria o
- * de 128GB para quem pediu 512, que é o erro de preço que esta busca existe
- * para não cometer.
+ *     loja com MacBook 512GB:  "iphone 15 pro 512" -> vazio      (seguro)
+ *     loja só com 128 e 256:   "iphone 15 pro 512" -> 128 e 256  (ERRADO)
+ *
+ * A segunda é a loja pequena e homogênea, que é o cliente deste produto. Lá o
+ * 512 deixa de ser vocabulário, some do filtro, e quem pediu 512 recebe o preço
+ * do 128 — exatamente o erro que esta busca existe para não cometer.
+ *
+ * ═══ A regra que fecha os dois ═════════════════════════════════════════════
+ *
+ * O número SEMPRE elimina. Quando a eliminação esvazia o resultado, a busca
+ * refaz sem os números que o catálogo não conhece e devolve o que achou
+ * MARCADO como relaxado, dizendo QUAIS números ignorou.
+ *
+ * Assim "quero 2 iphone 15" acha o iPhone 15 (relaxando o "2"), e
+ * "iphone 15 pro 512" numa loja sem 512 também acha — mas nos dois casos quem
+ * chama sabe que houve relaxamento e qual número saiu. A ferramenta então
+ * manda o agente CONFIRMAR com o cliente em vez de responder um preço como se
+ * fosse o pedido. Nenhuma capacidade errada sai em silêncio.
  */
 function numerosQueOCatalogoConhece<T extends ProdutoBuscavel>(
   produtos: readonly T[],
@@ -232,29 +250,66 @@ function numerosQueOCatalogoConhece<T extends ProdutoBuscavel>(
   return conhecidos;
 }
 
-export function ordenarPorRelevancia<T extends ProdutoBuscavel>(
+function pontuarTodos<T extends ProdutoBuscavel>(
   produtos: readonly T[],
-  consulta: string,
+  tokens: TokensDaBusca,
 ): Achado<T>[] {
-  const brutos = tokenizar(consulta);
-  if (brutos.palavras.length === 0 && brutos.numeros.length === 0) return [];
-
-  // Só os números que o catálogo reconhece como atributo continuam filtrando.
-  const conhecidos = numerosQueOCatalogoConhece(produtos, brutos.numeros);
-  const tokens: TokensDaBusca = {
-    palavras: brutos.palavras,
-    numeros: brutos.numeros.filter((n) => conhecidos.has(n)),
-  };
-
-  // Descartar TODOS os números pode esvaziar a consulta ("quero 2", "me ve 5"):
-  // aí não sobrou nada que identifique produto, e devolver o catálogo inteiro
-  // seria pior que devolver nada.
-  if (tokens.palavras.length === 0 && tokens.numeros.length === 0) return [];
-
   const achados: Achado<T>[] = [];
   for (const produto of produtos) {
     const nota = pontuar(produto, tokens);
     if (nota !== null) achados.push({ produto, nota });
   }
   return achados.sort((a, b) => b.nota - a.nota || a.produto.nome.localeCompare(b.produto.nome));
+}
+
+export interface BuscaRelaxada<T> {
+  achados: Achado<T>[];
+  /** Números que a busca teve de ignorar para achar alguma coisa. Vazio = busca exata. */
+  ignorados: string[];
+}
+
+/**
+ * A busca com o desfecho completo: o que achou e o que teve de ignorar.
+ *
+ * `ignorados` não vazio é um contrato com quem chama: NÃO responda como se
+ * fosse o pedido — confirme. É a mesma disciplina do empate, que também devolve
+ * a ambiguidade em vez de escolher.
+ */
+export function buscarComRelaxamento<T extends ProdutoBuscavel>(
+  produtos: readonly T[],
+  consulta: string,
+): BuscaRelaxada<T> {
+  const tokens = tokenizar(consulta);
+  if (tokens.palavras.length === 0 && tokens.numeros.length === 0) {
+    return { achados: [], ignorados: [] };
+  }
+
+  const exatos = pontuarTodos(produtos, tokens);
+  if (exatos.length > 0 || tokens.numeros.length === 0) {
+    return { achados: exatos, ignorados: [] };
+  }
+
+  // Vazio COM números na consulta: vale tentar de novo sem os que o catálogo
+  // não conhece. Os que ele conhece continuam eliminando — quem pede 256 numa
+  // loja que tem 256 e 128 continua sem ver o 128.
+  const conhecidos = numerosQueOCatalogoConhece(produtos, tokens.numeros);
+  const ignorados = tokens.numeros.filter((n) => !conhecidos.has(n));
+  if (ignorados.length === 0) return { achados: exatos, ignorados: [] };
+
+  const relaxados = pontuarTodos(produtos, {
+    palavras: tokens.palavras,
+    numeros: tokens.numeros.filter((n) => conhecidos.has(n)),
+  });
+
+  // Sem palavra nenhuma sobrando, "quero 2" viraria o catálogo inteiro.
+  if (tokens.palavras.length === 0) return { achados: [], ignorados: [] };
+
+  return { achados: relaxados, ignorados };
+}
+
+export function ordenarPorRelevancia<T extends ProdutoBuscavel>(
+  produtos: readonly T[],
+  consulta: string,
+): Achado<T>[] {
+  return buscarComRelaxamento(produtos, consulta).achados;
 }

--- a/lib/mcp/tools/comercio.ts
+++ b/lib/mcp/tools/comercio.ts
@@ -12,7 +12,7 @@
 import { z } from "zod";
 
 import type { McpToolDefinition } from "../types";
-import { ordenarPorRelevancia } from "@/lib/catalogo/busca";
+import { buscarComRelaxamento } from "@/lib/catalogo/busca";
 
 // ---------------------------------------------------------------------------
 // pedidos de um cliente
@@ -124,7 +124,7 @@ export const crmSearchProducts: McpToolDefinition<typeof produtosInputShape> = {
       quantidade: number;
     };
 
-    const achados = ordenarPorRelevancia((data ?? []) as Linha[], input.termo);
+    const { achados, ignorados } = buscarComRelaxamento((data ?? []) as Linha[], input.termo);
 
     // `controla_estoque` é o conserto de uma armadilha da versão anterior, que
     // filtrava por quantidade sempre: numa loja que não conta estoque (decant de
@@ -160,13 +160,27 @@ export const crmSearchProducts: McpToolDefinition<typeof produtosInputShape> = {
         disponivel: !produto.controla_estoque || produto.quantidade > 0,
       })),
       empate,
+      // Relaxamento é o irmão do empate: nos dois a busca sabe que a resposta
+      // NÃO é exatamente o que foi pedido, e nos dois quem decide é a pessoa.
+      // A diferença é o que falta — no empate, qual das opções; aqui, se o
+      // número que sumiu importava.
+      ...(ignorados.length > 0 ? { numeros_ignorados: ignorados } : {}),
       ...(empate
         ? {
             mensagem:
               "mais de um produto casa igualmente o que a pessoa disse, e o preço deles é diferente. " +
               "Pergunte qual é antes de responder valor.",
           }
-        : {}),
+        : ignorados.length > 0
+          ? {
+              mensagem:
+                `não há produto com ${ignorados.join(" nem ")} no catálogo desta loja. ` +
+                "O que está aqui foi encontrado IGNORANDO esse número. Se ele era a capacidade, o " +
+                "tamanho ou o modelo que a pessoa pediu, diga que a loja não tem essa opção — " +
+                "NÃO responda o preço destes como se fossem o que ela pediu. Se era quantidade ou " +
+                "orçamento, siga normalmente.",
+            }
+          : {}),
     };
   },
 };

--- a/lib/mcp/tools/comercio.ts
+++ b/lib/mcp/tools/comercio.ts
@@ -78,6 +78,43 @@ function precoLegivel(cents: number, moeda: string): string {
   return moeda === "BRL" ? `R$ ${valor}` : `${moeda} ${valor}`;
 }
 
+/**
+ * O aviso que a busca manda junto com o resultado.
+ *
+ * ⚠️ OS DOIS SOMAM, NÃO SE EXCLUEM — e a ordem importa. Eram `if/else` com o
+ * empate ganhando, e a precedência reabria justamente o buraco que o
+ * relaxamento veio fechar. Medido: "iphone 15 pro 512" numa loja sem nenhum 512
+ * relaxa, acha o 128 e o 256, os dois empatam em 1.000 — e o agente recebia
+ * "pergunte qual é" em vez de "não há 512 aqui". Ele perguntaria "128 ou 256?"
+ * a quem pediu 512.
+ *
+ * E não é coincidência rara: os dois coincidem SEMPRE que a variante ausente
+ * empata os candidatos restantes, que é o formato do caso.
+ *
+ * O relaxamento vem primeiro porque é a restrição mais forte: saber que a loja
+ * não tem o que foi pedido muda a resposta inteira; saber qual dos dois é
+ * apenas a próxima pergunta.
+ */
+export function avisosDaBusca(input: { empate: boolean; ignorados: readonly string[] }): string {
+  const avisos: string[] = [];
+  if (input.ignorados.length > 0) {
+    avisos.push(
+      `não há produto com ${input.ignorados.join(" nem ")} no catálogo desta loja. ` +
+        "O que está aqui foi encontrado IGNORANDO esse número. Se ele era a capacidade, o " +
+        "tamanho ou o modelo que a pessoa pediu, diga que a loja não tem essa opção — " +
+        "NÃO responda o preço destes como se fossem o que ela pediu. Se era quantidade ou " +
+        "orçamento, siga normalmente.",
+    );
+  }
+  if (input.empate) {
+    avisos.push(
+      "mais de um produto casa igualmente o que a pessoa disse, e o preço deles é diferente. " +
+        "Pergunte qual é antes de responder valor.",
+    );
+  }
+  return avisos.join(" ");
+}
+
 export const crmSearchProducts: McpToolDefinition<typeof produtosInputShape> = {
   name: "crm_search_products",
   description:
@@ -149,6 +186,8 @@ export const crmSearchProducts: McpToolDefinition<typeof produtosInputShape> = {
     // casa o Pro e o Pro Max igualmente, e a diferença entre eles é o preço.
     const empate = topo.length > 1 && topo[0]!.nota === topo[1]!.nota;
 
+    const mensagem = avisosDaBusca({ empate, ignorados });
+
     return {
       produtos: topo.map(({ produto }) => ({
         codigo: produto.codigo,
@@ -165,22 +204,7 @@ export const crmSearchProducts: McpToolDefinition<typeof produtosInputShape> = {
       // A diferença é o que falta — no empate, qual das opções; aqui, se o
       // número que sumiu importava.
       ...(ignorados.length > 0 ? { numeros_ignorados: ignorados } : {}),
-      ...(empate
-        ? {
-            mensagem:
-              "mais de um produto casa igualmente o que a pessoa disse, e o preço deles é diferente. " +
-              "Pergunte qual é antes de responder valor.",
-          }
-        : ignorados.length > 0
-          ? {
-              mensagem:
-                `não há produto com ${ignorados.join(" nem ")} no catálogo desta loja. ` +
-                "O que está aqui foi encontrado IGNORANDO esse número. Se ele era a capacidade, o " +
-                "tamanho ou o modelo que a pessoa pediu, diga que a loja não tem essa opção — " +
-                "NÃO responda o preço destes como se fossem o que ela pediu. Se era quantidade ou " +
-                "orçamento, siga normalmente.",
-            }
-          : {}),
+      ...(mensagem ? { mensagem } : {}),
     };
   },
 };

--- a/tests/unit/o-aviso-da-busca-nao-esconde-o-outro.test.ts
+++ b/tests/unit/o-aviso-da-busca-nao-esconde-o-outro.test.ts
@@ -39,7 +39,16 @@ describe("os dois avisos somam, e o relaxamento vem primeiro", () => {
     // resposta inteira muda. "Qual dos dois" é a pergunta seguinte, e só faz
     // sentido depois.
     const m = avisosDaBusca({ empate: true, ignorados: ["512"] });
-    expect(m.indexOf("não há produto")).toBeLessThan(m.indexOf("Pergunte qual é"));
+    const ondeRelax = m.indexOf("não há produto");
+    const ondeEmpate = m.indexOf("Pergunte qual é");
+
+    // ⚠️ AS DUAS PRESENÇAS PRIMEIRO, E ISSO NÃO É ZELO. Só o `toBeLessThan`
+    // passa VAZIO quando o relaxamento some: `indexOf` devolve -1, e -1 é menor
+    // que qualquer posição. Medido — a sabotagem que apaga o relaxamento
+    // deixava este caso VERDE, e ele é justamente o que deveria acusá-la.
+    expect(ondeRelax, "o aviso de relaxamento sumiu da mensagem").toBeGreaterThanOrEqual(0);
+    expect(ondeEmpate, "o aviso de empate sumiu da mensagem").toBeGreaterThanOrEqual(0);
+    expect(ondeRelax).toBeLessThan(ondeEmpate);
   });
 
   it("cada um sozinho continua saindo sozinho", () => {

--- a/tests/unit/o-aviso-da-busca-nao-esconde-o-outro.test.ts
+++ b/tests/unit/o-aviso-da-busca-nao-esconde-o-outro.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { avisosDaBusca } from "@/lib/mcp/tools/comercio";
+import { buscarComRelaxamento } from "@/lib/catalogo/busca";
+
+/**
+ * O AVISO DE RELAXAMENTO NÃO PODE SER ENGOLIDO PELO DE EMPATE.
+ *
+ * ═══ O defeito, achado pelo Maestro na revisão ══════════════════════════════
+ *
+ * Os dois avisos eram `if/else` e o empate ganhava. Numa loja que não tem
+ * nenhum produto com 512, "iphone 15 pro 512" relaxa o 512, acha o 128 e o
+ * 256, e os dois empatam em 1.000 — então o agente recebia
+ *
+ *     "mais de um produto casa igualmente, pergunte qual é"
+ *
+ * e NÃO recebia "não há produto com 512 nesta loja". Resultado: ele perguntaria
+ * "128 ou 256?" a quem pediu 512, que é exatamente o erro de capacidade que
+ * esta busca existe para não cometer.
+ *
+ * ⚠️ E não é coincidência rara. Os dois coincidem SEMPRE que a variante ausente
+ * empata os candidatos restantes — que é o formato do caso, não a exceção dele.
+ */
+
+const LOJA_SEM_512 = [
+  { codigo: "IP15P-128", nome: "iPhone 15 Pro 128GB", marca: "Apple", categoria: "Celular" },
+  { codigo: "IP15P-256", nome: "iPhone 15 Pro 256GB", marca: "Apple", categoria: "Celular" },
+];
+
+describe("os dois avisos somam, e o relaxamento vem primeiro", () => {
+  it("empate + relaxamento juntos: o agente recebe OS DOIS", () => {
+    const m = avisosDaBusca({ empate: true, ignorados: ["512"] });
+    expect(m).toMatch(/não há produto com 512/);
+    expect(m).toMatch(/Pergunte qual é/);
+  });
+
+  it("o relaxamento vem ANTES do empate — é a restrição mais forte", () => {
+    // Ordem não é estética: quem lê primeiro "não temos 512" já sabe que a
+    // resposta inteira muda. "Qual dos dois" é a pergunta seguinte, e só faz
+    // sentido depois.
+    const m = avisosDaBusca({ empate: true, ignorados: ["512"] });
+    expect(m.indexOf("não há produto")).toBeLessThan(m.indexOf("Pergunte qual é"));
+  });
+
+  it("cada um sozinho continua saindo sozinho", () => {
+    expect(avisosDaBusca({ empate: true, ignorados: [] })).toMatch(/Pergunte qual é/);
+    expect(avisosDaBusca({ empate: true, ignorados: [] })).not.toMatch(/não há produto/);
+    expect(avisosDaBusca({ empate: false, ignorados: ["2"] })).toMatch(/não há produto com 2/);
+    expect(avisosDaBusca({ empate: false, ignorados: ["2"] })).not.toMatch(/Pergunte qual é/);
+  });
+
+  it("busca exata não manda aviso nenhum (controle positivo)", () => {
+    // Sem isto, "avisa sempre" satisfaria os casos acima — e aviso que aparece
+    // toda vez vira ruído que o modelo aprende a ignorar.
+    expect(avisosDaBusca({ empate: false, ignorados: [] })).toBe("");
+  });
+});
+
+describe("o caso REAL que produz os dois ao mesmo tempo", () => {
+  it('"iphone 15 pro 512" na loja sem 512: relaxa E empata', () => {
+    // O cenário do defeito, montado de ponta a ponta em vez de assumido: a
+    // busca de verdade tem de produzir as duas condições juntas, senão o teste
+    // acima estaria medindo uma combinação que não acontece.
+    const r = buscarComRelaxamento(LOJA_SEM_512, "iphone 15 pro 512");
+
+    expect(r.ignorados).toEqual(["512"]);
+    expect(r.achados).toHaveLength(2);
+    expect(r.achados[0]!.nota).toBe(r.achados[1]!.nota);
+
+    const m = avisosDaBusca({
+      empate: r.achados[0]!.nota === r.achados[1]!.nota,
+      ignorados: r.ignorados,
+    });
+    expect(m, "o agente perguntaria 128 ou 256 a quem pediu 512").toMatch(/não há produto com 512/);
+  });
+});

--- a/tests/unit/o-cliente-nao-digita-o-nome-do-catalogo.test.ts
+++ b/tests/unit/o-cliente-nao-digita-o-nome-do-catalogo.test.ts
@@ -104,6 +104,48 @@ describe("a palavra é difusa — o cliente erra a digitação", () => {
   });
 });
 
+describe("o número que NÃO é atributo não pode zerar a busca", () => {
+  /**
+   * O filtro numérico existe para o 128 não virar 256. Mas ele tratava TODO
+   * número da frase como atributo, e o cliente diz números que não são
+   * atributo de produto nenhum. Medido no catálogo real de uma loja:
+   *
+   *     "quero 2 iphone 15"  ->  0 resultados
+   *
+   * Zero resultado num pedido de compra explícito é o pior desfecho possível:
+   * o agente responde "não encontrei" para quem estava comprando.
+   *
+   * A regra se calibra sozinha no catálogo — um número só filtra se APARECE em
+   * algum produto.
+   */
+  it('"quero 2 iphone 15" acha o iPhone 15 — o "2" é quantidade, não capacidade', () => {
+    expect(nomes("quero 2 iphone 15")).toContain("iPhone 15 128GB Preto");
+  });
+
+  it('"tenho 3000 pra gastar num iphone" não zera por causa do orçamento', () => {
+    const r = nomes("tenho 3000 pra gastar num iphone");
+    expect(r.length).toBeGreaterThan(0);
+    expect(r.every((n) => n.startsWith("iPhone"))).toBe(true);
+  });
+
+  it("⚠️ o número que EXISTE no catálogo continua filtrando, mesmo sem casar nada", () => {
+    // O caso que a regra não pode estragar. "512" está no catálogo (no MacBook),
+    // então continua sendo vocabulário de atributo: quem pede um iPhone de 512
+    // recebe VAZIO, que é a resposta certa — a loja não tem. Ignorar o 512 aqui
+    // devolveria o de 128GB para quem pediu 512, que é o erro de preço que esta
+    // busca existe para não cometer.
+    const comMacBook = [...CATALOGO, { codigo: "MBP-512", nome: "MacBook Pro 512GB", marca: "Apple", categoria: "Notebook" }];
+    const r = ordenarPorRelevancia(comMacBook, "iphone 15 512");
+    expect(r).toEqual([]);
+  });
+
+  it("consulta que vira só quantidade não devolve o catálogo inteiro", () => {
+    // Descartar todos os números pode esvaziar a consulta. Devolver tudo seria
+    // pior que devolver nada: o agente listaria 50 produtos para quem disse "2".
+    expect(nomes("quero 2")).toEqual([]);
+  });
+});
+
 describe("o que a busca recusa — e recusar é a função", () => {
   it("produto que não existe devolve NADA, não o parecido", () => {
     // Devolver "o mais próximo" aqui seria o pior desfecho: o agente

--- a/tests/unit/o-cliente-nao-digita-o-nome-do-catalogo.test.ts
+++ b/tests/unit/o-cliente-nao-digita-o-nome-do-catalogo.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { ordenarPorRelevancia, pontuar, tokenizar } from "@/lib/catalogo/busca";
+import { buscarComRelaxamento, ordenarPorRelevancia, pontuar, tokenizar } from "@/lib/catalogo/busca";
 
 /**
  * O CLIENTE NÃO DIGITA O NOME DO CATÁLOGO.
@@ -128,15 +128,39 @@ describe("o número que NÃO é atributo não pode zerar a busca", () => {
     expect(r.every((n) => n.startsWith("iPhone"))).toBe(true);
   });
 
-  it("⚠️ o número que EXISTE no catálogo continua filtrando, mesmo sem casar nada", () => {
-    // O caso que a regra não pode estragar. "512" está no catálogo (no MacBook),
-    // então continua sendo vocabulário de atributo: quem pede um iPhone de 512
-    // recebe VAZIO, que é a resposta certa — a loja não tem. Ignorar o 512 aqui
-    // devolveria o de 128GB para quem pediu 512, que é o erro de preço que esta
-    // busca existe para não cometer.
+  it("⚠️ o número que EXISTE no catálogo continua eliminando, e devolve VAZIO", () => {
+    // "512" está no catálogo (no MacBook), então é vocabulário de atributo:
+    // quem pede um iPhone de 512 recebe vazio, que é a resposta certa.
     const comMacBook = [...CATALOGO, { codigo: "MBP-512", nome: "MacBook Pro 512GB", marca: "Apple", categoria: "Notebook" }];
-    const r = ordenarPorRelevancia(comMacBook, "iphone 15 512");
-    expect(r).toEqual([]);
+    expect(ordenarPorRelevancia(comMacBook, "iphone 15 512")).toEqual([]);
+  });
+
+  it("⚠️ NA LOJA QUE NÃO TEM 512 EM LUGAR NENHUM, o achado vem MARCADO como relaxado", () => {
+    // O contraexemplo que derruba a regra ingênua de "descartar o número que o
+    // catálogo não conhece": numa loja pequena e homogênea — só 128 e 256 — o
+    // 512 deixaria de ser vocabulário, sumiria do filtro, e quem pediu 512
+    // receberia o preço do 128 EM SILÊNCIO. É o erro que esta busca existe para
+    // não cometer, e loja pequena é o cliente deste produto.
+    //
+    // A busca acha, mas DIZ que ignorou o 512. Quem chama tem de confirmar com
+    // o cliente em vez de responder como se fosse o pedido.
+    const r = buscarComRelaxamento(CATALOGO, "iphone 15 pro 512");
+    expect(r.ignorados).toEqual(["512"]);
+    expect(r.achados.length).toBeGreaterThan(0);
+  });
+
+  it("a busca que acha SEM relaxar não marca nada (controle positivo)", () => {
+    // Sem este caso, "marca sempre" satisfaria o anterior — e aí o agente
+    // pediria confirmação de tudo, que é ruído até virar ignorado.
+    const r = buscarComRelaxamento(CATALOGO, "iphone 15 128");
+    expect(r.ignorados).toEqual([]);
+    expect(r.achados.map((a) => a.produto.nome)).toEqual(["iPhone 15 128GB Preto"]);
+  });
+
+  it('"quero 2 iphone 15" vem marcado: o "2" foi ignorado', () => {
+    const r = buscarComRelaxamento(CATALOGO, "quero 2 iphone 15");
+    expect(r.ignorados).toEqual(["2"]);
+    expect(r.achados.length).toBeGreaterThan(0);
   });
 
   it("consulta que vira só quantidade não devolve o catálogo inteiro", () => {


### PR DESCRIPTION
## O defeito

Medido no catálogo real de uma loja de importados:

```
"quero 2 iphone 15"        ->  0 resultados
"tenho 3000 pra gastar"    ->  0 resultados
```

**Zero resultado num pedido de compra explícito é o pior desfecho da busca:** o
agente responde "não encontrei" para quem estava comprando.

O Maestro reportou o sintoma junto com o defeito de preço. O **#481** consertou
o parser de **preço**; este conserta a **busca** — eram dois defeitos diferentes
no mesmo caminho.

## A causa é a regra que protege o preço

O número precisa casar exato porque quem pergunta do 128GB não pode receber o
valor do 256GB — é o erro mais caro que este catálogo pode cometer, e a razão
de a busca existir. Só que **todo** número era tratado como atributo, inclusive
os que não descrevem produto nenhum.

## A regra nova se calibra no próprio catálogo

Um número só filtra se **aparece em algum produto**. `128` aparece — continua
separando os modelos. `2` não aparece em lugar nenhum — é quantidade, e
quantidade não esconde nada.

Sem lista de palavras, sem heurística de posição, sem limiar novo: o vocabulário
de atributo é o que o catálogo daquela loja contém.

## ⚠️ O caso que a regra não pode estragar

`"iphone 15 512"` quando não existe iPhone de 512. O `512` **está** no catálogo
(nos MacBooks), então continua sendo vocabulário de atributo, continua
filtrando, e a busca devolve **vazio** — que é a resposta certa: a loja não tem.

Ignorar o `512` ali devolveria o de 128GB para quem pediu 512. Tem teste
próprio, com o MacBook no catálogo para provar que o número é conhecido.

E quando descartar os números **esvazia** a consulta (`"quero 2"`), a busca
devolve nada em vez do catálogo inteiro: listar 50 produtos para quem disse "2"
é pior que não achar.

## Provas

Os 13 casos que já existiam continuam verdes — inclusive o que garante que quem
pede 128 não vê o 256.

**Duas sabotagens:**

| sabotagem | previsto | medido |
|---|---:|---:|
| todo número volta a filtrar (regra antiga) | 2 falhas | 2 |
| nenhum número filtra | 4 falhas | **7** |

Registro que errei a segunda: subestimei quantos casos dependem do filtro
numérico. O mecanismo era o previsto, a aritmética não — e é essa diferença que
mostra que a sabotagem alcançou mais do que eu pensava.
