### PR TITLE
fix(pacing): a proteção de envio salva com a data do número em branco

### DIFF
--- a/.changes/a-protecao-de-envio-salva-sem-a-data-do-numero.md
+++ b/.changes/a-protecao-de-envio-salva-sem-a-data-do-numero.md
@@ -1,0 +1,22 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A proteção de envio volta a salvar sem a data do número
+---
+
+Em **Conexões › Proteção de envio**, ajustar o horário de envio e salvar sem
+preencher "este número é usado desde" devolvia *"Falha ao salvar os knobs."* e
+não gravava nada — nem os campos que você tinha acabado de mudar.
+
+Isso atingia toda instalação nova, porque essa data começa em branco. E a
+armadilha era dupla: sem os limites salvos, o sistema trata o número como
+recém-criado e libera pouco por dia — exatamente o teto que a pessoa abriu a
+tela para corrigir.
+
+Agora o campo em branco significa o que a tela sempre prometeu: em número novo,
+ele é tratado como recém-criado. E, se você já tinha informado uma data antes,
+limpar o campo não a apaga — para trocá-la, informe outra. O texto de ajuda da
+tela passa a dizer isso.
+
+Junto vai um conserto de diagnóstico: quando o banco recusa um campo, o motivo
+passa a viajar junto do erro em vez de virar um "falha ao salvar" sem dono.

--- a/app/api/v1/ai/pacing/route.ts
+++ b/app/api/v1/ai/pacing/route.ts
@@ -81,12 +81,26 @@ export async function PUT(req: NextRequest): Promise<Response> {
       details: parsed.error.flatten(),
     });
   }
-  const { channel_session_id, daily_message_limit, skip_warmup, ...camposDiretos } = parsed.data;
+  const {
+    channel_session_id,
+    daily_message_limit,
+    skip_warmup,
+    number_activated_at,
+    ...camposDiretos
+  } = parsed.data;
   // `skip_warmup` é pergunta da TELA; a coluna guarda a forma que o motor lê.
   // A tradução mora aqui, num lugar só: a tela não deveria precisar conhecer o
   // formato dos degraus para dizer "este número já está aquecido".
   const knobFields = {
     ...camposDiretos,
+    // `null` na data é "não estou declarando", NUNCA "grave nulo": esta é a
+    // única coluna `not null` da tabela, e um null explícito ANULA o
+    // `default now()` em vez de cair nele — 23502, e a ficha inteira deixava de
+    // salvar para quem nunca informou a data (toda instalação nova). Omitindo,
+    // a linha nova nasce com `now()` (idade 0 — o "recém-criado" que a tela
+    // promete) e a linha existente preserva a data que já tem, em vez de
+    // rejuvenescer o número em silêncio de volta ao teto de 20 envios/dia.
+    ...(number_activated_at != null ? { number_activated_at } : {}),
     ...(skip_warmup !== undefined
       ? { warmup_daily_caps: skip_warmup ? [...WARMUP_PULADO] : null }
       : {}),
@@ -150,7 +164,13 @@ export async function PUT(req: NextRequest): Promise<Response> {
       { onConflict: "organization_id,channel_session_id" },
     );
     if (upErr) {
-      return fail("internal_error", "Falha ao salvar os knobs.", 500, { requestId });
+      // O motivo cru vai em `details`, não na `message` que o operador lê: foi a
+      // ausência dele que transformou um `not null` num diagnóstico de horas —
+      // nem a tela nem o log diziam QUAL campo o banco recusou.
+      return fail("internal_error", "Falha ao salvar os knobs.", 500, {
+        requestId,
+        details: { motivo: upErr.message },
+      });
     }
   }
 

--- a/components/connections/AntiBanSheet.tsx
+++ b/components/connections/AntiBanSheet.tsx
@@ -152,7 +152,7 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
             />
             <p className="text-xs text-muted-foreground">
               {t(
-                "A conexão pode ser nova sem que o número seja. O aquecimento conta a idade do NÚMERO — se você deixar em branco, ele é tratado como recém-criado e começa liberando pouco por dia.",
+                "A conexão pode ser nova sem que o número seja. O aquecimento conta a idade do NÚMERO — em branco, ele é tratado como recém-criado e começa liberando pouco por dia. Uma data já salva não some se você limpar o campo: para mudá-la, informe outra.",
               )}
             </p>
 

--- a/lib/i18n/dicionario.ts
+++ b/lib/i18n/dicionario.ts
@@ -2899,8 +2899,8 @@ export const DICIONARIO: Traducoes = {
     es: "Estos límites protegen el número contra el bloqueo de WhatsApp. Campo vacío usa el valor seguro predeterminado del sistema (que se muestra en el campo).",
   },
   "Este número é usado desde": { es: "Este número se usa desde" },
-  "A conexão pode ser nova sem que o número seja. O aquecimento conta a idade do NÚMERO — se você deixar em branco, ele é tratado como recém-criado e começa liberando pouco por dia.": {
-    es: "La conexión puede ser nueva sin que el número lo sea. El calentamiento cuenta la antigüedad del NÚMERO — si lo dejas en blanco, se trata como recién creado y empieza liberando poco por día.",
+  "A conexão pode ser nova sem que o número seja. O aquecimento conta a idade do NÚMERO — em branco, ele é tratado como recém-criado e começa liberando pouco por dia. Uma data já salva não some se você limpar o campo: para mudá-la, informe outra.": {
+    es: "La conexión puede ser nueva sin que el número lo sea. El calentamiento cuenta la antigüedad del NÚMERO — en blanco, se trata como recién creado y empieza liberando poco por día. Una fecha ya guardada no desaparece si limpias el campo: para cambiarla, informa otra.",
   },
   "Este número já está aquecido — pular o aquecimento": {
     es: "Este número ya está calentado — saltar el calentamiento",

--- a/tests/unit/protecao-de-envio-aceita-data-em-branco.test.ts
+++ b/tests/unit/protecao-de-envio-aceita-data-em-branco.test.ts
@@ -1,0 +1,313 @@
+/**
+ * PROTEÇÃO DE ENVIO: SALVAR COM "NÚMERO EM USO DESDE" EM BRANCO (issue #419).
+ *
+ * ─── O defeito, medido ─────────────────────────────────────────────────────
+ *
+ * `channel_knobs.number_activated_at` é a ÚNICA coluna da tabela com `not null`,
+ * e ela tem `default now()`. A ficha Anti-ban trata a data como opcional: com o
+ * campo vazio, `AntiBanSheet` envia `number_activated_at: null`, e o texto de
+ * ajuda promete que em branco o número "é tratado como recém-criado".
+ *
+ * Só que `null` EXPLÍCITO não cai no default — ele o anula. Reproduzido num
+ * Postgres 17 com o DDL extraído verbatim de `supabase/baseline.sql` e o payload
+ * exato que a rota monta:
+ *
+ *   ERROR:  null value in column "number_activated_at" of relation
+ *           "channel_knobs" violates not-null constraint
+ *
+ * O mesmo payload SEM a chave insere e a coluna nasce preenchida pelo default —
+ * é este o controle positivo que diz que o culpado é a chave, não o valor.
+ *
+ * Quem nunca declarou a data — toda instalação nova, já que `channel_knobs`
+ * nasce vazia — não conseguia ajustar a janela anti-banimento pela tela. E o
+ * agravante: sem linha, o motor lê idade 0 e aplica o degrau {minAgeDays: 0,
+ * cap: 20} dos PACING_DEFAULTS. O operador que tentava corrigir o teto de 20
+ * envios/dia esbarrava neste erro.
+ *
+ * ─── A regra ───────────────────────────────────────────────────────────────
+ *
+ * `number_activated_at: null` significa "não estou declarando esta data", e não
+ * "grave nulo": a chave sai do upsert. Em linha nova o `default now()` age
+ * (idade 0 = recém-criado, exatamente o que a tela promete); em linha existente
+ * a data já salva é PRESERVADA — apagar o campo não rejuvenesce o número em
+ * silêncio, que é o desfecho que voltaria a rebaixá-lo a 20 envios/dia.
+ *
+ * ─── E o erro do banco deixa de ser mistério ───────────────────────────────
+ *
+ * A rota descartava `upErr` e devolvia só "Falha ao salvar os knobs." — sem o
+ * nome do campo que recusou, nem na tela nem no log. Foi essa ausência que
+ * transformou um `not null` num diagnóstico de horas. O motivo cru do banco vai
+ * em `details`, nunca na `message` traduzida que o operador lê.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { audit } from "@/lib/audit";
+import { requireRole } from "@/lib/auth/require-role";
+import type { AuthUser } from "@/lib/auth/types";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+vi.mock("@/lib/auth/require-role", () => ({ requireRole: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
+vi.mock("@/lib/audit", () => ({ audit: vi.fn(async () => undefined) }));
+
+const ORG = "22222222-2222-4222-8222-222222222222";
+const USER = "11111111-1111-4111-8111-111111111111";
+const CANAL = "44444444-4444-4444-8444-444444444444";
+const DATA_JA_SALVA = "2026-01-10T12:00:00.000Z";
+
+type Linha = Record<string, unknown>;
+
+/** O 23502 que o Postgres devolve para o payload da tela (medido, não inventado). */
+const NAO_NULO = {
+  code: "23502",
+  message:
+    'null value in column "number_activated_at" of relation "channel_knobs" violates not-null constraint',
+};
+
+interface Registro {
+  /** Cargas entregues ao upsert de `channel_knobs`, na ordem. */
+  upserts: Linha[];
+  knobs: Linha | null;
+  sessao: Linha;
+}
+
+/**
+ * Dublê do PostgREST que faz o que o banco REAL faz com esta tabela: recusa o
+ * upsert que carrega `number_activated_at: null` e, quando a chave está
+ * ausente, aplica o `default now()` em linha nova e preserva o valor em linha
+ * existente. Sem isso o teste mediria só a forma da carga, e um conserto que
+ * mandasse null com outro nome passaria.
+ */
+function makeDb(knobsIniciais: Linha | null = null): Registro {
+  const registro: Registro = {
+    upserts: [],
+    knobs: knobsIniciais,
+    sessao: { id: CANAL, organization_id: ORG, archived_at: null, daily_message_limit: 250 },
+  };
+
+  class Q implements PromiseLike<unknown> {
+    private filtros: Array<[string, unknown]> = [];
+
+    constructor(
+      private readonly table: string,
+      private readonly op: "select" | "update" | "upsert",
+      private readonly patch: Linha | null = null,
+    ) {}
+
+    select(): this {
+      return this;
+    }
+    eq(col: string, val: unknown): this {
+      this.filtros.push([col, val]);
+      return this;
+    }
+    is(col: string, val: unknown): this {
+      this.filtros.push([col, val]);
+      return this;
+    }
+    maybeSingle(): this {
+      return this;
+    }
+
+    private casa(linha: Linha): boolean {
+      return this.filtros.every(([c, v]) => (linha[c] ?? null) === v);
+    }
+
+    private executar(): { data: unknown; error: unknown } {
+      if (this.op === "select") {
+        const linha = this.table === "channel_sessions" ? registro.sessao : registro.knobs;
+        return { data: linha && this.casa(linha) ? linha : null, error: null };
+      }
+
+      if (this.op === "update") {
+        if (this.casa(registro.sessao)) Object.assign(registro.sessao, this.patch);
+        return { data: null, error: null };
+      }
+
+      const carga = this.patch ?? {};
+      registro.upserts.push(carga);
+      // A constraint da coluna, exatamente como o Postgres a aplica.
+      if ("number_activated_at" in carga && carga.number_activated_at === null) {
+        return { data: null, error: NAO_NULO };
+      }
+      const anterior = registro.knobs;
+      registro.knobs = {
+        ...(anterior ?? { number_activated_at: "2026-09-01T00:00:00.000Z" /* default now() */ }),
+        ...carga,
+      };
+      return { data: null, error: null };
+    }
+
+    then<R1 = unknown, R2 = never>(
+      onOk?: ((v: { data: unknown; error: unknown }) => R1 | PromiseLike<R1>) | null,
+      onErr?: ((r: unknown) => R2 | PromiseLike<R2>) | null,
+    ): PromiseLike<R1 | R2> {
+      return Promise.resolve(this.executar()).then(onOk, onErr);
+    }
+  }
+
+  const client = {
+    from: (table: string) => ({
+      select: () => new Q(table, "select"),
+      update: (patch: Linha) => new Q(table, "update", patch),
+      upsert: (patch: Linha) => new Q(table, "upsert", patch),
+    }),
+  };
+  vi.mocked(createAdminClient).mockReturnValue(client as never);
+  return registro;
+}
+
+function authOk(): void {
+  const user: AuthUser = {
+    id: USER,
+    email: "dono@example.com",
+    full_name: null,
+    avatar_url: null,
+    is_platform_admin: false,
+    idioma: "pt-BR" as const,
+    organizations: [{ organization_id: ORG, organization_name: "Org", role: "admin" }],
+  };
+  vi.mocked(requireRole).mockResolvedValue({
+    ok: true,
+    user,
+    org: { orgId: ORG, name: "Org", role: "admin" as const },
+  } as never);
+}
+
+/** O corpo EXATO que `AntiBanSheet.handleSave` monta — nada aqui é simplificado. */
+function corpoDaTela(over: Linha = {}): Linha {
+  return {
+    channel_session_id: CANAL,
+    window_start_hour: 7,
+    window_end_hour: 22,
+    throttle_ms: 1200,
+    jitter_max_ms: 800,
+    allow_sunday: null,
+    timezone: null,
+    number_activated_at: null,
+    skip_warmup: false,
+    ...over,
+  };
+}
+
+const put = (corpo: Linha) =>
+  new NextRequest("http://localhost/api/v1/ai/pacing", {
+    method: "PUT",
+    body: JSON.stringify(corpo),
+    headers: { "content-type": "application/json" },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PUT /api/v1/ai/pacing — data em branco não impede salvar a janela", () => {
+  it("⭐ instalação nova (channel_knobs vazia): salva a janela com a data em branco", async () => {
+    authOk();
+    const db = makeDb(null);
+    const { PUT } = await import("@/app/api/v1/ai/pacing/route");
+    const res = await PUT(put(corpoDaTela()));
+
+    expect(res.status).toBe(200);
+    // A chave não pode chegar ao banco: `null` explícito anula o `default now()`.
+    expect(db.upserts[0]).not.toHaveProperty("number_activated_at");
+    // E o que o operador veio fazer tem de ter sido gravado.
+    expect(db.knobs).toMatchObject({ window_start_hour: 7, window_end_hour: 22 });
+  });
+
+  it("data já salva sobrevive a um save com o campo em branco", async () => {
+    authOk();
+    const db = makeDb({
+      organization_id: ORG,
+      channel_session_id: CANAL,
+      window_start_hour: 9,
+      window_end_hour: 18,
+      number_activated_at: DATA_JA_SALVA,
+    });
+    const { PUT } = await import("@/app/api/v1/ai/pacing/route");
+    const res = await PUT(put(corpoDaTela()));
+
+    expect(res.status).toBe(200);
+    // Rejuvenescer o número em silêncio o rebaixaria a 20 envios/dia — o mesmo
+    // teto que o operador abriu esta ficha para corrigir.
+    expect(db.knobs?.number_activated_at).toBe(DATA_JA_SALVA);
+  });
+
+  it("data informada continua sendo gravada (o campo não virou decorativo)", async () => {
+    authOk();
+    const db = makeDb(null);
+    const declarada = "2026-03-01T12:00:00.000Z";
+    const { PUT } = await import("@/app/api/v1/ai/pacing/route");
+    const res = await PUT(put(corpoDaTela({ number_activated_at: declarada })));
+
+    expect(res.status).toBe(200);
+    expect(db.upserts[0]?.number_activated_at).toBe(declarada);
+    expect(db.knobs?.number_activated_at).toBe(declarada);
+  });
+
+  it("o audit não afirma ter gravado uma data que não gravou", async () => {
+    authOk();
+    makeDb(null);
+    const { PUT } = await import("@/app/api/v1/ai/pacing/route");
+    await PUT(put(corpoDaTela()));
+
+    const metadata = vi.mocked(audit).mock.calls[0]?.[0]?.metadata as Linha | undefined;
+    expect(metadata).toBeDefined();
+    expect(metadata).not.toHaveProperty("number_activated_at");
+  });
+});
+
+describe("PUT /api/v1/ai/pacing — erro do banco diz QUAL campo recusou", () => {
+  it("⭐ o motivo cru do Postgres chega em details, e a mensagem lida segue humana", async () => {
+    authOk();
+    makeDb(null);
+    vi.mocked(createAdminClient).mockReturnValue({
+      from: (table: string) => ({
+        select: () => {
+          const q = {
+            eq: () => q,
+            is: () => q,
+            maybeSingle: async () =>
+              table === "channel_sessions"
+                ? { data: { id: CANAL, organization_id: ORG, archived_at: null }, error: null }
+                : { data: null, error: null },
+          };
+          return q;
+        },
+        upsert: async () => ({ data: null, error: NAO_NULO }),
+      }),
+    } as never);
+
+    const { PUT } = await import("@/app/api/v1/ai/pacing/route");
+    const res = await PUT(put(corpoDaTela({ number_activated_at: null })));
+    const corpo = await res.json();
+
+    expect(res.status).toBe(500);
+    // Sem isto, um `not null` vira "Falha ao salvar os knobs." e ninguém sabe
+    // qual campo recusou — foi essa ausência que custou o diagnóstico.
+    expect(corpo.error.details).toBeDefined();
+    expect(JSON.stringify(corpo.error.details)).toContain("number_activated_at");
+    // E o operador continua lendo português, não uma frase do Postgres.
+    expect(corpo.error.message).toBe("Falha ao salvar os knobs.");
+  });
+});
+
+describe("A TELA e o texto que ela promete", () => {
+  it("o texto de ajuda não promete rejuvenescer um número cuja data já está salva", () => {
+    const sheet = readFileSync(
+      join(process.cwd(), "components/connections/AntiBanSheet.tsx"),
+      "utf8",
+    );
+    // A promessa "em branco = recém-criado" vale para quem NUNCA declarou a
+    // data. Para quem já declarou, o campo vazio preserva — e a tela precisa
+    // dizer isso, senão ela oferece um apagamento que o código não faz.
+    expect(
+      /data já salva/i.test(sheet),
+      "AntiBanSheet não explica que apagar o campo NÃO apaga a data já salva",
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #419

## O que este PR faz

Em **Conexões › Proteção de envio**, salvar sem preencher "número em uso desde" devolvia `Falha ao salvar os knobs.` e não gravava nada. Atingia **toda instalação nova**, porque `channel_knobs` nasce vazia.

## A causa, medida

`channel_knobs.number_activated_at` é a única coluna `not null` da tabela, e tem `default now()`. A tela envia `number_activated_at: null` quando o campo está vazio (`AntiBanSheet.tsx:114`), e o texto de ajuda promete que em branco o número "é tratado como recém-criado". Só que `null` **explícito** anula o default em vez de cair nele:

```
ERROR: null value in column "number_activated_at" of relation "channel_knobs"
       violates not-null constraint
```

Controle positivo: o mesmo payload **sem a chave** insere, e a coluna nasce preenchida pelo default. O culpado é a chave, não o valor.

O agravante: sem linha em `channel_knobs`, o motor lê idade 0 e aplica o degrau `{minAgeDays: 0, cap: 20}` — o teto de 20 envios/dia que o operador abriu a ficha para corrigir.

## O conserto

`number_activated_at: null` passa a significar **"não estou declarando"**, e a chave sai do upsert:

- **linha nova** → o `default now()` age (idade 0 = recém-criado, o que a tela promete);
- **linha existente** → a data é **preservada**. Apagar o campo não rejuvenesce o número em silêncio.

O texto de ajuda passa a dizer isso (pt-BR e es), porque senão a tela ofereceria um apagamento que o código não faz.

Junto: a rota deixa de descartar `upErr`. O motivo cru do banco vai em `details`, nunca na `message` traduzida. Foi essa ausência que transformou um `not null` num diagnóstico de horas.

## Prova

O dublê aplica a constraint **como o Postgres a aplica** (recusa a chave nula, aplica o default quando ausente) — não mede só a forma da carga, então um conserto que mandasse null com outro nome reprovaria.

```
$ npx vitest run tests/unit/protecao-de-envio-aceita-data-em-branco.test.ts
  Test Files  1 passed (1)
       Tests  6 passed (6)
```

**Sabotagem** — revertendo só `app/api/v1/ai/pacing/route.ts` e mantendo o teste (previ 3 vermelhos, deu 4; o quarto é o do audit, que eu tinha marcado como incerto):

```
  × instalação nova (channel_knobs vazia): salva a janela com a data em branco
  × data já salva sobrevive a um save com o campo em branco
  × o audit não afirma ter gravado uma data que não gravou
  × o motivo cru do Postgres chega em details, e a mensagem lida segue humana
  Tests  4 failed | 2 passed (6)
```

## Gates

```
pnpm typecheck   exit=0 (0 errors)
pnpm lint        exit=0 (0 errors)
vizinhos (pacing + anti-ban)   3 arquivos / 18 testes, exit=0
```

## O que NÃO fiz

Não mexi na coluna. Trocar o `not null` por nullable custaria migration + apêndice no baseline e não paga: o significado certo de "campo vazio" é *não declarei*, não *é nulo*.

Não escrevi spec de tela: o defeito vive na rota, e o dublê já exercita o corpo exato que `handleSave` monta. A afirmação da tela que o PR muda (o texto de ajuda) é coberta por um caso que lê o `AntiBanSheet.tsx`.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam
- [x] Sem `console.log` esquecido
- [x] Fragmento em `.changes/` (`nada_mudou` / `corrigido`)
- [ ] Schema: não toca

🤖 Generated with [Claude Code](https://claude.com/claude-code)