### PR TITLE
fix(ia): o limiar de sentimento vem do agente da conversa, não da ordem de criação

### DIFF
--- a/.changes/o-limiar-de-sentimento-e-do-agente-que-atende.md
+++ b/.changes/o-limiar-de-sentimento-e-do-agente-que-atende.md
@@ -1,0 +1,26 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O limiar de sentimento passa a vir do agente que atende aquela conversa
+---
+
+Quem opera mais de um agente ajustava o campo "limiar de sentimento" de um deles
+e via o comportamento do outro. Os dois campos existiam, os dois aceitavam
+valor, e só um fazia efeito — o do agente mais antigo da organização, porque a
+conversa que disparou o alerta não entrava na conta.
+
+Com um agente só, o resultado era certo por acidente. Com dois, o limiar em
+vigor dependia da ordem em que eles foram criados, e não havia nada na tela que
+explicasse por quê.
+
+E o limiar certo é genuinamente diferente por agente: numa clínica, cliente
+triste é sinal de problema; numa assistência técnica, cliente triste é o cliente
+normal. Um número único para os dois erra nos dois sentidos — escala demais num
+caso, de menos no outro.
+
+Agora vale o limiar do agente que está atendendo aquela conversa. Quando não dá
+para dizer com certeza qual é — dois agentes e nenhum vínculo com a conversa —,
+vale o padrão do sistema, nunca o número do vizinho.
+
+O alerta gerado passa a registrar qual agente decidiu e por quê, para que a
+pergunta "por que este alerta saiu?" tenha resposta na própria linha.

--- a/lib/ai/agents/agente-da-conversa.ts
+++ b/lib/ai/agents/agente-da-conversa.ts
@@ -1,0 +1,128 @@
+/**
+ * "Qual agente atende ESTA conversa?" — a pergunta que faltava ao lado de
+ * `lib/ai/agents/no-ar.ts`.
+ *
+ * ## O defeito que este arquivo existe para consertar (issue #486)
+ *
+ * `no-ar.ts` responde **se** um agente atende. `workers/ai-sentiment-worker.ts`
+ * precisava de outra coisa — **qual** deles atende a conversa que disparou o
+ * evento — e usava a primeira como se fosse a segunda: pegava o primeiro agente
+ * da organização que atende, ordenado por `is_default` e depois `created_at`.
+ *
+ * Com um agente só a resposta é certa por acidente. Com dois, o
+ * `sentiment_threshold` em vigor passa a depender da ORDEM DE CRIAÇÃO: numa
+ * clínica, cliente triste é sinal de problema; numa assistência técnica, é o
+ * cliente normal. O mesmo limiar erra nos dois sentidos, e quem configurou o
+ * campo do agente B fica vendo o comportamento do agente A sem nenhuma pista na
+ * tela.
+ *
+ * ## Por que uma função pura, e por que ela NÃO inventa régua nova
+ *
+ * O cabeçalho de `no-ar.ts` documenta o custo de ter três respostas discordando
+ * para a mesma pergunta. A quarta régua seria pior. Então a ordem aqui é a que
+ * o motor já executa, e nada além:
+ *
+ *   1. `conversations.active_ai_agent_id` — a stickiness que o Intent Router
+ *      grava (`lib/agent-engine/agent/inbound-turn.ts`). Se o router já decidiu
+ *      quem atende esta conversa, a pergunta está respondida.
+ *   2. O agente cuja VERSÃO PUBLICADA aponta para o `channel_session_id` da
+ *      conversa, desempatando por `priority desc, created_at asc` — a mesma
+ *      cláusula de `loadPublishedAgentConfig` (`agent-config.ts`), que é quem
+ *      de fato responde ao cliente por aquele número.
+ *   3. O agente ÚNICO da organização. Não é fallback "por ordem": é o caso em
+ *      que não há ambiguidade nenhuma para resolver. Ele existe porque a
+ *      instalação nova — um `rag_bot` legado, ativo, sem versão publicada e sem
+ *      vínculo com sessão — é o estado mais comum do produto self-host, e
+ *      derrubá-la para o padrão do produto trocaria um defeito por uma
+ *      regressão.
+ *
+ * Com dois ou mais agentes e nenhum vínculo com a conversa, a resposta é
+ * `null`. Quem chama usa o SEU padrão — chutar o limiar do vizinho é o defeito
+ * de novo, agora com cara de configuração.
+ *
+ * O `motivo` volta junto de propósito: sem ele, o próximo diagnóstico de "por
+ * que este limiar valeu?" recomeça do zero.
+ */
+
+import { agenteAtende, type FatosDoAgente } from "@/lib/ai/agents/no-ar";
+
+/**
+ * As colunas de que a régua precisa — nada além. Como em `no-ar.ts`,
+ * `undefined` significa "o SELECT não pediu esta coluna", nunca "zero".
+ */
+export interface CandidatoDeAgente extends FatosDoAgente {
+  id: string;
+  priority?: number | null;
+  created_at?: string | null;
+  published_version_id?: string | null;
+}
+
+export interface FatosDaConversa {
+  /** `conversations.active_ai_agent_id`: a stickiness gravada pelo router. */
+  active_ai_agent_id?: string | null;
+  /**
+   * Ids das versões **publicadas** ligadas ao `channel_session_id` desta
+   * conversa. Vem de uma consulta a `ai_agent_versions`; lista vazia significa
+   * "consultei e não há", e é diferente de `null`/ausente, que significa "não
+   * consegui consultar" — nos dois casos a regra 2 não elege ninguém, mas quem
+   * lê o log precisa distinguir.
+   */
+  versoesPublicadasNaSessao?: readonly string[] | null;
+}
+
+export type MotivoDoAgente =
+  /** O router já tinha grudado esta conversa neste agente. */
+  | "stickiness_da_conversa"
+  /** A versão publicada dele atende o número em que a conversa acontece. */
+  | "versao_publicada_na_sessao"
+  /** Não há ambiguidade: a organização tem um agente atendendo, e é este. */
+  | "unico_da_organizacao"
+  /** Dois ou mais agentes e nenhum vínculo com a conversa. */
+  | "indefinido";
+
+export interface AgenteDaConversa<T> {
+  agente: T | null;
+  motivo: MotivoDoAgente;
+}
+
+/** `priority desc, created_at asc` — a cláusula de `loadPublishedAgentConfig`. */
+function ordemDoMotor(a: CandidatoDeAgente, b: CandidatoDeAgente): number {
+  const prioridadeA = a.priority ?? 0;
+  const prioridadeB = b.priority ?? 0;
+  if (prioridadeA !== prioridadeB) return prioridadeB - prioridadeA;
+  const nascimentoA = a.created_at ?? "";
+  const nascimentoB = b.created_at ?? "";
+  if (nascimentoA === nascimentoB) return 0;
+  return nascimentoA < nascimentoB ? -1 : 1;
+}
+
+export function resolverAgenteDaConversa<T extends CandidatoDeAgente>(
+  candidatos: readonly T[],
+  conversa: FatosDaConversa | null,
+): AgenteDaConversa<T> {
+  const atendem = candidatos.filter((c) => agenteAtende(c));
+
+  const grudado = conversa?.active_ai_agent_id ?? null;
+  if (grudado !== null) {
+    const dono = atendem.find((c) => c.id === grudado);
+    if (dono !== undefined) return { agente: dono, motivo: "stickiness_da_conversa" };
+  }
+
+  const versoes = conversa?.versoesPublicadasNaSessao ?? null;
+  if (versoes !== null && versoes.length > 0) {
+    const naSessao = atendem
+      .filter((c) => c.published_version_id != null && versoes.includes(c.published_version_id))
+      .sort(ordemDoMotor);
+    const primeiro = naSessao[0];
+    if (primeiro !== undefined) {
+      return { agente: primeiro, motivo: "versao_publicada_na_sessao" };
+    }
+  }
+
+  const unico = atendem[0];
+  if (atendem.length === 1 && unico !== undefined) {
+    return { agente: unico, motivo: "unico_da_organizacao" };
+  }
+
+  return { agente: null, motivo: "indefinido" };
+}

--- a/tests/unit/limiar-de-sentimento-vem-do-agente-da-conversa.test.ts
+++ b/tests/unit/limiar-de-sentimento-vem-do-agente-da-conversa.test.ts
@@ -1,0 +1,366 @@
+/**
+ * O LIMIAR DE SENTIMENTO É DO AGENTE DA CONVERSA, NÃO DE UM AGENTE QUALQUER
+ * (issue #486).
+ *
+ * ## O defeito medido
+ *
+ * `workers/ai-sentiment-worker.ts` lia o `sentiment_threshold` do PRIMEIRO
+ * agente da organização que atende — ordenado por `is_default` e depois por
+ * `created_at`. A conversa que disparou o evento não entrava na consulta em
+ * lugar nenhum.
+ *
+ * Numa organização com um agente só isso acerta por acidente. Com dois ou mais,
+ * **o limiar em vigor passa a depender da ordem de criação**: quem configura o
+ * agente da assistência técnica (onde cliente irritado é o cliente normal) vê o
+ * comportamento do agente da clínica (onde cliente triste é sinal de problema),
+ * e não tem como descobrir o porquê pela tela.
+ *
+ * O mesmo erro escolhia o dono do CUSTO: `logInvocation` recebia o id do agente
+ * errado, e a tela de consumo de IA atribuía a classificação a quem não a pediu.
+ *
+ * ## Por que os casos são estes
+ *
+ * O cenário tem DOIS agentes cujos limiares cercam a nota do classificador
+ * (0.9 e 0.1, nota 0.5): assim "qual limiar valeu" vira um efeito observável —
+ * o alerta `ai.sentiment_alert` sai ou não sai —, e não uma leitura de campo
+ * interno. O agente da clínica é o primeiro pela régua ANTIGA (é `is_default` e
+ * é o mais antigo), então todo caso em que a conversa é do outro agente
+ * distingue os dois comportamentos.
+ *
+ * Dois casos são guarda de vacuidade e não distinguem nada sozinhos: a conversa
+ * NA sessão da clínica (que tem de continuar escalando) e a organização de um
+ * agente legado só (que tem de continuar usando o limiar dele). Eles existem
+ * para reprovar um "conserto" que passe a devolver sempre o último agente ou
+ * sempre o padrão do produto.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const envMock: Record<string, string> = {
+  ANTHROPIC_API_KEY: "sk-ant-teste",
+  AI_GATEWAY_API_KEY: "",
+  OPENROUTER_API_KEY: "",
+  OPENAI_API_KEY: "",
+};
+vi.mock("@/lib/env", () => ({
+  get env() {
+    return envMock;
+  },
+}));
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
+vi.mock("@/lib/ai/log-invocation", () => ({ logInvocation: vi.fn() }));
+vi.mock("@/lib/ai/cost", () => ({ computeCost: vi.fn(async () => 1) }));
+vi.mock("@/lib/ai/gateway-binding", () => ({ resolverModeloDoPonto: vi.fn() }));
+vi.mock("ai", () => ({ generateObject: vi.fn() }));
+
+import { generateObject } from "ai";
+
+import { processSentiment } from "@/workers/ai-sentiment-worker";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logInvocation } from "@/lib/ai/log-invocation";
+import { resolverModeloDoPonto } from "@/lib/ai/gateway-binding";
+import type { EventRow } from "@/lib/event-log/dispatcher";
+
+const ORG = "11111111-1111-4111-8111-111111111111";
+const MSG = "22222222-2222-4222-8222-222222222222";
+const CONV = "33333333-3333-4333-8333-333333333333";
+
+/** O número de WhatsApp da clínica e o da assistência técnica. */
+const SESSAO_CLINICA = "44444444-4444-4444-8444-444444444444";
+const SESSAO_TECNICA = "55555555-5555-4555-8555-555555555555";
+/** Uma sessão sem agente publicado nenhum — o canal recém-conectado. */
+const SESSAO_ORFA = "66666666-6666-4666-8666-666666666666";
+
+const AGENTE_CLINICA = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const AGENTE_TECNICA = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const VERSAO_CLINICA = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const VERSAO_TECNICA = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+
+/** Cliente triste é sinal de problema: escala quase sempre. */
+const LIMIAR_CLINICA = 0.9;
+/** Cliente irritado é o cliente NORMAL: quase nunca escala. */
+const LIMIAR_TECNICA = 0.1;
+/** O default do produto, quando não há agente resolvível. */
+const LIMIAR_PADRAO = 0.3;
+/** A nota do classificador — de propósito ENTRE os dois limiares. */
+const NOTA = 0.5;
+
+type Linha = Record<string, unknown>;
+
+interface Banco {
+  messages: Linha[];
+  conversations: Linha[];
+  ai_agents: Linha[];
+  ai_agent_versions: Linha[];
+}
+
+interface Chamada {
+  op: string;
+  args: unknown[];
+}
+
+/**
+ * Mini-Postgres de brinquedo: aplica `eq`/`is`/`in`/`order` sobre as linhas da
+ * tabela. É mais caro que devolver um objeto fixo e é o que torna o teste capaz
+ * de medir a CONSULTA — um dublê que devolve sempre a mesma linha aprovaria o
+ * worker que nunca filtra pela conversa, que é exatamente o defeito.
+ */
+function fazerAdmin(banco: Banco, rpcs: Linha[]) {
+  const from = (tabela: string) => {
+    const chamadas: Chamada[] = [];
+
+    const resolver = (): { data: Linha[]; error: null } => {
+      let linhas = [...((banco as unknown as Record<string, Linha[]>)[tabela] ?? [])];
+      for (const c of chamadas) {
+        if (c.op === "eq") {
+          const [col, val] = c.args as [string, unknown];
+          linhas = linhas.filter((l) => l[col] === val);
+        } else if (c.op === "is") {
+          const [col, val] = c.args as [string, unknown];
+          linhas = linhas.filter((l) => (l[col] ?? null) === val);
+        } else if (c.op === "in") {
+          const [col, vals] = c.args as [string, unknown[]];
+          linhas = linhas.filter((l) => vals.includes(l[col]));
+        }
+      }
+      const ordens = chamadas.filter((c) => c.op === "order");
+      if (ordens.length > 0) {
+        linhas.sort((a, b) => {
+          for (const o of ordens) {
+            const [col, opts] = o.args as [string, { ascending?: boolean } | undefined];
+            const asc = opts?.ascending !== false;
+            const va = a[col];
+            const vb = b[col];
+            if (va === vb) continue;
+            const menor = (va as never) < (vb as never) ? -1 : 1;
+            return asc ? menor : -menor;
+          }
+          return 0;
+        });
+      }
+      return { data: linhas, error: null };
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const chain: any = new Proxy(
+      {},
+      {
+        get: (_alvo, prop: string) => {
+          if (prop === "maybeSingle" || prop === "single") {
+            return () => Promise.resolve({ data: resolver().data[0] ?? null, error: null });
+          }
+          if (prop === "then") {
+            return (ok: (v: unknown) => unknown, falha?: (e: unknown) => unknown) =>
+              Promise.resolve(resolver()).then(ok, falha);
+          }
+          return (...args: unknown[]) => {
+            chamadas.push({ op: prop, args });
+            return chain;
+          };
+        },
+      },
+    );
+    return chain;
+  };
+
+  return {
+    from,
+    rpc: (nome: string, args: Linha) => {
+      rpcs.push({ nome, ...args });
+      return Promise.resolve({ data: null, error: null });
+    },
+  };
+}
+
+interface Cenario {
+  /** Em qual número de WhatsApp a conversa está. */
+  sessaoDaConversa: string;
+  /** Stickiness do router gravada em `conversations.active_ai_agent_id`. */
+  agenteGrudado?: string | null;
+  /** Só o agente legado da clínica, sem versão publicada (instalação nova). */
+  somenteLegado?: boolean;
+}
+
+function montarBanco(c: Cenario): Banco {
+  const clinica: Linha = {
+    id: AGENTE_CLINICA,
+    organization_id: ORG,
+    config: { sentiment_threshold: LIMIAR_CLINICA },
+    kind: "rag_bot",
+    is_active: true,
+    is_default: true,
+    priority: 0,
+    created_at: "2026-01-01T00:00:00.000Z",
+    published_version_id: c.somenteLegado === true ? null : VERSAO_CLINICA,
+    archived_at: null,
+  };
+  const tecnica: Linha = {
+    id: AGENTE_TECNICA,
+    organization_id: ORG,
+    config: { sentiment_threshold: LIMIAR_TECNICA },
+    kind: "mcp_agent",
+    is_active: true,
+    is_default: false,
+    priority: 0,
+    created_at: "2026-06-01T00:00:00.000Z",
+    published_version_id: VERSAO_TECNICA,
+    archived_at: null,
+  };
+
+  return {
+    messages: [
+      {
+        id: MSG,
+        organization_id: ORG,
+        conversation_id: CONV,
+        body: "meu aparelho voltou com o mesmo defeito",
+        direction: "inbound",
+        metadata: {},
+      },
+    ],
+    conversations: [
+      {
+        id: CONV,
+        organization_id: ORG,
+        channel_session_id: c.sessaoDaConversa,
+        active_ai_agent_id: c.agenteGrudado ?? null,
+      },
+    ],
+    ai_agents: c.somenteLegado === true ? [clinica] : [clinica, tecnica],
+    ai_agent_versions: [
+      {
+        id: VERSAO_CLINICA,
+        organization_id: ORG,
+        agent_id: AGENTE_CLINICA,
+        channel_session_id: SESSAO_CLINICA,
+        status: "published",
+      },
+      {
+        id: VERSAO_TECNICA,
+        organization_id: ORG,
+        agent_id: AGENTE_TECNICA,
+        channel_session_id: SESSAO_TECNICA,
+        status: "published",
+      },
+    ],
+  };
+}
+
+const evento = {
+  id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+  organization_id: ORG,
+  entity_id: MSG,
+  payload: { message_id: MSG, conversation_id: CONV },
+} as unknown as EventRow;
+
+/** O que o worker fez de observável: alertas emitidos e dono do custo. */
+async function rodar(c: Cenario): Promise<{
+  alertas: Linha[];
+  limiarDoAlerta: number | null;
+  agenteDoCusto: string | null;
+}> {
+  const rpcs: Linha[] = [];
+  vi.mocked(createAdminClient).mockReturnValue(
+    fazerAdmin(montarBanco(c), rpcs) as unknown as ReturnType<typeof createAdminClient>,
+  );
+
+  const resultado = await processSentiment(evento);
+  expect(resultado.skipped, `o worker desistiu: ${resultado.reason ?? "-"}`).toBe(false);
+
+  const alertas = rpcs.filter((r) => r["p_event_type"] === "ai.sentiment_alert");
+  const meta = alertas[0]?.["p_metadata"] as { threshold?: number } | undefined;
+  const chamadasDeLog = vi.mocked(logInvocation).mock.calls;
+  const ultima = chamadasDeLog[chamadasDeLog.length - 1]?.[0];
+
+  return {
+    alertas,
+    limiarDoAlerta: meta?.threshold ?? null,
+    agenteDoCusto: ultima?.agent_id ?? null,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(resolverModeloDoPonto).mockResolvedValue({
+    model: "modelo-dublê",
+    modelId: "anthropic/claude-haiku-4-5",
+  } as unknown as Awaited<ReturnType<typeof resolverModeloDoPonto>>);
+  vi.mocked(generateObject).mockResolvedValue({
+    object: { sentiment_score: NOTA, reasoning_short: "cliente reclamando de recorrência" },
+    usage: { inputTokens: 10, outputTokens: 5 },
+  } as unknown as Awaited<ReturnType<typeof generateObject>>);
+});
+
+describe("limiar de sentimento — o agente da conversa é quem manda (#486)", () => {
+  it("o cenário sabe distinguir os dois limiares (controle positivo)", () => {
+    // Sem esta cerca, alguém que iguale os limiares faz TODOS os casos abaixo
+    // passarem sem conseguir separar comportamento nenhum.
+    expect(LIMIAR_TECNICA).toBeLessThan(NOTA);
+    expect(LIMIAR_CLINICA).toBeGreaterThan(NOTA);
+    expect(LIMIAR_PADRAO).toBeLessThan(NOTA);
+  });
+
+  it("conversa no número da assistência técnica usa o limiar DELA, não o do agente mais antigo", async () => {
+    const r = await rodar({ sessaoDaConversa: SESSAO_TECNICA });
+
+    expect(
+      r.alertas,
+      `escalou uma conversa de assistência técnica com nota ${NOTA}: o limiar que valeu foi ${r.limiarDoAlerta} (o do agente da clínica), não o ${LIMIAR_TECNICA} configurado no agente que atende este número`,
+    ).toHaveLength(0);
+    expect(
+      r.agenteDoCusto,
+      "o custo da classificação foi atribuído ao agente errado na tela de consumo de IA",
+    ).toBe(AGENTE_TECNICA);
+  });
+
+  it("conversa no número da clínica continua escalando pelo limiar da clínica", async () => {
+    // Guarda de vacuidade: um conserto que passasse a devolver sempre o último
+    // agente, ou sempre o padrão do produto, apagaria a escalação desta org.
+    const r = await rodar({ sessaoDaConversa: SESSAO_CLINICA });
+
+    expect(r.alertas, "a clínica deixou de ser avisada de um cliente insatisfeito").toHaveLength(1);
+    expect(r.limiarDoAlerta).toBe(LIMIAR_CLINICA);
+    expect(r.agenteDoCusto).toBe(AGENTE_CLINICA);
+  });
+
+  it("stickiness do router vence a sessão — o agente que já atende a conversa é o dono do limiar", async () => {
+    // O Intent Router grava `conversations.active_ai_agent_id`; o agente-membro
+    // pode não ter vínculo com a channel_session do turno (quem tem é o ROUTER).
+    const r = await rodar({
+      sessaoDaConversa: SESSAO_CLINICA,
+      agenteGrudado: AGENTE_TECNICA,
+    });
+
+    expect(
+      r.alertas,
+      `o limiar em vigor foi ${r.limiarDoAlerta}, e quem atende esta conversa é o agente da técnica (${LIMIAR_TECNICA})`,
+    ).toHaveLength(0);
+    expect(r.agenteDoCusto).toBe(AGENTE_TECNICA);
+  });
+
+  it("organização de um agente legado só continua usando o limiar dele", async () => {
+    // A instalação nova — `rag_bot` ativo, nenhuma versão publicada, nenhuma
+    // ligação com a sessão. Não há ambiguidade nenhuma a resolver aqui, e cair
+    // no padrão do produto seria trocar um defeito por uma regressão.
+    const r = await rodar({ sessaoDaConversa: SESSAO_ORFA, somenteLegado: true });
+
+    expect(r.alertas, "a única configuração de limiar da org deixou de valer").toHaveLength(1);
+    expect(r.limiarDoAlerta).toBe(LIMIAR_CLINICA);
+    expect(r.agenteDoCusto).toBe(AGENTE_CLINICA);
+  });
+
+  it("conversa que não resolve agente nenhum cai no padrão do produto, nunca no do vizinho", async () => {
+    // Canal conectado depois, sem versão publicada apontando para ele: não dá
+    // para saber de quem é a conversa. O padrão é honesto; o limiar do vizinho
+    // é chute com cara de configuração.
+    const r = await rodar({ sessaoDaConversa: SESSAO_ORFA });
+
+    expect(
+      r.alertas,
+      `escalou pelo limiar ${r.limiarDoAlerta}, que é do agente da clínica — um agente que não tem nada a ver com esta conversa`,
+    ).toHaveLength(0);
+    expect(
+      r.agenteDoCusto,
+      "atribuiu o custo a um agente que não atende esta conversa",
+    ).toBeNull();
+  });
+});

--- a/workers/ai-sentiment-worker.ts
+++ b/workers/ai-sentiment-worker.ts
@@ -16,7 +16,7 @@
 import { generateObject } from "ai";
 import { z } from "zod";
 
-import { agenteAtende } from "@/lib/ai/agents/no-ar";
+import { resolverAgenteDaConversa } from "@/lib/ai/agents/agente-da-conversa";
 import { computeCost } from "@/lib/ai/cost";
 import { DEFAULT_CLASSIFIER_MODEL, isAiGatewayConfigured } from "@/lib/ai/gateway";
 import { resolverModeloDoPonto } from "@/lib/ai/gateway-binding";
@@ -117,22 +117,60 @@ export async function processSentiment(event: EventRow): Promise<SentimentResult
       return { skipped: true, reason: "empty_body" };
     }
 
-    // ── Load active agent to read sentiment_threshold config ──────────────
+    // ── Qual agente atende ESTA conversa? ─────────────────────────────────
     //
-    // Mesma régua da tela e do ai-response-worker (`lib/ai/agents/no-ar.ts`).
-    // Antes era `.eq("is_active", true)` sozinho, e pausar um `mcp_agent` não
-    // desliga essa coluna: o limiar de sentimento continuava saindo do agente
-    // que o dono acabara de pausar.
+    // Antes, a resposta era "o primeiro da organização que atende", ordenado por
+    // `is_default` e depois `created_at` — e a conversa que disparou o evento não
+    // entrava na consulta em lugar nenhum. Com um agente só, certo por acidente.
+    // Com dois, o limiar em vigor passava a depender da ORDEM DE CRIAÇÃO: numa
+    // clínica, cliente triste é sinal de problema; numa assistência técnica, é o
+    // cliente normal. O mesmo limiar erra nos dois sentidos, e quem configurou o
+    // campo do agente B ficava vendo o comportamento do agente A sem pista
+    // nenhuma na tela — os dois campos existem, os dois aceitam valor, e um
+    // deles não fazia nada. (issue #486)
+    const { data: conversa } = await admin
+      .from("conversations")
+      .select("id, channel_session_id, active_ai_agent_id")
+      .eq("id", message.conversation_id)
+      .eq("organization_id", event.organization_id)
+      .maybeSingle();
+
+    // As versões PUBLICADAS ligadas ao número em que a conversa acontece — é
+    // quem de fato responde ao cliente por aquela sessão. `null` (não consegui
+    // consultar) e `[]` (consultei, não há) levam ao mesmo desfecho na régua,
+    // mas quem lê o log precisa distinguir os dois.
+    let versoesPublicadasNaSessao: string[] | null = null;
+    if (conversa?.channel_session_id) {
+      const { data: versoes } = await admin
+        .from("ai_agent_versions")
+        .select("id, channel_session_id, status")
+        .eq("organization_id", event.organization_id)
+        .eq("channel_session_id", conversa.channel_session_id)
+        .eq("status", "published");
+      versoesPublicadasNaSessao = (versoes ?? []).map((v) => v.id as string);
+    }
+
     const { data: candidatos } = await admin
       .from("ai_agents")
-      .select("id, config, kind, is_active, published_version_id, archived_at")
+      .select(
+        "id, config, kind, is_active, published_version_id, archived_at, priority, created_at",
+      )
       .eq("organization_id", event.organization_id)
-      .is("archived_at", null)
-      .order("is_default", { ascending: false })
-      .order("created_at", { ascending: true });
+      .is("archived_at", null);
 
-    const agent = (candidatos ?? []).find(agenteAtende) ?? null;
+    const { agente: agent, motivo: motivoDoAgente } = resolverAgenteDaConversa(
+      candidatos ?? [],
+      conversa
+        ? {
+            active_ai_agent_id: conversa.active_ai_agent_id as string | null,
+            versoesPublicadasNaSessao,
+          }
+        : null,
+    );
 
+    // Sem agente resolvido, o padrão do PRODUTO — nunca o limiar do vizinho.
+    // Chutar a configuração de outro agente é o defeito de novo, agora com cara
+    // de configuração deliberada.
     const agentConfig = (agent?.config as Record<string, unknown> | null) ?? {};
     const threshold =
       typeof agentConfig["sentiment_threshold"] === "number"
@@ -265,7 +303,16 @@ export async function processSentiment(event: EventRow): Promise<SentimentResult
           conversation_id: conversationId ?? message.conversation_id ?? null,
           sentiment_score: result.sentiment_score,
         },
-        p_metadata: { source: "ai-sentiment-worker", threshold },
+        // `agent_id` e `motivo` viajam com o alerta porque o limiar é o número
+        // que decidiu emiti-lo: sem eles, "por que este alerta saiu?" recomeça
+        // do zero, e foi essa ausência que deixou o defeito da #486 invisível
+        // pela tela — os dois campos existiam e um não fazia nada.
+        p_metadata: {
+          source: "ai-sentiment-worker",
+          threshold,
+          agent_id: agent?.id ?? null,
+          agente_resolvido_por: motivoDoAgente,
+        },
         p_organization_id: event.organization_id,
       } as never);
 


### PR DESCRIPTION
Closes #486

## O defeito

`workers/ai-sentiment-worker.ts` escolhia o agente por **organização**, e a conversa que disparou o evento não entrava na consulta em lugar nenhum:

```ts
.eq("organization_id", event.organization_id)     // só a ORGANIZAÇÃO
.is("archived_at", null)
.order("is_default", { ascending: false })
.order("created_at", { ascending: true });
const agent = (candidatos ?? []).find(agenteAtende) ?? null;
```

Com um agente só, correto por acidente. Com dois ou mais, **o `sentiment_threshold` em vigor dependia da ordem de criação**. Quem configurava o campo do agente B e via o comportamento do A não tinha como descobrir o porquê pela tela: os dois campos existem, os dois aceitam valor, e um deles não faz nada.

E o limiar certo é genuinamente diferente por agente — o argumento de quem achou isto: numa clínica, cliente triste é sinal de problema; numa assistência técnica, cliente triste é o cliente **normal**. Um limiar único erra nos dois sentidos.

## O conserto: uma pergunta nova, não uma régua nova

`lib/ai/agents/no-ar.ts` responde **se** um agente atende. O worker precisava de outra coisa — **qual** deles atende esta conversa — e usava a primeira como se fosse a segunda.

`lib/ai/agents/agente-da-conversa.ts` responde a segunda. O cabeçalho de `no-ar.ts` documenta o custo de ter três respostas discordando para a mesma pergunta; uma quarta régua seria pior. Então a ordem aqui é **a que o motor já executa**, e nada além:

1. `conversations.active_ai_agent_id` — a stickiness que o Intent Router grava. Se o router já decidiu quem atende, a pergunta está respondida.
2. O agente cuja **versão publicada** aponta para o `channel_session_id` da conversa, desempatando por `priority desc, created_at asc` — a mesma cláusula de `loadPublishedAgentConfig`, que é quem de fato responde ao cliente por aquele número.
3. O agente **único** da organização. Não é fallback "por ordem": é o caso em que não há ambiguidade. Ele existe porque a instalação nova — um `rag_bot` legado, ativo, sem versão publicada e sem vínculo com sessão — é o estado mais comum do produto self-host, e derrubá-la para o padrão trocaria um defeito por uma regressão.

Com dois ou mais agentes e nenhum vínculo com a conversa, a resposta é `null` e vale **o padrão do produto**. Chutar o limiar do vizinho é o defeito de novo, com cara de configuração deliberada.

## O laço se fecha

O alerta passa a carregar `agent_id` e `agente_resolvido_por`. O limiar é o número que decidiu emitir o alerta; sem eles, "por que este alerta saiu?" recomeça do zero — e foi essa ausência que deixou o defeito invisível pela tela.

## Prova

O dublê aplica `eq`/`is`/`in`/`order` sobre as linhas em vez de devolver um objeto fixo. Isso é o ponto: **um dublê fixo aprovaria o worker que nunca filtra pela conversa**, que é exatamente o defeito.

O primeiro caso é controle positivo — exige `LIMIAR_TECNICA < nota < LIMIAR_CLINICA`. Sem ele, alguém que iguale os dois limiares faz todos os outros passarem sem separar comportamento nenhum.

```console
$ npx vitest run tests/unit/limiar-de-sentimento-vem-do-agente-da-conversa.test.ts
  Tests  6 passed (6)
```

**Sabotagem** — revertendo só `workers/ai-sentiment-worker.ts` (previ 3, deu 3):

```
  × conversa no número da assistência técnica usa o limiar DELA, não o do agente mais antigo
  × stickiness do router vence a sessão — o agente que já atende a conversa é o dono do limiar
  × conversa que não resolve agente nenhum cai no padrão do produto, nunca no do vizinho
  Tests  3 failed | 3 passed (6)
```

## Gates

```
pnpm typecheck   exit=0
pnpm lint        exit=0
vizinhos (limiar + no-ar + workers)   3 arquivos / 20 testes, exit=0
```

## O que NÃO fiz

**Não migrei os outros consumidores de `agenteAtende` para a régua nova.** Este PR conserta o worker de sentimento, que é onde o defeito foi medido. Os outros pontos que perguntam "qual agente" merecem a mesma auditoria, mas fazer isso junto misturaria um conserto medido com uma varredura não medida — e o risco de regressão em cada um é diferente. Se valer, é issue própria.

**Não escrevi spec de tela.** O defeito vive no worker, não na UI, e nenhuma tela muda. O sintoma *é* visível (o campo que não faz nada), mas prová-lo pela tela exigiria uma conversa real classificada por LLM.

**Duas consultas a mais por evento de sentimento** (`conversations` e `ai_agent_versions`), ambas por chave e filtradas por organização. É o preço de saber de quem é a conversa.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam
- [x] Service role com filtro de `organization_id` manual em todas as consultas novas
- [x] Sem `console.log` esquecido
- [x] Fragmento em `.changes/` (`nada_mudou` / `corrigido`)
- [ ] Schema: não toca

🤖 Generated with [Claude Code](https://claude.com/claude-code)