### PR TITLE
fix(ia): o validador da OpenRouter aceitava qualquer string como credencial

### DIFF
--- a/lib/ai/provider-validators.test.ts
+++ b/lib/ai/provider-validators.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { validateOpenRouterKey } from "@/lib/ai/provider-validators";
+
+/**
+ * POR QUE ESTE ARQUIVO EXISTE
+ *
+ * O validador da OpenRouter chamava `/api/v1/models`, que é PÚBLICO: ele
+ * responde 200 sem header nenhum. Qualquer string era gravada como credencial
+ * validada, e a falha só aparecia no primeiro turno do agente — como
+ * `runtime_error: User not found.`, mensagem que não fala de credencial.
+ *
+ * O caso decisivo é o último: ele prende o ENDEREÇO da primeira chamada. Sem
+ * ele, alguém "simplifica" o validador de volta para uma requisição só, o
+ * catálogo responde 200 para chave falsa, e os dois primeiros casos aqui
+ * continuariam verdes — a família do teste que concorda com o próprio defeito.
+ */
+
+const chamadas: string[] = [];
+
+function fetchFalso(respostas: Record<string, { status: number; body?: unknown }>) {
+  return vi.fn(async (url: string) => {
+    chamadas.push(url);
+    const chave = Object.keys(respostas).find((k) => url.includes(k));
+    const r = chave ? respostas[chave]! : { status: 404 };
+    return {
+      ok: r.status >= 200 && r.status < 300,
+      status: r.status,
+      json: async () => r.body ?? {},
+    } as unknown as Response;
+  });
+}
+
+afterEach(() => {
+  chamadas.length = 0;
+  vi.unstubAllGlobals();
+});
+
+describe("validateOpenRouterKey", () => {
+  it("recusa a chave que a OpenRouter não reconhece", async () => {
+    // Era ESTE o caso que passava: /api/v1/models devolve 200 para qualquer um.
+    vi.stubGlobal(
+      "fetch",
+      fetchFalso({ "/api/v1/key": { status: 401 }, "/api/v1/models": { status: 200 } }),
+    );
+    const r = await validateOpenRouterKey("sk-or-v1-nao-existe");
+    expect(r.ok).toBe(false);
+    expect(r.ok === false && r.error).toBe("auth_failed_401");
+  });
+
+  it("aceita a chave boa e devolve o catálogo", async () => {
+    vi.stubGlobal(
+      "fetch",
+      fetchFalso({
+        "/api/v1/key": { status: 200, body: { data: { label: "x" } } },
+        "/api/v1/models": { status: 200, body: { data: [{ id: "minimax/minimax-m3:free" }] } },
+      }),
+    );
+    const r = await validateOpenRouterKey("sk-or-v1-boa");
+    expect(r.ok).toBe(true);
+    expect(r.ok === true && r.models).toEqual(["minimax/minimax-m3:free"]);
+  });
+
+  it("catálogo fora do ar não recusa chave que já provou ser válida", async () => {
+    // Trocar erro de credencial por erro de disponibilidade faria o operador
+    // caçar defeito na chave certa.
+    vi.stubGlobal(
+      "fetch",
+      fetchFalso({ "/api/v1/key": { status: 200 }, "/api/v1/models": { status: 503 } }),
+    );
+    const r = await validateOpenRouterKey("sk-or-v1-boa");
+    expect(r.ok).toBe(true);
+    expect(r.ok === true && r.models).toEqual([]);
+  });
+
+  it("a PROVA é o endpoint autenticado, e é o primeiro a ser chamado", async () => {
+    vi.stubGlobal(
+      "fetch",
+      fetchFalso({ "/api/v1/key": { status: 200 }, "/api/v1/models": { status: 200 } }),
+    );
+    await validateOpenRouterKey("sk-or-v1-boa");
+    expect(chamadas[0]).toContain("/api/v1/key");
+  });
+});

--- a/lib/ai/provider-validators.ts
+++ b/lib/ai/provider-validators.ts
@@ -116,22 +116,51 @@ export async function validateGoogleKey(apiKey: string): Promise<ValidationResul
 
 /**
  * OpenRouter expõe `/api/v1/key` (metadados da própria chave) e `/api/v1/models`
- * (catálogo). Validamos pelo catálogo porque ele responde a mesma pergunta —
- * "esta chave é aceita?" — e já devolve a lista de modelos que a interface usa,
- * do mesmo jeito que os três irmãos acima.
+ * (catálogo).
+ *
+ * ⚠️ `/api/v1/models` É PÚBLICO. Validar por ele não valida nada — e era o que
+ * este arquivo fazia. Medido em 2026-09-02, com a chave mais falsa possível:
+ *
+ *     GET /api/v1/models   sem header nenhum         → 200
+ *     GET /api/v1/models   Bearer sk-or-v1-...falsa  → 200
+ *     GET /api/v1/key      Bearer sk-or-v1-...falsa  → 401
+ *
+ * O comentário anterior dizia que o catálogo responde "esta chave é aceita?"
+ * do mesmo jeito que os três irmãos acima. Não responde: os outros três batem
+ * em endpoints que EXIGEM credencial, este não.
+ *
+ * O efeito medido é o pior para quem opera: QUALQUER string era gravada com
+ * `validated_at` preenchido, a tela dizia "validada" com o final da chave ao
+ * lado, e a falha só aparecia no primeiro turno do agente — como
+ * `runtime_error: User not found.`, mensagem que não menciona credencial
+ * nenhuma. Quem depurasse isso procuraria o defeito no modelo, no provedor ou
+ * no runtime; o operador tinha uma tela dizendo que a parte quebrada estava boa.
+ *
+ * A prova passa a ser `/api/v1/key`, que exige a credencial. O catálogo segue
+ * sendo lido DEPOIS, porque a lista de modelos é o que a interface usa — e ali
+ * ele é só dado, não prova. Catálogo fora do ar não recusa uma chave que já
+ * provou ser válida: seria trocar um erro de credencial por um de
+ * disponibilidade.
  */
 export async function validateOpenRouterKey(apiKey: string): Promise<ValidationResult> {
   try {
+    const auth = await timedFetch("https://openrouter.ai/api/v1/key", {
+      method: "GET",
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    if (auth.status === 401 || auth.status === 403) {
+      return { ok: false, error: "auth_failed_401" };
+    }
+    if (!auth.ok) {
+      return { ok: false, error: `provider_status_${auth.status}` };
+    }
+
     const res = await timedFetch("https://openrouter.ai/api/v1/models", {
       method: "GET",
       headers: { Authorization: `Bearer ${apiKey}` },
     });
-    if (res.status === 401 || res.status === 403) {
-      return { ok: false, error: "auth_failed_401" };
-    }
-    if (!res.ok) {
-      return { ok: false, error: `provider_status_${res.status}` };
-    }
+    if (!res.ok) return { ok: true, models: [] };
+
     const json = (await res.json()) as { data?: { id?: string }[] };
     const models = (json.data ?? []).map((m) => m.id ?? "").filter(Boolean);
     return { ok: true, models };


### PR DESCRIPTION
`validateOpenRouterKey` provava a chave contra `https://openrouter.ai/api/v1/models`.
Esse endpoint e PUBLICO. Medido em 2026-09-02:

    GET /api/v1/models   sem header nenhum         -> 200
    GET /api/v1/models   Bearer sk-or-v1-...falsa  -> 200
    GET /api/v1/key      Bearer sk-or-v1-...falsa  -> 401

O comentario da funcao afirmava que o catalogo responde "esta chave e aceita?"
do mesmo jeito que os tres irmaos acima. Nao responde: anthropic, openai e
google batem em endpoints que EXIGEM credencial, este nao batia.

Efeito medido numa instalacao real: duas credenciais gravadas com
`validated_at` preenchido, a tela mostrando "validada" com o final da chave ao
lado, e as duas recusadas pela OpenRouter. A falha so aparecia no primeiro
turno do agente, como `ai_agent_runs.error_message = "User not found."` — texto
que nao menciona credencial. Quem depura isso procura defeito no modelo, no
provedor ou no runtime, enquanto a tela afirma que a peca quebrada esta boa.

A prova passa a ser `/api/v1/key`, que exige a credencial. O catalogo segue
sendo lido DEPOIS, porque a lista de modelos e o que a interface usa — ali ele
e dado, nao prova. Catalogo fora do ar nao recusa chave ja provada: seria
trocar um erro de credencial por um de disponibilidade.

`lib/ai/provider-validators.test.ts` cobre os tres desfechos. O quarto caso
prende o ENDERECO da primeira chamada: sem ele, alguem "simplifica" de volta
para uma requisicao so, o catalogo responde 200 para chave falsa, e os outros
casos continuariam verdes — o teste concordando com o proprio defeito.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
