### PR TITLE
fix(release): o canal `stable` move em bloco, nunca por imagem

### DIFF
--- a/.changes/instalar-por-stable-nao-mistura-versoes.md
+++ b/.changes/instalar-por-stable-nao-mistura-versoes.md
@@ -1,0 +1,24 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Instalar pelo canal padrão não mistura mais versões entre os serviços
+---
+
+O DeskcommCRM roda três serviços que saem do mesmo código — o aplicativo, o
+trabalhador de fundo e o agendador. Quem instala pelo canal padrão espera os
+três na mesma versão.
+
+Até agora cada um deles avançava o canal por conta própria, ao terminar de ser
+publicado, sem saber se os irmãos tinham conseguido. Quando a publicação de um
+falhava por um problema de infraestrutura, os outros dois seguiam em frente — e
+quem instalasse naquela janela recebia uma instalação **misturada**, com peças
+de versões diferentes. Aconteceu de verdade no fechamento da versão anterior.
+
+Agora o canal só avança depois que as três imagens estão publicadas e o
+aplicativo provou que sobe. Se qualquer uma falhar, o canal fica onde estava —
+uma versão inteira e velha, em vez de uma nova pela metade.
+
+E o fechamento de cada versão passa a conferir isso antes de dar por concluído:
+não basta as imagens existirem, o canal precisa apontar para elas.
+
+Nada muda para quem já tem uma instalação funcionando.

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -156,20 +156,28 @@ jobs:
             # inteira depende — `latest` = topo da main, `stable` = última
             # release — e fazia `latest` oscilar entre os dois.
             type=raw,value=latest,enable=${{ github.ref_type == 'branch' && github.ref_name == 'main' }}
-            # `stable` = a última RELEASE publicada. Existe porque `latest` aqui
-            # significa topo da `main` (código não lançado), e o nome engana:
-            # quem quer "a última versão estável" pedia `latest` e recebia edge.
-            # Trocar o significado de `latest` faria downgrade silencioso em quem
-            # já o consome, então o canal novo é o que ganha o nome certo.
-            # Três condições, e cada uma barra um caminho medido. `ref_type ==
-            # 'tag'` sozinho deixaria um dispatch numa branch mover o canal;
-            # `startsWith(…, 'v')` barra tag de teste (o registry já tem uma
-            # `quebrada-teste`, que nenhum push na main consegue produzir);
-            # e `event_name == 'push'` barra o pior caso — um dispatch numa
-            # release ANTIGA faria `stable` REGREDIR, e todo self-hoster no
-            # default do compose sofreria downgrade silencioso no próximo
-            # `up -d`, com app velho sobre banco já migrado.
-            type=raw,value=stable,enable=${{ github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}
+            # `stable` NÃO sai daqui, e a razão é a issue #488. Ele já saiu: era
+            # mais um `type=raw` nesta lista, e por isso CADA imagem movia o
+            # canal sozinha, ao terminar, sem saber se as irmãs conseguiram.
+            # Medido no corte da v1.12.0 — o job do app morreu em `Set up
+            # Buildx`, antes de compilar coisa alguma, enquanto worker e
+            # scheduler seguiram e moveram o ponteiro:
+            #
+            #   deskcommcrm          1.12.0   404
+            #   deskcommcrm          stable   sha256:0235d02b…  ← 1.11.0
+            #   deskcomm-worker      stable   sha256:66c7bde4…  ← 1.12.0
+            #   deskcomm-scheduler   stable   sha256:ac6b87cc…  ← 1.12.0
+            #
+            # Quem instalasse por `stable` naquela janela recebia app 1.11.0 com
+            # worker e scheduler 1.12.0. `fail-fast: true` não resolveria: quando
+            # o app falhou, as irmãs JÁ tinham publicado e JÁ tinham movido o
+            # canal — abortá-las não desfaz o que foi publicado.
+            #
+            # Publicar por NÚMERO é o que continua aqui, e é seguro: `1.12.0`
+            # pode existir para uma imagem e não para outra sem prejuízo, porque
+            # ninguém instala por um número que o instalador não escreveu. Mover
+            # o CANAL é ato do job `promover-stable`, lá embaixo, quando o
+            # conjunto está completo.
           labels: |
             org.opencontainers.image.title=${{ matrix.title }}
 
@@ -281,6 +289,76 @@ jobs:
       - name: Encerrar
         if: always()
         run: docker rm -f smoke 2>/dev/null || true
+
+  # O CANAL `stable` MOVE AQUI, E SÓ AQUI — depois que o conjunto está completo.
+  #
+  # Antes, `stable` era mais um `type=raw` na lista de tags da matriz, e por isso
+  # CADA imagem movia o canal sozinha ao terminar, sem saber se as irmãs
+  # conseguiram. Medido no registro público durante o corte da v1.12.0 (issue
+  # #488), com sonda de DIGEST — a ingênua ("a tag `stable` existe?") devolve 200
+  # nas três e não prova nada, porque `stable` existe desde a 1.11.0:
+  #
+  #   deskcommcrm          1.12.0   404
+  #   deskcommcrm          stable   sha256:0235d02b…   <- 1.11.0
+  #   deskcomm-worker      stable   sha256:66c7bde4…   <- 1.12.0
+  #   deskcomm-scheduler   stable   sha256:ac6b87cc…   <- 1.12.0
+  #
+  # Quem instalasse por `stable` naquela janela recebia app 1.11.0 com worker e
+  # scheduler 1.12.0. Os três saem do mesmo repositório e compartilham código;
+  # rodar dois numa versão e o terceiro noutra é um estado que nenhum teste cobre
+  # e que ninguém escolheu. O job do app tinha morrido em `Set up Buildx` — antes
+  # de compilar qualquer coisa, portanto por infraestrutura e não por conteúdo.
+  #
+  # `fail-fast: true` na matriz seria o conserto óbvio, e chega tarde: quando o
+  # app falhou, as irmãs JÁ tinham publicado e JÁ tinham movido o canal. Abortar
+  # não desfaz o que foi publicado. O que separa os dois atos é publicar por
+  # NÚMERO sempre (cada imagem, independente — ninguém instala por um número que
+  # o instalador não escreveu) e mover o CANAL num job final.
+  promover-stable:
+    # Sem `always()`, e isso é o ponto: `needs` só libera quando as DUAS entradas
+    # deram `success`. Com `always()` o canal andaria por cima de uma irmã que
+    # falhou, que é exatamente o defeito de volta com outra roupa.
+    needs: [build-and-push, imagem-do-app-sobe]
+    # As três condições, e cada uma barra um caminho medido. Sem `push`, um
+    # dispatch numa release ANTIGA faria `stable` REGREDIR, e todo self-hoster no
+    # default do compose sofreria downgrade silencioso no próximo `up -d` — app
+    # velho sobre banco já migrado. Sem `tag`, um dispatch numa branch moveria o
+    # canal. Sem o `v`, uma tag de teste o move (o registro já tem uma
+    # `quebrada-teste`, que nenhum push na main consegue produzir).
+    if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+    runs-on: ubuntu-latest
+    permissions:
+      # O menor escopo que faz o trabalho: reapontar tag no GHCR. Sem o bloco, o
+      # GITHUB_TOKEN herdaria o default do REPOSITÓRIO — configuração que vive
+      # fora do repo, muda num clique e não passa por PR.
+      packages: write
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apontar `stable` para esta versão, nas três imagens
+        env:
+          VERSAO: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # `imagetools create` REAPONTA o índice que já foi publicado — não
+          # reconstrói. Reconstruir o mesmo commit dá um digest DIFERENTE (foi o
+          # que fez `stable` e `1.3.0` divergirem com o mesmo `revision`), e aí o
+          # canal deixaria de ser o mesmo manifesto que a versão.
+          dono=$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')
+          numero="${VERSAO#v}"
+          for img in deskcommcrm deskcomm-worker deskcomm-scheduler; do
+            echo "::group::${img}"
+            docker buildx imagetools create \
+              --tag "${REGISTRY}/${dono}/${img}:stable" \
+              "${REGISTRY}/${dono}/${img}:${numero}"
+            echo "::endgroup::"
+          done
+          echo "stable agora aponta para ${numero} nas três imagens"
 
   # Job de fachada: dá UM nome estável para a branch protection exigir. Sem ele,
   # o required check teria que listar as três instâncias da matriz pelo nome

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,27 +293,67 @@ jobs:
           # anônimo de pull do próprio registro. Não usa o GITHUB_TOKEN de
           # propósito — o que interessa provar é que a imagem está alcançável
           # para QUEM INSTALA, e quem instala não tem credencial nossa.
-          ghcr_status() {
+          #
+          # E ela lê DIGEST, não código de status. A sonda ingênua ("a tag
+          # responde 200?") é satisfeita pelo canal `stable` desde a 1.11.0 — ele
+          # existe sempre, apontando para o que quer que seja. Foi assim que a
+          # v1.12.0 saiu com `stable` do app na 1.11.0 e o das outras duas na
+          # 1.12.0 sem ninguém ver (issue #488): quem instalava por `stable`
+          # recebia um parque MISTURADO, e nenhum gate tinha opinião.
+          ghcr_digest() {
             local t
             t=$(curl -s "https://ghcr.io/token?scope=repository:${GITHUB_REPOSITORY_OWNER}/$1:pull&service=ghcr.io" \
                 | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
-            curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $t" \
+            curl -sI -H "Authorization: Bearer $t" \
               -H 'Accept: application/vnd.oci.image.index.v1+json' \
-              "https://ghcr.io/v2/${GITHUB_REPOSITORY_OWNER}/$1/manifests/$2"
+              -H 'Accept: application/vnd.docker.distribution.manifest.list.v2+json' \
+              "https://ghcr.io/v2/${GITHUB_REPOSITORY_OWNER}/$1/manifests/$2" \
+              | tr -d '\r' | tr '[:upper:]' '[:lower:]' \
+              | sed -n 's/^docker-content-digest: //p'
           }
           echo "esperando a publicação de v${VERSAO}…"
           for _ in $(seq 1 60); do
             faltando=""
             for img in deskcommcrm deskcomm-worker deskcomm-scheduler; do
-              [ "$(ghcr_status "$img" "${VERSAO}")" = "200" ] || faltando="${faltando} ${img}"
+              [ -n "$(ghcr_digest "$img" "${VERSAO}")" ] || faltando="${faltando} ${img}"
             done
             if [ -z "$faltando" ]; then
               echo "as três imagens respondem em ${VERSAO}"
-              exit 0
+              break
             fi
             sleep 30
           done
-          echo "::error::A tag v${VERSAO} foi criada, mas as imagens não apareceram:${faltando}"
-          echo "::error::O parque instalado NÃO consegue atualizar para esta versão."
-          echo "::error::Confira o run de publish-image.yml para a tag v${VERSAO}."
-          exit 1
+          if [ -n "$faltando" ]; then
+            echo "::error::A tag v${VERSAO} foi criada, mas as imagens não apareceram:${faltando}"
+            echo "::error::O parque instalado NÃO consegue atualizar para esta versão."
+            echo "::error::Confira o run de publish-image.yml para a tag v${VERSAO}."
+            exit 1
+          fi
+
+          # ─── O CANAL ACOMPANHOU? ──────────────────────────────────────────
+          #
+          # `stable` é o que o instalador escreve por padrão, então ele é o que
+          # o parque realmente recebe. Um canal que ficou para trás numa das três
+          # imagens é pior que uma imagem ausente: a instalação SOBE, misturada,
+          # e o defeito aparece semanas depois como comportamento inexplicável.
+          echo "conferindo se o canal stable acompanhou v${VERSAO}…"
+          divergentes=""
+          for _ in $(seq 1 20); do
+            divergentes=""
+            for img in deskcommcrm deskcomm-worker deskcomm-scheduler; do
+              d_versao=$(ghcr_digest "$img" "${VERSAO}")
+              d_stable=$(ghcr_digest "$img" stable)
+              echo "  ${img}: ${VERSAO}=${d_versao:-ausente} stable=${d_stable:-ausente}"
+              [ -n "${d_versao}" ] && [ "${d_versao}" = "${d_stable}" ] || divergentes="${divergentes} ${img}"
+            done
+            [ -z "${divergentes}" ] && break
+            sleep 30
+          done
+          if [ -n "${divergentes}" ]; then
+            echo "::error::v${VERSAO} publicou, mas o canal stable NÃO acompanhou em:${divergentes}"
+            echo "::error::Quem instalar por stable agora recebe um parque MISTURADO — serviços do mesmo"
+            echo "::error::repositório em versões diferentes, estado que nenhum teste cobre."
+            echo "::error::Confira o job promover-stable no run de publish-image.yml da tag v${VERSAO}."
+            exit 1
+          fi
+          echo "stable e ${VERSAO} são o mesmo manifesto nas três imagens"

--- a/tests/unit/canal-stable-move-em-bloco.test.ts
+++ b/tests/unit/canal-stable-move-em-bloco.test.ts
@@ -1,0 +1,152 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * O CANAL `stable` MOVE EM BLOCO, NUNCA POR IMAGEM.
+ *
+ * ## O que aconteceu
+ *
+ * Medido no registro público durante o corte da v1.12.0 (issue #488), com sonda
+ * de DIGEST — a ingênua ("a tag `stable` existe?") devolve `200` nas três e não
+ * prova nada, porque `stable` existe desde a 1.11.0:
+ *
+ *     deskcommcrm          1.12.0   404
+ *     deskcommcrm          stable   sha256:0235d02b…   ← 1.11.0
+ *     deskcomm-worker      stable   sha256:66c7bde4…   ← 1.12.0
+ *     deskcomm-scheduler   stable   sha256:ac6b87cc…   ← 1.12.0
+ *
+ * Quem instalasse por `stable` naquela janela recebia **app 1.11.0 com worker e
+ * scheduler 1.12.0**. Os três serviços saem do mesmo repositório e compartilham
+ * código; rodar dois numa versão e o terceiro noutra é um estado que nenhum
+ * teste cobre e que ninguém escolheu.
+ *
+ * A causa foi de FORMA, não de conteúdo: `type=raw,value=stable` vivia dentro do
+ * job da matriz, então cada imagem movia o canal sozinha, sem saber se as irmãs
+ * conseguiram. O job do app morreu em `Set up Buildx` — antes de compilar
+ * qualquer coisa — enquanto worker e scheduler seguiram até o fim e moveram o
+ * ponteiro.
+ *
+ * ## Por que `fail-fast: true` não seria o conserto
+ *
+ * É o conserto óbvio e ele chega tarde: quando o job do app falhou, as irmãs já
+ * tinham publicado e já tinham movido `stable`. Abortá-las não desfaz o que já
+ * foi publicado. O que separa os dois atos é publicar por NÚMERO sempre (cada
+ * imagem, independente — ninguém instala por um número que o instalador não
+ * escreveu) e mover o CANAL num job final, quando o conjunto está completo.
+ *
+ * ## O que este arquivo prova, e o que ele NÃO prova
+ *
+ * Ele mede a FORMA do YAML. A prova de comportamento só existe num push de tag
+ * real — é o único evento que move `stable` —, e quem a faz é o passo "As três
+ * imagens…" de `release.yml`, que agora compara DIGEST e falha alto quando o
+ * canal não acompanhou a versão. Aqui se guarda a estrutura que torna aquele
+ * passo verdadeiro; lá se guarda o efeito.
+ */
+const RAIZ = process.cwd();
+const publish = readFileSync(join(RAIZ, ".github/workflows/publish-image.yml"), "utf8");
+const release = readFileSync(join(RAIZ, ".github/workflows/release.yml"), "utf8");
+
+/**
+ * O corpo de um job, do cabeçalho até o próximo job.
+ *
+ * Começa no bloco `jobs:` de propósito: `on:` tem `  push:` na mesma indentação
+ * de um job, e um helper que varra o arquivo inteiro devolveria aquilo como se
+ * fosse job.
+ */
+function job(yml: string, nome: string): string {
+  const linhas = yml.split("\n");
+  const iJobs = linhas.findIndex((l) => /^jobs:\s*$/.test(l));
+  if (iJobs === -1) return "";
+  const i = linhas.findIndex((l, n) => n > iJobs && l === `  ${nome}:`);
+  if (i === -1) return "";
+  const fim = linhas.findIndex((l, n) => n > i && /^ {2}[A-Za-z0-9_-]+:\s*$/.test(l));
+  return linhas.slice(i, fim === -1 ? undefined : fim).join("\n");
+}
+
+/** O mesmo corpo, sem os comentários. */
+function corpo(yml: string, nome: string): string {
+  const t = job(yml, nome);
+  expect(t, `o job \`${nome}\` sumiu de publish-image.yml/release.yml`).not.toBe("");
+  return t
+    .split("\n")
+    .filter((l) => !l.trimStart().startsWith("#"))
+    .join("\n");
+}
+
+const IMAGENS = ["deskcommcrm", "deskcomm-worker", "deskcomm-scheduler"];
+
+describe("o canal `stable` move em bloco", () => {
+  it("o instrumento está vivo: enxerga os jobs de publish-image.yml", () => {
+    // Controle positivo. Sem ele, um helper que parou de casar devolve "" e as
+    // asserções de ausência abaixo passam por vacuidade — vigiando nada.
+    expect(job(publish, "build-and-push")).not.toBe("");
+    expect(job(publish, "imagens-ok")).not.toBe("");
+    expect(job(publish, "build-and-push")).toContain("matrix:");
+  });
+
+  it("nenhuma imagem move o canal sozinha dentro da matriz", () => {
+    const linhas = corpo(publish, "build-and-push")
+      .split("\n")
+      .filter((l) => l.includes("value=stable"));
+    expect(
+      linhas,
+      "`stable` de volta na matriz: cada imagem volta a mover o canal sem saber das irmãs",
+    ).toEqual([]);
+  });
+
+  it("o job de promoção espera as três imagens E o boot do app — nem uma a menos", () => {
+    const needs = /needs:\s*\[([^\]]*)\]/.exec(corpo(publish, "promover-stable"))?.[1];
+    expect(needs, "o job de promoção não declara `needs`").toBeDefined();
+    // Conjunto exato, não `toContain`: exigir a presença de um deixaria remover
+    // o outro, e é a remoção que reabre o buraco.
+    expect(needs?.split(",").map((s) => s.trim()).sort()).toEqual([
+      "build-and-push",
+      "imagem-do-app-sobe",
+    ]);
+  });
+
+  it("a promoção NÃO roda com `always()` — isso a faria promover por cima de uma irmã que falhou", () => {
+    expect(corpo(publish, "promover-stable")).not.toMatch(/always\(\)/);
+  });
+
+  it("as três imagens são promovidas — o canal não anda pela metade nem aqui", () => {
+    const t = corpo(publish, "promover-stable");
+    for (const img of IMAGENS) expect(t, `a promoção não cita ${img}`).toContain(img);
+  });
+
+  it("a promoção REAPONTA o manifesto publicado, nunca reconstrói", () => {
+    // Reconstruir o mesmo commit dá um digest DIFERENTE — foi o que aconteceu na
+    // v1.3.0 e fez `stable` e `1.3.0` divergirem com o mesmo `revision`.
+    // `imagetools create` copia o índice que já existe.
+    expect(corpo(publish, "promover-stable")).toMatch(/imagetools create/);
+  });
+
+  it("o canal só se move num push de tag `vX.Y.Z`", () => {
+    const cond = / {4}if:\s*(.+)/.exec(corpo(publish, "promover-stable"))?.[1] ?? "";
+    // As três condições, e cada uma barra um caminho medido: sem `push`, um
+    // dispatch numa release ANTIGA faria `stable` REGREDIR; sem `tag`, um
+    // dispatch numa branch moveria o canal; sem o `v`, uma tag de teste o move
+    // (o registro já tem uma `quebrada-teste`).
+    expect(cond).toContain("github.event_name == 'push'");
+    expect(cond).toContain("github.ref_type == 'tag'");
+    expect(cond).toContain("startsWith(github.ref_name, 'v')");
+  });
+
+  it("a promoção declara o privilégio que ela usa, no menor escopo", () => {
+    expect(corpo(publish, "promover-stable")).toMatch(/^ {6}packages: write$/m);
+  });
+});
+
+describe("o corte da release confere o CANAL, não só a existência da versão", () => {
+  it("compara DIGEST — `stable` e a versão têm de ser o mesmo manifesto", () => {
+    const t = corpo(release, "cortar-tag");
+    expect(t, "a conferência não lê digest: `200` na tag `stable` é satisfeito desde a 1.11.0").toContain(
+      "docker-content-digest",
+    );
+    expect(t, "a conferência não olha o canal `stable`").toContain("stable");
+    for (const img of IMAGENS) expect(t, `a conferência não cobre ${img}`).toContain(img);
+    expect(t).toMatch(/::error::/);
+  });
+});

--- a/tests/unit/packaging-artefato-do-cliente.test.ts
+++ b/tests/unit/packaging-artefato-do-cliente.test.ts
@@ -229,7 +229,12 @@ describe("packaging — o artefato que o cliente instala", () => {
     expect(wf, "publish-image.yml não passa APP_VERSION como build-arg").toContain(
       "APP_VERSION=",
     );
-    expect(wf, "publish-image.yml não cria o canal 'stable'").toContain("value=stable");
+    // A sonda prende o EFEITO (o canal `stable` passa a existir), não a forma.
+    // Ela já mudou uma vez: `stable` saiu da lista de tags da matriz — onde cada
+    // imagem o movia sozinha — para o job `promover-stable`, que só roda com as
+    // três publicadas (issue #488). Prender `value=stable` fazia esta guarda
+    // reprovar justamente o conserto.
+    expect(wf, "publish-image.yml não cria o canal 'stable'").toMatch(/:stable\b/);
   });
 
   it("nenhum gatilho reconstrói uma tag já publicada", () => {

--- a/tests/unit/tag-so-nasce-da-main.test.ts
+++ b/tests/unit/tag-so-nasce-da-main.test.ts
@@ -75,7 +75,10 @@ describe("a tag nasce no CI, e nunca do GITHUB_TOKEN", () => {
 
   it("o corte da tag prova que as imagens saíram — a falha aqui é silenciosa por natureza", () => {
     const t = job(release, "cortar-tag");
-    expect(t).toContain("ghcr_status");
+    // A sonda prende o COMPORTAMENTO (consultar o manifesto no registro público),
+    // não o nome da função — que já mudou uma vez, quando a conferência passou a
+    // comparar digest em vez de código de status (issue #488).
+    expect(t, "o corte não consulta mais o registro").toMatch(/ghcr\.io\/v2\//);
     for (const img of ["deskcommcrm", "deskcomm-worker", "deskcomm-scheduler"]) {
       expect(t, `a conferência não cobre ${img}`).toContain(img);
     }


### PR DESCRIPTION
Closes #488

## O estado medido

No registro público, durante o corte da v1.12.0 — sonda de **digest**, não de existência (a ingênua "a tag `stable` existe?" devolve `200` nas três e não prova nada: `stable` existe desde a 1.11.0):

```
deskcommcrm          1.12.0   404
deskcommcrm          stable   sha256:0235d02b…   <- 1.11.0
deskcomm-worker      stable   sha256:66c7bde4…   <- 1.12.0
deskcomm-scheduler   stable   sha256:ac6b87cc…   <- 1.12.0
```

Quem instalasse por `stable` naquela janela recebia **app 1.11.0 com worker e scheduler 1.12.0**. Os três serviços saem do mesmo repositório e compartilham código; rodar dois numa versão e o terceiro noutra é um estado que nenhum teste cobre e que ninguém escolheu.

## A causa é de forma, não de conteúdo

`type=raw,value=stable` vivia dentro do job da matriz, então **cada imagem movia o canal sozinha** ao terminar, sem saber se as irmãs conseguiram. O job do app morreu em `Set up Buildx` — antes de compilar qualquer coisa, portanto por infraestrutura e não por conteúdo — enquanto worker e scheduler seguiram até o fim e moveram o ponteiro.

## Por que `fail-fast: true` não é o conserto

É o conserto óbvio, e ele chega tarde: quando o job do app falhou, as irmãs **já tinham publicado e já tinham movido o canal**. Abortá-las não desfaz o que foi publicado.

## O que separa os dois atos

**Publicar por número** continua na matriz, e é seguro: `1.12.0` pode existir para uma imagem e não para outra sem prejuízo, porque ninguém instala por um número que o instalador não escreveu.

**Mover o canal** vira o job `promover-stable`:

- `needs: [build-and-push, imagem-do-app-sobe]` e **sem `always()`** — só roda com as duas em `success`. Com `always()`, o canal andaria por cima de uma irmã que falhou, que é o defeito de volta com outra roupa.
- `imagetools create` **reaponta** o índice já publicado, não reconstrói. Reconstruir o mesmo commit dá digest diferente — foi o que fez `stable` e `1.3.0` divergirem com o mesmo `revision`.
- As três condições do `if:` ficam, e cada uma barra um caminho medido: sem `push`, um dispatch numa release **antiga** faria `stable` **regredir** (downgrade silencioso no próximo `up -d`, app velho sobre banco migrado); sem `tag`, um dispatch numa branch move o canal; sem o `v`, uma tag de teste o move — o registro já tem uma `quebrada-teste`.
- `permissions: packages: write`, o menor escopo que faz o trabalho.

## E o corte da release passa a conferir o canal

Antes conferia só que a versão **existia** (`http 200`). Agora lê `docker-content-digest` e exige que `stable` e a versão sejam o **mesmo manifesto** nas três imagens. Um canal atrasado é pior que uma imagem ausente: a instalação **sobe**, misturada, e o defeito aparece semanas depois como comportamento inexplicável.

## Prova

```console
$ npx vitest run tests/unit/canal-stable-move-em-bloco.test.ts
  Tests  9 passed (9)
```

**Sabotagem** — revertendo os dois workflows para a `main` e mantendo o teste (previ 8 vermelhos, deu 8):

```
  Tests  8 failed | 1 passed (9)
```

O único verde é o caso de controle, que prova que o instrumento enxerga os jobs — sem ele, um helper que parasse de casar devolveria `""` e as asserções de ausência passariam por vacuidade.

YAML validado nos dois arquivos com `yaml.safe_load`.

## Gates

```
pnpm typecheck   exit=0
pnpm lint        exit=0
vizinhos (canal-stable + tag-so-nasce-da-main + workflows-tem-permissions)  3 arquivos / 22 testes, exit=0
```

## O que NÃO fiz

**O canal do parque instalado hoje não é corrigido por este PR.** Ele conserta o mecanismo daqui para frente; reapontar o `stable` do app para a 1.12.0 agora é ato de operação, não de merge. (No momento em que medi, os três já batiam — a divergência descrita na issue foi transitória.)

**Este PR não prova comportamento, prova forma.** O único evento que move `stable` é um push de tag real; a prova de efeito é o passo do `release.yml` que agora compara digest e falha alto. Aqui se guarda a estrutura que torna aquele passo verdadeiro; lá se guarda o efeito. Isso está escrito no cabeçalho do teste, para ninguém ler o verde como mais do que ele é.

Não mexi em `fail-fast: false` da matriz — ele existe por outra razão (se o worker quebrar, ainda quero saber se o app também quebrou) e continua certa.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam
- [x] Fragmento em `.changes/` (`nada_mudou` / `corrigido`)
- [x] Packaging: nenhum serviço ficou `build:`-only; a atualização não pede edição manual de arquivo
- [ ] Schema: não toca

🤖 Generated with [Claude Code](https://claude.com/claude-code)