### PR TITLE
fix(inbox): a busca acha pelo nome e pelo telefone do contato

### DIFF
--- a/.changes/a-busca-do-inbox-acha-pelo-nome-do-cliente.md
+++ b/.changes/a-busca-do-inbox-acha-pelo-nome-do-cliente.md
@@ -1,0 +1,19 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A busca do Inbox passa a achar pelo nome e pelo telefone do cliente
+---
+
+Digitar o nome de um cliente na caixa de busca do Inbox não trazia a conversa
+dele — a busca olhava só o texto das mensagens. Na prática, achar uma conversa
+pelo nome só funcionava por acidente: se o nome tivesse sido escrito dentro de
+alguma mensagem.
+
+Para quem atende, procurar pelo nome é o caso mais comum — bem mais frequente
+que lembrar um trecho exato de mensagem. E com alguns milhares de contatos
+importados, a única alternativa era rolar a lista.
+
+Agora a busca cobre nome, telefone e o texto das mensagens ao mesmo tempo. O
+campo passa a dizer isso, em vez de prometer só mensagens.
+
+Contato anonimizado continua fora da busca por nome — anonimizar é definitivo.

--- a/app/api/v1/conversations/_handler.ts
+++ b/app/api/v1/conversations/_handler.ts
@@ -145,7 +145,52 @@ export async function listConversationsHandler(
 
   if (q.search) {
     const s = q.search.trim().replace(/[%_]/g, (m) => `\\${m}`);
-    query = query.ilike("last_message_preview", `%${s}%`);
+
+    // ─── A BUSCA ALCANÇA O CONTATO, NÃO SÓ A ÚLTIMA MENSAGEM ──────────────
+    //
+    // Aqui havia só o `ilike` em `last_message_preview`. Para um atendente,
+    // achar a conversa pelo NOME do cliente é o caso mais comum — bem mais que
+    // lembrar um trecho literal de mensagem —, e com milhares de contatos
+    // importados a única saída era rolar a lista. (issue #341)
+    //
+    // Dois passos, e não um `!inner` no embed do contato: transformar o embed
+    // em inner mudaria a semântica da LISTA inteira (conversa sem contato
+    // sumiria da caixa). A consulta curta abaixo devolve ids e o predicado os
+    // soma ao casamento por conteúdo, que continua valendo.
+    const somenteDigitos = s.replace(/\D/g, "");
+    // 4 dígitos é o piso: "12" casaria metade da base e devolveria a lista
+    // inteira embaralhada — pior que não achar, porque PARECE que funcionou.
+    const pareceTelefone = somenteDigitos.length >= 4;
+
+    const camposDoContato = [
+      `display_name.ilike.*${s}*`,
+      `name.ilike.*${s}*`,
+      ...(pareceTelefone ? [`phone_number.ilike.*${somenteDigitos}*`] : []),
+    ].join(",");
+
+    const { data: contatos } = await supabase
+      .from("contacts")
+      .select("id")
+      // Service role bypassa RLS: o filtro de organização é manual e obrigatório.
+      .eq("organization_id", ctx.organization_id)
+      // Anonimizar é direito do titular. Voltar a encontrá-lo pelo nome antigo
+      // criaria um vazamento onde não havia.
+      .eq("is_anonymized", false)
+      .or(camposDoContato)
+      // Teto obrigatório: a lista de ids viaja na URL do PostgREST, e uma busca
+      // por "a" sem limite estoura a requisição.
+      .limit(200);
+
+    const ids = (contatos ?? []).map((c) => (c as { id: string }).id);
+    if (ids.length > 0) {
+      query = query.or(
+        `last_message_preview.ilike.*${s}*,contact_id.in.(${ids.join(",")})`,
+      );
+    } else {
+      // Sem ids casados, um `contact_id.in.()` vazio é SQL inválido no
+      // PostgREST — a busca por conteúdo segue sozinha, como antes.
+      query = query.ilike("last_message_preview", `%${s}%`);
+    }
   }
 
   if (q.cursor) {

--- a/components/inbox/InboxFilters.tsx
+++ b/components/inbox/InboxFilters.tsx
@@ -116,7 +116,7 @@ export function InboxFilters({ value, onChange }: Props) {
         <Input
           value={searchInput}
           onChange={(e) => setSearchInput(e.target.value)}
-          placeholder={t("Buscar mensagens…")}
+          placeholder={t("Buscar por nome, telefone ou mensagem…")}
           className="h-8 pl-8 text-sm"
           aria-label={t("Buscar conversas")}
         />

--- a/lib/i18n/dicionario.ts
+++ b/lib/i18n/dicionario.ts
@@ -79,6 +79,9 @@ export const DICIONARIO: Traducoes = {
   Buscar: { es: "Buscar" },
 
   // ─── Inbox: filtros e lista ───
+  "Buscar por nome, telefone ou mensagem…": {
+    es: "Buscar por nombre, teléfono o mensaje…",
+  },
   "Buscar mensagens…": { es: "Buscar mensajes…" },
   "Todos os números": { es: "Todos los números" },
   "Todas as tags": { es: "Todas las etiquetas" },

--- a/tests/unit/inbox-busca-acha-pelo-contato.test.ts
+++ b/tests/unit/inbox-busca-acha-pelo-contato.test.ts
@@ -1,0 +1,182 @@
+/**
+ * A BUSCA DO INBOX ACHA PELO NOME E PELO TELEFONE DO CONTATO (issue #341).
+ *
+ * ─── O defeito, medido em c5b45b24 ──────────────────────────────────────────
+ *
+ * `app/api/v1/conversations/_handler.ts:146` filtrava só o corpo da mensagem:
+ *
+ *     if (q.search) {
+ *       const s = q.search.trim().replace(/[%_]/g, (m) => `\\${m}`);
+ *       query = query.ilike("last_message_preview", `%${s}%`);
+ *     }
+ *
+ * Sonda por qualquer predicado que alcance o contato — só o keyset do cursor
+ * aparece. CONTROLE POSITIVO: `grep contacts` no mesmo arquivo ACHA a linha 28,
+ * onde o contato é EMBUTIDO no select. Ou seja, o contato está ali e nenhum
+ * filtro casa contra ele — a ausência é real, não sonda cega.
+ *
+ * Pior: nem o corpo inteiro é buscado. `last_message_preview` é só a ÚLTIMA
+ * mensagem da conversa, então "busca por conteúdo" já era menos do que promete.
+ *
+ * Para um atendente, achar a conversa pelo nome do cliente é o caso mais comum —
+ * bem mais que lembrar um trecho literal de mensagem. Com milhares de contatos
+ * importados, sem isso a única saída é rolar a lista.
+ *
+ * ─── Por que dois passos, e não um join ─────────────────────────────────────
+ *
+ * O PostgREST não filtra por coluna de tabela embutida sem transformar o
+ * embed em `!inner`, o que mudaria a semântica da lista inteira (conversa sem
+ * contato sumiria). Dois passos preservam isso: uma consulta curta em
+ * `contacts` da MESMA organização devolve ids, e o predicado vira
+ * `or(preview.ilike, contact_id.in.(...))`.
+ *
+ * O teto de ids é obrigatório, não zelo: a lista viaja na URL do PostgREST, e
+ * uma busca por "a" sem limite estoura a requisição.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { listConversationsHandler } from "@/app/api/v1/conversations/_handler";
+
+interface Chamada {
+  tabela: string;
+  metodo: string;
+  args: unknown[];
+}
+
+/**
+ * Dublê que registra a cadeia POR TABELA. Registrar sem a tabela não serviria:
+ * metade do conserto é a consulta NOVA em `contacts`, e um registro achatado não
+ * distinguiria um `ilike` lá de um `ilike` em `conversations`.
+ */
+function fakeSupabase(contatosEncontrados: Array<{ id: string }>) {
+  const chamadas: Chamada[] = [];
+  const client = {
+    from: (tabela: string) => {
+      const proxy: Record<string, unknown> = new Proxy(
+        {},
+        {
+          get(_t, prop) {
+            if (prop === "then") {
+              return (ok: (v: unknown) => unknown) =>
+                ok({ data: tabela === "contacts" ? contatosEncontrados : [], error: null });
+            }
+            return (...args: unknown[]) => {
+              chamadas.push({ tabela, metodo: String(prop), args });
+              return proxy;
+            };
+          },
+        },
+      );
+      return proxy;
+    },
+  };
+  return { client: client as never, chamadas };
+}
+
+const ctx = {
+  organization_id: "org-1",
+  requestId: "req-1",
+  actor: { type: "user" as const, id: "user-1" },
+} as never;
+
+async function buscar(search: string, contatos: Array<{ id: string }> = []) {
+  const { client, chamadas } = fakeSupabase(contatos);
+  await listConversationsHandler(client, ctx, { limit: 50, search } as never);
+  return chamadas;
+}
+
+/** Todos os argumentos de string entregues a um método, numa tabela. */
+const args = (c: Chamada[], tabela: string, metodo: string) =>
+  c.filter((x) => x.tabela === tabela && x.metodo === metodo).flatMap((x) => x.args).join(" | ");
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("busca do inbox — o contato entra no predicado", () => {
+  it("⭐ o nome do cliente encontra a conversa, mesmo sem aparecer em mensagem nenhuma", async () => {
+    const c = await buscar("Maria", [{ id: "contato-maria" }]);
+
+    // 1ª metade: a consulta em contacts existe, é da MESMA organização, e casa
+    // os dois campos de nome (o produto usa `display_name` e `name`).
+    const nomes = args(c, "contacts", "or");
+    expect(nomes, "nenhuma consulta em contacts: a busca segue cega ao nome").toContain(
+      "display_name",
+    );
+    expect(nomes).toContain("name");
+    expect(
+      args(c, "contacts", "eq"),
+      "consulta em contacts sem filtro de organização — service role bypassa RLS",
+    ).toContain("org-1");
+    expect(
+      c.some((x) => x.tabela === "contacts" && x.metodo === "limit"),
+      "consulta em contacts sem teto: a lista de ids viaja na URL e uma busca por 'a' estoura a requisição",
+    ).toBe(true);
+
+    // 2ª metade: os ids achados entram no predicado da lista, SEM perder o
+    // casamento por conteúdo — quem busca um trecho de mensagem continua achando.
+    const filtro = args(c, "conversations", "or");
+    expect(filtro, "os ids do contato não chegaram ao predicado da lista").toContain(
+      "contato-maria",
+    );
+    expect(filtro, "a busca por conteúdo foi perdida no caminho").toContain(
+      "last_message_preview",
+    );
+  });
+
+  it("⭐ contato anonimizado não volta a ser encontrável pelo nome antigo", async () => {
+    // A anonimização é direito do titular. Se a busca voltasse a achá-lo pelo
+    // nome, o conserto criaria um vazamento onde não havia.
+    const c = await buscar("Maria", [{ id: "contato-maria" }]);
+    const filtros = c.filter((x) => x.tabela === "contacts");
+    const texto = JSON.stringify(filtros);
+    expect(texto, "a varredura de nome não exclui contato anonimizado").toContain(
+      "is_anonymized",
+    );
+  });
+
+  it("telefone com dígitos suficientes também procura o número", async () => {
+    const c = await buscar("991234567", [{ id: "contato-tel" }]);
+    expect(args(c, "contacts", "or")).toContain("phone_number");
+  });
+
+  it("termo curto de dígitos não vira busca de telefone", async () => {
+    // "12" casaria metade da base e devolveria a lista inteira embaralhada —
+    // pior que não achar, porque parece que a busca funcionou.
+    const c = await buscar("12", []);
+    expect(args(c, "contacts", "or")).not.toContain("phone_number");
+  });
+
+  it("sem contato casado, a busca por conteúdo continua funcionando sozinha", async () => {
+    const c = await buscar("orçamento", []);
+    const conv = c.filter((x) => x.tabela === "conversations");
+    const texto = JSON.stringify(conv);
+    expect(texto).toContain("last_message_preview");
+    // Sem ids, um `contact_id.in.()` vazio viraria SQL inválido no PostgREST.
+    expect(texto, "montou um `in` vazio, que o PostgREST recusa").not.toContain("contact_id.in.()");
+  });
+
+  it("sem termo de busca, nada de contatos é consultado", async () => {
+    const { client, chamadas } = fakeSupabase([]);
+    await listConversationsHandler(client, ctx, { limit: 50 } as never);
+    expect(
+      chamadas.filter((x) => x.tabela === "contacts"),
+      "consultou contatos sem ninguém ter buscado — uma ida ao banco por listagem",
+    ).toEqual([]);
+  });
+});
+
+describe("a tela promete o que a busca entrega", () => {
+  it("o campo não diz mais 'Buscar mensagens'", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const fonte = readFileSync(
+      join(process.cwd(), "components/inbox/InboxFilters.tsx"),
+      "utf8",
+    );
+    // Controle positivo: a sonda tem de achar o placeholder onde ele está.
+    expect(fonte).toContain("placeholder=");
+    expect(
+      /Buscar mensagens/.test(fonte),
+      "o campo promete só mensagens enquanto a busca já cobre nome e telefone",
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #341

## O defeito

`app/api/v1/conversations/_handler.ts:146` filtrava só o corpo da mensagem:

```ts
if (q.search) {
  const s = q.search.trim().replace(/[%_]/g, (m) => `\\${m}`);
  query = query.ilike("last_message_preview", `%${s}%`);
}
```

Sonda por qualquer predicado que alcance o contato — só o keyset do cursor aparece. **Controle positivo:** `grep contacts` no mesmo arquivo **acha** a linha 28, onde o contato é *embutido* no select. O contato está ali e nenhum filtro casa contra ele: a ausência é real, não sonda cega.

Para quem atende, achar a conversa pelo nome do cliente é o caso mais comum — bem mais que lembrar um trecho literal de mensagem. Com milhares de contatos importados, a única saída era rolar a lista.

## Dois passos, e não um `!inner`

Transformar o embed do contato em `!inner` mudaria a semântica da **lista inteira**: conversa sem contato sumiria da caixa. Então uma consulta curta em `contacts` da mesma organização devolve ids, e o predicado vira `or(last_message_preview.ilike, contact_id.in.(...))` — o casamento por conteúdo continua valendo.

## Quatro decisões, e o teste prende as quatro

- **filtro de `organization_id` manual** na consulta nova — service role bypassa RLS;
- **`is_anonymized = false`** — anonimizar é direito do titular; voltar a encontrá-lo pelo nome antigo criaria um vazamento onde não havia;
- **teto de 200 ids** — a lista viaja na URL do PostgREST, e uma busca por `"a"` sem limite estoura a requisição;
- **piso de 4 dígitos** para procurar telefone — `"12"` casaria metade da base e devolveria a lista embaralhada, que é **pior** que não achar, porque parece que funcionou.

Sem ids casados, o caminho volta ao `ilike` sozinho: um `contact_id.in.()` vazio é SQL inválido no PostgREST.

O placeholder deixa de dizer `"Buscar mensagens…"` — o campo prometia menos do que agora entrega, e controle que promete errado é o defeito de novo.

## Prova

O dublê registra a cadeia **por tabela**. Isso é o ponto: um registro achatado não distinguiria um `ilike` em `contacts` de um `ilike` em `conversations`, e metade do conserto é a consulta nova.

```console
$ npx vitest run tests/unit/inbox-busca-acha-pelo-contato.test.ts
  Tests  7 passed (7)
```

**Duas sabotagens** — previ 3 e 1, deu 3 e 1:

```
A) reverto o handler (placeholder intacto):
   × o nome do cliente encontra a conversa, mesmo sem aparecer em mensagem nenhuma
   × contato anonimizado não volta a ser encontrável pelo nome antigo
   × telefone com dígitos suficientes também procura o número

B) troco o piso de 4 dígitos por 1:
   × termo curto de dígitos não vira busca de telefone
```

## Gates

```
pnpm typecheck   exit=0
pnpm lint        exit=0
pnpm test:unit   617 arquivos / 6813 testes, exit=0   (suíte COMPLETA, não só vizinhos)
```

A suíte completa pegou algo que os vizinhos não pegariam: a string nova do placeholder passa por `t()` e reprovava `i18n-espanhol-cobre-a-tela`. Está traduzida.

## O que NÃO fiz

**Não escrevi spec Playwright.** O DoD 12 pede prova pela tela e eu não a tenho — o teste dirige o handler, não o navegador. Estou declarando em vez de marcar o item. A spec natural seria semear um contato cujo nome não aparece em mensagem nenhuma e digitar o nome na caixa.

**Não indexei nada.** `ILIKE %x%` em `name`/`phone_number` é seq scan; em base de milhares é aceitável, em dezenas de milhares pede `pg_trgm` GIN — e aí vira mudança de schema (migration + apêndice no baseline + MANIFEST), que é outro PR com outra prova.

**A busca por conteúdo continua limitada a `last_message_preview`**, ou seja, à ÚLTIMA mensagem da conversa — a caixa nunca buscou o histórico inteiro. Este PR não piora nem melhora isso, mas vale dizer: o campo ainda promete mais do que entrega nessa dimensão.

**Busca + paginação:** já existe um `.or()` no mesmo query (o keyset do cursor). Dois `.or()` no PostgREST viram `AND` entre eles, que é o desejado — mas não escrevi caso para a página 2 de uma busca.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam (suíte completa)
- [x] Service role com filtro de `organization_id` manual na consulta nova
- [x] Sem `console.log` esquecido
- [x] Fragmento em `.changes/` (`nada_mudou` / `corrigido`)
- [ ] Prova pela tela em Playwright: **não feita** — ver acima
- [ ] Schema: não toca

🤖 Generated with [Claude Code](https://claude.com/claude-code)