### PR TITLE
fix(followup): fluxo publicado deixa de abrir vazio no construtor

### DIFF
--- a/.changes/o-fluxo-publicado-abre-como-esta-no-ar.md
+++ b/.changes/o-fluxo-publicado-abre-como-esta-no-ar.md
@@ -18,9 +18,9 @@ coisa e salvasse estaria salvando por cima — com o desenho vazio que a tela
 mostrou. Um "publicar" depois disso trocaria o fluxo que está funcionando por
 esse vazio, sem aviso nenhum.
 
-Agora, quando não existe cópia de trabalho, a tela abre **exatamente o que está
-no ar**. Quem nunca editou vê o fluxo publicado; quem tem trabalho salvo e não
-publicado continua vendo o seu trabalho, que segue tendo prioridade.
+Agora, quando não existe cópia de trabalho, a tela abre **exatamente o que está no ar**.
+Quem nunca editou vê o fluxo publicado; quem tem trabalho salvo e não publicado
+continua vendo o seu trabalho, que segue tendo prioridade.
 
 Para quem opera uma instalação, nada muda no dia a dia: nenhuma configuração
 nova, nenhum passo de atualização.

--- a/.changes/o-fluxo-publicado-abre-como-esta-no-ar.md
+++ b/.changes/o-fluxo-publicado-abre-como-esta-no-ar.md
@@ -1,0 +1,26 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Um fluxo de retorno publicado não abre mais vazio na tela
+---
+
+Um fluxo de retorno que estava **no ar e funcionando** podia abrir **em branco**
+no construtor. A automação rodava normalmente e conversava com os clientes; a
+tela é que não mostrava nada.
+
+Acontecia quando o fluxo foi publicado por fora do construtor — restauração de
+backup, instalação assistida, importação de outra instalação. Nesses casos o
+sistema guarda a versão publicada mas não guarda uma cópia de trabalho, e a tela
+só sabia abrir a cópia de trabalho.
+
+**O risco era maior do que a tela vazia.** Quem abrisse, mexesse em qualquer
+coisa e salvasse estaria salvando por cima — com o desenho vazio que a tela
+mostrou. Um "publicar" depois disso trocaria o fluxo que está funcionando por
+esse vazio, sem aviso nenhum.
+
+Agora, quando não existe cópia de trabalho, a tela abre **exatamente o que está
+no ar**. Quem nunca editou vê o fluxo publicado; quem tem trabalho salvo e não
+publicado continua vendo o seu trabalho, que segue tendo prioridade.
+
+Para quem opera uma instalação, nada muda no dia a dia: nenhuma configuração
+nova, nenhum passo de atualização.

--- a/app/api/v1/ai/followup-flows/[id]/route.ts
+++ b/app/api/v1/ai/followup-flows/[id]/route.ts
@@ -7,6 +7,7 @@
  * DELETE /api/v1/ai/followup-flows/:id — apaga o pointer (manager+). Enrollment
  *   e versões saem no cascade / na ordem abaixo; não dá para desfazer.
  */
+import { rascunhoDoFluxo } from "@/lib/followup/rascunho";
 import { randomUUID } from "node:crypto";
 import type { NextRequest } from "next/server";
 
@@ -59,9 +60,19 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
     .order("created_at", { ascending: false });
   if (versionsErr) return fail("internal_error", versionsErr.message, 500, { requestId });
 
+  // Rascunho ausente COM versão publicada: a tela abre o que está NO AR. Ver
+  // `lib/followup/rascunho.ts` — um fluxo publicado por fora do construtor
+  // abria vazio, e salvar por cima trocava o fluxo do ar por quase-nada.
+  const draft_graph = await rascunhoDoFluxo(
+    supabase,
+    data as unknown as { draft_graph: unknown; active_version_id: string | null },
+    activeOrg.orgId,
+  );
+
   return ok(
     {
       ...data,
+      draft_graph,
       versions_count: versionRows?.length ?? 0,
       previous_version_id: versionRows?.[1]?.id ?? null,
     },

--- a/app/app/ai/followups/[id]/page.tsx
+++ b/app/app/ai/followups/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound, redirect } from "next/navigation";
 
+import { rascunhoDoFluxo } from "@/lib/followup/rascunho";
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
 import { ROLE_RANK } from "@/lib/auth/types";
 import { createClient } from "@/lib/supabase/server";
@@ -43,8 +44,17 @@ export default async function FollowupFlowBuilderPage({
 
   if (!pointer) notFound();
 
+  // Mesma regra da rota: rascunho ausente COM versão publicada abre o que está
+  // NO AR. Ver `lib/followup/rascunho.ts`.
+  const draft_graph = await rascunhoDoFluxo(
+    supabase,
+    pointer as unknown as { draft_graph: unknown; active_version_id: string | null },
+    activeOrg.orgId,
+  );
+
   const flow: FollowupFlowDetailRow = {
     ...(pointer as unknown as Omit<FollowupFlowDetailRow, "versions_count" | "previous_version_id">),
+    draft_graph,
     versions_count: versionRows?.length ?? 0,
     previous_version_id: versionRows?.[1]?.id ?? null,
   };

--- a/lib/followup/rascunho.ts
+++ b/lib/followup/rascunho.ts
@@ -1,0 +1,54 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { FlowGraph } from "./graph-schema";
+
+/**
+ * O RASCUNHO QUE A TELA DESENHA — e por que ele não pode ser só a coluna.
+ *
+ * ═══ O defeito, medido numa instalação real ═════════════════════════════════
+ *
+ * Um fluxo com 23 nós PUBLICADO e ATIVO abria VAZIO no construtor. A versão
+ * ativa estava lá, o motor a estava usando, e a tela desenhava nada — porque o
+ * canvas lê `draft_graph`, e `draft_graph` era NULL.
+ *
+ * Isso acontece sempre que a versão nasce por fora do construtor: publicação
+ * por script, restauração de backup, importação de outra instalação. O ponteiro
+ * ganha `active_version_id` e nunca ganha rascunho.
+ *
+ * ⚠️ E o estrago não para em "a tela está vazia". `savedGraph` também nascia
+ * vazio, então bastava arrastar um nó e salvar para o rascunho virar quase-nada
+ * — e o "Publicar" seguinte trocaria o fluxo que está NO AR por esse quase-nada.
+ * A tela oferecia publicar por cima de um fluxo que ela não conseguia mostrar.
+ *
+ * ═══ A regra ═══════════════════════════════════════════════════════════════
+ *
+ * Rascunho ausente COM versão publicada = a tela abre o que está no ar. É o
+ * único significado que não perde trabalho: quem nunca editou tem como
+ * rascunho exatamente aquilo que está valendo.
+ *
+ * Rascunho ausente SEM versão publicada = fluxo novo de verdade, e aí o canvas
+ * em branco é a resposta certa.
+ */
+export async function rascunhoDoFluxo(
+  supabase: SupabaseClient,
+  pointer: {
+    organization_id?: string;
+    draft_graph: unknown;
+    active_version_id: string | null;
+  },
+  organizationId: string,
+): Promise<FlowGraph | null> {
+  if (pointer.draft_graph) return pointer.draft_graph as FlowGraph;
+  if (!pointer.active_version_id) return null;
+
+  const { data } = await supabase
+    .from("followup_flow_versions")
+    .select("graph")
+    .eq("id", pointer.active_version_id)
+    .eq("organization_id", organizationId)
+    .maybeSingle();
+
+  // Falha de leitura devolve null, que é o canvas em branco — o mesmo que
+  // acontecia antes. Não é ideal, mas é o desfecho já conhecido: nunca pior.
+  return ((data as { graph?: FlowGraph } | null)?.graph as FlowGraph | undefined) ?? null;
+}

--- a/tests/unit/o-fluxo-publicado-nao-abre-vazio.test.ts
+++ b/tests/unit/o-fluxo-publicado-nao-abre-vazio.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { rascunhoDoFluxo } from "@/lib/followup/rascunho";
+
+/**
+ * FLUXO PUBLICADO NÃO ABRE VAZIO NO CONSTRUTOR.
+ *
+ * ═══ O defeito, medido numa instalação real ═════════════════════════════════
+ *
+ * Um fluxo de 23 nós PUBLICADO e ATIVO abria vazio na tela. A versão ativa
+ * estava lá, o motor a estava usando para conversar com clientes, e o canvas
+ * desenhava nada — porque ele lê `draft_graph`, e `draft_graph` era NULL.
+ *
+ * Acontece sempre que a versão nasce por fora do construtor: publicação por
+ * script, restauração de backup, importação de outra instalação. O ponteiro
+ * ganha `active_version_id` e nunca ganha rascunho.
+ *
+ * ⚠️ E O ESTRAGO NÃO PARA EM "A TELA ESTÁ VAZIA". No `FlowCanvas`, o mesmo
+ * `?? EMPTY_GRAPH` alimentava `savedGraph`. Bastava arrastar um nó e salvar
+ * para o rascunho virar quase-nada, e o "Publicar" seguinte trocaria o fluxo
+ * que está NO AR por esse quase-nada. A tela oferecia publicar por cima de um
+ * fluxo que ela não conseguia mostrar.
+ */
+
+const GRAFO_NO_AR = {
+  nodes: [
+    { id: "t1", type: "trigger", label: "Conversa esfriou", position: { x: 0, y: 0 }, config: {} },
+    { id: "e1", type: "end", label: "Fim", position: { x: 200, y: 0 }, config: { outcome: "exhausted" } },
+  ],
+  edges: [{ id: "a", source: "t1", target: "e1", priority: 0, condition: { type: "always" } }],
+};
+
+/** Dublê mínimo do PostgREST: só o encadeamento que `rascunhoDoFluxo` usa. */
+function supabaseFake(versao: unknown, espiao?: (filtros: Record<string, string>) => void) {
+  const filtros: Record<string, string> = {};
+  const chain = {
+    select: () => chain,
+    eq: (col: string, val: string) => {
+      filtros[col] = val;
+      return chain;
+    },
+    maybeSingle: async () => {
+      espiao?.(filtros);
+      return { data: versao, error: null };
+    },
+  };
+  return { from: () => chain } as never;
+}
+
+describe("o rascunho que a tela desenha", () => {
+  it("rascunho AUSENTE com versão publicada: abre o que está NO AR", () => {
+    return expect(
+      rascunhoDoFluxo(
+        supabaseFake({ graph: GRAFO_NO_AR }),
+        { draft_graph: null, active_version_id: "v1" },
+        "org-1",
+      ),
+    ).resolves.toEqual(GRAFO_NO_AR);
+  });
+
+  it("rascunho PRESENTE vence a versão publicada — nunca sobrescreve edição em curso", () => {
+    // O controle que impede o conserto de virar outro defeito: quem tem
+    // trabalho salvo e não publicado não pode ver esse trabalho sumir.
+    const rascunho = { nodes: [{ id: "x" }], edges: [] };
+    return expect(
+      rascunhoDoFluxo(
+        supabaseFake({ graph: GRAFO_NO_AR }),
+        { draft_graph: rascunho, active_version_id: "v1" },
+        "org-1",
+      ),
+    ).resolves.toEqual(rascunho);
+  });
+
+  it("fluxo NOVO de verdade (sem rascunho e sem versão) abre em branco", () => {
+    // Sem este caso, "sempre buscar a versão" satisfaria o primeiro — e o
+    // canvas em branco é a resposta certa para quem está começando.
+    return expect(
+      rascunhoDoFluxo(supabaseFake(null), { draft_graph: null, active_version_id: null }, "org-1"),
+    ).resolves.toBeNull();
+  });
+
+  it("a busca da versão é filtrada por ORGANIZAÇÃO, não só por id", () => {
+    // `active_version_id` vem de uma linha que a RLS já filtrou, mas a consulta
+    // seguinte é nova: sem o filtro de org, um id vazado leria o fluxo de outro
+    // tenant. Regra dura nº 10 do CLAUDE.md — o filtro é programático, sempre.
+    const visto: Record<string, string>[] = [];
+    return rascunhoDoFluxo(
+      supabaseFake({ graph: GRAFO_NO_AR }, (f) => visto.push({ ...f })),
+      { draft_graph: null, active_version_id: "v1" },
+      "org-1",
+    ).then(() => {
+      expect(visto[0]).toEqual({ id: "v1", organization_id: "org-1" });
+    });
+  });
+
+  it("falha ao ler a versão degrada para branco, e não explode a tela", () => {
+    // ⚠️ O dublê aceita QUALQUER número de `.eq()`, de propósito. A primeira
+    // versão encadeava exatamente dois, e aí ele reprovava junto com o caso do
+    // filtro de organização quando um `.eq` era removido — dois vermelhos, um
+    // defeito só. Teste que quebra pela FORMA do dublê não mede o que promete.
+    const chain: Record<string, unknown> = {};
+    chain.select = () => chain;
+    chain.eq = () => chain;
+    chain.maybeSingle = async () => ({ data: null, error: { message: "boom" } });
+    const quebrado = { from: () => chain } as never;
+    return expect(
+      rascunhoDoFluxo(quebrado, { draft_graph: null, active_version_id: "v1" }, "org-1"),
+    ).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## O defeito

Medido numa instalação real: um fluxo de retorno com **23 nós, publicado e
ativo**, abria **vazio** no construtor. A versão ativa estava no banco, o motor
a estava usando para conversar com clientes, e o canvas desenhava nada.

A causa é uma linha:

```ts
toReactFlow(initialData.draft_graph ?? EMPTY_GRAPH)
```

O canvas lê `draft_graph`. Uma versão que nasce **por fora do construtor** —
publicação por script, restauração de backup, importação de outra instalação —
dá ao ponteiro um `active_version_id` e **nenhum rascunho**.

## ⚠️ O estrago não para na tela vazia

O mesmo `?? EMPTY_GRAPH` alimenta `savedGraph`. Então bastava **arrastar um nó e
salvar** para o rascunho virar quase-nada — e o "Publicar" seguinte trocaria o
fluxo que está **no ar** por esse quase-nada, sem aviso.

A tela oferecia publicar por cima de um fluxo que ela não conseguia mostrar. É a
família do *controle decorativo* que este repo já catalogou, só que pior: aqui o
controle **funciona**, e destrói.

## A regra

| estado | o que a tela abre |
|---|---|
| rascunho presente | **o rascunho** — edição em curso nunca é sobrescrita |
| sem rascunho, com versão ativa | **o que está no ar** |
| sem rascunho, sem versão | **branco** — é fluxo novo de verdade |

"O que está no ar" é o único significado que não perde trabalho: quem nunca
editou tem como rascunho exatamente aquilo que está valendo.

O helper é compartilhado pela rota (`/api/v1/ai/followup-flows/:id`) e pela
página RSC, e **não duplicado** — são os dois caminhos que alimentam o mesmo
canvas, e duas cópias divergiriam.

## Provas

**Cinco casos**, incluindo dois que existem para o conserto não virar outro
defeito: rascunho presente vencendo a versão (senão comeria edição não
publicada) e fluxo novo abrindo branco (senão "sempre buscar a versão"
satisfaria o caso principal).

E um de isolamento: **a busca da versão é filtrada por organização**, não só por
id. `active_version_id` vem de uma linha que a RLS já filtrou, mas a consulta
seguinte é nova — regra dura nº 10 do CLAUDE.md.

**Três sabotagens, três previsões acertadas** — voltar ao comportamento antigo,
versão vencendo o rascunho, filtro de organização removido.

⚠️ A terceira **só acertou na segunda tentativa**. O dublê encadeava exatamente
dois `.eq()`, então remover o filtro derrubava também o caso de erro de leitura:
dois vermelhos para um defeito. Teste que quebra pela **forma do dublê** não mede
o que promete. O dublê agora aceita qualquer número de `.eq()`.

## Como apareceu

O dono da instalação apagou a conexão de WhatsApp e criou outra. Ao reapontar o
time para o número novo, fui conferir o fluxo e ele estava vazio na tela — com
os 23 nós intactos no banco.
