### PR TITLE
fix(waha): o eco do próprio envio deixa de calar a IA por três horas

### DIFF
--- a/.changes/a-ia-nao-se-cala-por-ter-falado.md
+++ b/.changes/a-ia-nao-se-cala-por-ter-falado.md
@@ -1,0 +1,22 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A inteligência artificial não se cala mais por três horas depois de responder
+---
+
+Sempre que o CRM enviava uma mensagem pelo WhatsApp, o próprio WhatsApp
+devolvia um eco dela de volta. O sistema lia esse eco como **"um atendente
+humano acabou de responder pelo celular"** e desligava a IA por três horas.
+
+Ou seja: a IA se calava por ter falado. O cliente ficava sem resposta e a tela
+mostrava **"Automático pausado"** — um estado legítimo, que ninguém investiga,
+porque é exatamente o que aparece quando alguém assume a conversa de propósito.
+
+Atingia qualquer instalação e qualquer conversa, sem depender de configuração.
+
+Agora o sistema distingue o eco do próprio envio de uma digitação de verdade. E
+a distinção só protege o silêncio: a mensagem continua sendo gravada como
+sempre, porque perder uma mensagem é pior do que registrar uma a mais.
+
+Quando o atendente responde mesmo pelo celular, a IA continua se calando — essa
+parte não mudou.

--- a/.changes/a-ia-nao-se-cala-por-ter-falado.md
+++ b/.changes/a-ia-nao-se-cala-por-ter-falado.md
@@ -5,11 +5,11 @@ titulo: A inteligência artificial não se cala mais por três horas depois de r
 ---
 
 Sempre que o CRM enviava uma mensagem pelo WhatsApp, o próprio WhatsApp
-devolvia um eco dela de volta. O sistema lia esse eco como **"um atendente
-humano acabou de responder pelo celular"** e desligava a IA por três horas.
+devolvia um eco dela de volta. O sistema lia esse eco como se um atendente
+humano tivesse respondido pelo celular, e **desligava a IA por três horas.**
 
 Ou seja: a IA se calava por ter falado. O cliente ficava sem resposta e a tela
-mostrava **"Automático pausado"** — um estado legítimo, que ninguém investiga,
+mostrava **"Automático pausado"** — estado legítimo, que ninguém investiga,
 porque é exatamente o que aparece quando alguém assume a conversa de propósito.
 
 Atingia qualquer instalação e qualquer conversa, sem depender de configuração.

--- a/lib/waha/ingest-celular.test.ts
+++ b/lib/waha/ingest-celular.test.ts
@@ -54,14 +54,44 @@ function bancoDeMentira(preexistentes: Array<Partial<LinhaMessage>> = []): Duplo
   const consulta = () => {
     let org: string | null = null;
     let externos: string[] = [];
+    const filtrosExtras: Array<[string, unknown]> = [];
     const q = {
       eq(coluna: string, valor: string) {
         if (coluna === "organization_id") org = valor;
+        else filtrosExtras.push([coluna, valor]);
         return q;
       },
       in(coluna: string, valores: string[]) {
         if (coluna === "external_id") externos = valores;
+        else filtrosExtras.push([coluna, valores]);
         return q;
+      },
+      is(coluna: string, valor: unknown) {
+        // `.is(col, null)` = `col IS NULL`. A checagem de eco do próprio envio
+        // (`ehEcoDeEnvioNosso`, ver `lib/waha/ingest.ts`) pergunta por linhas
+        // ainda SEM `external_id`; sem este elo o dublê estoura em
+        // "is is not a function" e nove casos deste arquivo caem por um motivo
+        // que nada tem a ver com o que eles medem.
+        filtrosExtras.push([coluna, valor]);
+        return q;
+      },
+      gte() {
+        return q;
+      },
+      order() {
+        return q;
+      },
+      then(ok: (v: unknown) => unknown) {
+        // A checagem de eco lê uma LISTA (sem `.maybeSingle()`). Este arquivo
+        // não mede o silêncio — quem mede é
+        // `tests/unit/eco-do-envio-nao-silencia-o-bot.test.ts` —, então aqui
+        // basta responder no formato certo.
+        const casadas = messages.filter(
+          (m) =>
+            (org === null || m.organization_id === org) &&
+            filtrosExtras.every(([c, v]) => (Array.isArray(v) ? v.includes(m[c]) : (m[c] ?? null) === v)),
+        );
+        return Promise.resolve(ok({ data: casadas, error: null }));
       },
       limit() {
         return q;

--- a/lib/waha/ingest.ts
+++ b/lib/waha/ingest.ts
@@ -87,6 +87,73 @@ export async function silenciarBotPorRetomadaHumana(
   }
 }
 
+/**
+ * Quanto tempo um envio nosso pode ficar "em voo" antes de o eco deixar de ser
+ * explicável por ele.
+ *
+ * 60s é folgado de propósito: o custo de errar para o lado permissivo é uma
+ * digitação real do celular não silenciar a IA por um minuto; o custo de errar
+ * para o outro lado é a IA muda por três horas. Os dois erros não são simétricos.
+ */
+const JANELA_DO_ECO_MS = 60_000;
+
+/**
+ * A mensagem `fromMe` que chegou é o eco de um envio que ESTE CRM acabou de
+ * fazer — e não alguém digitando no celular?
+ *
+ * A prova exigida é forte: uma linha nossa na MESMA conversa, ainda sem
+ * `external_id` (portanto ainda em voo), com o MESMO corpo, dentro da janela.
+ * Qualquer uma dessas faltando, a resposta é "não sei" — e "não sei" silencia,
+ * porque é o desfecho seguro do lado do atendente humano (#371).
+ *
+ * Mídia não tem corpo comparável (o eco traz `media_url`, não texto): ali a
+ * prova cai para "existe envio nosso em voo do mesmo tipo na janela", que é mais
+ * permissivo e assumidamente mais fraco.
+ */
+async function ehEcoDeEnvioNosso(
+  admin: Admin,
+  organizationId: string,
+  conversationId: string,
+  p: WahaPayload,
+): Promise<boolean> {
+  const desde = new Date(Date.now() - JANELA_DO_ECO_MS).toISOString();
+  const { data, error } = await admin
+    .from("messages")
+    .select("id, body, type")
+    .eq("organization_id", organizationId)
+    .eq("conversation_id", conversationId)
+    .eq("direction", "outbound")
+    // `sent_via` separa o que NASCEU aqui do que veio do celular: a linha do
+    // celular é gravada como `external_device` e nunca pode servir de álibi.
+    .in("sent_via", ["ai", "user"])
+    // Sem `external_id` = ainda não confirmada pelo canal = ainda em voo. É esta
+    // a janela exata em que o eco é indistinguível de digitação humana.
+    .is("external_id", null)
+    .in("status", ["queued", "sending"])
+    .gte("created_at", desde)
+    .limit(20);
+
+  if (error) {
+    // Falha de leitura não pode virar "é eco": na dúvida, silencia — o
+    // desfecho seguro é o do atendente humano.
+    console.error("[waha.ingest] checagem de eco falhou", error.message);
+    return false;
+  }
+
+  const corpo = (p.body ?? "").trim();
+  for (const linha of data ?? []) {
+    const l = linha as { body: string | null; type?: string | null };
+    if (p.type && p.type !== "chat") {
+      // Mídia: sem corpo para comparar, a existência do envio em voo é a prova
+      // possível. Mais fraco, e escrito para ninguém supor o contrário.
+      if ((l.type ?? "chat") !== "chat") return true;
+      continue;
+    }
+    if (corpo.length > 0 && (l.body ?? "").trim() === corpo) return true;
+  }
+  return false;
+}
+
 interface Session {
   id: string;
   organization_id: string;
@@ -854,7 +921,26 @@ async function handleOutboundFromUserPhone(
   // Ver `silenciarBotPorRetomadaHumana` — um humano acabou de responder direto pelo
   // WhatsApp dele, fora do composer/IA; dá a ele uma janela curta de controle da
   // conversa sem precisar "assumir" formalmente no CRM.
-  await silenciarBotPorRetomadaHumana(admin, session.organization_id, conversationId);
+  //
+  // ⚠️ MAS ANTES: isto é MESMO um humano, ou é o eco do nosso próprio envio?
+  //
+  // Todo envio do CRM grava a linha ANTES de falar com o canal (`queued`,
+  // `external_id` null) — o id só existe depois que o WAHA responde. Nessa
+  // janela o dedup por `external_id` não casa nada, o eco chega com `fromMe` e
+  // esta função concluía "humano assumiu": a IA se calava por TRÊS HORAS por
+  // ter falado, e a tela mostrava "Automático pausado", um estado legítimo que
+  // ninguém investiga. (issue #519)
+  //
+  // As DUAS decisões que eram uma só se separam aqui, e em direções OPOSTAS de
+  // propósito:
+  //   gravar a linha  -> tolerante  (na dúvida grava; perder mensagem é pior que
+  //                                  duplicar — é o #108, que já custou caro)
+  //   silenciar o bot -> ESTRITO    (na dúvida NÃO cala; calar a IA por engano é
+  //                                  pior que não calar)
+  // Quem reaproveitar esta condição para pular o INSERT reabre o #108.
+  if (!(await ehEcoDeEnvioNosso(admin, session.organization_id, conversationId, p))) {
+    await silenciarBotPorRetomadaHumana(admin, session.organization_id, conversationId);
+  }
 
   await audit({
     action: "message.sent",

--- a/tests/unit/eco-do-envio-nao-silencia-o-bot.test.ts
+++ b/tests/unit/eco-do-envio-nao-silencia-o-bot.test.ts
@@ -1,0 +1,283 @@
+/**
+ * O ECO DO PRÓPRIO ENVIO NÃO CALA A IA POR TRÊS HORAS (issue #519).
+ *
+ * ─── O defeito, medido em c5b45b24 ──────────────────────────────────────────
+ *
+ * Todo envio do CRM (IA, composer, follow-up, MCP) grava a linha ANTES de falar
+ * com o canal: `status='queued'`, `external_id=null`. O `external_id` só existe
+ * DEPOIS que o WAHA responde. Nessa janela, o eco do WhatsApp chega com
+ * `fromMe: true`, o dedup por `external_id` não casa nada (a linha do envio
+ * ainda não tem id), e `handleOutboundFromUserPhone` conclui que um humano
+ * respondeu pelo celular:
+ *
+ *     lib/waha/ingest.ts:857   await silenciarBotPorRetomadaHumana(...)
+ *     lib/waha/ingest.ts:47    HUMAN_TAKEOVER_SILENCE_MS = 3 * 60 * 60 * 1000
+ *
+ * A IA se cala por TRÊS HORAS por ter falado. E a tela mostra "Automático
+ * pausado" — um estado legítimo, que ninguém investiga
+ * (`lib/inbox/comando-da-conversa.ts:239` deriva `automaticoAtivo` do silêncio).
+ *
+ * A janela já estava documentada como defeito aberto na própria suíte:
+ * `lib/waha/ingest-celular.test.ts:315` — "JANELA CONHECIDA: enquanto o envio
+ * está `queued` sem external_id, o eco duplica".
+ *
+ * ─── Por que o gate barra o SILÊNCIO e não o INSERT ─────────────────────────
+ *
+ * O #108 já custou caro nesta casa: casar o eco por proximidade descartou uma
+ * mensagem legítima digitada no celular ("esperado 2 mensagens e obtido 1"), e o
+ * comentário de `_handler.ts:47-53` registra isso.
+ *
+ * Por isso as duas decisões, que hoje são uma só, se separam: **gravar a linha
+ * continua tolerante** (na dúvida, grava — perder mensagem é pior que duplicar)
+ * e **silenciar o bot passa a ser estrito** (na dúvida, não cala — calar a IA
+ * por engano é pior que não calar). São direções opostas de propósito.
+ *
+ * Quem reaproveitar a condição deste gate para pular o INSERT reabre o #108.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/audit", () => ({ audit: vi.fn() }));
+
+import { dispatchWahaEvent, type WahaEnvelope, type WahaPayload } from "@/lib/waha/ingest";
+
+interface Linha {
+  id: string;
+  organization_id: string;
+  conversation_id?: string;
+  external_id: string | null;
+  direction?: string;
+  status?: string;
+  body?: string | null;
+  sent_via?: string;
+  sent_at?: string | null;
+  type?: string;
+  [k: string]: unknown;
+}
+
+/**
+ * Dublê que, além de `messages`, guarda a linha de `conversations` e REGISTRA os
+ * updates nela. O dublê do arquivo irmão descarta updates — e é justamente o
+ * update de `bot_silenced_until` que este teste precisa ver.
+ */
+function banco(preexistentes: Array<Partial<Linha>> = []) {
+  const messages: Linha[] = preexistentes.map((m, i) => ({
+    id: `pre-${i + 1}`,
+    organization_id: "org-1",
+    conversation_id: "conversa-1",
+    external_id: null,
+    ...m,
+  }));
+  const conversa: Record<string, unknown> = {
+    id: "conversa-1",
+    organization_id: "org-1",
+    bot_silenced_until: null,
+  };
+
+  const consultaMessages = () => {
+    let org: string | null = null;
+    let externos: string[] = [];
+    const filtros: Array<[string, unknown]> = [];
+    const q: Record<string, unknown> = {
+      eq(coluna: string, valor: unknown) {
+        if (coluna === "organization_id") org = valor as string;
+        else filtros.push([coluna, valor]);
+        return q;
+      },
+      in(coluna: string, valores: string[]) {
+        if (coluna === "external_id") externos = valores;
+        else filtros.push([coluna, valores]);
+        return q;
+      },
+      is(coluna: string, valor: unknown) {
+        // `.is(col, null)` no PostgREST é `col IS NULL` — o dublê tem de aplicar
+        // o predicado, senão a consulta que separa "em voo" de "já confirmada"
+        // devolveria tudo e o gate passaria pelo motivo errado.
+        filtros.push([coluna, valor]);
+        return q;
+      },
+      gte: () => q,
+      order: () => q,
+      limit: () => q,
+      async maybeSingle() {
+        const achou = messages.find(
+          (m) =>
+            m.organization_id === org &&
+            m.external_id !== null &&
+            externos.includes(m.external_id) &&
+            filtros.every(([c, v]) => (Array.isArray(v) ? v.includes(m[c]) : m[c] === v)),
+        );
+        return { data: achou ? { id: achou.id } : null, error: null };
+      },
+      then(ok: (v: unknown) => unknown) {
+        const casadas = messages.filter(
+          (m) =>
+            (org === null || m.organization_id === org) &&
+            filtros.every(([c, v]) => (Array.isArray(v) ? v.includes(m[c]) : m[c] === v)) &&
+            (externos.length === 0 || (m.external_id !== null && externos.includes(m.external_id))),
+        );
+        return Promise.resolve(ok({ data: casadas, error: null }));
+      },
+    };
+    return q;
+  };
+
+  const consultaConversa = () => {
+    const q: Record<string, unknown> = {
+      eq: () => q,
+      async maybeSingle() {
+        return { data: { bot_silenced_until: conversa.bot_silenced_until }, error: null };
+      },
+    };
+    return q;
+  };
+
+  const tabela = (nome: string) => ({
+    select: () => (nome === "conversations" ? consultaConversa() : consultaMessages()),
+    insert: (linha: Record<string, unknown>) => ({
+      select: () => ({
+        async maybeSingle() {
+          if (nome !== "messages") return { data: { id: "x" }, error: null };
+          const externo = linha.external_id as string | null;
+          if (
+            externo !== null &&
+            messages.some((m) => m.organization_id === linha.organization_id && m.external_id === externo)
+          ) {
+            return { data: null, error: { code: "23505", message: "duplicate key" } };
+          }
+          const nova = { id: `msg-${messages.length + 1}`, ...linha } as Linha;
+          messages.push(nova);
+          return { data: { id: nova.id }, error: null };
+        },
+      }),
+    }),
+    update: (patch: Record<string, unknown>) => {
+      if (nome === "conversations") Object.assign(conversa, patch);
+      const enc: Record<string, unknown> = { error: null };
+      enc.eq = () => enc;
+      enc.in = () => enc;
+      return enc;
+    },
+  });
+
+  const admin = {
+    from: (nome: string) => tabela(nome),
+    rpc: async (fn: string) => {
+      if (fn === "fn_upsert_wa_contact") return { data: "contato-1", error: null };
+      if (fn === "fn_upsert_wa_conversation") return { data: "conversa-1", error: null };
+      return { data: null, error: null };
+    },
+  };
+
+  return { admin, messages, conversa };
+}
+
+const SESSION = { id: "sessao-1", organization_id: "org-1" };
+const TEXTO = "Thiago, consigo te colocar amanhã às 15h. Fica bom?";
+
+const envelope = (p: WahaPayload): WahaEnvelope => ({
+  event: "message.any",
+  session: "default",
+  payload: p,
+});
+
+/** O eco do próprio envio, no formato `@lid_` do NOWEB. */
+const eco = (body: string): WahaPayload => ({
+  id: "true_10200698331209@lid_3EB0C767D097E9ECA6B1",
+  from: "10200698331209@lid",
+  fromMe: true,
+  body,
+  timestamp: 1_760_000_000,
+});
+
+/** Uma linha de envio do CRM ainda EM VOO: gravada, sem id do canal. */
+const emVoo = (over: Partial<Linha> = {}): Partial<Linha> => ({
+  conversation_id: "conversa-1",
+  external_id: null,
+  direction: "outbound",
+  status: "queued",
+  sent_via: "ai",
+  body: TEXTO,
+  type: "chat",
+  sent_at: new Date().toISOString(),
+  ...over,
+});
+
+describe("eco do próprio envio — a IA não se cala por ter falado", () => {
+  it("⭐ envio da IA em voo + eco com o MESMO texto: o bot NÃO é silenciado", async () => {
+    const { admin, conversa } = banco([emVoo()]);
+
+    await dispatchWahaEvent(admin as never, SESSION as never, envelope(eco(TEXTO)), "req-1");
+
+    expect(
+      conversa.bot_silenced_until,
+      "a IA se calou por três horas por ter falado — e a tela mostra 'Automático pausado', um estado legítimo que ninguém investiga",
+    ).toBeNull();
+  });
+
+  it("⭐ CONTROLE POSITIVO: digitação real no celular AINDA silencia", async () => {
+    // Sem este caso, um "conserto" que simplesmente removesse a chamada de
+    // silêncio ficaria verde — e mataria a feature que o #371 pede.
+    const { admin, conversa } = banco([emVoo()]);
+
+    await dispatchWahaEvent(
+      admin as never,
+      SESSION as never,
+      envelope(eco("oi, aqui é o Rafael falando do meu celular")),
+      "req-2",
+    );
+
+    expect(
+      conversa.bot_silenced_until,
+      "o atendente respondeu pelo celular e a IA continuou solta — é o defeito do #371 de volta",
+    ).not.toBeNull();
+  });
+
+  it("CONTROLE 2: sem envio em voo, qualquer mensagem do celular silencia", async () => {
+    // A janela de tempo sozinha não pode ser o gate: sem uma linha nossa em voo,
+    // não há eco possível, e toda mensagem `fromMe` é digitação humana.
+    const { admin, conversa } = banco([]);
+
+    await dispatchWahaEvent(admin as never, SESSION as never, envelope(eco(TEXTO)), "req-3");
+
+    expect(conversa.bot_silenced_until).not.toBeNull();
+  });
+
+  it("CONTROLE 3: envio em voo com texto DIFERENTE não protege o eco", async () => {
+    const { admin, conversa } = banco([emVoo({ body: "outra coisa completamente" })]);
+
+    await dispatchWahaEvent(admin as never, SESSION as never, envelope(eco(TEXTO)), "req-4");
+
+    expect(conversa.bot_silenced_until).not.toBeNull();
+  });
+
+  it("o envio do COMPOSER também é protegido — não é privilégio da IA", async () => {
+    const { admin, conversa } = banco([emVoo({ sent_via: "user" })]);
+
+    await dispatchWahaEvent(admin as never, SESSION as never, envelope(eco(TEXTO)), "req-5");
+
+    expect(conversa.bot_silenced_until).toBeNull();
+  });
+
+  it("⭐ a linha continua sendo GRAVADA — o gate barra o silêncio, nunca o insert", async () => {
+    // A direção oposta, e ela é o coração do desenho: gravar é tolerante
+    // (perder mensagem é pior que duplicar, é o #108), silenciar é estrito
+    // (calar a IA por engano é pior que não calar).
+    const { admin, messages } = banco([emVoo()]);
+
+    await dispatchWahaEvent(admin as never, SESSION as never, envelope(eco(TEXTO)), "req-6");
+
+    expect(
+      messages.length,
+      "o gate pulou o INSERT — isso reabre o #108, em que uma mensagem legítima do celular sumiu",
+    ).toBe(2);
+  });
+
+  it("silêncio permanente (handoff formal) não é tocado", async () => {
+    const { admin, conversa } = banco([emVoo({ body: "digitei no celular" })]);
+    conversa.bot_silenced_until = "infinity";
+
+    await dispatchWahaEvent(admin as never, SESSION as never, envelope(eco("digitei no celular")), "req-7");
+
+    expect(conversa.bot_silenced_until, "encurtou um handoff formal").toBe("infinity");
+  });
+});


### PR DESCRIPTION
Closes #519

## O defeito

Todo envio do CRM (IA, composer, follow-up, MCP) grava a linha **antes** de falar com o canal: `status="queued"`, `external_id=null`. O id só existe depois que o WAHA responde.

Nessa janela o eco chega com `fromMe: true`, o dedup por `external_id` **não casa nada** — a linha do envio ainda não tem id — e `handleOutboundFromUserPhone` concluía que um humano respondeu pelo celular:

```
lib/waha/ingest.ts:857   await silenciarBotPorRetomadaHumana(...)
lib/waha/ingest.ts:47    HUMAN_TAKEOVER_SILENCE_MS = 3 * 60 * 60 * 1000
```

**A IA se calava por três horas por ter falado.** E o pior é o disfarce: a tela mostra `Automático pausado` (`lib/inbox/comando-da-conversa.ts:239` deriva `automaticoAtivo` do silêncio) — um estado legítimo, que ninguém investiga.

Atinge qualquer instalação e qualquer conversa, sem pré-condição.

A janela **já estava documentada como defeito aberto** na própria suíte: `lib/waha/ingest-celular.test.ts:315` — *"JANELA CONHECIDA: enquanto o envio está `queued` sem external_id, o eco duplica"*.

## O desenho: duas decisões que eram uma só

```
gravar a linha   ->  tolerante   na dúvida grava; perder mensagem é pior que duplicar
silenciar o bot  ->  ESTRITO     na dúvida NÃO cala; calar a IA por engano é pior
```

As direções são **opostas de propósito**. O #108 já custou caro aqui — casar o eco por proximidade descartou uma mensagem legítima digitada no celular, e o comentário de `_handler.ts:47-53` registra isso. Por isso o gate barra **só o silêncio**, nunca o INSERT. Quem reaproveitar esta condição para pular a gravação reabre o #108, e há um caso de teste exatamente para isso.

## A prova que o gate exige

Linha nossa na **mesma conversa**, com `sent_via in (ai, user)`, ainda **sem `external_id`** (portanto em voo), `status in (queued, sending)`, dentro de 60s, e com o **mesmo corpo**. Faltando qualquer uma, a resposta é *"não sei"* — e "não sei" silencia, que é o desfecho seguro do lado do atendente humano (#371). Falha de leitura também silencia.

`sent_via` separa o que **nasceu aqui** do que veio do celular: a linha do celular é gravada como `external_device` e nunca serve de álibi.

**Mídia é mais fraca, e está escrito no código:** o eco traz `media_url`, não texto, então a prova cai para "existe envio nosso em voo do mesmo tipo na janela". Assumidamente mais permissivo.

## Prova

```console
$ npx vitest run tests/unit/eco-do-envio-nao-silencia-o-bot.test.ts
  Tests  7 passed (7)
```

**Duas sabotagens, e a segunda é a que importa:**

```
A) reverto o gate — previ 2, deu 2:
   × envio da IA em voo + eco com o MESMO texto: o bot NÃO é silenciado
   × o envio do COMPOSER também é protegido — não é privilégio da IA

B) gate FROUXO (só "há envio em voo", sem comparar o corpo) — previ 2, deu 2:
   × CONTROLE POSITIVO: digitação real no celular AINDA silencia
   × CONTROLE 3: envio em voo com texto DIFERENTE não protege o eco
```

A sabotagem B derruba **outros dois casos** — os controles positivos. É ela que prova que a guarda **discrimina**, em vez de só existir: um gate que sempre dissesse "é eco" passaria na A e mataria a feature do #371.

## Gates

```
pnpm typecheck   exit=0
pnpm lint        exit=0
pnpm test:unit   617 arquivos / 6814 testes, exit=0   (suíte COMPLETA)
```

O dublê de `ingest-celular.test.ts` ganhou `.is()`, `.gte()`, `.order()` e resolução de lista — a consulta nova precisa ser respondida, senão nove casos daquele arquivo caem por um motivo que nada tem a ver com o que eles medem.

## O que NÃO fiz

**A duplicata continua nascendo.** Este PR conserta o *silêncio*, não a duplicação — a linha do eco ainda entra ao lado da do envio, e o caso `JANELA CONHECIDA` segue verde afirmando `toHaveLength(2)`. Fechar aquilo exige casar o eco com o envio por identidade, que é o caminho que produziu o #108. Deixei como está de propósito: o dano visível (duas linhas na conversa) é muito menor que o dano silencioso (IA muda por 3h), e resolver os dois no mesmo PR faria a sabotagem de um esconder a do outro.

**Não restauro um silêncio já gravado.** Se o defeito já silenciou a conversa numa instalação, ela continua muda até o prazo vencer — o conserto é daqui para a frente. Desfazer exigiria distinguir silêncio-por-engano de silêncio-legítimo já gravado, e essa informação não existe na linha.

**Não registrei o silenciamento na Central**, que a issue também pede: `agent_inbox_items` precisaria de um `kind` novo, e isso é migration + baseline + MANIFEST. Escopo próprio.

**Custo:** uma consulta a mais por mensagem `fromMe` — e só nesse ramo.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam (suíte completa)
- [x] Service role com filtro de `organization_id` manual na consulta nova
- [x] Sem `console.log` esquecido (o `console.error` do ramo de falha é o padrão do arquivo)
- [x] Fragmento em `.changes/` (`nada_mudou` / `corrigido`)
- [ ] Schema: não toca

🤖 Generated with [Claude Code](https://claude.com/claude-code)