### PR TITLE
fix(catalogo): planilha em latin-1 deixa de entrar corrompida sem erro

### DIFF
--- a/.changes/planilha-do-excel-com-acento-entra-inteira.md
+++ b/.changes/planilha-do-excel-com-acento-entra-inteira.md
@@ -1,0 +1,27 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Planilha exportada do Excel com acento entra inteira, sem virar caractere estranho
+---
+
+O Excel em português salva planilha num formato de texto antigo, e é o padrão
+dele — quem exporta a lista de produtos ou de contatos quase sempre manda esse
+arquivo. O sistema lia todos como se fossem do formato moderno, e o resultado
+dependia de onde estava o acento.
+
+Quando o acento estava nos **dados**, era o pior caso: a importação dizia
+"pronto, N produtos importados" e o catálogo ficava com nomes como
+`A��o C�nica` — sem um erro sequer. É esse nome corrompido que o atendente de IA
+lia em voz alta para o cliente, e ninguém confere linha a linha numa lista de
+300 itens.
+
+Quando o acento estava no **cabeçalho**, o arquivo inteiro era recusado com uma
+mensagem ilegível.
+
+Agora o sistema identifica o formato pelo próprio conteúdo do arquivo e lê os
+dois corretamente — sem você precisar reexportar nada. Vale para a importação de
+produtos e para a de contatos.
+
+E um arquivo que não é planilha de texto (um `.xlsx` renomeado, por exemplo)
+passa a ser recusado com a instrução do que fazer, em vez de virar centenas de
+linhas ilegíveis no seu catálogo.

--- a/app/api/v1/contacts/import/route.ts
+++ b/app/api/v1/contacts/import/route.ts
@@ -27,6 +27,7 @@ import { encryptCpfSql, hashCpf } from "@/lib/contacts/cpf";
 import {
   CSV_MAX_BYTES,
   CSV_MAX_DATA_ROWS,
+  decodificarCsv,
   mapHeader,
   mapLinha,
   parseCsv,
@@ -92,7 +93,12 @@ export async function POST(req: NextRequest): Promise<Response> {
   }
 
   // ─── Parse + validação de linhas (puro; nada tocou no banco ainda) ───────
-  const text = await file.text();
+  // Os BYTES, não `file.text()` — ver `decodificarCsv` (#483).
+  const decodificado = decodificarCsv(await file.arrayBuffer());
+  if ("erro" in decodificado) {
+    return fail("validation_failed", decodificado.erro, 422, { requestId });
+  }
+  const text = decodificado.texto;
   const rows = parseCsv(text);
   if (rows.length < 2) {
     return fail("validation_failed", "CSV vazio ou sem linhas de dados.", 422, { requestId });

--- a/app/api/v1/products/import/route.ts
+++ b/app/api/v1/products/import/route.ts
@@ -23,7 +23,7 @@ import { audit } from "@/lib/audit";
 import { fail, ok } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { lerPlanilha, type ErroDaLinha } from "@/lib/catalogo/planilha";
-import { CSV_MAX_BYTES, CSV_MAX_DATA_ROWS } from "@/lib/contacts/csv";
+import { CSV_MAX_BYTES, CSV_MAX_DATA_ROWS, decodificarCsv } from "@/lib/contacts/csv";
 import { COLUNAS_DO_PRODUTO } from "@/lib/schemas/produtos";
 import { createClient } from "@/lib/supabase/server";
 
@@ -87,7 +87,14 @@ export async function POST(req: NextRequest): Promise<Response> {
     );
   }
 
-  const lido = lerPlanilha(await arquivo.text());
+  // Os BYTES, não `arquivo.text()`: o Excel em pt-BR exporta cp1252 e
+  // `File.text()` decodifica sempre como UTF-8 — o nome entrava corrompido no
+  // catálogo sem um erro sequer, e é ele que o agente lê para o cliente (#483).
+  const decodificado = decodificarCsv(await arquivo.arrayBuffer());
+  if ("erro" in decodificado) {
+    return fail("validation_failed", decodificado.erro, 422, { requestId });
+  }
+  const lido = lerPlanilha(decodificado.texto);
   // Problema do ARQUIVO (falta a coluna de preço) é 422 com a frase inteira —
   // e não um relatório com 300 erros idênticos.
   if ("erro" in lido) return fail("validation_failed", lido.erro, 422, { requestId });

--- a/lib/contacts/csv.ts
+++ b/lib/contacts/csv.ts
@@ -12,6 +12,55 @@ import { normalizePhoneBR } from "@/lib/webhooks/inbound";
  */
 
 /** Máximo defensivo: arquivo maior que isso é recusado antes do parse. */
+/**
+ * Os BYTES do upload viram texto — e o arquivo que não é texto é RECUSADO.
+ *
+ * `File.text()` decodifica sempre como UTF-8. O Excel em português exporta
+ * cp1252 por padrão, e o desfecho dependia de onde estava o acento (issue #483):
+ *
+ *   acento nos DADOS      -> IMPORTAVA, com `nome = "A��o C�nica �"`
+ *   acento no CABEÇALHO   -> 422 "Encontrei: C�digo, Produto, Pre�o, Marca."
+ *
+ * O segundo falha fechado e até é didático. O primeiro falha ABERTO: entra lixo
+ * no catálogo sem um erro sequer, e é esse nome que o agente lê para o cliente.
+ *
+ * O desempate não é detecção de charset, é uma prova: `TextDecoder("utf-8")` só
+ * produz U+FFFD quando o byte-stream NÃO é UTF-8 válido. Ausência de U+FFFD é
+ * prova de que UTF-8 é a leitura certa; presença é prova de que não é.
+ *
+ * O `windows-1252` "consegue" ler qualquer byte, então cair nele sem olhar o
+ * resultado transformaria um .xlsx renomeado em 300 produtos de nome ilegível.
+ * Por isso a segunda leitura é CONFERIDA: byte de controle (fora de TAB, CR e
+ * LF) não aparece em CSV de verdade, e aí o arquivo é recusado com a mesma
+ * instrução que a tela já dá.
+ *
+ * O que isto NÃO alcança, e está escrito para ninguém supor: o mojibake da
+ * ORIGEM — "AÃ§Ã£o", UTF-8 já gravado como latin-1 pelo sistema que gerou a
+ * planilha — é UTF-8 VÁLIDO, não tem U+FFFD nenhum, e passa limpo. É outro
+ * defeito, com outra evidência.
+ */
+export function decodificarCsv(bytes: ArrayBuffer | Uint8Array): { texto: string } | { erro: string } {
+  const buf = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+
+  const utf8 = new TextDecoder("utf-8").decode(buf);
+  if (!utf8.includes("\uFFFD")) return { texto: semBom(utf8) };
+
+  const latin = new TextDecoder("windows-1252").decode(buf);
+  // eslint-disable-next-line no-control-regex -- é exatamente o que se procura
+  if (/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/.test(latin)) {
+    return {
+      erro:
+        "Este arquivo não parece ser um CSV de texto. No Excel use “Salvar como” → “CSV UTF-8 (delimitado por vírgulas)”.",
+    };
+  }
+  return { texto: semBom(latin) };
+}
+
+/** O BOM vira caractere invisível no primeiro cabeçalho e cria coluna fantasma. */
+function semBom(texto: string): string {
+  return texto.charCodeAt(0) === 0xfeff ? texto.slice(1) : texto;
+}
+
 export const CSV_MAX_BYTES = 5 * 1024 * 1024;
 
 /** Teto de linhas de dados por importação (protege o round-trip do handler). */

--- a/tests/unit/planilha-em-latin-1-nao-entra-corrompida.test.ts
+++ b/tests/unit/planilha-em-latin-1-nao-entra-corrompida.test.ts
@@ -1,0 +1,154 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { lerPlanilha } from "@/lib/catalogo/planilha";
+import { decodificarCsv } from "@/lib/contacts/csv";
+
+/**
+ * A PLANILHA QUE SAIU DO EXCEL EM LATIN-1 NÃO ENTRA CORROMPIDA (issue #483).
+ *
+ * ─── O defeito, medido no HEAD c5b45b24 ─────────────────────────────────────
+ *
+ * As duas rotas de importação liam o arquivo com `await file.text()`, que
+ * decodifica SEMPRE como UTF-8. O Excel em português exporta cp1252 por padrão,
+ * e o desfecho dependia de onde estava o acento:
+ *
+ *   acento nos DADOS      -> IMPORTAVA, com o nome corrompido:
+ *                            nome = "A��o C�nica �"
+ *   acento no CABEÇALHO   -> 422: "A planilha precisa de uma coluna de preço.
+ *                            Encontrei: C�digo, Produto, Pre�o, Marca."
+ *
+ * O primeiro é o grave: falha ABERTA. A tela diz "N produtos importados", o
+ * catálogo fica com lixo, e é esse nome que o agente lê para o cliente.
+ *
+ * ─── Por que o desempate é "tem U+FFFD?" e não uma detecção de charset ──────
+ *
+ * `TextDecoder("utf-8")` só produz U+FFFD quando o byte-stream NÃO é UTF-8
+ * válido. Então a ausência de U+FFFD é prova de que UTF-8 é a leitura certa, e
+ * a presença é prova de que não é. Não há adivinhação no caso comum.
+ *
+ * ─── O que este conserto NÃO alcança (escreva antes de alguém supor) ────────
+ *
+ * O mojibake da ORIGEM — "AÃ§Ã£o", que é UTF-8 já gravado como latin-1 pelo
+ * sistema que gerou a planilha — é UTF-8 válido, não tem U+FFFD nenhum, e passa
+ * limpo pelo desempate. Ele continua entrando. É outro defeito, com outra
+ * evidência, e resolvê-lo exige heurística de plausibilidade que esta não tem.
+ */
+
+const cp1252 = (texto: string) => Buffer.from(texto, "latin1");
+const bytes = (b: number[]) => Buffer.from(b);
+
+/** O caminho de produção inteiro, sem HTTP: decodifica os bytes, depois lê. */
+function importar(buf: Buffer): ReturnType<typeof lerPlanilha> {
+  const d = decodificarCsv(buf);
+  if ("erro" in d) return { erro: d.erro };
+  return lerPlanilha(d.texto);
+}
+
+describe("bytes cp1252 do Excel pt-BR", () => {
+  it("acento nos DADOS chega ao catálogo inteiro, não corrompido", () => {
+    // Era o caso que falhava ABERTO: importava com "A��o C�nica �".
+    const r = importar(cp1252("codigo,produto,preco\nA1,Ação Cônica Ç,5499,00\n"));
+
+    expect("erro" in r).toBe(false);
+    if ("erro" in r) return;
+    expect(r.produtos).toHaveLength(1);
+    // Igualdade, não `toMatch`: um sufixo de lixo colado passaria numa busca.
+    expect(r.produtos[0]?.nome).toBe("Ação Cônica Ç");
+    expect(r.produtos[0]?.nome).not.toContain("�");
+  });
+
+  it("acento no CABEÇALHO deixa de recusar o arquivo", () => {
+    // Era 422 com a mensagem ilegível — o arquivo inteiro morria na borda.
+    const r = importar(cp1252("Código;Produto;Preço;Marca\nIP15;iPhone 15;R$ 5.499,00;Apple\n"));
+
+    expect("erro" in r).toBe(false);
+    if ("erro" in r) return;
+    expect(r.produtos).toHaveLength(1);
+    expect(r.produtos[0]?.preco_cents).toBe(549900);
+    expect(r.produtos[0]?.codigo).toBe("IP15");
+    expect(r.colunasIgnoradas).toEqual([]);
+  });
+
+  it("o acento sobrevive também no que NÃO é o nome", () => {
+    const r = importar(cp1252("nome,preco,marca,categoria\nFone,199,Genérico,Áudio\n"));
+
+    if ("erro" in r) throw new Error(r.erro);
+    expect(r.produtos[0]?.marca).toBe("Genérico");
+    expect(r.produtos[0]?.categoria).toBe("Áudio");
+  });
+});
+
+describe("o que não é texto é RECUSADO, nunca adivinhado", () => {
+  it("arquivo binário renomeado para .csv vira erro de arquivo", () => {
+    // Assinatura de .xlsx (PK\x03\x04) + bytes altos: o utf-8 falha, e o
+    // windows-1252 "consegue" ler qualquer byte — se ninguém olhasse o
+    // resultado, este arquivo viraria produtos de nome ilegível.
+    const r = decodificarCsv(bytes([0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x00, 0x00, 0x08, 0x00, 0xe7, 0x9c, 0xff]));
+
+    expect("erro" in r).toBe(true);
+    if (!("erro" in r)) return;
+    expect(r.erro).toContain("CSV UTF-8");
+  });
+
+  it("tabulação, CR e LF continuam sendo texto", () => {
+    // O guarda mira byte de controle, e TAB é delimitador legítimo aqui.
+    const r = decodificarCsv(cp1252("nome\tpreço\r\nCafé\t9,90\r\n"));
+
+    if ("erro" in r) throw new Error(r.erro);
+    expect(r.texto).toBe("nome\tpreço\r\nCafé\t9,90\r\n");
+  });
+});
+
+describe("o arquivo que já estava certo não muda", () => {
+  it("UTF-8 continua UTF-8", () => {
+    const r = importar(Buffer.from("nome,preco\nAção Cônica Ç,5499,00\n", "utf8"));
+
+    if ("erro" in r) throw new Error(r.erro);
+    expect(r.produtos[0]?.nome).toBe("Ação Cônica Ç");
+  });
+
+  it("BOM de UTF-8 não vira coluna fantasma", () => {
+    const r = importar(Buffer.from("﻿nome,preco\nCafé,9,90\n", "utf8"));
+
+    if ("erro" in r) throw new Error(r.erro);
+    expect(r.produtos).toHaveLength(1);
+    expect(r.produtos[0]?.nome).toBe("Café");
+  });
+});
+
+/**
+ * O guarda acima mede a FUNÇÃO. Sem este, consertar a função e deixar a rota
+ * chamando `file.text()` passaria verde — que é exatamente o estado de hoje.
+ */
+describe("as rotas de importação decodificam pelos BYTES", () => {
+  const ROTAS = [
+    "app/api/v1/products/import/route.ts",
+    "app/api/v1/contacts/import/route.ts",
+  ] as const;
+
+  /** Comentário é prosa: um `file.text()` CITADO num comentário não é chamada. */
+  const semComentarios = (fonte: string) =>
+    fonte.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+
+  it.each(ROTAS)("%s não lê o upload com .text()", (rota) => {
+    const codigo = semComentarios(readFileSync(join(process.cwd(), rota), "utf8"));
+
+    // Booleano em vez do texto inteiro: o diff de um `toContain` sobre um
+    // arquivo de 200 linhas enterra o motivo da falha.
+    expect(codigo.includes("decodificarCsv(")).toBe(true);
+    // `req.text()` de webhook é outra coisa; o que não pode é o ARQUIVO.
+    expect(/\b(arquivo|file)\.text\(\)/.test(codigo)).toBe(false);
+  });
+
+  it("o guarda enxerga a chamada quando ela existe (controle positivo)", () => {
+    // Sem isto, "não achei `file.text()`" poderia ser sonda cega em vez de
+    // ausência: a mesma sonda tem de ACHAR num código que a contém.
+    const comDefeito = "const t = await file.text();\n// decodificarCsv(bytes)\n";
+
+    expect(/\b(arquivo|file)\.text\(\)/.test(semComentarios(comDefeito))).toBe(true);
+    expect(semComentarios(comDefeito).includes("decodificarCsv(")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #483

## O defeito

`app/api/v1/products/import/route.ts:90` fazia `await arquivo.text()`, que decodifica **sempre** como UTF-8. Planilha de loja brasileira sai do Excel em cp1252 com frequência, e o desfecho dependia de onde estava o acento:

```
[dados acentuados, cabeçalho ASCII]  -> IMPORTADO, com o nome corrompido:
     nome = "A��o C�nica �"     (era "Ação Cônica Ç")

[cabeçalho acentuado em latin-1]     -> ARQUIVO RECUSADO (422):
     "A planilha precisa de uma coluna de preço. Encontrei: C�digo, Produto, Pre�o, Marca."
```

O caso do **cabeçalho** falha fechado e até é didático — a mensagem de erro exibe o defeito sem querer. O caso dos **dados** falha **aberto**: entra lixo no catálogo, sem um erro sequer, e o nome corrompido é o que o agente lê para o cliente. Ninguém confere linha a linha numa lista de 300 itens.

É a mesma família do defeito do preço (#481): a entrada suja não é recusada, é **adivinhada**.

## Por que o desempate é uma prova, não uma detecção de charset

`TextDecoder("utf-8")` só produz `U+FFFD` quando o byte-stream **não é UTF-8 válido**. Então:

- ausência de `U+FFFD` → prova de que UTF-8 é a leitura certa;
- presença → prova de que não é.

Não há adivinhação no caso comum.

## E o que não é texto é recusado, nunca adivinhado

`windows-1252` **consegue ler qualquer byte** — cair nele sem olhar o resultado transformaria um `.xlsx` renomeado em 300 produtos de nome ilegível. Por isso a segunda leitura é conferida: byte de controle (fora de TAB, CR e LF) não aparece em CSV de verdade, e o arquivo é recusado com a mesma instrução que a tela já dá.

## A rota irmã levou o mesmo conserto

`app/api/v1/contacts/import/route.ts:95` tinha o mesmo `file.text()`. Consertar só a que foi reportada deixaria a irmã com o defeito **e sem sonda** — o teste cobre as duas.

Junto: o BOM de UTF-8 passa a ser removido; ele virava caractere invisível no primeiro cabeçalho e criava coluna fantasma.

## Prova

O teste percorre o caminho de produção inteiro (bytes → decodificação → `lerPlanilha`) e compara por **igualdade**, não `toMatch` — um sufixo de lixo colado passaria numa busca.

```console
$ npx vitest run tests/unit/planilha-em-latin-1-nao-entra-corrompida.test.ts
  Tests  10 passed (10)
```

**Duas sabotagens independentes**, porque o conserto tem duas metades:

```
A) desligo só as ROTAS (função intacta) — previ 2, deu 2:
   × app/api/v1/products/import/route.ts não lê o upload com .text()
   × app/api/v1/contacts/import/route.ts não lê o upload com .text()

B) tiro o fallback latin-1 (rotas intactas) — previ 4, deu 5:
   × acento nos DADOS chega ao catálogo inteiro, não corrompido
   × acento no CABEÇALHO deixa de recusar o arquivo
   × o acento sobrevive também no que NÃO é o nome
   × arquivo binário renomeado para .csv vira erro de arquivo
   × tabulação, CR e LF continuam sendo texto
```

A sabotagem (A) existe porque consertar a função e deixar a rota chamando `file.text()` passaria verde — que era exatamente o estado de hoje. O guarda de rota tem controle positivo: a mesma sonda **acha** `file.text()` num código que a contém, então o vazio é ausência real e não sonda cega.

## Gates

```
pnpm typecheck   exit=0
pnpm lint        exit=0
vizinhos (catalogo + contacts + as duas rotas de import)   48 testes, exit=0
```

## O que NÃO fiz

**O mojibake da origem continua entrando** — `"AÃ§Ã£o"`, UTF-8 já gravado como latin-1 pelo sistema que gerou a planilha, é UTF-8 **válido**, não tem `U+FFFD` nenhum, e passa limpo pelo desempate. É outro defeito, com outra evidência, e resolvê-lo exige heurística de plausibilidade que esta não tem. Está escrito no cabeçalho do teste e da função, para ninguém supor cobertura que não existe.

**Não corrijo o que já entrou corrompido.** Quem importou antes segue com os nomes estragados no catálogo; reimportar o arquivo agora resolve.

**UTF-16** (que o Excel também oferece em "Texto Unicode") não é tratado — ele produziria bytes nulos e cai na recusa, que é o desfecho seguro, mas a mensagem fala de CSV UTF-8.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam
- [x] Sem `console.log` esquecido
- [x] Fragmento em `.changes/` (`nada_mudou` / `corrigido`)
- [ ] Schema: não toca

🤖 Generated with [Claude Code](https://claude.com/claude-code)