### PR TITLE
fix(ia): o checkpoint declara o referencial, e cadastro vazio deixa de ser autoridade

### DIFF
--- a/.changes/o-agente-para-de-repetir-pergunta-ja-respondida.md
+++ b/.changes/o-agente-para-de-repetir-pergunta-ja-respondida.md
@@ -1,0 +1,27 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O agente para de repetir uma pergunta que o cliente já respondeu
+---
+
+Numa conversa real, o agente pediu o e-mail do cliente **quatro vezes** — com o
+cliente respondendo três. Para quem está do outro lado, isso não parece um
+sistema: parece desatenção.
+
+Eram duas causas somadas.
+
+A primeira: ao fechar cada turno, o agente anota qual é a "próxima ação". Como
+essa anotação é escrita logo depois de ele perguntar e antes de a resposta
+chegar, ele anotava como próxima ação **a pergunta que acabara de fazer**. No
+turno seguinte essa anotação voltava no topo das instruções, acima do histórico
+— e mandava perguntar de novo o que o histórico logo abaixo já respondia.
+
+A segunda: o cadastro do contato aparecia com o e-mail em branco, e o agente lia
+isso como um fato ("não tem e-mail"), com mais autoridade do que a mensagem em
+que o cliente tinha acabado de digitá-lo. E como esse campo nunca é preenchido
+sozinho, o pedido se repetia indefinidamente.
+
+Agora a anotação diz explicitamente que se refere ao **depois** da resposta, o
+bloco avisa que foi escrito antes da última mensagem do cliente — e que, em caso
+de desacordo, vale o histórico —, e o cadastro em branco vem com a ressalva de
+que a informação pode já ter sido dada na conversa.

--- a/lib/agent-engine/agent/inbound-turn.ts
+++ b/lib/agent-engine/agent/inbound-turn.ts
@@ -390,6 +390,22 @@ export const CHECKPOINT_INSTRUCTION =
   '{"commitments": string[], "objections": string[], "next_action": string|null, "rolling_summary": string} ' +
   '— compromissos assumidos, objeções do lead, próxima ação e o resumo acumulado ' +
   'da conversa até aqui (inclua o que o resumo anterior já dizia). ' +
+  // ⚠️ O REFERENCIAL DE `next_action`, e ele não é zelo de redação.
+  //
+  // Este JSON é escrito no FECHO do turno: a pergunta já saiu, a resposta ainda
+  // não chegou. Sem dizer QUANDO, "próxima ação" é ambígua entre "o que acabei
+  // de fazer" e "o que farei depois" — e o modelo gravava a primeira. No turno
+  // seguinte o texto volta como o PRIMEIRO bloco do prompt, acima do histórico,
+  // e manda repetir a pergunta que o histórico logo abaixo já responde. Medido
+  // numa conversa real: o agente pediu o e-mail QUATRO vezes, com o cliente
+  // respondendo três. (issue #510)
+  //
+  // A negação explícita está aqui porque dizer o que É não basta quando o erro
+  // tem um atrator forte: a pergunta recém-feita é o texto mais fresco no
+  // contexto do modelo.
+  'Em `next_action`, escreva a ação que vem DEPOIS da resposta que você está ' +
+  'esperando — nunca a pergunta que você acabou de fazer. Se o turno terminou ' +
+  'perguntando, a próxima ação é o que fazer COM a resposta quando ela chegar. ' +
   DECLARACAO_INSTRUCTION +
   ' Sem texto fora do JSON.';
 
@@ -937,7 +953,15 @@ export function ritualBlocks(
       })
     : 'sem registro — o lead está em "new"';
   return [
-    '## Checkpoint anterior (compromissos, objeções, próxima ação)',
+    // O cabeçalho declara QUANDO isto foi escrito e QUEM MANDA no desacordo.
+    //
+    // Este é o PRIMEIRO bloco do prompt, acima do histórico — posição que um
+    // modelo lê como "a instrução mais recente". Ele é o oposto disso: foi
+    // escrito no fecho do turno ANTERIOR, antes da mensagem que o cliente
+    // acabou de mandar. Sem dizer isso, um checkpoint desatualizado vence o
+    // histórico que o contradiz. (issue #510)
+    '## Checkpoint anterior — escrito ANTES da última mensagem do cliente',
+    '(Se o histórico abaixo já responde o que este bloco pede, o histórico manda.)',
     checkpointBlock,
     '',
     '## Resumo acumulado da conversa',
@@ -959,6 +983,21 @@ export function ritualBlocks(
     notesIndexBlock,
     '',
     '## Contexto do lead (contato + últimas mensagens)',
+    // Campo de cadastro VAZIO não é prova de que a informação não existe.
+    //
+    // `contact.email: null` chegava como fato, e o modelo o lia com autoridade
+    // de cadastro — vencendo o histórico onde o cliente ACABOU de digitar o
+    // e-mail. E como não há caminho de escrita, o campo nunca deixa de ser
+    // null: o pedido se repetia para sempre. A ressalva é CONDICIONAL de
+    // propósito — pô-la sempre ensinaria o modelo a duvidar de dado bom, que é
+    // o defeito espelhado. (issue #510)
+    ...(context.contact?.email == null
+      ? [
+          '(O e-mail não está confirmado no cadastro. Isso NÃO quer dizer que o ' +
+            'cliente não tenha dado: ele pode já ter sido dito no histórico abaixo. ' +
+            'Confira lá antes de pedir de novo.)',
+        ]
+      : []),
     // A projeção (spec 16 §4) fecha a terceira porta: sem ela, `lead_id`,
     // `conversation_id` e `media_storage_path` chegam crus ao prompt — e UUID
     // cru na tela do cliente foi MEDIDO. Ela só arma quando o turno não tem

--- a/tests/unit/checkpoint-declara-o-referencial.test.ts
+++ b/tests/unit/checkpoint-declara-o-referencial.test.ts
@@ -1,0 +1,138 @@
+/**
+ * O CHECKPOINT DIZ QUANDO FOI ESCRITO, E O CADASTRO VAZIO NÃO É AUTORIDADE
+ * (issue #510).
+ *
+ * ─── O defeito, medido numa conversa real ───────────────────────────────────
+ *
+ * O agente pediu o e-mail do cliente QUATRO vezes na mesma conversa, com o
+ * cliente respondendo três. Duas causas somadas:
+ *
+ * 1. `CHECKPOINT_INSTRUCTION` pede "próxima ação" SEM referencial. O checkpoint
+ *    é escrito no FECHO do turno — depois de a pergunta já ter saído e ANTES de
+ *    a resposta chegar. Sem referencial, o modelo grava como próxima ação a
+ *    pergunta que ACABOU de fazer. No turno seguinte esse texto volta como o
+ *    PRIMEIRO bloco do prompt, acima do histórico — e a instrução mais recente
+ *    manda repetir a pergunta que o histórico logo abaixo já responde.
+ *
+ * 2. `contact.email: null` chega ao contexto como fato. O modelo lê "não tem
+ *    e-mail" com a autoridade de um cadastro, e essa leitura vence o histórico
+ *    onde o cliente acabou de digitar o e-mail. Não há caminho de escrita: o
+ *    campo NUNCA deixa de ser null, então o pedido se repete para sempre.
+ *
+ * ─── ⚠️ O QUE ESTE ARQUIVO NÃO PROVA ────────────────────────────────────────
+ *
+ * Ele vigia TEXTO, não comportamento. `toContain` sobre uma instrução é BUSCA:
+ * impede a REGRESSÃO da frase, não garante que o modelo parou de repetir. A
+ * prova do efeito é conversa real com o modelo em produção, e ela não cabe em
+ * vitest.
+ *
+ * Isso está escrito aqui de propósito, para o verde não virar álibi.
+ */
+import { describe, expect, it } from "vitest";
+
+import { CHECKPOINT_INSTRUCTION, ritualBlocks } from "@/lib/agent-engine/agent/inbound-turn";
+
+describe("a instrução do checkpoint declara O QUANDO da próxima ação", () => {
+  it("⭐ amarra a próxima ação à resposta que ainda NÃO chegou", () => {
+    // Sem referencial, "próxima ação" no fecho do turno é ambígua entre "o que
+    // eu acabei de fazer" e "o que farei depois" — e o modelo grava a primeira.
+    expect(
+      /depois da resposta/i.test(CHECKPOINT_INSTRUCTION),
+      "a instrução não diz que a próxima ação vem DEPOIS da resposta que o agente está esperando",
+    ).toBe(true);
+  });
+
+  it("⭐ nega explicitamente a pergunta recém-feita", () => {
+    // Dizer o que É não basta quando o erro tem um atrator forte. A negação é o
+    // que separa a instrução nova da anterior para um modelo pequeno.
+    expect(
+      /nunca a pergunta que você acabou de fazer/i.test(CHECKPOINT_INSTRUCTION),
+      "a instrução não proíbe gravar como próxima ação a pergunta que acabou de sair",
+    ).toBe(true);
+  });
+
+  it("a declaração obrigatória do turno continua dentro da instrução", () => {
+    // Guarda contra o conserto quebrar o que já estava certo: `declaracao-do-turno`
+    // exige que DECLARACAO_INSTRUCTION esteja aqui, e a concatenação é posicional.
+    expect(CHECKPOINT_INSTRUCTION).toContain("Sem texto fora do JSON.");
+    expect(CHECKPOINT_INSTRUCTION).toContain('"next_action"');
+  });
+});
+
+describe("o bloco do checkpoint declara a precedência do histórico", () => {
+  const checkpoint = {
+    commitments: ["enviar proposta"],
+    objections: [],
+    next_action: "pedir o e-mail do cliente",
+    rolling_summary: "cliente pediu orçamento",
+  } as never;
+
+  const blocos = () =>
+    ritualBlocks(
+      checkpoint as never,
+      null,
+      { contact: { name: "Cliente", email: null } } as never,
+      "sem notas",
+      false,
+    ).join("\n");
+
+  it("⭐ o cabeçalho diz que o checkpoint foi escrito ANTES da última mensagem", () => {
+    // Ele volta como PRIMEIRO bloco do prompt, acima do histórico. Sem dizer
+    // quando foi escrito, ele lê como a instrução mais recente — e vence o
+    // histórico que o contradiz.
+    const t = blocos();
+    expect(
+      /antes da última mensagem/i.test(t),
+      "o cabeçalho do checkpoint não diz que ele é anterior à última mensagem do cliente",
+    ).toBe(true);
+  });
+
+  it("⭐ e diz quem manda quando os dois discordam", () => {
+    expect(
+      /o histórico manda|prevalece o histórico|vale o histórico/i.test(blocos()),
+      "o cabeçalho não declara a precedência: com checkpoint e histórico discordando, o modelo não sabe qual seguir",
+    ).toBe(true);
+  });
+
+  it("controle positivo: o instrumento enxerga os blocos", () => {
+    // Sem isto, um `ritualBlocks` que devolvesse vazio faria as asserções acima
+    // falharem por motivo errado — e as de ausência passariam por vacuidade.
+    const t = blocos();
+    expect(t).toContain("Checkpoint anterior");
+    expect(t).toContain("pedir o e-mail do cliente");
+  });
+});
+
+describe("cadastro vazio não se apresenta como fato", () => {
+  it("⭐ `email: null` no contexto vem com a ressalva de que o histórico pode ter", () => {
+    // É a segunda camada, e é ela que mata o caso medido de 4×: o campo NUNCA
+    // deixa de ser null (não há caminho de escrita), então lido como autoridade
+    // ele repete o pedido para sempre.
+    const t = ritualBlocks(
+      null,
+      null,
+      { contact: { name: "Cliente", email: null } } as never,
+      "sem notas",
+      false,
+    ).join("\n");
+
+    expect(
+      /não confirmado no cadastro|pode já ter sido dito|cadastro pode estar vazio/i.test(t),
+      "o contexto apresenta `email: null` como fato — o modelo lê 'não tem e-mail' com autoridade de cadastro e ignora o histórico onde o cliente acabou de dizer",
+    ).toBe(true);
+  });
+
+  it("cadastro PREENCHIDO não ganha ressalva — ela existe para o vazio", () => {
+    // Controle na direção oposta: uma ressalva incondicional ensinaria o modelo
+    // a duvidar de dado bom, que é o defeito espelhado.
+    const t = ritualBlocks(
+      null,
+      null,
+      { contact: { name: "Cliente", email: "cliente@exemplo.com" } } as never,
+      "sem notas",
+      false,
+    ).join("\n");
+
+    expect(/não confirmado no cadastro/i.test(t)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #510

## O caso medido

Numa conversa real, o agente pediu o e-mail do cliente **quatro vezes**, com o cliente respondendo três. Duas causas somadas — e consertar só uma deixa o caso vivo.

## Causa 1 — `next_action` sem referencial

```
lib/agent-engine/agent/inbound-turn.ts:388
  "… compromissos assumidos, objeções do lead, próxima ação e o resumo acumulado …"
```

O JSON é escrito no **fecho** do turno: a pergunta já saiu, a resposta ainda não chegou. Sem dizer *quando*, "próxima ação" é ambígua entre *"o que acabei de fazer"* e *"o que farei depois"* — e o modelo gravava a primeira.

No turno seguinte esse texto volta como o **primeiro bloco do prompt**, acima do histórico, e manda repetir a pergunta que o histórico logo abaixo já responde.

A **negação explícita** (`nunca a pergunta que você acabou de fazer`) está lá porque dizer o que *é* não basta quando o erro tem um atrator forte: a pergunta recém-feita é o texto mais fresco no contexto do modelo.

## Causa 2 — `contact.email: null` lido como fato

O modelo lia "não tem e-mail" com autoridade de **cadastro**, e essa leitura vencia o histórico onde o cliente acabara de digitar. E como **não há caminho de escrita**, o campo nunca deixa de ser null: o pedido se repetia para sempre.

A ressalva é **condicional** de propósito — pô-la sempre ensinaria o modelo a duvidar de dado bom, que é o defeito espelhado. Há caso de teste para essa direção.

## E o cabeçalho passa a declarar a precedência

```diff
- ## Checkpoint anterior (compromissos, objeções, próxima ação)
+ ## Checkpoint anterior — escrito ANTES da última mensagem do cliente
+ (Se o histórico abaixo já responde o que este bloco pede, o histórico manda.)
```

Ele é o primeiro bloco do prompt — posição que um modelo lê como *"a instrução mais recente"*. É o oposto disso.

## ⚠️ O que este PR NÃO prova

**O teste vigia texto, não comportamento.** `toContain` sobre uma instrução é **busca**: impede a *regressão* da frase, não garante que o modelo parou de repetir. A prova do efeito é conversa real com o modelo em produção, e ela não cabe em vitest.

Isso está escrito no cabeçalho do arquivo de teste, para o verde não virar álibi. Se você quiser a prova de comportamento antes de mergear, ela é uma conversa de aceite — e o par (agente + ferramenta) é a unidade, como a #489 argumenta.

## Prova

```console
$ npx vitest run tests/unit/checkpoint-declara-o-referencial.test.ts
  Tests  8 passed (8)
```

**Duas sabotagens** — previ 5 e 1, deu 5 e 1:

```
A) reverto tudo                          → 5 vermelhos
B) tiro só a ressalva do e-mail          → 1: `email: null` vem com a ressalva
```

A sabotagem B existe porque as duas causas são somadas: sem ela, um PR que consertasse só a instrução ficaria verde deixando vivo o pior caso da issue.

## Gates

```
pnpm typecheck   exit=0
pnpm lint        exit=0
pnpm test:unit   617 arquivos / 6815 testes, exit=0   (suíte COMPLETA)
```

## O que NÃO fiz

**Não migrei as linhas antigas de `next_action`.** O significado do campo muda daqui para a frente; as linhas já gravadas ficam com a semântica velha e aparecem em duas superfícies (`lib/leads/checkpoint-diff.ts` e o card em `ProposalsList.tsx`), que passam a misturar duas gerações. Migrar exigiria reinterpretar texto livre — preferi a mistura declarada a uma reescrita adivinhada.

**Não dei caminho de escrita ao `contact.email`.** A ressalva impede o modelo de tratar o vazio como fato, mas o campo continua nunca sendo preenchido pela conversa. Fazer o agente gravar o e-mail que o cliente diz é feature, com escrita em `contacts` e as perguntas de LGPD que vêm junto.

**Não toquei nos outros campos do cadastro** (telefone, tags). O e-mail foi o medido; estender a ressalva a todos sem caso medido seria adivinhação — e cada ressalva a mais dilui as outras.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam (suíte completa)
- [x] Sem `console.log` esquecido
- [x] Fragmento em `.changes/` (`nada_mudou` / `corrigido`)
- [ ] Prova de comportamento com modelo real: **não feita** — ver acima
- [ ] Schema: não toca

🤖 Generated with [Claude Code](https://claude.com/claude-code)