### PR TITLE
fix(ia): o prompt editado pela tela é o que o motor executa

### DIFF
--- a/.changes/o-prompt-que-voce-salva-e-o-que-o-agente-executa.md
+++ b/.changes/o-prompt-que-voce-salva-e-o-que-o-agente-executa.md
@@ -1,0 +1,22 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O prompt que você salva passa a ser o que o agente realmente executa
+---
+
+Editar as instruções de um agente **já publicado** e salvar mostrava o texto novo
+na tela — enquanto o agente continuava atendendo no WhatsApp com o texto
+anterior. Não havia erro, nem aviso: quem editava concluía que a mudança estava
+no ar, e ela não estava.
+
+A causa é que existem dois lugares onde as instruções podem morar: o cadastro do
+agente e a **versão publicada**. Quem atende o cliente é a versão. A tela mandava
+alguns agentes para o editor antigo, que grava no cadastro — o lugar que o
+atendimento não lê quando há versão publicada.
+
+Agora quem tem versão publicada é levado direto ao editor de versões, que grava
+onde o atendimento lê. E, se alguma outra ferramenta tentar mudar as instruções
+ou o modelo pelo caminho antigo, a resposta passa a ser um erro que explica o
+caminho certo, em vez de um sucesso que não teve efeito.
+
+Agente sem versão publicada continua exatamente como estava.

--- a/app/api/v1/ai/agents/[id]/route.ts
+++ b/app/api/v1/ai/agents/[id]/route.ts
@@ -128,6 +128,34 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
     return fail("not_found", "Agent não encontrado.", 404, { requestId });
   }
 
+  // ─── CONTEÚDO DE VERSÃO PUBLICADA NÃO SE EDITA PELO CADASTRO ───────────
+  //
+  // `system_prompt` e `model` existem nas DUAS tabelas. Quando há versão
+  // publicada, é a versão que o motor lê (`agent-config.ts:123`) — gravar em
+  // `ai_agents` devolvia 200, a tela mostrava o texto novo, e o agente seguia
+  // respondendo ao cliente com o prompt anterior. Sem erro em lugar nenhum.
+  //
+  // O banco já sabia disso: `fn_ai_agent_version_content_immutable` recusa
+  // mudar conteúdo de versão publicada com esta mesma frase. Faltava a rota
+  // seguir a mesma regra — falhar FECHADO, e ensinar o caminho.
+  //
+  // Sem versão publicada, `ai_agents.system_prompt` É a fonte legítima (é o que
+  // `workers/ai-response-worker.ts` lê), e continua editável. (issue #456)
+  const CONTEUDO_DA_VERSAO = ["system_prompt", "model"] as const;
+  if (existing.published_version_id != null) {
+    const barrados = CONTEUDO_DA_VERSAO.filter((c) => patch[c] !== undefined);
+    if (barrados.length > 0) {
+      return fail(
+        "state_conflict",
+        `Este agente tem uma versão publicada, e é ela que o atendimento executa. ` +
+          `Mudança de conteúdo (${barrados.join(", ")}) = versão draft nova; publica. ` +
+          `Edite pela aba Modelo do editor de versões.`,
+        409,
+        { requestId, details: { campos: barrados, published_version_id: existing.published_version_id } },
+      );
+    }
+  }
+
   // Build UPDATE payload. Para `config`, faz merge preservando defaults.
   const update: Record<string, unknown> = {};
 

--- a/app/app/ai/agents/[id]/page.tsx
+++ b/app/app/ai/agents/[id]/page.tsx
@@ -70,8 +70,16 @@ export default async function AgentEditorPage({
   const agent = agentRow as unknown as AgentRow;
   const readOnly = ROLE_RANK[activeOrg.role] < ROLE_RANK.admin;
 
-  // Caminho legado: rag_bot continua usando o editor pré-EPIC-13.
-  if ((agent.kind ?? "rag_bot") !== "mcp_agent") {
+  // Caminho legado: rag_bot SEM versão publicada continua no editor pré-EPIC-13.
+  //
+  // A segunda condição é o conserto da #456. A régua do runtime já está escrita
+  // em `lib/ai/agents/no-ar.ts`: `published_version_id != null` significa "no ar
+  // pela versão", e `kind` só decide quando NÃO há versão. Esta tela era o
+  // último lugar que perguntava `kind` primeiro — e por isso entregava ao dono
+  // um campo de prompt que grava em `ai_agents`, a coluna que o motor não lê
+  // quando existe versão publicada. Ele digitava, via sucesso, e o agente
+  // continuava respondendo com o texto anterior.
+  if ((agent.kind ?? "rag_bot") !== "mcp_agent" && agent.published_version_id == null) {
     return (
       <div className="flex h-full flex-col gap-6 p-6">
         <AgentEditorClient agentId={agent.id} initialData={agent} readOnly={readOnly} />

--- a/tests/unit/prompt-editado-e-o-que-o-motor-executa.test.ts
+++ b/tests/unit/prompt-editado-e-o-que-o-motor-executa.test.ts
@@ -1,0 +1,211 @@
+/**
+ * O PROMPT QUE A TELA SALVA É O QUE O MOTOR EXECUTA (issue #456).
+ *
+ * ─── O defeito, medido em c5b45b24 ──────────────────────────────────────────
+ *
+ * Editar o System Prompt de um agente JÁ PUBLICADO, salvar, e o texto aparece
+ * atualizado na tela — enquanto o agente continua respondendo no WhatsApp com o
+ * prompt anterior. Duas colunas divergem depois do Salvar:
+ *
+ *   ai_agents.system_prompt      -> atualizada com o texto novo
+ *   ai_agent_versions.system_prompt (na linha apontada por
+ *     ai_agents.published_version_id, que é a que o motor lê) -> intacta
+ *
+ * A causa NÃO é a hipotetizada na issue (`is_default`): é o `kind`. A cadeia:
+ *
+ *   page.tsx:74     if ((agent.kind ?? "rag_bot") !== "mcp_agent") -> editor legado
+ *   AgentEditor:83  patch.system_prompt = current.system_prompt
+ *   useAgent:65     PATCH /api/v1/ai/agents/:id
+ *   route.ts:135    update.system_prompt = patch.system_prompt   (em ai_agents)
+ *
+ * ─── Por que a régua certa é `published_version_id`, e não `kind` ───────────
+ *
+ * `lib/ai/agents/no-ar.ts` já decidiu isto para o RUNTIME, e escreveu por quê:
+ * `published_version_id != null` significa "no ar pela versão", e `kind` só
+ * entra quando NÃO há versão publicada. A tela era o único lugar que ainda
+ * perguntava `kind` primeiro — e por isso oferecia um campo que o motor ignora.
+ *
+ * O próprio banco já sabia: `fn_ai_agent_version_content_immutable` recusa
+ * mudar conteúdo de versão publicada com "mudança de conteúdo = versão draft
+ * nova; publica". A rota é que não seguia a mesma regra.
+ *
+ * ─── As duas metades, e por que uma sozinha não serve ───────────────────────
+ *
+ * A ROTA falhando fechada mata a divergência para todo chamador. Sozinha, ela
+ * deixaria quem tem versão publicada sem NENHUM caminho para editar o prompt —
+ * trocaria uma mentira por uma parede. Por isso a TELA passa a mandar quem tem
+ * versão publicada para o editor de versões, que grava onde o motor lê.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { requireRole } from "@/lib/auth/require-role";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+vi.mock("@/lib/auth/require-role", () => ({ requireRole: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
+vi.mock("@/lib/audit", () => ({ audit: vi.fn(async () => undefined) }));
+
+const ORG = "22222222-2222-4222-8222-222222222222";
+const AGENT = "55555555-5555-4555-8555-555555555555";
+const VERSAO = "99999999-9999-4999-8999-999999999999";
+const PROMPT_ANTIGO = "Você é o Tobias, atendente da loja.";
+
+/** O que foi efetivamente escrito em `ai_agents`. `null` = nada. */
+let gravado: Record<string, unknown> | null;
+
+function agente(over: Record<string, unknown> = {}) {
+  return {
+    id: AGENT,
+    organization_id: ORG,
+    name: "Tobias",
+    description: null,
+    model: "anthropic/claude-sonnet-4-6",
+    system_prompt: PROMPT_ANTIGO,
+    is_active: true,
+    is_default: true,
+    kind: "rag_bot",
+    priority: 0,
+    published_version_id: null,
+    archived_at: null,
+    config: {},
+    guardrails: [],
+    active_kb_version_id: null,
+    created_at: "2026-08-01T10:00:00Z",
+    updated_at: "2026-08-01T10:00:00Z",
+    ...over,
+  };
+}
+
+function admin(linha: Record<string, unknown>) {
+  const q = (op: "select" | "update", patch?: Record<string, unknown>) => {
+    const enc = {
+      select: () => enc,
+      eq: () => enc,
+      is: () => enc,
+      maybeSingle: async () => ({ data: linha, error: null }),
+      single: async () => {
+        if (op === "update") {
+          gravado = patch ?? {};
+          return { data: { ...linha, ...patch }, error: null };
+        }
+        return { data: linha, error: null };
+      },
+    };
+    return enc;
+  };
+  return {
+    from: () => ({
+      select: () => q("select"),
+      update: (patch: Record<string, unknown>) => q("update", patch),
+    }),
+  };
+}
+
+function autenticar() {
+  vi.mocked(requireRole).mockResolvedValue({
+    ok: true,
+    user: { id: "11111111-1111-4111-8111-111111111111" },
+    org: { orgId: ORG, name: "Org", role: "admin" as const },
+  } as never);
+}
+
+async function patch(corpo: Record<string, unknown>, linha: Record<string, unknown>) {
+  autenticar();
+  vi.mocked(createAdminClient).mockReturnValue(admin(linha) as never);
+  const { PATCH } = await import("@/app/api/v1/ai/agents/[id]/route");
+  const req = new NextRequest(`http://localhost/api/v1/ai/agents/${AGENT}`, {
+    method: "PATCH",
+    body: JSON.stringify(corpo),
+    headers: { "content-type": "application/json" },
+  });
+  const res = await PATCH(req, { params: Promise.resolve({ id: AGENT }) } as never);
+  return { status: res.status, corpo: await res.json() };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  gravado = null;
+});
+
+describe("PATCH /api/v1/ai/agents/:id — conteúdo de versão publicada não se edita pelo cadastro", () => {
+  it("⭐ recusa system_prompt quando o agente tem versão publicada", async () => {
+    const r = await patch(
+      { system_prompt: "Texto NOVO que o dono acredita ter publicado" },
+      agente({ published_version_id: VERSAO }),
+    );
+
+    // O que não pode acontecer é 200: a tela conclui "salvou" e o motor segue
+    // com o prompt anterior, sem erro em lugar nenhum.
+    expect(r.status).toBe(409);
+    expect(gravado, "gravou em ai_agents um prompt que o motor não lê").toBeNull();
+    // A mensagem tem de ENSINAR o caminho, e é a mesma frase que o trigger do
+    // banco já usa — duas frases diferentes para a mesma regra confundem.
+    expect(String(r.corpo.error.message)).toMatch(/vers/i);
+    expect(r.corpo.error.code).toBe("state_conflict");
+  });
+
+  it("recusa também o modelo — ele é conteúdo de versão do mesmo jeito", async () => {
+    const r = await patch(
+      { model: "anthropic/claude-haiku-4-5" },
+      agente({ published_version_id: VERSAO }),
+    );
+    expect(r.status, JSON.stringify(r.corpo)).toBe(409);
+    expect(gravado).toBeNull();
+  });
+
+  it("⭐ o rag_bot SEM versão publicada continua editando pelo cadastro", async () => {
+    // Aqui `ai_agents.system_prompt` É a fonte legítima: é o que
+    // `workers/ai-response-worker.ts` lê. Endurecer isto seria regressão na
+    // instalação nova, que é o estado mais comum do produto self-host.
+    const r = await patch({ system_prompt: "Texto novo do atendente, com pelo menos vinte caracteres." }, agente({ published_version_id: null }));
+
+    expect(r.status, JSON.stringify(r.corpo)).toBe(200);
+    expect(gravado).toMatchObject({ system_prompt: "Texto novo do atendente, com pelo menos vinte caracteres." });
+  });
+
+  it("o que NÃO é conteúdo de versão continua editável com versão publicada", async () => {
+    // Nome, descrição e ligar/desligar moram em `ai_agents` e não têm par na
+    // versão — recusá-los junto trocaria um defeito por outro.
+    const r = await patch(
+      { name: "Tobias II", is_active: false },
+      agente({ published_version_id: VERSAO }),
+    );
+
+    expect(r.status).toBe(200);
+    expect(gravado).toMatchObject({ name: "Tobias II", is_active: false });
+    expect(gravado).not.toHaveProperty("system_prompt");
+  });
+});
+
+describe("a TELA manda quem tem versão publicada para o editor que grava onde o motor lê", () => {
+  const fonte = readFileSync(
+    join(process.cwd(), "app/app/ai/agents/[id]/page.tsx"),
+    "utf8",
+  );
+
+  it("o instrumento está vivo: acha o desvio de editor (controle positivo)", () => {
+    // Sem isto, um arquivo reescrito faria as asserções abaixo passarem por
+    // vacuidade — procurando um trecho que não existe mais.
+    expect(fonte).toContain("AgentEditorClient");
+    expect(fonte).toContain('!== "mcp_agent"');
+  });
+
+  it("⭐ o desvio para o editor legado consulta published_version_id", () => {
+    // A régua do runtime (`lib/ai/agents/no-ar.ts`) é: versão publicada manda,
+    // e `kind` só decide quando NÃO há versão. A tela era o último lugar que
+    // perguntava `kind` primeiro — e por isso oferecia um campo decorativo.
+    // A condição contém parênteses (`agent.kind ?? "rag_bot"`), então recortar
+    // por `[^)]*` pararia no primeiro fecha — e devolveria string vazia, que
+    // passaria por vacuidade. Recorta-se a LINHA do desvio até o `{`.
+    const desvio = /if \(.*!== "mcp_agent".*\) \{/.exec(fonte)?.[0] ?? "";
+    expect(
+      desvio,
+      "o desvio de editor ignora published_version_id: agente publicado cai no editor legado, que grava em ai_agents — a coluna que o motor NÃO lê",
+    ).toContain("published_version_id");
+  });
+});


### PR DESCRIPTION
Closes #456

## O defeito

Editar o System Prompt de um agente **já publicado**, salvar, e o texto aparece atualizado na tela — enquanto o agente continua respondendo no WhatsApp com o prompt anterior. Sem erro, sem aviso.

```
ai_agents.system_prompt          -> atualizada com o texto novo
ai_agent_versions.system_prompt  -> intacta      (a linha apontada por
   ai_agents.published_version_id, que é a que o motor lê)
```

## A causa não é a que a issue supôs

A issue hipotetiza `is_default`. Medido em `c5b45b24`, o gatilho é o **`kind`**:

```
page.tsx:74     if ((agent.kind ?? "rag_bot") !== "mcp_agent")  -> editor legado
AgentEditor:83  patch.system_prompt = current.system_prompt
useAgent:65     PATCH /api/v1/ai/agents/:id
route.ts:135    update.system_prompt = patch.system_prompt      (em ai_agents)
```

## A régua certa já estava escrita — só não na tela

`lib/ai/agents/no-ar.ts` decidiu isto para o **runtime**, e escreveu por quê: `published_version_id != null` significa "no ar pela versão", e `kind` só entra quando **não** há versão publicada. Esta tela era o último lugar que perguntava `kind` primeiro — e por isso oferecia um campo que o motor ignora.

O banco também já sabia. `fn_ai_agent_version_content_immutable` recusa mudar conteúdo de versão publicada com *"mudança de conteúdo = versão draft nova; publica"* — foi exatamente o que o autor da issue encontrou ao tentar corrigir por SQL e ser **corretamente** recusado. O produto já tinha a regra; faltava a rota segui-la.

## As duas metades, e por que uma sozinha não serve

**Rota** — `system_prompt` e `model` viram **409** quando há versão publicada, com a **mesma frase** do trigger (duas frases diferentes para a mesma regra confundem) e o caminho: *"Edite pela aba Modelo do editor de versões"*. Falhar fechado mata a divergência para **todo** chamador, não só para esta tela.

Sozinha, ela deixaria quem tem versão publicada sem **nenhum** caminho para editar o prompt — trocaria uma mentira por uma parede.

**Tela** — o desvio para o editor legado passa a exigir `published_version_id == null`. Quem tem versão publicada cai no editor de versões, que grava onde o motor lê.

## O que continua igual, de propósito

- **`rag_bot` sem versão publicada** segue editando pelo cadastro: ali `ai_agents.system_prompt` **é** a fonte legítima — é o que `workers/ai-response-worker.ts` lê. Endurecer isso seria regressão na instalação nova, que é o estado mais comum do produto self-host.
- **Nome, descrição e ligar/desligar** continuam editáveis com versão publicada. Eles não têm par na versão; recusá-los junto trocaria um defeito por outro.

## Prova

```console
$ npx vitest run tests/unit/prompt-editado-e-o-que-o-motor-executa.test.ts
  Tests  6 passed (6)
```

**Duas sabotagens**, uma por metade — previ 2 e 1, deu 2 e 1:

```
A) reverto só a ROTA:
   × recusa system_prompt quando o agente tem versão publicada
   × recusa também o modelo — ele é conteúdo de versão do mesmo jeito

B) reverto só a TELA:
   × o desvio para o editor legado consulta published_version_id
```

O guarda da tela tem controle positivo (exige achar `AgentEditorClient` e `!== "mcp_agent"` no arquivo), porque um recorte que parasse de casar devolveria string vazia e passaria por vacuidade. A primeira versão dele fazia exatamente isso — o recorte por `[^)]*` parava no `)` de `agent.kind ?? "rag_bot"` — e o controle é o que expôs.

## Gates

```
pnpm typecheck   exit=0
pnpm lint        exit=0
vizinhos (rota de agentes + lib/ai/agents + editor)   5 arquivos / 25 testes, exit=0
```

## O que NÃO fiz

**Não escrevi spec Playwright.** O desvio vive num Server Component; o guarda que tenho lê a condição no fonte, com controle positivo. É mais fraco que a tela de pé, e estou declarando em vez de marcar o item do DoD 12.

**Não verifiquei em ambiente real que um `rag_bot` com versão publicada renderiza bem no `AgentForm`.** Os `fetch` de versões/credenciais/canais já rodam depois do desvio, então os dados chegam — mas o par (`kind = rag_bot`, versão publicada) é raro e não tenho instalação com ele para abrir a tela. É o risco conhecido deste PR, e o motivo de a rota falhar fechada **de qualquer jeito**: mesmo que a tela erre, o dado errado não é gravado.

**Não desabilitei o campo no editor legado** para o caso acima — com o desvio novo ele não é mais alcançado por agente publicado, e uma segunda defesa no componente seria código sem chamador.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam
- [x] Zod valida o input externo (o schema já existia; a guarda nova roda depois dele)
- [x] Sem `console.log` esquecido
- [x] Fragmento em `.changes/` (`nada_mudou` / `corrigido`)
- [ ] Prova pela tela em Playwright: **não feita** — ver acima
- [ ] Schema: não toca

🤖 Generated with [Claude Code](https://claude.com/claude-code)