### PR TITLE
fix(agent): aumenta teto de espera pela transcrição de áudio de 45s para 120s

### DIFF
--- a/.changes/agente-nao-diz-mais-nao-entendi-o-audio-cedo-demais.md
+++ b/.changes/agente-nao-diz-mais-nao-entendi-o-audio-cedo-demais.md
@@ -1,0 +1,20 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Áudio que demora para transcrever não faz mais o agente dizer "não entendi"
+---
+
+Um cliente mandou um áudio perguntando sobre troca de peça de uma moto elétrica. A
+transcrição terminou certinha — mas 18 segundos tarde demais: o agente já tinha
+respondido "recebi seu áudio, mas não consegui identificar o conteúdo", e o cliente
+teve que digitar a pergunta de novo.
+
+A causa era um teto fixo de 45 segundos de espera pela transcrição antes de o turno
+seguir sem o texto. Medindo as transcrições reais desta instalação, 45s não é raro
+de estourar em áudios normais — só é curto demais para a cauda longa (minutos, quando
+há retry por falha transitória), que nenhum teto razoável cobre sem o cliente esperando
+minutos pela primeira resposta.
+
+O teto passou para 120 segundos, o suficiente para cobrir esse tipo de atraso comum sem
+impor uma espera longa em todo áudio. Para quem opera uma instalação, nada muda no dia
+a dia.

--- a/lib/agent-engine/edge/crm/drain.test.ts
+++ b/lib/agent-engine/edge/crm/drain.test.ts
@@ -81,7 +81,7 @@ it('áudio JÁ transcrito: turno segue normalmente', async () => {
 
 it('derivação travada além do teto: segue SEM o texto em vez de deixar o cliente esperando', async () => {
   const calls: string[] = [];
-  process.env.__ESPERA__ = '90000'; // 90s — muito além do teto de 45s
+  process.env.__ESPERA__ = '150000'; // 150s — muito além do teto de 120s
   await drainTick(poolFalso({ type: 'audio', media_derived_status: null }, calls), knobs, log);
   expect(calls.some((s) => s.includes('job_queue'))).toBe(true);
 });

--- a/lib/agent-engine/edge/crm/drain.ts
+++ b/lib/agent-engine/edge/crm/drain.ts
@@ -123,8 +123,18 @@ const ESPERA_DERIVACAO_MS = 4_000;
  * Teto da espera. Passado isto o turno segue SEM o texto derivado: melhor uma
  * resposta tarde e sem transcrição do que cliente esperando para sempre porque
  * a derivação travou.
+ *
+ * Era 45s até 2026-09-03, quando um áudio real (cliente "Alfran") levou ~86s
+ * para transcrever: o turno estourou o teto, respondeu "não consegui ouvir
+ * seu áudio" às 14:25:46, e a transcrição correta só ficou pronta às 14:26:04
+ * — 18s tarde demais, e o cliente teve que digitar a pergunta de novo.
+ * Medição de p50/p90/p99 de conclusão de transcrição nos últimos 7 dias desta
+ * instalação: 14s / 407s / 2538s — a cauda longa (minutos) é de retry após
+ * falha transitória, não do Whisper em si, e nenhum teto razoável a cobre sem
+ * o cliente esperando minutos pela primeira resposta. 120s cobre o caso comum
+ * de transcrição lenta (como o do Alfran) sem impor essa espera longa.
  */
-const TETO_ESPERA_DERIVACAO_MS = 45_000;
+const TETO_ESPERA_DERIVACAO_MS = 120_000;
 
 type DesfechoEvento = 'processado' | 'adiar';
 


### PR DESCRIPTION
## Resumo

- Um cliente real (Alfran) mandou um áudio perguntando sobre troca de freio de moto elétrica; a transcrição levou ~86s, mas o turno já tinha estourado o teto de 45s e respondido "recebi seu áudio, mas não consegui identificar o conteúdo" 18s antes de a transcrição terminar — o cliente teve que digitar a pergunta de novo.
- Medindo as transcrições reais desta instalação nos últimos 7 dias (p50=14s, p90=407s, p99=2538s), 45s estoura com frequência em áudios normais. O teto sobe para 120s, o suficiente para cobrir esse atraso comum sem impor espera longa em todo áudio — a cauda de minutos (retry por falha transitória) nenhum teto razoável cobre de qualquer forma.
- Teste `drain.test.ts` atualizado para o novo teto.
- Fragmento em `.changes/` (`impacto: nada_mudou`, `secao: corrigido`).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint` (0 erros, warnings pré-existentes)
- [x] `npx vitest run lib/agent-engine/edge/crm/drain.test.ts` (8/8 passando)
- [x] `pnpm release:conferir` reconhece o fragmento

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY6EddKDBCz3rhhjHJbgXD