### PR TITLE
fix(e2e): build para de morrer sem diagnostico quando o .env.local e parcial

### DIFF
--- a/scripts/e2e-build.sh
+++ b/scripts/e2e-build.sh
@@ -44,7 +44,7 @@ pnpm exec next build
 # O host vem do PRÓPRIO .env.local, então a guarda continua valendo se alguém
 # apontar aquele arquivo para outro projeto.
 if [ -f .env.local ]; then
-  HOST_PROD="$(grep -E '^NEXT_PUBLIC_SUPABASE_URL=' .env.local | cut -d= -f2- | sed -E 's#https?://##; s#/.*##')"
+  HOST_PROD="$(grep -E '^NEXT_PUBLIC_SUPABASE_URL=' .env.local | cut -d= -f2- | sed -E 's#https?://##; s#/.*##' || true)"
   if [ -n "$HOST_PROD" ] && [ "$HOST_PROD" != "127.0.0.1:54321" ]; then
     if grep -rqF "$HOST_PROD" .next/static 2>/dev/null; then
       echo "==> FALHOU: o bundle do browser contém o host de produção ($HOST_PROD)." >&2


### PR DESCRIPTION
`scripts/e2e-build.sh` roda sob `set -euo pipefail`. A linha

    HOST_PROD="$(grep -E '^NEXT_PUBLIC_SUPABASE_URL=' .env.local | cut ... | sed ...)"

assume que todo `.env.local` aponta para producao. Quando o arquivo existe mas
NAO tem essa chave, o `grep` sai com 1, o `pipefail` propaga, e o script morre
na atribuicao — ANTES das duas guardas e antes de imprimir qualquer coisa.

Sintoma medido: `pnpm e2e:build` compila com sucesso (`Compiled successfully in
73s`, TypeScript OK, tabela de rotas impressa) e termina com `ELIFECYCLE
Command failed with exit code 1`, sem UMA linha dizendo o que falhou. O `.next`
fica valido no disco, entao o build deu certo e o operador nao tem como saber.

O caso que reproduz nao e exotico: e o `.env.local` de quem so configurou a
marca — `APP_NAME`/`APP_LOGO_URL`/`APP_ACCENT_HEX` —, que e o primeiro arquivo
que um revendedor escreve seguindo `docs/white-label.md`.

`|| true` na atribuicao: ausencia da chave passa a significar "nao ha host de
producao para vazar", que e a verdade, e a guarda seguinte ja trata `HOST_PROD`
vazio com `[ -n "$HOST_PROD" ]`. O controle positivo do bundle continua intacto.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
