### PR TITLE
fix(waha): toda chamada ao WAHA ganha teto de relógio

### DIFF
--- a/.changes/o-whatsapp-fora-do-ar-nao-pendura-mais-a-tela.md
+++ b/.changes/o-whatsapp-fora-do-ar-nao-pendura-mais-a-tela.md
@@ -1,0 +1,22 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Um WhatsApp fora do ar deixa de pendurar a tela até o navegador desistir
+---
+
+Quando o serviço que conversa com o WhatsApp fica indisponível, o CRM ficava
+esperando por ele sem limite. A tela de conexão girava, o envio não voltava, e o
+único desfecho era o navegador ou o servidor desistirem sozinhos, minutos depois
+e sem explicação.
+
+O caso ruim não é o serviço recusar a conexão — isso já dava erro na hora. É o
+serviço aceitar e nunca responder, que é o que acontece quando ele está
+sobrecarregado ou travando: dali não vinha erro nenhum, só espera.
+
+Agora toda conversa com esse serviço tem prazo. Passou do prazo, o CRM desiste e
+diz que foi o tempo — em vez de deixar você olhando para uma tela parada sem
+saber se funcionou.
+
+Envio de áudio e vídeo tem prazo maior, de propósito: eles são convertidos antes
+de sair, e cortá-los no mesmo tempo de uma mensagem de texto faria mensagem
+legítima deixar de ser enviada.

--- a/lib/waha/client.test.ts
+++ b/lib/waha/client.test.ts
@@ -1,0 +1,167 @@
+/**
+ * TODA CHAMADA AO WAHA TEM TETO DE RELÓGIO (issue #470).
+ *
+ * ─── O defeito, medido em c5b45b24 ──────────────────────────────────────────
+ *
+ *     $ grep -cE "AbortController|AbortSignal|setTimeout" lib/waha/client.ts
+ *     0
+ *     $ grep -c "fetch(" lib/waha/client.ts
+ *     14
+ *
+ * CONTROLE POSITIVO (a mesma sonda, em arquivos que TÊM teto):
+ *     lib/messaging/media/waha-source.ts:37   signal: AbortSignal.timeout(...)
+ *     lib/automation/actions/call-webhook.ts:121  signal: AbortSignal.timeout(...)
+ *
+ * O WAHA é dependência externa e cai. Sem teto, uma Server Action ou rota fica
+ * presa até o limite do runtime.
+ *
+ * ─── Por que o dublê é um socket que ACEITA E NÃO RESPONDE ──────────────────
+ *
+ * Recusa imediata (porta fechada) e aceita-e-cala dão desfechos OPOSTOS: a
+ * primeira devolve `ECONNREFUSED` na hora e nenhum teto é exercitado — um teste
+ * contra porta fechada fica verde com o defeito inteiro no lugar. É o segundo
+ * caso que pendura o processo, e é o único que mede o conserto.
+ *
+ * ─── Dois tetos, e por que um só não serve ──────────────────────────────────
+ *
+ * `lib/waha/media-send.ts:28,31` manda `convert: true` em `sendVideo` e
+ * `sendVoice`: o WAHA roda ffmpeg e BAIXA a URL do Storage antes de responder.
+ * Um teto único calibrado para `sendText` cortaria envio de áudio legítimo — o
+ * conserto viraria um defeito novo, e mais difícil de ver que o original.
+ */
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { TETO_PADRAO_MS, TETO_DE_MIDIA_MS, WahaClient } from "./client";
+
+/** Sockets aceitos e deixados pendurados — o modo de falha caro. */
+let mudo: Server;
+let urlMudo = "";
+/** Responde, mas devagar: separa o teto padrão do teto da mídia. */
+let lento: Server;
+let urlLento = "";
+const ATRASO_DO_LENTO_MS = 400;
+
+beforeAll(async () => {
+  mudo = createServer(() => {
+    /* aceita a conexão e NUNCA responde — de propósito */
+  });
+  lento = createServer((_req, res) => {
+    setTimeout(() => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ id: "ok" }));
+    }, ATRASO_DO_LENTO_MS);
+  });
+  await Promise.all([
+    new Promise<void>((r) => mudo.listen(0, "127.0.0.1", r)),
+    new Promise<void>((r) => lento.listen(0, "127.0.0.1", r)),
+  ]);
+  urlMudo = `http://127.0.0.1:${(mudo.address() as AddressInfo).port}`;
+  urlLento = `http://127.0.0.1:${(lento.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await Promise.all([
+    new Promise<void>((r) => mudo.close(() => r())),
+    new Promise<void>((r) => lento.close(() => r())),
+  ]);
+});
+
+/** Quanto tempo a promessa levou para rejeitar, e com qual mensagem. */
+async function medir(fn: () => Promise<unknown>): Promise<{ ms: number; erro: string }> {
+  const t0 = performance.now();
+  try {
+    await fn();
+    return { ms: performance.now() - t0, erro: "" };
+  } catch (e) {
+    return { ms: performance.now() - t0, erro: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+describe("as constantes de teto são as que a spec prescreve", () => {
+  it("o teto padrão é 15s — o número de docs/specs/03-spec-whatsapp-waha.md:636", () => {
+    // Não inventar 10s: a spec deste arquivo já prescreve `timeoutMs ?? 15_000`,
+    // e duas réguas para a mesma grandeza divergem na primeira mudança.
+    expect(TETO_PADRAO_MS).toBe(15_000);
+  });
+
+  it("o teto da mídia é MAIOR — `convert: true` faz o WAHA rodar ffmpeg antes de responder", () => {
+    // Sem esta diferença, o conserto do timeout cortaria envio de áudio
+    // legítimo: um defeito novo, e mais difícil de ver que o original.
+    expect(TETO_DE_MIDIA_MS).toBeGreaterThan(TETO_PADRAO_MS);
+  });
+});
+
+describe("socket que aceita e não responde — a chamada desiste, não pendura", () => {
+  const cliente = () => new WahaClient(urlMudo, "chave-de-teste");
+
+  it("⭐ sendMessage desiste dentro do teto", async () => {
+    // Teto de 250ms injetado: medir os 15s reais faria a suíte esperar 15s por
+    // caso. O que se prova aqui é que EXISTE teto e ele é respeitado.
+    const c = new WahaClient(urlMudo, "chave-de-teste", { tetoMs: 250 });
+    const { ms, erro } = await medir(() => c.sendMessage("sessao", "5511999@c.us", "oi"));
+    expect(erro, "a chamada não falhou — ficou pendurada até o timeout do vitest").not.toBe("");
+    expect(ms, `demorou ${Math.round(ms)}ms com teto de 250ms`).toBeLessThan(3_000);
+  });
+
+  it("startSession desiste dentro do teto", async () => {
+    const c = new WahaClient(urlMudo, "chave-de-teste", { tetoMs: 250 });
+    const { ms, erro } = await medir(() => c.startSession("sessao"));
+    expect(erro).not.toBe("");
+    expect(ms).toBeLessThan(3_000);
+  });
+
+  it("o erro DIZ que foi o relógio, e não se disfarça de recusa do WAHA", async () => {
+    // Sem isto, um estouro de teto vira "waha_start_undefined" no log e o
+    // diagnóstico começa procurando defeito de contrato.
+    const c = new WahaClient(urlMudo, "chave-de-teste", { tetoMs: 250 });
+    const { erro } = await medir(() => c.sendMessage("sessao", "5511999@c.us", "oi"));
+    expect(erro.toLowerCase()).toMatch(/timeout|tempo|abort/);
+  });
+
+  it("controle positivo: contra um servidor que RESPONDE, a mesma chamada passa", async () => {
+    // Sem este caso, um "conserto" que quebrasse toda chamada ao WAHA deixaria
+    // os casos acima verdes — eles só exigem que a promessa rejeite.
+    const c = new WahaClient(urlLento, "chave-de-teste", { tetoMs: 5_000 });
+    const { erro } = await medir(() => c.sendMessage("sessao", "5511999@c.us", "oi"));
+    expect(erro, "o cliente passou a falhar mesmo contra um WAHA saudável").toBe("");
+  });
+
+  it("o cliente sem opções usa o teto padrão, não fica sem teto", () => {
+    // A injeção existe para o teste. O caminho de produção é o construtor de
+    // dois argumentos, e é ele que precisa estar coberto.
+    const c = cliente() as unknown as { tetoMs: number };
+    expect(c.tetoMs).toBe(TETO_PADRAO_MS);
+  });
+});
+
+describe("a superfície inteira — nenhum fetch fica de fora", () => {
+  it("⭐ nenhum `fetch(` cru sobrou em lib/waha/client.ts", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const fonte = readFileSync(join(process.cwd(), "lib/waha/client.ts"), "utf8");
+
+    // Controle positivo: a sonda tem de achar o wrapper, senão o vazio abaixo
+    // seria "procurei errado" lido como "está tudo coberto".
+    expect(fonte, "o wrapper com teto não existe neste arquivo").toContain("fetchComTeto");
+
+    // O ÚNICO `fetch(` cru permitido é o de dentro do wrapper — e ele só é
+    // permitido porque carrega o sinal. Aceitar qualquer linha com "fetch" abriria
+    // a porta para o próximo call site sem teto passar despercebido.
+    const crus = fonte
+      .split("\n")
+      .map((l, i) => [i + 1, l] as const)
+      .filter(
+        ([, l]) =>
+          /(?<![\w.])fetch\(/.test(l) &&
+          !l.includes("fetchComTeto") &&
+          !l.includes("AbortSignal.timeout"),
+      );
+    expect(
+      crus.map(([n, l]) => `${n}: ${l.trim()}`),
+      "estas chamadas ao WAHA não têm teto de relógio — com o WAHA fora do ar elas penduram a requisição até o limite do runtime",
+    ).toEqual([]);
+  });
+});

--- a/lib/waha/client.ts
+++ b/lib/waha/client.ts
@@ -54,11 +54,73 @@ export const CONVERSAS_IGNORADAS = {
   groups: true,
 } as const;
 
+/**
+ * Teto de relógio das chamadas ao WAHA.
+ *
+ * 15s não é número escolhido aqui: é o que `docs/specs/03-spec-whatsapp-waha.md`
+ * já prescrevia na linha 636 (`timeoutMs: cfg?.timeoutMs ?? 15_000`). Duas
+ * réguas para a mesma grandeza divergem na primeira mudança.
+ *
+ * O WAHA é dependência externa e cai. O modo de falha caro não é a recusa
+ * imediata — essa devolve `ECONNREFUSED` na hora — é o socket que ACEITA e não
+ * responde: sem teto, a Server Action ou a rota fica presa até o limite do
+ * runtime. (issue #470)
+ */
+export const TETO_PADRAO_MS = 15_000;
+
+/**
+ * Mídia tem teto MAIOR, e por um motivo medível: `lib/waha/media-send.ts:28,31`
+ * manda `convert: true` em `sendVideo` e `sendVoice`. O WAHA roda ffmpeg e BAIXA
+ * a URL do Storage antes de responder.
+ *
+ * Um teto único calibrado para `sendText` cortaria envio de áudio legítimo — o
+ * conserto do timeout viraria um defeito novo, e mais difícil de ver que o
+ * original, porque a mensagem simplesmente não sai.
+ *
+ * 30s é o mesmo teto que a mídia de ENTRADA já usa
+ * (`lib/messaging/media/waha-source.ts:18`).
+ */
+export const TETO_DE_MIDIA_MS = 30_000;
+
+export interface WahaClientOpts {
+  /** Sobrescreve o teto padrão. Existe para o teste; produção usa o default. */
+  tetoMs?: number;
+}
+
 export class WahaClient {
+  private readonly tetoMs: number;
+
   constructor(
     private readonly baseUrl: string,
     private readonly apiKey: string,
-  ) {}
+    opts: WahaClientOpts = {},
+  ) {
+    this.tetoMs = opts.tetoMs ?? TETO_PADRAO_MS;
+  }
+
+  /**
+   * `fetch` com teto, e com erro que DIZ que foi o relógio.
+   *
+   * Sem a segunda parte, um estouro de teto chega ao log como um erro de rede
+   * genérico e o diagnóstico começa procurando defeito de contrato — que é o
+   * caminho mais caro possível para "a dependência externa não respondeu".
+   */
+  private async fetchComTeto(
+    url: string | URL,
+    init: RequestInit,
+    tetoMs?: number,
+  ): Promise<Response> {
+    const teto = tetoMs ?? this.tetoMs;
+    try {
+      return await fetch(url, { ...init, signal: AbortSignal.timeout(teto) });
+    } catch (e) {
+      const nome = e instanceof Error ? e.name : "";
+      if (nome === "TimeoutError" || nome === "AbortError") {
+        throw new Error(`waha_timeout: o WAHA não respondeu em ${teto}ms (${url})`);
+      }
+      throw e;
+    }
+  }
 
   /**
    * Idempotent: ensures session exists, then starts it.
@@ -68,7 +130,7 @@ export class WahaClient {
    */
   async startSession(name: string): Promise<{ qr?: string; status: string }> {
     // 1) Create session (ignore 422/409 = already exists)
-    const createRes = await fetch(`${this.baseUrl}/api/sessions`, {
+    const createRes = await this.fetchComTeto(`${this.baseUrl}/api/sessions`, {
       method: "POST",
       headers: { "X-Api-Key": this.apiKey, "Content-Type": "application/json" },
       body: JSON.stringify({ name, config: { ignore: CONVERSAS_IGNORADAS } }),
@@ -87,7 +149,7 @@ export class WahaClient {
     }
 
     // 2) Start session
-    const startRes = await fetch(
+    const startRes = await this.fetchComTeto(
       `${this.baseUrl}/api/sessions/${encodeURIComponent(name)}/start`,
       {
         method: "POST",
@@ -111,7 +173,7 @@ export class WahaClient {
    * are treated as success so callers can compose reconnect = stop + start.
    */
   async stopSession(name: string): Promise<void> {
-    const res = await fetch(
+    const res = await this.fetchComTeto(
       `${this.baseUrl}/api/sessions/${encodeURIComponent(name)}/stop`,
       {
         method: "POST",
@@ -139,7 +201,7 @@ export class WahaClient {
    * como sucesso — quem chama quer o efeito, não a transição.
    */
   async logoutSession(name: string): Promise<void> {
-    const res = await fetch(
+    const res = await this.fetchComTeto(
       `${this.baseUrl}/api/sessions/${encodeURIComponent(name)}/logout`,
       {
         method: "POST",
@@ -183,7 +245,7 @@ export class WahaClient {
   async convergirConfigDaSessao(name: string): Promise<void> {
     const url = `${this.baseUrl}/api/sessions/${encodeURIComponent(name)}`;
     try {
-      const atual = await fetch(url, { headers: { "X-Api-Key": this.apiKey } });
+      const atual = await this.fetchComTeto(url, { headers: { "X-Api-Key": this.apiKey } });
       if (!atual.ok) {
         logger.warn("[waha] não li a config da sessão; não vou reescrevê-la", {
           status: atual.status,
@@ -215,7 +277,7 @@ export class WahaClient {
         );
       if (jaConvergida) return;
 
-      const res = await fetch(url, {
+      const res = await this.fetchComTeto(url, {
         method: "PUT",
         headers: { "X-Api-Key": this.apiKey, "Content-Type": "application/json" },
         body: JSON.stringify({ name, config }),
@@ -240,7 +302,7 @@ export class WahaClient {
    * Idempotente pelo mesmo motivo do logout: 404 = já não existe = sucesso.
    */
   async deleteSession(name: string): Promise<void> {
-    const res = await fetch(
+    const res = await this.fetchComTeto(
       `${this.baseUrl}/api/sessions/${encodeURIComponent(name)}`,
       {
         method: "DELETE",
@@ -254,7 +316,7 @@ export class WahaClient {
   }
 
   async getSessionQr(name: string): Promise<{ qr?: string; status: string }> {
-    const res = await fetch(`${this.baseUrl}/api/sessions/${encodeURIComponent(name)}`, {
+    const res = await this.fetchComTeto(`${this.baseUrl}/api/sessions/${encodeURIComponent(name)}`, {
       headers: { "X-Api-Key": this.apiKey },
     });
     if (!res.ok) throw new Error(`waha_${res.status}`);
@@ -275,7 +337,7 @@ export class WahaClient {
    */
   async getProfilePictureUrl(session: string, chatId: string): Promise<string | null> {
     try {
-      const res = await fetch(
+      const res = await this.fetchComTeto(
         `${this.baseUrl}/api/contacts/profile-picture` +
           `?session=${encodeURIComponent(session)}&contactId=${encodeURIComponent(chatId)}`,
         { headers: { "X-Api-Key": this.apiKey } },
@@ -305,7 +367,7 @@ export class WahaClient {
    */
   async resolvePhoneForLid(session: string, lid: string): Promise<string | null> {
     try {
-      const res = await fetch(
+      const res = await this.fetchComTeto(
         `${this.baseUrl}/api/${encodeURIComponent(session)}/lids/${encodeURIComponent(lid)}`,
         { headers: { "X-Api-Key": this.apiKey } },
       );
@@ -352,7 +414,7 @@ export class WahaClient {
     text: string,
     replyTo?: string | null,
   ): Promise<unknown> {
-    const res = await fetch(`${this.baseUrl}/api/sendText`, {
+    const res = await this.fetchComTeto(`${this.baseUrl}/api/sendText`, {
       method: "POST",
       headers: {
         "X-Api-Key": this.apiKey,
@@ -377,7 +439,7 @@ export class WahaClient {
     const url = new URL(`${this.baseUrl}/api/contacts/check-exists`);
     url.searchParams.set("session", session);
     url.searchParams.set("phone", phoneDigits.replace(/\D/g, ""));
-    const res = await fetch(url, {
+    const res = await this.fetchComTeto(url, {
       headers: { "X-Api-Key": this.apiKey, Accept: "application/json" },
     });
     if (!res.ok) {
@@ -397,7 +459,7 @@ export class WahaClient {
       vcard: string;
     }>,
   ): Promise<unknown> {
-    const res = await fetch(`${this.baseUrl}/api/sendContactVcard`, {
+    const res = await this.fetchComTeto(`${this.baseUrl}/api/sendContactVcard`, {
       method: "POST",
       headers: {
         "X-Api-Key": this.apiKey,
@@ -417,11 +479,15 @@ export class WahaClient {
     chatId: string,
     plan: { endpoint: string; payload: Record<string, unknown> },
   ): Promise<unknown> {
-    const res = await fetch(`${this.baseUrl}/api/${plan.endpoint}`, {
+    // Teto MAIOR aqui: `media-send.ts` manda `convert: true` em vídeo e áudio, e
+    // o WAHA roda ffmpeg e baixa a URL do Storage antes de responder. Com o teto
+    // de texto, o envio de áudio legítimo seria cortado — o conserto do timeout
+    // viraria um defeito novo, e mais silencioso que o original.
+    const res = await this.fetchComTeto(`${this.baseUrl}/api/${plan.endpoint}`, {
       method: "POST",
       headers: { "X-Api-Key": this.apiKey, "Content-Type": "application/json" },
       body: JSON.stringify({ session, chatId, ...plan.payload }),
-    });
+    }, TETO_DE_MIDIA_MS);
     if (!res.ok) {
       const body = await res.text().catch(() => "");
       throw new Error(`waha_${res.status}: ${body.slice(0, 200)}`);


### PR DESCRIPTION
Closes #470

Crédito da observação original a @prevprocesso-maker (#465). Este PR não colhe o patch de lá — ele decide as três coisas que a issue deixou em aberto, e traz teste.

## O defeito

```console
$ grep -cE "AbortController|AbortSignal|setTimeout" lib/waha/client.ts
0
$ grep -c "fetch(" lib/waha/client.ts
14
```

**Controle positivo** — a mesma sonda, em arquivos que têm teto:

```
lib/messaging/media/waha-source.ts:37        AbortSignal.timeout(...)
lib/automation/actions/call-webhook.ts:121   AbortSignal.timeout(...)
```

O WAHA é dependência externa e cai. Sem teto, uma Server Action ou rota fica presa até o limite do runtime — e isso destoava da própria casa (mídia de entrada 30s, meta-cloud e zernio 15s, session-reconciler 15s/10s, call-webhook 10s, provider-validators 5s).

## As três decisões que a issue pedia

**1. O valor: 15s.** Não inventado — `docs/specs/03-spec-whatsapp-waha.md:636` já prescreve `timeoutMs ?? 15_000`. A proposta do #465 usava 10s; duas réguas para a mesma grandeza divergem na primeira mudança, então vale a que já está escrita.

**2. Mídia tem teto próprio e maior (30s).** `lib/waha/media-send.ts:28,31` manda `convert: true` em `sendVideo` e `sendVoice`: o WAHA roda ffmpeg e **baixa a URL do Storage** antes de responder. Um teto único calibrado para `sendText` cortaria envio de áudio legítimo — o conserto do timeout viraria um defeito novo, e **mais silencioso** que o original, porque a mensagem simplesmente não sai. 30s é o mesmo teto que a mídia de *entrada* já usa.

**3. O erro diz que foi o relógio:** `waha_timeout: o WAHA não respondeu em Nms (<url>)`. Sem isso, um estouro chega ao log como erro de rede genérico e o diagnóstico começa procurando defeito de contrato — o caminho mais caro possível para *"a dependência externa não respondeu"*.

## Por que o dublê é um socket que aceita e não responde

Recusa imediata (porta fechada) e aceita-e-cala dão desfechos **opostos**: a primeira devolve `ECONNREFUSED` na hora e **nenhum teto é exercitado** — um teste contra porta fechada fica verde com o defeito inteiro no lugar. É o socket mudo que pendura o processo, e é o único que mede o conserto.

Junto vai um **controle positivo** contra um servidor que responde: sem ele, um "conserto" que quebrasse toda chamada ao WAHA deixaria os outros casos verdes, porque eles só exigem que a promessa rejeite.

E uma varredura fecha a classe: nenhum `fetch(` cru pode sobrar no arquivo, com exceção do de dentro do wrapper — e ele só passa porque carrega o sinal. Aceitar qualquer linha com "fetch" abriria a porta para o próximo call site sem teto.

## Prova

```console
$ npx vitest run lib/waha/client.test.ts
  Tests  8 passed (8)
```

**Duas sabotagens** — previ 6 e 1, deu 6 e 1:

```
A) reverto lib/waha/client.ts:
   × o teto padrão é 15s — o número da spec
   × o teto da mídia é MAIOR
   × sendMessage desiste dentro do teto        (15004ms — pendurou até o timeout do vitest)
   × startSession desiste dentro do teto       (15005ms)
   × o erro DIZ que foi o relógio
   × nenhum `fetch(` cru sobrou em lib/waha/client.ts

B) igualo TETO_DE_MIDIA_MS ao teto padrão:
   × o teto da mídia é MAIOR — `convert: true` faz o WAHA rodar ffmpeg antes de responder
```

Os `15004ms` da sabotagem A são a assinatura do defeito: sem teto, a chamada não falha — ela **espera**.

## Gates

```
pnpm typecheck   exit=0
pnpm lint        exit=0
pnpm test:unit   617 arquivos / 6816 testes, exit=0   (suíte COMPLETA)
```

## O que NÃO fiz

**Não mexi nos `body.slice(0, 200)`.** O #465 os removia junto; é outro assunto, e mudaria o que `app/api/v1/onboarding/whatsapp/session/route.ts:173` casa por `includes("422")`/`includes("409")`.

**Não medi a latência real de `convert: true` contra um WAHA de pé.** Os 30s vêm do teto que a mídia de entrada já usa, não de medição do ffmpeg. É a única incógnita do PR: se um vídeo grande demorar mais que isso, o envio passa a falhar onde antes esperava. Considerei isso melhor que o estado atual (esperar para sempre), mas quem tiver um WAHA com vídeos grandes deveria confirmar.

**Não criei env nova.** Um `WAHA_REQUEST_TIMEOUT_MS` no `.env` faria toda instalação existente precisar decidir um número; o default vem da spec e o único ajuste hoje é por código.

**Não estendi a guarda a `lib/channels/**`.** Um gate genérico exigindo `AbortSignal` em todo fetch de canal nasceria vermelho contra a `main` — é dívida a congelar em issue própria, não a empurrar junto de um conserto.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam (suíte completa)
- [x] Sem `console.log` esquecido
- [x] Env vars novas: **nenhuma** (o default vem da spec)
- [x] Fragmento em `.changes/` (`nada_mudou` / `corrigido`)
- [ ] Schema: não toca

🤖 Generated with [Claude Code](https://claude.com/claude-code)