### PR TITLE
fix(ia): o editor de agente passa a salvar nome, descrição e ordem

### DIFF
--- a/.changes/o-nome-do-agente-que-voce-salva-e-o-que-fica.md
+++ b/.changes/o-nome-do-agente-que-voce-salva-e-o-que-fica.md
@@ -1,0 +1,22 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O nome, a descrição e a ordem do agente passam a ser salvos de verdade
+---
+
+Na tela de um agente, trocar o **Nome** não mudava nada. A pessoa digitava,
+salvava, publicava — e o nome continuava o mesmo, no editor e na lista.
+**Descrição** e **Ordem de preferência** sumiam do mesmo jeito.
+
+O que tornava isso difícil de perceber é que nada falhava: o campo aceitava a
+digitação, o aviso verde dizia "Rascunho salvo", e a publicação respondia com
+sucesso. Todas essas mensagens eram verdadeiras — a respeito da **versão**, que
+era a única coisa realmente gravada. Recarregar a página não ajudava, porque o
+valor nunca chegou a ser gravado.
+
+Agora os três são salvos junto com o rascunho, e a lista de agentes reflete o
+nome novo na hora.
+
+Dois detalhes que vêm junto: apagar a descrição realmente a apaga (antes o campo
+vazio seria interpretado como "não mexi"), e uma ordem de preferência fora de
+0 a 1000 é avisada embaixo do campo, em vez de virar erro genérico depois.

--- a/app/app/ai/agents/[id]/_actions.ts
+++ b/app/app/ai/agents/[id]/_actions.ts
@@ -26,9 +26,10 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { mensagemDoEscopo, validarEscopoDaVersao } from "@/lib/ai/agents/escopo";
 import {
   agentMcpCreateSchema,
+  agentMcpPatchSchema,
+  PUBLISH_ERROR_CODES,
   versionCreateSchema,
   versionPatchSchema,
-  PUBLISH_ERROR_CODES,
 } from "@/lib/ai/agents/validation";
 import { publishAgentVersion } from "@/lib/ai/agents/publish";
 import { VALID_TOOL_IDS } from "@/lib/mcp/tools";
@@ -57,9 +58,66 @@ async function ensureAdmin() {
 // saveAgentDraftAction
 // ---------------------------------------------------------------------------
 
+/**
+ * Grava as colunas de cadastro em `ai_agents` — e só quando alguma mudou.
+ *
+ * Uma rodada que não mudou nada não é mutação, e auditar todo "Salvar rascunho"
+ * encheria `api_audit_log` de linha sem efeito. A comparação é contra a linha
+ * lida no mesmo request.
+ */
+async function gravarCadastroDoAgente(
+  admin: ReturnType<typeof createAdminClient>,
+  args: {
+    agentId: string;
+    orgId: string;
+    actorUserId: string;
+    requestId: string;
+    atual: { name?: unknown; description?: unknown; priority?: unknown };
+    pedido: { name?: string; description?: string | null; priority?: number };
+  },
+): Promise<{ erro: string } | { mudou: string[] }> {
+  const patch: Record<string, unknown> = {};
+  for (const campo of ["name", "description", "priority"] as const) {
+    const novo = args.pedido[campo];
+    if (novo === undefined) continue;
+    if ((args.atual[campo] ?? null) === (novo ?? null)) continue;
+    patch[campo] = novo ?? null;
+  }
+  if (Object.keys(patch).length === 0) return { mudou: [] };
+
+  // Service role bypassa RLS: o filtro de organização é manual e obrigatório.
+  const { error } = await admin
+    .from("ai_agents")
+    .update({ ...patch, updated_at: new Date().toISOString() })
+    .eq("id", args.agentId)
+    .eq("organization_id", args.orgId);
+  if (error) return { erro: error.message };
+
+  void audit({
+    action: "ai_agent.updated",
+    actorUserId: args.actorUserId,
+    organizationId: args.orgId,
+    resourceType: "ai_agent",
+    resourceId: args.agentId,
+    requestId: args.requestId,
+    metadata: { fields: Object.keys(patch) },
+  });
+  return { mudou: Object.keys(patch) };
+}
+
 export async function saveAgentDraftAction(
   agentId: string,
   payload: unknown,
+  /**
+   * Nome, descrição e ordem de preferência — as três colunas que moram em
+   * `ai_agents` e que `ai_agent_versions` NÃO tem. Elas viajavam só na criação;
+   * em modo edição, `toVersionPayload` era o único construtor do envio e não as
+   * incluía. A pessoa digitava o nome, via "Rascunho vN salvo.", publicava com
+   * sucesso — e o cartão da lista seguia com o nome antigo, porque nada daquilo
+   * era mentira: tudo se referia à VERSÃO, a única coisa realmente gravada.
+   * (issue #463)
+   */
+  cadastro?: unknown,
 ): Promise<ActionResult<{ version_id: string; version_number: number }>> {
   if (!UUID_RX.test(agentId)) return { ok: false, error: "invalid_request" };
   const guard = await ensureAdmin();
@@ -74,6 +132,18 @@ export async function saveAgentDraftAction(
       details: parsed.error.flatten(),
     };
   }
+  // Validado ANTES de qualquer escrita, junto do resto. Se o cadastro fosse
+  // conferido depois, uma ordem inválida devolveria erro com a versão já
+  // gravada; se fosse GRAVADO antes, um escopo inválido devolveria erro com o
+  // nome já trocado — a lista mostrando o novo e o editor o velho.
+  // `agentMcpPatchSchema` é a régua que a rota REST já usa: uma quarta régua
+  // para o mesmo campo é o defeito seguinte.
+  const cadastroParsed =
+    cadastro === undefined ? null : agentMcpPatchSchema.safeParse(cadastro);
+  if (cadastroParsed && !cadastroParsed.success) {
+    return { ok: false, error: "validation_failed", details: cadastroParsed.error.flatten() };
+  }
+
   const v = parsed.data;
   const requestId = randomUUID();
   const admin = createAdminClient();
@@ -81,7 +151,7 @@ export async function saveAgentDraftAction(
   // Sanity: o agent existe e é da org? não está arquivado?
   const { data: agent } = await admin
     .from("ai_agents")
-    .select("id, kind, archived_at")
+    .select("id, kind, archived_at, name, description, priority")
     .eq("id", agentId)
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
@@ -138,6 +208,27 @@ export async function saveAgentDraftAction(
       requestId,
       metadata: { agent_id: agentId, fields: Object.keys(update) },
     });
+
+    if (cadastroParsed?.success) {
+      const r = await gravarCadastroDoAgente(admin, {
+        agentId,
+        orgId: activeOrg.orgId,
+        actorUserId: authUser.id,
+        requestId,
+        atual: agent,
+        pedido: cadastroParsed.data,
+      });
+      // As duas escritas não são atômicas. O desfecho tem de dizer o que
+      // gravou: um toast verde genérico aqui reproduz o defeito com outra cara.
+      if ("erro" in r) {
+        return {
+          ok: false,
+          error: "internal_error",
+          message: `O rascunho foi salvo, mas o cadastro do agente não: ${r.erro}`,
+        };
+      }
+      if (r.mudou.length > 0) revalidatePath("/app/ai/agents");
+    }
 
     revalidatePath(`/app/ai/agents/${agentId}`);
     return {
@@ -206,6 +297,25 @@ export async function saveAgentDraftAction(
         requestId,
         metadata: { agent_id: agentId, version_number: created.version_number },
       });
+      if (cadastroParsed?.success) {
+        const r = await gravarCadastroDoAgente(admin, {
+          agentId,
+          orgId: activeOrg.orgId,
+          actorUserId: authUser.id,
+          requestId,
+          atual: agent,
+          pedido: cadastroParsed.data,
+        });
+        if ("erro" in r) {
+          return {
+            ok: false,
+            error: "internal_error",
+            message: `O rascunho foi salvo, mas o cadastro do agente não: ${r.erro}`,
+          };
+        }
+        if (r.mudou.length > 0) revalidatePath("/app/ai/agents");
+      }
+
       revalidatePath(`/app/ai/agents/${agentId}`);
       return { ok: true, data: { version_id: created.id, version_number: created.version_number } };
     }

--- a/app/app/ai/agents/[id]/_components/AgentForm.tsx
+++ b/app/app/ai/agents/[id]/_components/AgentForm.tsx
@@ -56,7 +56,11 @@ import {
   createMcpAgentAction,
 } from "../_actions";
 
-import { versionCreateSchema, agentMcpCreateSchema } from "@/lib/ai/agents/validation";
+import {
+  versionCreateSchema,
+  agentMcpCreateSchema,
+  agentMcpPatchSchema,
+} from "@/lib/ai/agents/validation";
 import type { SelectableChannel as ChannelSessionLite } from "@/lib/channels/selectable";
 import type { AgentRow } from "@/hooks/ai/useAgent";
 import type { AgentVersionRow } from "@/hooks/ai/useAgentVersions";
@@ -223,6 +227,26 @@ function buildState(args: {
   };
 }
 
+/**
+ * As três colunas que moram em `ai_agents`, não em `ai_agent_versions`.
+ *
+ * Existir separado não é gosto: `versionCreateSchema` é `.strict()` e recusa
+ * estes campos, com razão — eles não descrevem a versão. O que faltava era o
+ * segundo construtor, e sem ele o modo EDIÇÃO mandava só a versão: a pessoa
+ * digitava o nome, via "Rascunho vN salvo.", publicava com sucesso, e o cartão
+ * da lista seguia com o nome antigo (issue #463). O modo CRIAÇÃO sempre
+ * mandou os três, e é por isso que o defeito só aparecia ao editar.
+ */
+function toCadastroPayload(s: FormState) {
+  return {
+    name: s.name.trim(),
+    // "" na tela é APAGAR, e apagar é `null` no banco — `undefined` seria
+    // "não mexi", e a descrição antiga sobreviveria a um campo esvaziado.
+    description: s.description.trim() === "" ? null : s.description.trim(),
+    priority: s.priority,
+  };
+}
+
 function toVersionPayload(s: FormState) {
   return {
     system_prompt: s.system_prompt,
@@ -311,6 +335,11 @@ export function AgentForm(props: Props) {
     // usuário de errar é a primeira coisa que ele vê nesta tela.
     if (form.name.trim().length === 0) errors.name = t("Dê um nome para este agente.");
     if (form.name.length > 120) errors.name = t("O nome pode ter até 120 caracteres.");
+    // A rota REST já cobra `0..1000` (`app/api/v1/ai/agents/[id]/route.ts:90`).
+    // Sem a mesma régua aqui, o número inválido só reprovaria no servidor e o
+    // aviso chegaria como erro genérico, depois de a versão já ter sido gravada.
+    if (!Number.isInteger(form.priority) || form.priority < 0 || form.priority > 1000)
+      errors.priority = t("A ordem de preferência vai de 0 a 1000.");
     if (form.system_prompt.trim().length < 10)
       errors.system_prompt = t("Escreva as instruções do agente (pelo menos uma frase).");
     // `.trim()` porque é o que o servidor mede: `z.string().trim().max(20000)`
@@ -378,7 +407,18 @@ export function AgentForm(props: Props) {
     setSaving(true);
     try {
       if (isEdit) {
-        const res = await saveAgentDraftAction(props.agent.id, toVersionPayload(form));
+        // A mesma régua do servidor, aqui, para o erro aparecer no campo em vez
+        // de voltar como 500 depois de a versão já ter sido gravada.
+        const cadastro = agentMcpPatchSchema.safeParse(toCadastroPayload(form));
+        if (!cadastro.success) {
+          toast.error(t("Validação falhou."));
+          return;
+        }
+        const res = await saveAgentDraftAction(
+          props.agent.id,
+          toVersionPayload(form),
+          cadastro.data,
+        );
         if (!res.ok) {
           toast.error(res.message ?? `${t("Erro")}: ${res.error}`);
           return;
@@ -636,7 +676,11 @@ export function AgentForm(props: Props) {
                 value={form.priority}
                 onChange={(e) => patch({ priority: Number(e.target.value) })}
                 disabled={disabled}
+                aria-invalid={!!validation.priority}
               />
+              {validation.priority ? (
+                <p className="text-xs text-destructive">{validation.priority}</p>
+              ) : null}
               <p className="text-xs text-muted-foreground">
                 {t(
                   "Quando mais de um agente puder atender a mesma conversa, o de número maior tenta primeiro. Se você só tem um agente, pode deixar como está.",

--- a/lib/i18n/dicionario.ts
+++ b/lib/i18n/dicionario.ts
@@ -2898,6 +2898,9 @@ export const DICIONARIO: Traducoes = {
   "Estes limites protegem o número contra bloqueio do WhatsApp. Campo vazio usa o padrão seguro do sistema (mostrado no campo).": {
     es: "Estos límites protegen el número contra el bloqueo de WhatsApp. Campo vacío usa el valor seguro predeterminado del sistema (que se muestra en el campo).",
   },
+  "A ordem de preferência vai de 0 a 1000.": {
+    es: "El orden de preferencia va de 0 a 1000.",
+  },
   "Este número é usado desde": { es: "Este número se usa desde" },
   "A conexão pode ser nova sem que o número seja. O aquecimento conta a idade do NÚMERO — se você deixar em branco, ele é tratado como recém-criado e começa liberando pouco por dia.": {
     es: "La conexión puede ser nueva sin que el número lo sea. El calentamiento cuenta la antigüedad del NÚMERO — si lo dejas en blanco, se trata como recién creado y empieza liberando poco por día.",

--- a/tests/unit/editor-de-agente-salva-o-cadastro.test.tsx
+++ b/tests/unit/editor-de-agente-salva-o-cadastro.test.tsx
@@ -1,0 +1,449 @@
+/**
+ * O EDITOR DE AGENTE TEM DE SALVAR O QUE ELE DEIXA EDITAR.
+ *
+ * ─── O defeito, medido na fonte ─────────────────────────────────────────────
+ *
+ * Em `/app/ai/agents/[id]`, os campos **Nome**, **Descrição** e **Ordem de
+ * preferência** aceitavam digitação, tinham validação própria e habilitavam o
+ * botão "Salvar rascunho" — e o envio os descartava inteiros.
+ *
+ * A causa é de uma linha: em modo edição, o único construtor do envio era
+ * `toVersionPayload()`, que monta as colunas de `ai_agent_versions`. Os três
+ * campos moram em `ai_agents`, tabela que a server action só LIA (o SELECT de
+ * sanidade) e nunca escrevia. Publicar também não os copia:
+ * `fn_publish_ai_agent_version` toca `published_version_id` e `updated_at`.
+ *
+ * O que torna isso caro é que nada falha: a validação passa, o aviso verde diz
+ * "Rascunho vN salvo." e a publicação responde sucesso. Todas as frases são
+ * verdadeiras — a respeito da VERSÃO, a única coisa gravada. Numa auditoria de
+ * instalação self-host: 8 `ai_agent.published`, 7 `ai_agent.version_created`,
+ * ZERO `ai_agent.updated`.
+ *
+ * E `priority` é o desempate que o motor usa (`order by a.priority desc`, em
+ * `lib/agent-engine/agent/agent-config.ts`): numa organização com dois agentes,
+ * o dono não conseguia escolher qual atende o cliente.
+ *
+ * ─── O que cada bloco vigia ────────────────────────────────────────────────
+ *
+ * 1. A TELA — clicar em "Salvar rascunho" leva os três campos ao servidor.
+ *    É o defeito relatado, exercitado pelo DOM: digita, clica, e se cobra o que
+ *    saiu daqui.
+ * 2. O SERVIDOR — a action grava em `ai_agents` filtrando a organização, e só
+ *    quando algo mudou (rodada sem efeito não é mutação e não vira auditoria).
+ *    Inclui a ORDEM: escopo inválido não pode deixar o nome já trocado.
+ * 3. A CLASSE — todo campo do formulário sai em ALGUM payload. É a guarda
+ *    contra a repetição: o próximo campo que alguém acrescentar ao estado sem
+ *    acrescentar ao envio reprova aqui, e não em produção.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+const ORG = "33333333-3333-4333-8333-333333333333";
+const AGENTE = "44444444-4444-4444-8444-444444444444";
+const CREDENCIAL = "11111111-1111-4111-8111-111111111111";
+const CANAL = "22222222-2222-4222-8222-222222222222";
+
+const acoes = vi.hoisted(() => ({ salvar: vi.fn(), publicar: vi.fn(), criar: vi.fn() }));
+/** Estado do dublê de escopo. Içado junto com o `vi.mock` que o lê. */
+const cena = vi.hoisted(() => ({ escopo: { ok: true } as { ok: boolean } }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn(), replace: vi.fn() }),
+  usePathname: () => `/app/ai/agents/${AGENTE}`,
+  useSearchParams: () => new URLSearchParams(),
+}));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn(), message: vi.fn() } }));
+vi.mock("@/app/app/ai/agents/[id]/_actions", () => ({
+  saveAgentDraftAction: acoes.salvar,
+  publishAgentAction: acoes.publicar,
+  createMcpAgentAction: acoes.criar,
+}));
+
+// Dependências da server action (bloco 2). Ficam no topo porque `vi.mock` é
+// içado; o bloco 1 não as toca.
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
+vi.mock("@/lib/auth/server", () => ({
+  loadAuthUser: vi.fn(async () => ({ id: "user-1", email: "u@example.com" })),
+  resolveActiveOrg: vi.fn(async () => ({ orgId: ORG, name: "Org", role: "admin" })),
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/audit", () => ({ audit: vi.fn() }));
+vi.mock("@/lib/ai/agents/escopo", () => ({
+  validarEscopoDaVersao: vi.fn(async () => cena.escopo),
+  mensagemDoEscopo: () => "Escopo inválido.",
+}));
+
+import { AgentForm } from "@/app/app/ai/agents/[id]/_components/AgentForm";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { audit } from "@/lib/audit";
+import { revalidatePath } from "next/cache";
+
+// ---------------------------------------------------------------------------
+// 1. A TELA
+// ---------------------------------------------------------------------------
+
+const CREDENCIAIS = [
+  { id: CREDENCIAL, provider: "anthropic", label: "chave da casa", is_active: true },
+];
+const SESSOES = [{ id: CANAL, label: "WhatsApp da clínica", status: "WORKING" }];
+
+const AGENTE_ROW = {
+  id: AGENTE,
+  organization_id: ORG,
+  name: "Recepção",
+  description: "atende quem chega",
+  priority: 3,
+  model: "claude-sonnet-5",
+  system_prompt: "x",
+  is_active: true,
+  is_default: false,
+  config: {},
+  guardrails: [],
+  active_kb_version_id: null,
+  kind: "mcp_agent",
+  published_version_id: "v1",
+  archived_at: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const VERSAO = {
+  id: "v1",
+  organization_id: ORG,
+  agent_id: AGENTE,
+  version_number: 1,
+  status: "published",
+  system_prompt: "Você é a recepção da clínica. Atenda com educação.",
+  provider: "anthropic",
+  model: "claude-sonnet-5",
+  credential_id: CREDENCIAL,
+  tool_ids: [],
+  channel_session_id: CANAL,
+  max_steps: 10,
+  token_budget: 50000,
+  cost_budget_cents: 50,
+  history_message_window: 20,
+  history_token_window: 8000,
+  handoff_keywords: [],
+  handoff_tool_enabled: true,
+  cases_enabled: false,
+  split_messages: false,
+  split_max_chars: 600,
+  followup: { enabled: false, flow_pointer_ids: [] },
+  operator_enabled: false,
+  operator_model: null,
+  operator_tool_ids: [],
+  pipeline_ids: [],
+  knowledge_source_ids: [],
+  trigger_config: null,
+  published_at: "2026-01-01T00:00:00Z",
+  superseded_at: null,
+  created_at: "2026-01-01T00:00:00Z",
+  created_by: null,
+};
+
+function abrirEditor() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const { container } = render(
+    <QueryClientProvider client={qc}>
+      <AgentForm
+        mode="edit"
+        agent={AGENTE_ROW as never}
+        credentials={CREDENCIAIS as never}
+        channelSessions={SESSOES as never}
+        draft={null}
+        published={VERSAO as never}
+        base={VERSAO as never}
+        draftObsoleto={null}
+      />
+    </QueryClientProvider>,
+  );
+  const campo = (id: string) => {
+    const el = container.querySelector(`#${id}`);
+    if (!el) throw new Error(`campo #${id} não existe na tela`);
+    return el as HTMLInputElement | HTMLTextAreaElement;
+  };
+  return { campo };
+}
+
+async function salvarRascunho() {
+  fireEvent.click(screen.getByRole("button", { name: /salvar rascunho/i }));
+  await waitFor(() => expect(acoes.salvar).toHaveBeenCalled());
+  // O cadastro é o SEGUNDO argumento; antes do conserto só existia o primeiro.
+  return acoes.salvar.mock.calls[0]?.[2] as Record<string, unknown> | undefined;
+}
+
+describe("editor de agente — a tela", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    acoes.salvar.mockResolvedValue({ ok: true, data: { version_id: "v2", version_number: 2 } });
+  });
+
+  it("leva o nome novo ao servidor quando a pessoa salva o rascunho", async () => {
+    const { campo } = abrirEditor();
+    fireEvent.change(campo("name"), { target: { value: "Vitória da Recepção" } });
+    const cadastro = await salvarRascunho();
+    expect(
+      cadastro,
+      "o envio não levou o cadastro: a pessoa digita o nome, vê 'Rascunho salvo.' e o nome continua o antigo",
+    ).toBeDefined();
+    expect(cadastro).toHaveProperty("name", "Vitória da Recepção");
+  });
+
+  it("leva também a descrição e a ordem de preferência", async () => {
+    const { campo } = abrirEditor();
+    fireEvent.change(campo("description"), { target: { value: "cuida do primeiro contato" } });
+    fireEvent.change(campo("priority"), { target: { value: "700" } });
+    const cadastro = await salvarRascunho();
+    expect(cadastro).toMatchObject({
+      description: "cuida do primeiro contato",
+      // A `priority` é o desempate do motor: sem ela gravada, quem tem dois
+      // agentes não escolhe qual atende.
+      priority: 700,
+    });
+  });
+
+  it("deixa apagar a descrição — vazio na tela é nulo no banco, não a antiga", async () => {
+    const { campo } = abrirEditor();
+    fireEvent.change(campo("description"), { target: { value: "   " } });
+    const cadastro = await salvarRascunho();
+    expect(cadastro).toHaveProperty("description", null);
+  });
+
+  it("recusa uma ordem de preferência fora de 0..1000 pela mesma régua do servidor", async () => {
+    // A rota REST já cobra `0..1000`. Sem a mesma régua aqui, o número inválido
+    // só reprovaria no servidor, e o aviso chegaria como erro genérico.
+    const { campo } = abrirEditor();
+    fireEvent.change(campo("priority"), { target: { value: "5000" } });
+    fireEvent.click(screen.getByRole("button", { name: /salvar rascunho/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/ordem de preferência vai de 0 a 1000/i)).toBeInTheDocument(),
+    );
+    expect(acoes.salvar, "mandou um valor que o servidor recusa").not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. O SERVIDOR
+// ---------------------------------------------------------------------------
+
+interface Gravacoes {
+  cadastro: Record<string, unknown> | null;
+  filtros: Array<[string, unknown]>;
+  versao: Record<string, unknown> | null;
+}
+
+let gravado: Gravacoes;
+
+function adminDuble(agente: Record<string, unknown>) {
+  return {
+    from: (tabela: string) => {
+      if (tabela === "ai_agents") {
+        const sel: Record<string, unknown> = {
+          eq: () => sel,
+          maybeSingle: async () => ({ data: agente, error: null }),
+        };
+        const upd = {
+          eq: (col: string, val: unknown) => {
+            gravado.filtros.push([col, val]);
+            return upd;
+          },
+          then: (r: (v: { error: null }) => unknown) => r({ error: null }),
+        };
+        return {
+          select: () => sel,
+          update: (payload: Record<string, unknown>) => {
+            gravado.cadastro = payload;
+            return upd;
+          },
+        };
+      }
+      // ai_agent_versions. As DUAS consultas da action passam por aqui e se
+      // distinguem pelo select: a de rascunho vigente pede "id, version_number"
+      // (aqui: não há rascunho), a do maior número pede só "version_number".
+      // Um dublê que devolvesse a mesma linha para as duas mandaria a action
+      // pelo ramo do PATCH, e este arquivo mediria o caminho errado.
+      const selDe = (cols: string) => {
+        const sel: Record<string, unknown> = {
+          eq: () => sel,
+          order: () => sel,
+          limit: () => sel,
+          maybeSingle: async () => ({
+            data: cols.includes("id") ? null : { version_number: 1 },
+            error: null,
+          }),
+        };
+        return sel;
+      };
+      return {
+        select: (cols: string) => selDe(cols),
+        insert: (payload: Record<string, unknown>) => {
+          gravado.versao = payload;
+          return {
+            select: () => ({
+              single: async () => ({ data: { id: "v2", version_number: 2 }, error: null }),
+            }),
+          };
+        },
+      };
+    },
+  };
+}
+
+const VERSION_PAYLOAD = {
+  system_prompt: VERSAO.system_prompt,
+  provider: "anthropic",
+  model: "claude-sonnet-5",
+  credential_id: CREDENCIAL,
+  tool_ids: [],
+  channel_session_id: CANAL,
+  max_steps: 10,
+  token_budget: 50000,
+  cost_budget_cents: 50,
+  history_message_window: 20,
+  history_token_window: 8000,
+  handoff_keywords: [],
+  handoff_tool_enabled: true,
+  cases_enabled: false,
+  split_messages: false,
+  split_max_chars: 600,
+  followup: { enabled: false, flow_pointer_ids: [] },
+  operator_enabled: false,
+  operator_model: null,
+  operator_tool_ids: [],
+  pipeline_ids: [],
+  knowledge_source_ids: [],
+};
+
+const CADASTRO_ATUAL = { id: AGENTE, kind: "mcp_agent", archived_at: null, name: "Recepção", description: "atende quem chega", priority: 3 };
+
+async function salvarNoServidor(cadastro: unknown, agente = CADASTRO_ATUAL) {
+  vi.mocked(createAdminClient).mockReturnValue(adminDuble(agente) as never);
+  const real = await vi.importActual<typeof import("@/app/app/ai/agents/[id]/_actions")>(
+    "@/app/app/ai/agents/[id]/_actions",
+  );
+  return (real.saveAgentDraftAction as (a: string, b: unknown, c: unknown) => Promise<unknown>)(
+    AGENTE,
+    VERSION_PAYLOAD,
+    cadastro,
+  );
+}
+
+describe("saveAgentDraftAction — o cadastro do agente", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cena.escopo = { ok: true };
+    gravado = { cadastro: null, filtros: [], versao: null };
+  });
+
+  it("grava nome, descrição e ordem em ai_agents, filtrando a organização", async () => {
+    const res = (await salvarNoServidor({
+      name: "Vitória",
+      description: "primeiro contato",
+      priority: 700,
+    })) as { ok: boolean };
+
+    expect(res.ok, JSON.stringify(res)).toBe(true);
+    expect(gravado.cadastro, "nada foi gravado no cadastro do agente").not.toBeNull();
+    expect(gravado.cadastro).toMatchObject({
+      name: "Vitória",
+      description: "primeiro contato",
+      priority: 700,
+    });
+    // Service role não tem RLS: o filtro de organização é manual e obrigatório.
+    expect(
+      gravado.filtros,
+      "UPDATE em ai_agents sem filtro de organização — service role bypassa RLS",
+    ).toContainEqual(["organization_id", ORG]);
+    expect(gravado.filtros).toContainEqual(["id", AGENTE]);
+    expect(vi.mocked(audit).mock.calls.map((c) => (c[0] as { action: string }).action)).toContain(
+      "ai_agent.updated",
+    );
+    // Sem isto, o cartão da lista segue mostrando o nome antigo — o mesmo
+    // sintoma do defeito, agora por cache.
+    expect(vi.mocked(revalidatePath).mock.calls.flat()).toContain("/app/ai/agents");
+  });
+
+  it("não escreve nada quando o escopo da versão é inválido", async () => {
+    // A ordem é o ponto: se o cadastro fosse gravado antes da validação de
+    // escopo, um escopo inválido devolveria erro com o nome JÁ trocado — a
+    // lista mostrando o novo e o editor o velho.
+    cena.escopo = { ok: false };
+    const res = (await salvarNoServidor({
+      name: "Vitória",
+      description: null,
+      priority: 700,
+    })) as { ok: boolean };
+
+    expect(res.ok).toBe(false);
+    expect(gravado.cadastro, "gravou o nome mesmo recusando o salvamento").toBeNull();
+    expect(gravado.versao).toBeNull();
+  });
+
+  it("recusa uma ordem de preferência fora de 0..1000", async () => {
+    const res = (await salvarNoServidor({
+      name: "Vitória",
+      description: null,
+      priority: 5000,
+    })) as { ok: boolean; error?: string };
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe("validation_failed");
+    expect(gravado.cadastro).toBeNull();
+  });
+
+  it("rodada que não mudou o cadastro não vira linha de auditoria", async () => {
+    const res = (await salvarNoServidor({
+      name: "Recepção",
+      description: "atende quem chega",
+      priority: 3,
+    })) as { ok: boolean };
+    expect(res.ok).toBe(true);
+    expect(gravado.cadastro, "gravou um UPDATE que não mudou nada").toBeNull();
+    expect(
+      vi.mocked(audit).mock.calls.map((c) => (c[0] as { action: string }).action),
+    ).not.toContain("ai_agent.updated");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. A CLASSE — nenhum campo do formulário fica de fora do envio
+// ---------------------------------------------------------------------------
+
+describe("todo campo do formulário viaja em algum payload", () => {
+  it("as chaves de FormState são cobertas pelos construtores do envio", () => {
+    const fonte = readFileSync(
+      join(process.cwd(), "app/app/ai/agents/[id]/_components/AgentForm.tsx"),
+      "utf8",
+    );
+
+    const bloco = (re: RegExp, rotulo: string) => {
+      const m = re.exec(fonte);
+      if (!m?.[1]) throw new Error(`não achei ${rotulo} em AgentForm.tsx`);
+      return m[1];
+    };
+
+    const estado = bloco(/interface FormState \{\n([\s\S]*?)\n\}/, "interface FormState");
+    const campos = [...estado.matchAll(/^ {2}(\w+)\??:/gm)].map((m) => m[1]!);
+    // Controle positivo: se a forma do arquivo mudar, esta sonda estoura em vez
+    // de devolver lista vazia e passar por vacuidade.
+    expect(campos.length, "não li os campos de FormState").toBeGreaterThan(20);
+
+    const enviados = new Set(
+      [...fonte.matchAll(/function to\w*Payload\(s: FormState\) \{\n([\s\S]*?)\n\}/g)]
+        .flatMap((m) => [...m[1]!.matchAll(/^ {4}(\w+):/gm)])
+        .map((m) => m[1]!),
+    );
+    expect(enviados.size, "não li nenhum construtor de payload").toBeGreaterThan(20);
+
+    const esquecidos = campos.filter((c) => !enviados.has(c));
+    expect(
+      esquecidos,
+      `estes campos são editáveis na tela e NENHUM payload os leva ao servidor: ${esquecidos.join(", ")}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #463

## O defeito

Em `/app/ai/agents/[id]`, editar o **Nome** não muda nada. Descrição e Ordem de preferência somem igual.

O que torna isso difícil de perceber é que **nada falha**: o campo aceita a digitação, a validação passa, o aviso verde diz `Rascunho vN salvo.` e a publicação responde com sucesso. Todas essas mensagens são **verdadeiras** — a respeito da **versão**, que é a única coisa realmente gravada.

Os três campos moram em `ai_agents`; `ai_agent_versions` não tem essas colunas. Em modo edição, `toVersionPayload()` era o **único** construtor do envio, e ele começa em `system_prompt`:

```ts
// AgentForm.tsx:381 — modo EDIÇÃO
const res = await saveAgentDraftAction(props.agent.id, toVersionPayload(form));
```

Em modo **criação** o nome viaja normalmente — por isso o defeito só aparece ao editar.

## O conserto, nas duas metades

**Tela** — `toCadastroPayload()`, um segundo construtor. Ele existe separado porque `versionCreateSchema` é `.strict()` e recusa esses campos **com razão**: eles não descrevem a versão. O que faltava era o segundo payload.

`""` na descrição vira `null` (apagar), não `undefined` (não mexi) — senão um campo esvaziado de propósito ressuscita o texto antigo.

**Servidor** — a action recebe o segundo payload, valida com `agentMcpPatchSchema` (**a régua que a rota REST já usa**; uma quarta régua para o mesmo campo é o defeito seguinte) e grava em `ai_agents` filtrando `organization_id` à mão, porque service role bypassa RLS.

## A ordem é parte do conserto

Tudo é validado **antes** de qualquer escrita. Se o cadastro fosse gravado antes de `validarEscopoDaVersao`, um escopo inválido devolveria erro **com o nome já trocado** — a lista mostrando o novo e o editor o velho.

E o UPDATE só sai quando algum campo mudou de verdade: auditar todo "Salvar rascunho" encheria `api_audit_log` de linha sem efeito — a mesma doutrina do `cron` que só audita quando houve efeito.

As duas escritas **não são atômicas**, e o desfecho diz o que gravou: se o cadastro falhar depois da versão, a mensagem é `O rascunho foi salvo, mas o cadastro do agente não: …`, nunca um verde genérico — que reproduziria o defeito com outra cara.

`revalidatePath("/app/ai/agents")` porque sem ele o cartão da lista segue com o nome antigo: mesmo sintoma, agora por cache.

## Contra a repetição

Um caso lê `AgentForm.tsx` e exige que **toda** chave de `FormState` apareça em algum construtor de payload. Com controle positivo: se a forma do arquivo mudar, a sonda estoura em vez de devolver lista vazia e passar por vacuidade.

## Prova

```console
$ npx vitest run tests/unit/editor-de-agente-salva-o-cadastro.test.tsx
  Tests  9 passed (9)
```

**Duas sabotagens**, uma por metade:

```
A) reverto só a TELA (servidor intacto) — previ 4-5, deu 5:
   × leva o nome novo ao servidor quando a pessoa salva o rascunho
   × leva também a descrição e a ordem de preferência
   × deixa apagar a descrição — vazio na tela é nulo no banco, não a antiga
   × recusa uma ordem de preferência fora de 0..1000 pela mesma régua do servidor
   × as chaves de FormState são cobertas pelos construtores do envio

B) reverto só o SERVIDOR (tela intacta) — previ 3-4, deu 2:
   × grava nome, descrição e ordem em ai_agents, filtrando a organização
   × recusa uma ordem de preferência fora de 0..1000
```

**A sabotagem B reprovou menos do que previ, e isso é um ponto cego que prefiro nomear.** Dois casos — "não escreve nada quando o escopo é inválido" e "rodada que não mudou o cadastro não vira linha de auditoria" — passam **por vacuidade** contra o servidor revertido: lá o cadastro nunca é gravado, então `gravado.cadastro === null` é trivialmente verdadeiro. Eles guardam **ordem** e **não-auditar-à-toa**, invariantes que só podem ser violados por uma implementação que já escreve. São guardas reais para o futuro, mas não discriminam o defeito de hoje — quem discrimina é o primeiro caso.

## Gates

```
pnpm typecheck   exit=0
pnpm lint        exit=0
vizinhos (editor + agentes + lib/ai/agents)   9 arquivos / 50 testes, exit=0
```

## O que NÃO fiz

**Não escrevi spec Playwright.** O DoD 12 pede prova pela tela, e o que tenho é um teste que renderiza o `AgentForm` de verdade e dispara os eventos reais (digitar, clicar em "Salvar rascunho") — mais forte que um unitário de função, mais fraco que a tela ponta a ponta com servidor de pé. Estou declarando isso em vez de marcar o item.

**Não toquei no `AgentEditor` legado** (`rag_bot`), que é outro editor com outro defeito — esse é o #456, e misturar os dois faria um PR em que a sabotagem de um esconde a do outro.

**A ordem de preferência não é validada em tempo real no `onChange`** — só na validação do formulário, que é onde o erro aparece embaixo do campo.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam
- [x] Service role com filtro de `organization_id` manual no UPDATE novo
- [x] Audit log emitido (`ai_agent.updated`), e só quando houve efeito
- [x] Zod valida o input novo (`agentMcpPatchSchema`, a mesma régua do REST)
- [x] Sem `console.log` esquecido
- [x] Fragmento em `.changes/` (`nada_mudou` / `corrigido`)
- [ ] Prova pela tela em Playwright: **não feita** — ver acima
- [ ] Schema: não toca

🤖 Generated with [Claude Code](https://claude.com/claude-code)