### PR TITLE
fix(branding): a suite deixa de reprovar em instalacao com marca propria

### DIFF
--- a/tests/unit/branding-saida.test.ts
+++ b/tests/unit/branding-saida.test.ts
@@ -75,9 +75,24 @@ beforeEach(() => {
   respostaDaOrganizacao = { data: null, error: null };
   clienteExplode = false;
   linhaDaInstalacao = null;
+  // A marca do OPERADOR nao pode decidir o resultado destes testes: eles
+  // afirmam o piso DO PRODUTO. O mock acima cobre `marcaDaInstalacao`, mas
+  // `lib/branding/resolve.ts` tambem le `APP_NAME`/`APP_ACCENT_HEX` do `.env`
+  // — e numa instalacao white-label essas chaves vem PREENCHIDAS, que e o caso
+  // normal deste repo (docs/white-label.md). Sem os stubs abaixo, quem troca a
+  // marca pelo caminho documentado herda tres testes vermelhos que nao tem
+  // relacao nenhuma com a mudanca dele.
+  //
+  // Vazio e nao `delete`: chave declarada e vazia e exatamente o estado que o
+  // `install.sh` grava quando o operador aperta Enter, e `resolve.ts` ja o
+  // trata como "ninguem configurou". Stubar com o valor real do caminho real
+  // prova o piso sem inventar um terceiro estado.
+  vi.stubEnv("APP_NAME", "");
+  vi.stubEnv("APP_ACCENT_HEX", "");
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
 


### PR DESCRIPTION
`tests/unit/branding-saida.test.ts` afirma o PISO do produto: sem marca em
lugar nenhum, `marcaDaSaida()` devolve o accent da regua e o nome padrao. O
arquivo ja mocka `marcaDaInstalacao`, mas `lib/branding/resolve.ts` tambem le
`APP_NAME`/`APP_ACCENT_HEX` do `.env` — e essas chaves nao estavam neutralizadas.

Consequencia medida: em qualquer instalacao que trocou a marca pelo caminho
que `docs/white-label.md` manda usar, tres testes reprovam. Reproduzido com
`APP_NAME=Elev CRM` e `APP_ACCENT_HEX=#7a5cd6` no `.env.local`:

    AssertionError: expected 'Elev CRM' to be 'DeskcommCRM'
    AssertionError: expected '#604aa6' to be '#506d48'  (x2)

Sem o `.env`: 13/13 passam. Com ele: 3 reprovam. Ou seja, o resultado da suite
dependia da marca do operador — e quem revende o sistema, que e o publico
declarado do projeto, herda vermelho que nao tem relacao com a mudanca dele.
Num repo em que agente de codigo usa `pnpm gov:verify` como prova, isso custa
o sinal.

Stub com string VAZIA e nao `delete`: chave declarada e vazia e o estado que o
`install.sh` grava quando o operador aperta Enter, e `resolve.ts` ja o trata
como "ninguem configurou" (o comentario na linha 431 diz isso). Reproduz o
caminho real em vez de inventar um terceiro estado.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
