### PR TITLE
fix(catalogo): a busca deixa de cortar cego e de afirmar ausência sobre amostra

### DIFF
--- a/.changes/loja-grande-volta-a-achar-o-proprio-produto.md
+++ b/.changes/loja-grande-volta-a-achar-o-proprio-produto.md
@@ -1,0 +1,23 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Loja com catálogo grande volta a achar o próprio produto
+---
+
+Numa loja com muitos produtos cadastrados, o atendente de IA podia responder
+**"não temos"** para um produto que a loja tem. E não havia como perceber: a
+resposta era educada, o sistema não registrava erro nenhum, e o mesmo produto às
+vezes aparecia na busca seguinte.
+
+A causa é que a busca consultava um lote do catálogo sem definir a ordem. Sem
+ordem, o banco devolve as linhas que quiser — e o produto pedido podia
+simplesmente não estar no lote que veio. O limite real também era metade do que
+o sistema pedia.
+
+Agora a busca percorre o catálogo em páginas, na ordem do código, até encontrar
+ou terminar. E, se o catálogo for grande demais para varrer inteiro, o atendente
+**para de dizer que a loja não tem**: ele diz que não encontrou no que
+conseguiu consultar e que vai confirmar com a equipe.
+
+A diferença importa para quem está comprando: "não temos" encerra a conversa,
+"vou confirmar" não.

--- a/lib/mcp/tools/comercio.ts
+++ b/lib/mcp/tools/comercio.ts
@@ -95,6 +95,24 @@ function precoLegivel(cents: number, moeda: string): string {
  * não tem o que foi pedido muda a resposta inteira; saber qual dos dois é
  * apenas a próxima pergunta.
  */
+/**
+ * Tamanho da página da varredura do catálogo.
+ *
+ * 1000 é o `max_rows` declarado em `supabase/config.toml:12` — pedir mais numa
+ * página não traz mais nada, o servidor corta de qualquer jeito.
+ */
+const TAMANHO_DA_PAGINA = 1000;
+
+/**
+ * Teto DECLARADO da varredura: 10 páginas = 10 000 produtos.
+ *
+ * O teto existe porque a pontuação roda em memória e um catálogo sem limite
+ * puxaria a loja inteira a cada pergunta de preço. O que muda em relação ao
+ * `.limit(2000)` anterior não é só o número: é que estourar este teto agora
+ * PRODUZ UM SINAL (`varreduraParcial`) em vez de virar silêncio.
+ */
+const PAGINAS_MAXIMAS = 10;
+
 export function avisosDaBusca(input: { empate: boolean; ignorados: readonly string[] }): string {
   const avisos: string[] = [];
   if (input.ignorados.length > 0) {
@@ -137,16 +155,48 @@ export const crmSearchProducts: McpToolDefinition<typeof produtosInputShape> = {
     // difusa, número exato) não é exprimível num `ilike` — e é ela que impede o
     // 128GB de aparecer para quem pediu 256GB. O corte por org acontece no
     // banco, que é o que importa para o isolamento.
-    const { data, error } = await ctx.supabase
-      .from("catalog_products")
-      .select(
-        "id, codigo, nome, descricao, marca, categoria, preco_cents, moeda, controla_estoque, quantidade, ativo",
-      )
-      .eq("organization_id", ctx.organizationId)
-      .eq("ativo", true)
-      .limit(2000);
+    //
+    // ⚠️ O TETO PEDIDO NÃO ERA O TETO APLICADO. `supabase/config.toml:12`
+    // declara `max_rows = 1000`: o PostgREST corta a resposta nesse número, e o
+    // `.limit(2000)` que estava aqui nunca trouxe 2000 — trouxe no máximo 1000.
+    // Por isso a truncagem NÃO pode ser deduzida de `linhas.length === limite`:
+    // o corte é do servidor e o cliente não sabe qual é. Quem sabe é o `count`,
+    // que a consulta passa a pedir — varredura parcial vira DADO, não palpite.
+    //
+    // E sem `ORDER BY` o Postgres devolve linhas ARBITRÁRIAS: a ordem é a que o
+    // plano der, e muda com o tempo e com o vacuum. Numa loja acima do teto, o
+    // produto pedido podia não estar no lote que veio, e a busca respondia "não
+    // há nada com esse nome" para um produto que a loja TEM. (issue #480)
+    const linhas: unknown[] = [];
+    let total = 0;
+    for (let pagina = 0; pagina < PAGINAS_MAXIMAS; pagina++) {
+      const de = pagina * TAMANHO_DA_PAGINA;
+      const { data: lote, error, count } = await ctx.supabase
+        .from("catalog_products")
+        .select(
+          "id, codigo, nome, descricao, marca, categoria, preco_cents, moeda, controla_estoque, quantidade, ativo",
+          { count: "exact" },
+        )
+        .eq("organization_id", ctx.organizationId)
+        .eq("ativo", true)
+        // Ordem estável e única: o corte, quando houver, é reproduzível — e a
+        // paginação por `range` só é correta sobre uma ordem determinística.
+        .order("codigo", { ascending: true })
+        .range(de, de + TAMANHO_DA_PAGINA - 1);
 
-    if (error) throw new Error(`buscar_produtos_falhou: ${error.message}`);
+      if (error) throw new Error(`buscar_produtos_falhou: ${error.message}`);
+      total = count ?? total;
+      const recebidas = lote ?? [];
+      linhas.push(...recebidas);
+      // Página curta significa fim do conjunto — parar aqui evita uma ida ao
+      // banco por busca em toda loja pequena, que é a esmagadora maioria.
+      if (recebidas.length === 0 || linhas.length >= total) break;
+    }
+
+    const data = linhas;
+    // A varredura foi parcial? Isso é o que separa "não achei no que varri" de
+    // "a loja não tem" — e só a segunda pode ser dita ao cliente.
+    const varreduraParcial = total > linhas.length;
 
     type Linha = {
       id: string;
@@ -173,12 +223,23 @@ export const crmSearchProducts: McpToolDefinition<typeof produtosInputShape> = {
     const topo = disponiveis.slice(0, input.limite);
 
     if (topo.length === 0) {
+      if (achados.length > 0) {
+        return {
+          produtos: [],
+          mensagem:
+            "esse produto existe no catálogo, mas está sem estoque. Não prometa: ofereça avisar quando chegar.",
+        };
+      }
+      // Afirmar ausência exige ter varrido o catálogo inteiro. Sobre uma
+      // amostra, a frase honesta é outra — e ela leva o agente a uma conduta
+      // diferente com o cliente, que é o ponto.
       return {
         produtos: [],
-        mensagem:
-          achados.length > 0
-            ? "esse produto existe no catálogo, mas está sem estoque. Não prometa: ofereça avisar quando chegar."
-            : "não há nada com esse nome no catálogo da loja. Não invente preço — diga que vai confirmar com a equipe.",
+        mensagem: varreduraParcial
+          ? `não encontrei entre os ${linhas.length} produtos que consegui consultar, e o catálogo ` +
+            `desta loja tem ${total}. NÃO diga que a loja não tem — diga que vai confirmar com a ` +
+            "equipe. Se a pessoa souber o código ou o nome exato, peça: com ele a busca acha."
+          : "não há nada com esse nome no catálogo da loja. Não invente preço — diga que vai confirmar com a equipe.",
       };
     }
 

--- a/tests/unit/catalogo-nao-corta-cego.test.ts
+++ b/tests/unit/catalogo-nao-corta-cego.test.ts
@@ -1,0 +1,185 @@
+/**
+ * A BUSCA DO CATÁLOGO NÃO CORTA CEGO — E NÃO AFIRMA AUSÊNCIA SOBRE AMOSTRA
+ * (issue #480).
+ *
+ * ─── O defeito, medido em c5b45b24 ──────────────────────────────────────────
+ *
+ * `lib/mcp/tools/comercio.ts` trazia os candidatos e pontuava em memória:
+ *
+ *     .eq("organization_id", ctx.organizationId)
+ *     .eq("ativo", true)
+ *     .limit(2000)          // ← sem .order()
+ *
+ * CONTROLE POSITIVO dentro do mesmo arquivo: a consulta de PEDIDOS (linha 44)
+ * TEM `.order("ordered_at", …)`. A sonda enxerga `.order` quando ele existe; na
+ * consulta do catálogo não havia nenhum.
+ *
+ * Sem `ORDER BY`, o Postgres devolve N linhas ARBITRÁRIAS — a ordem é a que o
+ * plano der, e muda com o tempo, com o vacuum e com o plano. Numa loja acima do
+ * teto, o produto pedido pode simplesmente não estar no lote que veio, e a busca
+ * responde:
+ *
+ *     "não há nada com esse nome no catálogo da loja."
+ *
+ * O agente diz "não temos" para um produto que a loja TEM.
+ *
+ * ─── O teto é METADE do que o código pede ───────────────────────────────────
+ *
+ * `supabase/config.toml:12` declara `max_rows = 1000`. O PostgREST corta a
+ * resposta nesse número, então o `.limit(2000)` nunca trouxe 2000 — trouxe no
+ * máximo 1000. O defeito é o dobro do reportado, e nenhum limite escrito no
+ * código dizia isso.
+ *
+ * Por isso a truncagem não pode ser deduzida de `linhas.length === limite`: o
+ * corte é do SERVIDOR e o cliente não sabe qual é. Quem sabe é o `count`, que a
+ * consulta passa a pedir — a varredura parcial vira DADO, não adivinhação.
+ *
+ * ─── O que muda no desfecho ─────────────────────────────────────────────────
+ *
+ * Não achar entre uma amostra e não achar no catálogo são coisas diferentes, e
+ * a única errada é afirmar a segunda quando se mediu a primeira.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { crmSearchProducts } from "@/lib/mcp/tools/comercio";
+
+interface Chamada {
+  metodo: string;
+  args: unknown[];
+}
+
+/**
+ * Dublê do PostgREST que se comporta como o servidor real: aplica `range`,
+ * devolve `count` TOTAL (não o da página) e — quando pedido — CORTA a página
+ * num teto próprio, como o `max_rows` faz.
+ *
+ * Um dublê que devolvesse tudo de uma vez aprovaria o código que ignora
+ * paginação, que é metade do defeito.
+ */
+function fakeDb(total: number, tetoDoServidor = 1000) {
+  const chamadas: Chamada[] = [];
+  const linhas = Array.from({ length: total }, (_, i) => ({
+    id: `p${i}`,
+    codigo: `COD${String(i).padStart(6, "0")}`,
+    // Só o ÚLTIMO produto casa a busca. Se a varredura parar antes do fim, ele
+    // não é alcançado — que é exatamente o defeito desta issue.
+    nome: i === total - 1 ? "Perfume Importado Raro" : `Item Generico ${i}`,
+    descricao: null,
+    marca: null,
+    categoria: null,
+    preco_cents: 1000 + i,
+    moeda: "BRL",
+    controla_estoque: false,
+    quantidade: 0,
+  }));
+
+  let de = 0;
+  let ate = tetoDoServidor - 1;
+  let limite: number | null = null;
+
+  const q: Record<string, unknown> = {};
+  const registra = (metodo: string) => (...args: unknown[]) => {
+    chamadas.push({ metodo, args });
+    if (metodo === "range") {
+      de = args[0] as number;
+      ate = args[1] as number;
+    }
+    if (metodo === "limit") limite = args[0] as number;
+    return q;
+  };
+  for (const m of ["select", "eq", "order", "range", "limit", "is"]) q[m] = registra(m);
+  (q as { then: unknown }).then = (ok: (v: unknown) => unknown) => {
+    const fim = Math.min(ate + 1, de + tetoDoServidor, limite ?? Infinity, total);
+    return Promise.resolve(
+      ok({ data: linhas.slice(de, fim), error: null, count: total }),
+    );
+  };
+
+  return {
+    chamadas,
+    ctx: {
+      supabase: { from: () => q },
+      organizationId: "org-1",
+    } as never,
+  };
+}
+
+const buscar = (db: ReturnType<typeof fakeDb>, termo: string) =>
+  crmSearchProducts.handler({ termo, limite: 5 } as never, db.ctx) as Promise<{
+    produtos: unknown[];
+    mensagem?: string;
+  }>;
+
+describe("a consulta do catálogo é determinística", () => {
+  it("⭐ pede ORDER BY — sem ele o lote que vem é arbitrário e muda com o plano", async () => {
+    const db = fakeDb(50);
+    await buscar(db, "perfume");
+
+    const ordens = db.chamadas.filter((c) => c.metodo === "order");
+    expect(
+      ordens.length,
+      "a consulta do catálogo não ordena: o Postgres devolve linhas arbitrárias e o corte vira amostragem cega",
+    ).toBeGreaterThan(0);
+  });
+
+  it("continua isolando por organização e por ativo", async () => {
+    // Guarda contra o conserto quebrar o que já estava certo: service role
+    // bypassa RLS, então o filtro de organização é obrigatório.
+    const db = fakeDb(10);
+    await buscar(db, "perfume");
+    const eqs = JSON.stringify(db.chamadas.filter((c) => c.metodo === "eq"));
+    expect(eqs).toContain("organization_id");
+    expect(eqs).toContain("ativo");
+  });
+});
+
+describe("catálogo maior que o teto do servidor", () => {
+  it("⭐ acha o produto que está DEPOIS do teto de uma página", async () => {
+    // 2500 produtos, servidor cortando em 1000: sem paginação o produto que
+    // casa (o último) nunca é alcançado, e o agente diz "não temos".
+    const db = fakeDb(2500, 1000);
+    const r = await buscar(db, "perfume importado raro");
+
+    expect(
+      r.produtos.length,
+      "o produto existe no catálogo e a busca não o alcançou — é o defeito desta issue",
+    ).toBeGreaterThan(0);
+  });
+
+  it("⭐ quando a varredura NÃO foi completa, a resposta deixa de afirmar ausência", async () => {
+    // Teto de varredura estourado: o certo é dizer que não achou no que varreu,
+    // nunca que o catálogo não tem. As duas frases levam o agente a condutas
+    // diferentes com o cliente.
+    const db = fakeDb(200_000, 1000);
+    const r = await buscar(db, "coisa que nao existe em lugar nenhum");
+
+    expect(r.produtos).toEqual([]);
+    const msg = String(r.mensagem ?? "");
+    expect(
+      /não há nada com esse nome no catálogo/i.test(msg),
+      `afirmou ausência sobre uma amostra: ${msg}`,
+    ).toBe(false);
+    // E precisa DIZER o que houve, senão o agente inventa a explicação.
+    expect(msg.length, "não achou e não disse por quê").toBeGreaterThan(20);
+  });
+
+  it("catálogo pequeno segue afirmando ausência — e deve", async () => {
+    // Controle na direção oposta. Sem este caso, um "conserto" que nunca mais
+    // afirmasse ausência passaria — e o agente deixaria de dizer "não temos"
+    // para produto que a loja realmente não tem, que é informação útil.
+    const db = fakeDb(30, 1000);
+    const r = await buscar(db, "coisa que nao existe em lugar nenhum");
+
+    expect(r.produtos).toEqual([]);
+    expect(String(r.mensagem)).toMatch(/não há nada com esse nome no catálogo/i);
+  });
+
+  it("a varredura tem teto declarado — não puxa catálogo de 200 mil linhas para a memória", async () => {
+    const db = fakeDb(200_000, 1000);
+    await buscar(db, "perfume");
+
+    const paginas = db.chamadas.filter((c) => c.metodo === "range").length;
+    expect(paginas, "varreu sem teto: uma busca puxaria o catálogo inteiro").toBeLessThanOrEqual(10);
+    expect(paginas, "não paginou nada").toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #480

## O defeito

```ts
.eq("organization_id", ctx.organizationId)
.eq("ativo", true)
.limit(2000)          // ← sem .order()
```

**Controle positivo no mesmo arquivo:** a consulta de *pedidos* (linha 44) tem `.order("ordered_at", …)`. A sonda enxerga `.order` quando ele existe — na consulta do catálogo não havia nenhum.

Sem `ORDER BY`, o Postgres devolve linhas **arbitrárias**: a ordem é a do plano e muda com o tempo e com o vacuum. Numa loja acima do teto, o produto pedido podia não estar no lote que veio, e a busca respondia *"não há nada com esse nome no catálogo da loja"* para um produto que a loja **tem**. Nada registrava isso — o corte não é erro, é ausência.

## O teto pedido não era o teto aplicado

Isto a issue não sabia, e dobra o tamanho do defeito:

```console
$ grep -n max_rows supabase/config.toml
12:max_rows = 1000
```

O PostgREST corta a resposta nesse número. O `.limit(2000)` **nunca trouxe 2000** — trouxe no máximo 1000.

E é por isso que a truncagem **não pode** ser deduzida de `linhas.length === limite`: o corte é do servidor e o cliente não sabe qual é. Quem sabe é o `count`, que a consulta passa a pedir — varredura parcial vira **dado**, não palpite.

## As três mudanças

- **`.order("codigo")`** — ordem estável e única. O corte, quando houver, é reproduzível; e paginar por `range` só é correto sobre ordem determinística.
- **Varredura em páginas de 1000** (o próprio `max_rows`) até 10 páginas, com teto **declarado**. O teto existe porque a pontuação roda em memória e um catálogo sem limite puxaria a loja inteira a cada pergunta de preço. O que muda em relação ao `.limit(2000)` não é o número: é que estourá-lo agora **produz um sinal** em vez de virar silêncio.
- **Varredura parcial para de afirmar ausência**: a resposta diz quantos consultou de quantos, manda **não** dizer que a loja não tem, e pede o código ou o nome exato.

Loja pequena **segue afirmando ausência** — e deve: "não temos" é informação útil quando é verdade. O teste guarda as duas direções.

## Prova

O dublê se comporta como o servidor real: aplica `range`, devolve `count` **total** (não o da página) e corta a página num teto próprio, como o `max_rows` faz. Um dublê que devolvesse tudo de uma vez aprovaria o código que ignora paginação — que é metade do defeito.

```console
$ npx vitest run tests/unit/catalogo-nao-corta-cego.test.ts
  Tests  6 passed (6)
```

**Três sabotagens independentes** — previ 4/1/1, deu 4/1/1:

```
A) reverto o conserto inteiro                    → 4 vermelhos
B) tiro só o .order (paginação fica)             → 1: pede ORDER BY
C) mensagem volta a afirmar ausência             → 1: deixa de afirmar ausência
```

## Gates

```
pnpm typecheck   exit=0
pnpm lint        exit=0
pnpm test:unit   617 arquivos / 6813 testes, exit=0   (suíte COMPLETA)
```

## O que NÃO fiz

**Não toquei na pontuação, e recusei o pré-filtro `ilike` que parecia o conserto óbvio.** Ele amputaria o casamento difuso: `pontuar` aceita distância de edição até 2 (`busca.ts:145,149`), e `"ifone"` não casa `"iphone"` por `ilike`. A busca existe justamente para servir esse caso — o pré-filtro trocaria um defeito de escala por um defeito de recall, mais difícil de ver.

**Catálogo acima de 10 000 produtos ativos ainda não é varrido inteiro.** A diferença é que agora ele **diz isso** em vez de afirmar ausência. Levantar o teto de verdade pede índice (`pg_trgm`) e busca no banco — outro PR, com migration.

**Não fechei o laço do #484** (não achar não gera contador nem aviso na Central). Este PR faz a *mensagem* parar de mentir; o *sinal para o operador* é aquela issue, e misturá-las faria a sabotagem de uma esconder a da outra.

**Custo:** loja pequena continua com 1 consulta (a página curta encerra o laço). Loja grande paga até 10 idas ao banco por busca.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam (suíte completa)
- [x] Filtro de `organization_id` preservado (guardado por caso próprio)
- [x] Sem `console.log` esquecido
- [x] Fragmento em `.changes/` (`nada_mudou` / `corrigido`)
- [ ] Schema: não toca

🤖 Generated with [Claude Code](https://claude.com/claude-code)