### PR TITLE
fix(agenda): id que não é lead deixa de virar "nada marcado"

### DIFF
--- a/.changes/o-agente-nao-nega-mais-uma-reuniao-que-ele-marcou.md
+++ b/.changes/o-agente-nao-nega-mais-uma-reuniao-que-ele-marcou.md
@@ -4,10 +4,10 @@ secao: corrigido
 titulo: O agente para de dizer que o cliente não tem nada marcado quando tem
 ---
 
-O atendente de IA podia marcar uma reunião e, logo depois, **negar ao cliente
-que ela existia** — pedindo desculpas por tê-la marcado. Não havia erro em lugar
-nenhum: a consulta era válida e devolvia "nenhum compromisso", que é uma
-resposta legítima.
+O atendente de IA podia marcar uma reunião e, minutos depois, dizer ao próprio
+cliente que **ela não existia** — pedindo desculpas por tê-la marcado. Não havia
+erro em lugar nenhum: a consulta era válida e devolvia "nenhum compromisso", que
+é uma resposta legítima.
 
 A causa é um nome. Dentro do motor, o campo que identifica **a pessoa** da
 conversa se chama `lead_id` — mas nas ferramentas de agenda esse mesmo nome
@@ -16,8 +16,8 @@ identificador da pessoa no lugar do negócio, a busca não encontrava vínculo
 nenhum e respondia "nada marcado".
 
 Agora, quando o identificador não corresponde a um negócio do funil, a resposta
-deixa de ser "nada marcado" e passa a ser uma recusa que **ensina o caminho
-certo** — e que instrui o agente a dizer que vai confirmar com a equipe, nunca
+deixa de ser "nada marcado" e passa a ser uma **recusa que ensina o caminho certo**
+— e que instrui o agente a dizer que vai confirmar com a equipe, nunca
 que o cliente não tem nada.
 
 Um negócio de verdade sem compromissos continua respondendo "nada marcado", que

--- a/.changes/o-agente-nao-nega-mais-uma-reuniao-que-ele-marcou.md
+++ b/.changes/o-agente-nao-nega-mais-uma-reuniao-que-ele-marcou.md
@@ -1,0 +1,24 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O agente para de dizer que o cliente não tem nada marcado quando tem
+---
+
+O atendente de IA podia marcar uma reunião e, logo depois, **negar ao cliente
+que ela existia** — pedindo desculpas por tê-la marcado. Não havia erro em lugar
+nenhum: a consulta era válida e devolvia "nenhum compromisso", que é uma
+resposta legítima.
+
+A causa é um nome. Dentro do motor, o campo que identifica **a pessoa** da
+conversa se chama `lead_id` — mas nas ferramentas de agenda esse mesmo nome
+significa **o negócio no funil**, que é outra coisa. O agente passava o
+identificador da pessoa no lugar do negócio, a busca não encontrava vínculo
+nenhum e respondia "nada marcado".
+
+Agora, quando o identificador não corresponde a um negócio do funil, a resposta
+deixa de ser "nada marcado" e passa a ser uma recusa que **ensina o caminho
+certo** — e que instrui o agente a dizer que vai confirmar com a equipe, nunca
+que o cliente não tem nada.
+
+Um negócio de verdade sem compromissos continua respondendo "nada marcado", que
+é a resposta certa.

--- a/lib/agenda/consulta.ts
+++ b/lib/agenda/consulta.ts
@@ -376,7 +376,15 @@ export interface ParametrosDaLista {
 
 export type ResultadoDaLista =
   | { ok: true; agendamentos: AgendamentoListado[] }
-  | { ok: false; codigo: "erro_interno" | "sem_alvo"; motivoParaOperador: string; motivoParaCliente: string };
+  | {
+      ok: false;
+      // `alvo_nao_e_lead`: o id veio no parâmetro `lead_id` e não é um negócio
+      // do funil — quase sempre um id de CONTATO, que é o que o contexto do
+      // turno chama de `lead_id`. Ver o ramo que o emite. (issue #509)
+      codigo: "erro_interno" | "sem_alvo" | "alvo_nao_e_lead";
+      motivoParaOperador: string;
+      motivoParaCliente: string;
+    };
 
 /** O embed do PostgREST vem objeto ou array conforme o gerador de tipos; aceite os dois. */
 function nomeDoContato(
@@ -426,9 +434,44 @@ export async function listaAgendamentos(
       };
     }
     idsPorLead = (data ?? []).map((l) => String(l.target_id));
-    // Lead sem nenhum vínculo: lista vazia é a resposta CERTA aqui — a pergunta era
-    // "o que este negócio tem marcado?" e a resposta é "nada". Diferente de não saber.
-    if (idsPorLead.length === 0) return { ok: true, agendamentos: [] };
+    if (idsPorLead.length === 0) {
+      // ⚠️ SEM VÍNCULO, HÁ DUAS HISTÓRIAS DIFERENTES — e só uma delas pode ser
+      // contada ao cliente.
+      //
+      // "Este negócio não tem nada marcado" é resposta CERTA, e o comentário
+      // que estava aqui defendia isso com razão. Mas ela era dada TAMBÉM quando
+      // o id nem é um lead — e no motor `leadId` É o `contact_id`
+      // (`inbound-turn.ts:1121`, `get-lead-context.ts:193`), enquanto o campo
+      // publicado no contexto do turno se chama `lead_id`. O modelo passava o
+      // id do contato para cá, a busca por vínculo não achava nada, e o agente
+      // NEGAVA ao cliente um compromisso que ele mesmo tinha acabado de marcar.
+      //
+      // Nada reclamava: consulta válida, lista vazia é legítima, e o modelo não
+      // tinha como suspeitar. A consulta abaixo separa as duas histórias, e só
+      // roda no ramo que já ia devolver vazio. (issue #509)
+      const { data: ehLead } = await supabase
+        .from("crm_leads")
+        .select("id")
+        .eq("organization_id", organizationId)
+        .eq("id", params.leadId)
+        .maybeSingle();
+
+      if (!ehLead) {
+        return {
+          ok: false,
+          codigo: "alvo_nao_e_lead",
+          motivoParaOperador:
+            `o id ${params.leadId} não é um negócio do funil. No contexto do turno, o campo ` +
+            "`lead_id` carrega o id do CONTATO — para consultar os compromissos de uma pessoa, " +
+            "use `contact_id`.",
+          motivoParaCliente:
+            "Não consegui confirmar a agenda dessa pessoa agora. NÃO diga que ela não tem nada " +
+            "marcado — diga que vai confirmar com a equipe.",
+        };
+      }
+      // Lead de verdade, sem nenhum vínculo: "nada marcado" é a resposta certa.
+      return { ok: true, agendamentos: [] };
+    }
   }
 
   let q = supabase

--- a/lib/agent-engine/edge/crm/get-lead-context.ts
+++ b/lib/agent-engine/edge/crm/get-lead-context.ts
@@ -64,7 +64,18 @@ export interface UltimaDecisaoHumana {
 
 /** Payload curado que o modelo recebe. */
 export interface LeadContext {
+  /** ⚠️ É o id do CONTATO, não de um lead do funil. Ver `contact_id` abaixo. */
   lead_id: string;
+  /**
+   * O mesmo valor de `lead_id`, com o nome verdadeiro (issue #509).
+   *
+   * OPCIONAL no tipo, e não por preguiça: exigir o campo obrigaria a editar
+   * fixtures em `tests/invariants/**`, que é CONGELADO pelo hook de governança
+   * (`loop/hooks/freeze-invariants.sh` — invariante existente não se edita). A
+   * produção sempre o preenche; quem constrói contexto à mão num teste não
+   * precisa dele.
+   */
+  contact_id?: string;
   contact: {
     name: string | null;
     phone: string | null;
@@ -233,7 +244,17 @@ export async function getLeadContext(
 
   const context = fitToBudget(
     {
+      // ⚠️ `lead_id` aqui é, e sempre foi, o id do CONTATO (ver o comentário da
+      // consulta acima e `inbound-turn.ts:1121`). O nome mente, e o modelo
+      // acreditava: passava este valor ao parâmetro `lead_id` das ferramentas
+      // de agenda, que espera um NEGÓCIO do funil. (issue #509)
+      //
+      // O campo antigo fica — ele circula por follow-up, case-reply e escalação,
+      // e por invariantes congelados; trocar o nome custa uma wave inteira e
+      // somar o certo custa uma linha. `contact_id` é a porta para o modelo
+      // acertar; as descrições das ferramentas apontam para ela.
       lead_id: input.leadId,
+      contact_id: input.leadId,
       contact: {
         name: contact.display_name ?? contact.name,
         phone: contact.phone_number,

--- a/lib/mcp/tools/agendamento.ts
+++ b/lib/mcp/tools/agendamento.ts
@@ -271,8 +271,26 @@ export const crmFindFreeSlots: McpToolDefinition<typeof horariosLivresShape> = {
 
 
 const listarShape = {
-  contact_id: z.string().uuid().optional(),
-  lead_id: z.string().uuid().optional(),
+  // As duas descrições existem porque o modelo escolhia entre os dois campos no
+  // escuro — nenhum tinha `.describe()`, e a única pista era o nome do campo no
+  // contexto do turno, que chama o CONTATO de `lead_id`. (issue #509)
+  contact_id: z
+    .string()
+    .uuid()
+    .optional()
+    .describe(
+      "o id da PESSOA (o contato da conversa). É este que você quer na quase totalidade dos " +
+        "casos: o campo `lead_id` do contexto do turno carrega justamente o id do contato, " +
+        "então passe aquele valor AQUI.",
+    ),
+  lead_id: z
+    .string()
+    .uuid()
+    .optional()
+    .describe(
+      "o id do NEGÓCIO no funil (a oportunidade), não o da pessoa. Só use quando estiver " +
+        "consultando os compromissos vinculados a um negócio específico.",
+    ),
   dia: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/)

--- a/tests/unit/agenda-nao-mente-sobre-id-de-contato.test.ts
+++ b/tests/unit/agenda-nao-mente-sobre-id-de-contato.test.ts
@@ -1,0 +1,148 @@
+/**
+ * A AGENDA NÃO DEVOLVE "NADA MARCADO" PARA UM ID QUE NÃO É LEAD (issue #509).
+ *
+ * ─── A cadeia, medida em c5b45b24 ───────────────────────────────────────────
+ *
+ * No motor, `leadId` É o `contact_id` — e o próprio arquivo declara isso:
+ *
+ *     lib/agent-engine/agent/inbound-turn.ts:1121
+ *         const leadIdDoJob = job.contact_id;
+ *     lib/agent-engine/edge/crm/get-lead-context.ts:193
+ *         // Filtra por `contact_id` porque deste lado da casa `leadId` é o CONTATO
+ *
+ * Só que o campo publicado no contexto do turno chama-se `lead_id`
+ * (get-lead-context.ts:236). O modelo lê "lead_id" e passa esse valor ao
+ * parâmetro `lead_id` de `crm_list_appointments` — que espera o id de um
+ * NEGÓCIO do funil.
+ *
+ * A consulta então procura vínculos em `crm_lead_links` para um id que não é
+ * lead, não acha nenhum, e devolve `{ ok: true, agendamentos: [] }`
+ * (consulta.ts:431). O agente conclui que o cliente não tem nada marcado —
+ * e NEGA ao cliente um compromisso que ele mesmo acabou de marcar.
+ *
+ * Nada reclama: a consulta é válida, lista vazia é resposta legítima, e o
+ * modelo não tem como suspeitar.
+ *
+ * ─── E os dois parâmetros não se distinguem ─────────────────────────────────
+ *
+ *     lib/mcp/tools/agendamento.ts:274-275
+ *         contact_id: z.string().uuid().optional(),
+ *         lead_id: z.string().uuid().optional(),
+ *
+ * Nenhum dos dois tem `.describe()`. O modelo escolhe entre eles sem nada que
+ * os separe — e a única pista que ele tem é o nome do campo no contexto, que
+ * está errado.
+ */
+import { describe, expect, it } from "vitest";
+
+import { listaAgendamentos } from "@/lib/agenda/consulta";
+import { crmListAppointments } from "@/lib/mcp/tools/agendamento";
+
+const ORG = "22222222-2222-4222-8222-222222222222";
+const ID = "33333333-3333-4333-8333-333333333333";
+
+/**
+ * Dublê que distingue as tabelas: `crm_lead_links` sem vínculo, e `crm_leads`
+ * respondendo se aquele id É um lead. Sem a segunda, o teste não conseguiria
+ * separar "lead sem nada marcado" de "isto nem é um lead" — que é a distinção
+ * inteira desta issue.
+ */
+function db(opts: { ehLead: boolean; vinculos?: string[] }) {
+  const consultas: string[] = [];
+  const q = (tabela: string) => {
+    const enc: Record<string, unknown> = {};
+    const passa = () => enc;
+    for (const m of ["select", "eq", "in", "order", "limit", "gte", "lt", "lte", "is", "not"]) {
+      enc[m] = passa;
+    }
+    enc.maybeSingle = async () => ({
+      data: tabela === "crm_leads" && opts.ehLead ? { id: ID } : null,
+      error: null,
+    });
+    enc.then = (ok: (v: unknown) => unknown) => {
+      consultas.push(tabela);
+      if (tabela === "crm_lead_links") {
+        return Promise.resolve(
+          ok({ data: (opts.vinculos ?? []).map((t) => ({ target_id: t })), error: null }),
+        );
+      }
+      if (tabela === "crm_leads") {
+        return Promise.resolve(ok({ data: opts.ehLead ? [{ id: ID }] : [], error: null }));
+      }
+      return Promise.resolve(ok({ data: [], error: null }));
+    };
+    return enc;
+  };
+  return { consultas, supabase: { from: (t: string) => q(t) } as never };
+}
+
+describe("listaAgendamentos — id que não é lead não vira 'nada marcado'", () => {
+  it("⭐ id de CONTATO passado como lead_id vira recusa que ensina, não lista vazia", async () => {
+    const { supabase } = db({ ehLead: false, vinculos: [] });
+
+    const r = await listaAgendamentos(supabase, ORG, { leadId: ID, limite: 10 } as never);
+
+    expect(
+      r.ok,
+      "devolveu lista vazia para um id que não é lead — o agente conclui que o cliente não tem nada marcado e nega um compromisso que ele mesmo criou",
+    ).toBe(false);
+    if (r.ok) return;
+    // A recusa tem de NOMEAR o caminho certo: sem isso o modelo repete o erro.
+    expect(String(r.motivoParaOperador ?? "") + String(r.motivoParaCliente ?? "")).toContain(
+      "contact_id",
+    );
+  });
+
+  it("⭐ lead REAL sem nada marcado continua devolvendo lista vazia — e deve", async () => {
+    // Controle na direção oposta. Sem ele, um conserto que recusasse todo lead
+    // sem vínculo passaria — e quebraria a resposta certa para "este negócio
+    // não tem nada marcado", que é diferente de "não sei".
+    const { supabase } = db({ ehLead: true, vinculos: [] });
+
+    const r = await listaAgendamentos(supabase, ORG, { leadId: ID, limite: 10 } as never);
+
+    expect(r.ok, "recusou um lead legítimo que simplesmente não tem compromissos").toBe(true);
+    if (!r.ok) return;
+    expect(r.agendamentos).toEqual([]);
+  });
+
+  it("a checagem extra só roda no ramo que ia devolver vazio", async () => {
+    // Custo: nenhum lead com vínculos paga a consulta a mais.
+    const { supabase, consultas } = db({ ehLead: true, vinculos: ["ag-1"] });
+
+    await listaAgendamentos(supabase, ORG, { leadId: ID, limite: 10 } as never);
+
+    expect(consultas.filter((t) => t === "crm_leads")).toEqual([]);
+  });
+
+  it("busca por contact_id não é tocada pelo conserto", async () => {
+    const { supabase } = db({ ehLead: false });
+
+    const r = await listaAgendamentos(supabase, ORG, { contactId: ID, limite: 10 } as never);
+
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe("a ferramenta distingue os dois parâmetros", () => {
+  const shape = (crmListAppointments as { inputSchema: Record<string, { description?: string }> })
+    .inputSchema;
+
+  it("controle positivo: o instrumento enxerga descrições onde elas já existem", () => {
+    // `dia` já tinha `.describe()`. Sem esta cerca, um recorte que parasse de
+    // ler as descrições faria as asserções abaixo passarem por vacuidade.
+    expect(shape.dia?.description ?? "").not.toBe("");
+  });
+
+  it("⭐ contact_id diz que é a PESSOA, e cita o campo do contexto do turno", () => {
+    const d = shape.contact_id?.description ?? "";
+    expect(d, "contact_id não tem descrição: o modelo escolhe entre os dois no escuro").not.toBe("");
+    expect(/pessoa|contato/i.test(d)).toBe(true);
+  });
+
+  it("⭐ lead_id diz que é o NEGÓCIO do funil, não a pessoa", () => {
+    const d = shape.lead_id?.description ?? "";
+    expect(d, "lead_id não tem descrição").not.toBe("");
+    expect(/negóci|funil|oportunidade/i.test(d)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #509

## A cadeia

No motor, `leadId` **é** o `contact_id` — e o código já dizia isso:

```
lib/agent-engine/agent/inbound-turn.ts:1121    const leadIdDoJob = job.contact_id;
lib/agent-engine/edge/crm/get-lead-context.ts:193
    // Filtra por `contact_id` porque deste lado da casa `leadId` é o CONTATO
```

Só que o campo publicado no contexto do turno se chama **`lead_id`**. O modelo lia esse nome e passava o valor ao parâmetro `lead_id` de `crm_list_appointments`, que espera um **negócio do funil**. A consulta procurava vínculos em `crm_lead_links` para um id que não é lead, não achava nenhum, e devolvia `{ ok: true, agendamentos: [] }` (`consulta.ts:431`).

**O agente negava ao cliente um compromisso que ele mesmo acabara de marcar** — e pedia desculpas por tê-lo marcado.

Nada reclamava: consulta válida, lista vazia é resposta legítima, e o modelo não tinha como suspeitar.

## E os dois parâmetros não se distinguiam

```ts
// lib/mcp/tools/agendamento.ts:274-275
contact_id: z.string().uuid().optional(),
lead_id: z.string().uuid().optional(),
```

Nenhum `.describe()`. O modelo escolhia entre eles **no escuro**, e a única pista era o nome errado no contexto.

## Três consertos — e o barato é o que rende mais

1. **`.describe()` nos dois parâmetros**, dizendo qual é a *pessoa* e qual é o *negócio*. O de `contact_id` aponta explicitamente que o `lead_id` do contexto do turno carrega o id do contato, então é ali que ele vai. É a linha mais barata do PR e provavelmente a mais eficaz.
2. **`listaAgendamentos` separa duas histórias que eram uma:** *"este negócio não tem nada marcado"* (segue `ok:true, []` — o comentário que defendia isso estava certo **para o caso dele**) de *"este id nem é um lead"* → recusa com código próprio, nomeando `contact_id` e instruindo a **não** dizer ao cliente que ele não tem nada. A consulta extra roda **só** no ramo que já ia devolver vazio.
3. **O contexto publica `contact_id`** junto de `lead_id`, com o mesmo valor.

## Por que somar o nome em vez de trocar

Renomear `lead_id` de vez é a tentação e é armadilha: o campo circula por follow-up, case-reply e escalação, e por invariantes **congelados** pelo hook de governança. Somar o nome certo custa uma linha; trocar custa uma wave.

`contact_id` é **opcional** no tipo pelo mesmo motivo: exigi-lo obrigaria a editar fixture em `tests/invariants/**`, que `loop/hooks/freeze-invariants.sh` proíbe editar. A produção sempre o preenche; quem monta contexto à mão num teste não precisa.

## Prova

O dublê distingue `crm_lead_links` de `crm_leads` — sem a segunda tabela, o teste não conseguiria separar *"lead sem nada marcado"* de *"isto nem é um lead"*, que é a distinção inteira desta issue.

```console
$ npx vitest run tests/unit/agenda-nao-mente-sobre-id-de-contato.test.ts
  Tests  7 passed (7)
```

**Duas sabotagens** — previ 1 e 2, deu 1 e 2:

```
A) reverto a consulta      → 1: id de CONTATO passado como lead_id vira recusa
B) reverto as descrições   → 2: contact_id diz que é a PESSOA / lead_id o NEGÓCIO
```

Há **controle na direção oposta**: lead real sem compromisso continua devolvendo lista vazia. Sem ele, um conserto que recusasse todo lead sem vínculo passaria — e quebraria a resposta certa.

## Gates

```
pnpm typecheck   exit=0
pnpm lint        exit=0
pnpm test:unit   617 arquivos / 6814 testes, exit=0   (suíte COMPLETA)
```

## O que NÃO fiz

**Não renomeei `lead_id`.** Ver acima — o nome mentiroso continua no contexto, agora com comentário e com um `contact_id` correto ao lado. Trocar de vez é trabalho próprio.

**Não provei com modelo real que ele passa a escolher `contact_id`.** As descrições são instrução, não garantia; a prova de comportamento é conversa de aceite, e o par (agente + ferramenta) é a unidade — que é exatamente o argumento da #489.

**Não toquei na #512** (o contexto não trazer os compromissos). As duas saíram da mesma conversa de produção e têm raiz comum, mas são defeitos distintos: consertar a 512 mascara o sintoma desta sem consertar a causa. PR separado, teste separado.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam (suíte completa)
- [x] Filtro de `organization_id` na consulta nova
- [x] Sem `console.log` esquecido
- [x] Fragmento em `.changes/` (`nada_mudou` / `corrigido`)
- [ ] Schema: não toca

🤖 Generated with [Claude Code](https://claude.com/claude-code)