### PR TITLE
fix(onboarding): renderiza o QR code no passo de conectar o WhatsApp

### DIFF
--- a/app/onboarding/connect-whatsapp/_client.tsx
+++ b/app/onboarding/connect-whatsapp/_client.tsx
@@ -475,6 +475,19 @@ export function ConnectWhatsappClient({
             </div>
           )}
 
+          {showQr && (
+            <div className="mt-3 flex justify-center">
+              {/* eslint-disable-next-line @next/next/no-img-element -- vem de rota proxy, muda a cada poll */}
+              <img
+                src={`/api/v1/onboarding/whatsapp/qr?t=${qrTick}`}
+                alt="Código para digitalizar com o WhatsApp"
+                width={220}
+                height={220}
+                className="rounded-md border bg-white p-2"
+              />
+            </div>
+          )}
+
           {status === "WORKING" && (
             <p className="mt-3 text-sm font-medium text-emerald-700 dark:text-emerald-400">
               ✓ {t("Conectado! Avançando…")}


### PR DESCRIPTION
## Resumo
- O passo "O telefone dele" do wizard de onboarding mostrava a caixa "Pronto para conectar / Digitalize o código abaixo" **sem nenhum QR code** — o componente já controlava `showQr`/`qrTick` para saber quando reemitir o pedido, mas nunca renderizava o `<img>` que aponta para a rota proxy `/api/v1/onboarding/whatsapp/qr` (que já existia e funcionava).
- Achado ao inspecionar um screenshot do painel em produção.
- (Substitui #514, que foi aberto por engano em cima da `main` desatualizada do fork em vez da `main` real — diff enorme e não-mergeável. Este PR está em cima da `upstream/main` correta.)

## Mudança
- `app/onboarding/connect-whatsapp/_client.tsx`: adiciona o `<img>` do QR quando `showQr` é verdadeiro, usando `qrTick` como cache-buster (o QR expira e muda a cada poll).

## Test plan
- [x] `pnpm typecheck` limpo
- [x] `pnpm lint` limpo (arquivo alterado)
- [ ] **Prova visual pelo browser NÃO feita nesta sessão** — a doutrina de QA Visual do repo (CLAUDE.md) exige provar mudança de UI pela tela, num ambiente fresco estilo VPS (Supabase local + WAHA local + Redis local). A tentativa de montar esse ambiente sofreu timeouts de TLS repetidos nos downloads Docker; a pedido do autor, o teste será feito em produção após o deploy.
- Já existe cobertura automatizada para isto: `tests/e2e/vps-fresh-onboarding.spec.ts` (`J1.5`) já afirma `img[src*="/whatsapp/qr"]` visível — essa spec está fora do gate de CI (depende de WAHA/Redis reais).

🤖 Generated with [Claude Code](https://claude.com/claude-code)