### PR TITLE
fix(release): título de fragmento com aspa no meio deixa de chegar torto

### DIFF
--- a/.changes/o-titulo-da-novidade-nao-chega-torto.md
+++ b/.changes/o-titulo-da-novidade-nao-chega-torto.md
@@ -1,0 +1,19 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Título de novidade com aspas no meio chega inteiro à tela de atualização
+---
+
+O texto que descreve cada novidade é lido por quem opera a instalação, na tela
+de atualização, antes de decidir atualizar. Um título que citasse uma frase
+entre aspas chegava lá **torto**: a aspa de abertura sumia e a do meio ficava
+solta, como se o texto estivesse cortado.
+
+Num sistema de atendimento, citar o que o cliente escreve é o caso natural de um
+título — não a exceção. O primeiro título que precisou disso já saiu errado.
+
+Agora aspas no meio do texto são preservadas, e só somem quando envolvem o
+título inteiro — que é como alguém escreveria para "escapar" o texto.
+
+Nada muda no dia a dia de quem opera: nenhuma configuração nova, nenhum passo de
+atualização.

--- a/lib/release/fragmento.ts
+++ b/lib/release/fragmento.ts
@@ -114,7 +114,18 @@ function separarFrontmatter(texto: string): { campos: Record<string, string>; co
     // entregaria à tela do dono da VPS um título cortado no meio.
     const cru = linha.slice(sep + 1);
     const valor = (VOCABULARIO_FECHADO.has(chave) ? cru.replace(/\s+#.*$/, "") : cru).trim();
-    campos[chave] = valor.replace(/^["']|["']$/g, "");
+    // ⚠️ SÓ TIRA ASPA COM PAR. O `replace(/^["']|["']$/g, "")` que morava aqui
+    // tirava cada ponta INDEPENDENTE, e um título com aspa no meio saía torto:
+    //
+    //     titulo: "Quero 2 iPhone 15" volta a encontrar o iPhone 15
+    //          →  Quero 2 iPhone 15" volta a encontrar o iPhone 15
+    //
+    // A aspa de abertura some, a do meio fica órfã, e é ISSO que chega ao
+    // CHANGELOG que o dono da VPS lê antes de atualizar. Aspa citando o que o
+    // cliente digita é o caso natural num produto de atendimento — o título
+    // acima é real, e passou pelo gate.
+    const aspas = /^(["'])([\s\S]*)\1$/.exec(valor);
+    campos[chave] = aspas ? aspas[2]! : valor;
   }
   return { campos, corpo: linhas.slice(fim + 1).join("\n").trim() };
 }

--- a/tests/unit/fragmentos-de-release.test.ts
+++ b/tests/unit/fragmentos-de-release.test.ts
@@ -61,4 +61,35 @@ describe("os fragmentos de .changes/ estão em forma de chegar à tela", () => {
       parseFragmento("ruim.md", "---\nimpacto: minor\nsecao: corrigido\ntitulo: x\n---\n\ncorpo"),
     ).toThrow(FragmentoInvalido);
   });
+
+  it("título com aspa NO MEIO chega inteiro à tela", () => {
+    // ⚠️ Defeito real, e ele passou por este gate: a limpeza de aspas tirava
+    // cada ponta INDEPENDENTE, então
+    //
+    //     titulo: "Quero 2 iPhone 15" volta a encontrar o iPhone 15
+    //
+    // virava `Quero 2 iPhone 15" volta a encontrar o iPhone 15` — a aspa de
+    // abertura sumia e a do meio ficava órfã. É ISSO que chega ao CHANGELOG que
+    // o dono da VPS lê antes de atualizar.
+    //
+    // Num produto de atendimento, citar o que o cliente digita é o caso natural
+    // do título, não a exceção.
+    const comAspa = parseFragmento(
+      "x.md",
+      ['---', 'impacto: nada_mudou', 'secao: corrigido',
+       'titulo: "Quero 2 iPhone 15" volta a encontrar o iPhone 15', '---', '', 'corpo.'].join("\n"),
+    );
+    expect(comAspa.titulo).toBe('"Quero 2 iPhone 15" volta a encontrar o iPhone 15');
+  });
+
+  it("aspas que ENVOLVEM o título inteiro continuam sendo removidas (controle)", () => {
+    // Sem este caso, "nunca tirar aspa" satisfaria o anterior — e aí todo
+    // título escrito no estilo YAML chegaria com as aspas na tela.
+    const envolvido = parseFragmento(
+      "x.md",
+      ['---', 'impacto: nada_mudou', 'secao: corrigido',
+       'titulo: "o título inteiro entre aspas"', '---', '', 'corpo.'].join("\n"),
+    );
+    expect(envolvido.titulo).toBe("o título inteiro entre aspas");
+  });
 });


### PR DESCRIPTION
## O defeito

A limpeza de aspas do frontmatter tirava **cada ponta independente**:

```ts
valor.replace(/^["']|["']$/g, "")
```

Então um título que cita uma frase saía mutilado:

```
titulo: "Quero 2 iPhone 15" volta a encontrar o iPhone 15
     →  Quero 2 iPhone 15" volta a encontrar o iPhone 15
```

A aspa de abertura some, a do meio fica órfã — e **é isso que chega ao CHANGELOG
que o dono da VPS lê antes de atualizar.**

O título acima é real: eu o escrevi ontem no PR #487, ele passou pelo gate, e
está na `main`.

## ⚠️ Uma correção de enquadramento, antes do conserto

Eu ia reportar isto como *"o gate não valida YAML"*. **É falso.** Este parser
não é YAML **de propósito**, e o comentário logo acima dele explica por quê: um
título que cita `#351` teria o resto comido como comentário.

O defeito é mais estreito e é outro: **aspa sem par**.

## O conserto

Só remove aspa que **envolve o valor inteiro**, com o mesmo caractere nas duas
pontas.

Num produto de atendimento, citar o que o cliente digita é o caso natural de um
título — não a exceção. O primeiro título que precisou disso já saiu errado.

## Provas

Dois casos, e o segundo existe para que **"nunca tirar aspa"** não satisfaça o
primeiro — aí todo título escrito no estilo YAML chegaria com as aspas na tela.

**Sabotagem:** voltar à limpeza independente derruba 1 caso, como previsto.

E o fragmento do #487 volta a ser exibido inteiro:

```console
$ pnpm release:conferir
  nada_mudou  corrigido  "Quero 2 iPhone 15" volta a encontrar o iPhone 15
```
