### PR TITLE
feat(ia): o contexto do turno passa a trazer os compromissos do contato

### DIFF
--- a/.changes/o-agente-enxerga-os-compromissos-que-ele-marcou.md
+++ b/.changes/o-agente-enxerga-os-compromissos-que-ele-marcou.md
@@ -1,0 +1,21 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O atendente de IA passa a enxergar os compromissos já marcados do cliente
+---
+
+O atendente de IA marcava uma reunião e, minutos depois, agia como se ela não
+existisse: dizia que o horário estava ocupado por outra pessoa quando o ocupante
+era a reunião do próprio cliente.
+
+A causa é simples: o contexto que o agente recebe a cada mensagem trazia o
+histórico, as anotações e o estágio do funil — e **nenhuma agenda**. Ele só
+sabia dos compromissos se fosse consultá-los, e não tinha por que desconfiar de
+que precisava.
+
+Agora o contexto de cada conversa traz os compromissos futuros daquele contato,
+com data, horário e título. Se houver mais do que cabe, ele diz que a lista está
+incompleta em vez de deixar o agente concluir que aquilo é tudo.
+
+Compromissos cancelados ficam de fora: um compromisso desmarcado nessa lista
+faria o agente confirmar ao cliente uma reunião que não existe mais.

--- a/lib/agent-engine/agent/compromissos-do-contato.ts
+++ b/lib/agent-engine/agent/compromissos-do-contato.ts
@@ -1,0 +1,105 @@
+/**
+ * OS COMPROMISSOS JÁ MARCADOS DESTE CONTATO, NO RITUAL DE ABERTURA (issue #512).
+ *
+ * ─── O que faltava ──────────────────────────────────────────────────────────
+ *
+ * O contexto do turno entregava checkpoint, resumo, funil, memória e mensagens —
+ * e nenhuma agenda:
+ *
+ *     $ grep -ciE "appointment|agendamento|calendar" get-lead-context.ts   -> 0
+ *     CONTROLE POSITIVO, arquivo irmão:
+ *     $ grep -ciE "appointment|agendamento|calendar" mcp/tools/agendamento.ts -> 45
+ *
+ * O agente marcava uma reunião e, minutos depois, não sabia que ela existia:
+ * dizia ao cliente que o horário estava ocupado por outra pessoa quando o
+ * ocupante era a reunião DELE, e negava o agendamento que ele mesmo tinha feito.
+ *
+ * ─── A armadilha que este arquivo evita de propósito ────────────────────────
+ *
+ * No motor, `leadId` É o `contact_id` (é a causa da issue #509). Uma consulta
+ * que confiasse no NOME da variável em vez do significado plantaria a #509
+ * dentro do conserto da #512. Por isso o parâmetro aqui se chama `contactId`, e
+ * quem chama tem de olhar para o valor antes de passar.
+ *
+ * ─── Orçamento, e por que ele não é zelo ────────────────────────────────────
+ *
+ * O bloco vai no SUFIXO do prompt, depois do prefixo cacheável — então é pago em
+ * TODA conversa, inclusive nas que nunca falam de horário. Sem teto, uma
+ * instalação com muitos compromissos por contato vira regressão de custo em
+ * cada turno. O teto corta a lista e DIZ que cortou.
+ */
+import type { Queryable } from "../queue/queue";
+
+export interface CompromissoDoContato {
+  id: string;
+  title: string | null;
+  starts_at: string;
+  ends_at: string | null;
+  status: string;
+}
+
+/** Quantos compromissos futuros cabem no bloco antes de ele passar a truncar. */
+export const MAXIMO_DE_COMPROMISSOS_NO_BLOCO = 5;
+
+/**
+ * Os compromissos ATIVOS e FUTUROS deste contato.
+ *
+ * `cancelled` fica de fora: um compromisso cancelado no bloco faria o agente
+ * afirmar ao cliente uma reunião que não existe mais — trocaria o defeito de
+ * "não vê o que marcou" por "promete o que foi desmarcado", que é pior.
+ */
+export async function compromissosDoContato(
+  db: Queryable,
+  organizationId: string,
+  contactId: string,
+  agora: Date,
+): Promise<CompromissoDoContato[]> {
+  const { rows } = await db.query<CompromissoDoContato>(
+    `select id, title, starts_at, ends_at, status
+       from calendar_appointments
+      where organization_id = $1
+        and contact_id = $2
+        and status <> 'cancelled'
+        and ends_at >= $3
+      order by starts_at
+      limit $4`,
+    [organizationId, contactId, agora.toISOString(), MAXIMO_DE_COMPROMISSOS_NO_BLOCO + 1],
+  );
+  return rows;
+}
+
+/**
+ * O bloco em texto. Vazio quando não há nada — um bloco dizendo "nenhum" custaria
+ * tokens em toda conversa para informar ausência que o modelo não precisa saber.
+ */
+export function renderCompromissos(linhas: readonly CompromissoDoContato[]): string {
+  if (linhas.length === 0) return "";
+
+  const cabem = linhas.slice(0, MAXIMO_DE_COMPROMISSOS_NO_BLOCO);
+  const truncou = linhas.length > MAXIMO_DE_COMPROMISSOS_NO_BLOCO;
+
+  const itens = cabem.map((c) => {
+    const titulo = (c.title ?? "").trim() || "compromisso";
+    const fim = c.ends_at ? ` até ${c.ends_at}` : "";
+    return `- ${c.starts_at}${fim} — ${titulo} (${c.status})`;
+  });
+
+  // Truncar em silêncio faria o modelo afirmar que o cliente só tem estes — a
+  // mesma classe de erro que a busca do catálogo cometia (#480).
+  if (truncou) {
+    itens.push(
+      `- (há mais compromissos além destes ${MAXIMO_DE_COMPROMISSOS_NO_BLOCO}. ` +
+        "NÃO diga que esta é a lista completa — consulte com crm_list_appointments se precisar.)",
+    );
+  }
+  return itens.join("\n");
+}
+
+export async function buildCompromissosBlock(
+  db: Queryable,
+  organizationId: string,
+  contactId: string,
+  agora: Date,
+): Promise<string> {
+  return renderCompromissos(await compromissosDoContato(db, organizationId, contactId, agora));
+}

--- a/lib/agent-engine/agent/inbound-turn.ts
+++ b/lib/agent-engine/agent/inbound-turn.ts
@@ -59,6 +59,7 @@ import { buildNativeMediaParts } from './media-parts';
 import { enqueueJob, rescheduleJob, type JobRow, type Queryable } from '../queue/queue';
 import { applyLeadStateUpdate, getLeadState, type LeadStage, type LeadStateRow } from './lead-state';
 import { applySaveLeadNote, buildNotesIndexBlock, getLeadNoteBody } from './lead-notes';
+import { buildCompromissosBlock } from './compromissos-do-contato';
 import { applyScheduleFollowup, type FollowupWindowKnobs } from './schedule-followup';
 import {
   avisarLeadDaEscalacao,
@@ -918,6 +919,16 @@ export function ritualBlocks(
    * consegue usar um id para alguma coisa?".
    */
   projeta = false,
+  /**
+   * Os compromissos já marcados deste contato, em texto (issue #512).
+   *
+   * OPCIONAL e último de propósito: `ritualBlocks` tem quatro chamadores
+   * (inbound, follow-up, resposta de caso, retomada da escalação) e o bloco é
+   * pago no SUFIXO, em TODA conversa. Ligar os quatro de uma vez daria tokens a
+   * turnos que talvez nunca falem de horário — cada chamador decide, e hoje só
+   * o inbound decidiu.
+   */
+  compromissosBlock = '',
 ): string[] {
   const checkpointBlock = previous
     ? JSON.stringify({
@@ -958,6 +969,12 @@ export function ritualBlocks(
     '## Memória do lead (índice de notas — corpo sob demanda via get_lead_note)',
     notesIndexBlock,
     '',
+    // Só entra quando há algo: um bloco dizendo "nenhum compromisso" custaria
+    // tokens em toda conversa para informar uma ausência que o modelo não
+    // precisa saber.
+    ...(compromissosBlock.trim() !== ''
+      ? ['## Compromissos já marcados deste contato', compromissosBlock, '']
+      : []),
     '## Contexto do lead (contato + últimas mensagens)',
     // A projeção (spec 16 §4) fecha a terceira porta: sem ela, `lead_id`,
     // `conversation_id` e `media_storage_path` chegam crus ao prompt — e UUID
@@ -985,12 +1002,14 @@ export function buildOpeningMessage(
    * quando limparam só a descrição (`crm_list_webhook_sources`, medido).
    */
   entregues: readonly string[] = [],
+  /** Os compromissos já marcados deste contato, em texto (issue #512). */
+  compromissosBlock = '',
 ): string {
   const entregue = (nome: string): boolean => entregues.includes(nome);
   return [
     'Novo turno de atendimento: o lead enviou uma mensagem (a última inbound do histórico abaixo).',
     '',
-    ...ritualBlocks(previous, leadState, context, notesIndexBlock, projeta),
+    ...ritualBlocks(previous, leadState, context, notesIndexBlock, projeta, compromissosBlock),
     '',
     'Responda ao lead usando a tool send_message — NUNCA escreva a resposta como texto direto',
     '(texto fora de tool é descartado pelo runtime). Use get_lead_context se precisar reler o contexto.',
@@ -1025,6 +1044,15 @@ export interface AgentTurnInput {
     context: LeadContext;
     /** índice da memória do lead (F3-05), já dentro do orçamento; vai no sufixo. */
     notesIndexBlock: string;
+    /**
+     * Compromissos já marcados deste contato (issue #512).
+     *
+     * OPCIONAL pela mesma razão que `projeta`, e ela é externa ao desenho:
+     * `tests/invariants/**` é congelado por hook de governança, e torná-lo
+     * obrigatório forçaria a editar um invariante existente só para satisfazer
+     * o compilador.
+     */
+    compromissosBlock?: string;
     /**
      * Projetar o contexto (spec 16 §4)? Decidido pelo turno, ver `turnoProjeta`.
      *
@@ -1680,6 +1708,11 @@ async function executarTurnoDoAgente(
   // injetado no SUFIXO da abertura (não invalida o prefixo cacheável F2-17). Montado
   // DEPOIS do flush (F3-07) para que as notas gravadas neste turno já entrem no índice.
   const notesIndexBlock = await buildNotesIndexBlock(pool, tenantId, leadId, deps.knobs.notesIndexMaxTokens);
+  // ⚠️ `leadId` AQUI É O CONTATO (`leadIdDoJob = job.contact_id`, e o comentário
+  // de `get-lead-context.ts:193` diz o mesmo). Passar essa variável para um
+  // parâmetro chamado `contactId` é correto pelo VALOR; o nome é que mente, e é
+  // o que a issue #509 conserta. Não troque por um `lead_id` "mais coerente".
+  const compromissosBlock = await buildCompromissosBlock(pool, tenantId, leadId, new Date());
   // Observabilidade da memória (Fase 2A): SÓ ids/contagens no log — headline/corpo
   // são PII e nunca saem do prompt. Prova auditável de que a memória durável do
   // lead entrou no contexto DESTE turno.
@@ -2783,6 +2816,7 @@ async function executarTurnoDoAgente(
     notesIndexBlock,
     projeta: projetaContexto,
     entregues,
+    compromissosBlock,
   });
   // Sufixos por-lead (situacionais, voláteis — depois do prefixo cacheável F2-17): corpos de
   // skill casadas (F3-09) + hint do classificador (F3-11) + instrução de split (F4-xx, quando
@@ -3236,8 +3270,24 @@ export function createInboundTurnHandler(deps: InboundTurnDeps) {
     await runAgentTurn(deps, job, pool, ctx, {
       channelSessionId: payload.channel_session_id,
       conversationId: payload.conversation_id,
-      buildOpening: ({ previous, leadState, context, notesIndexBlock, projeta, entregues }) =>
-        buildOpeningMessage(previous, leadState, context, notesIndexBlock, projeta, entregues),
+      buildOpening: ({
+        previous,
+        leadState,
+        context,
+        notesIndexBlock,
+        projeta,
+        entregues,
+        compromissosBlock,
+      }) =>
+        buildOpeningMessage(
+          previous,
+          leadState,
+          context,
+          notesIndexBlock,
+          projeta,
+          entregues,
+          compromissosBlock,
+        ),
     });
   };
 }

--- a/tests/unit/o-agente-enxerga-os-compromissos-do-contato.test.ts
+++ b/tests/unit/o-agente-enxerga-os-compromissos-do-contato.test.ts
@@ -1,0 +1,128 @@
+/**
+ * O CONTEXTO DO TURNO TRAZ OS COMPROMISSOS JÁ MARCADOS (issue #512).
+ *
+ * O agente marcava uma reunião e, minutos depois, não sabia que ela existia:
+ * dizia que o horário estava ocupado por OUTRA pessoa quando o ocupante era a
+ * reunião do próprio cliente, e negava o agendamento que ele mesmo fizera.
+ *
+ * Medido: `grep -ciE "appointment|agendamento|calendar" get-lead-context.ts` → 0.
+ * CONTROLE POSITIVO na mesma sonda, arquivo irmão: `mcp/tools/agendamento.ts` → 45.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  MAXIMO_DE_COMPROMISSOS_NO_BLOCO,
+  compromissosDoContato,
+  renderCompromissos,
+} from "@/lib/agent-engine/agent/compromissos-do-contato";
+import { ritualBlocks } from "@/lib/agent-engine/agent/inbound-turn";
+
+const ORG = "org-1";
+const CONTATO = "contato-1";
+const AGORA = new Date("2026-09-03T12:00:00Z");
+
+/** Captura o SQL e os parâmetros — é a consulta que este teste precisa medir. */
+function db(rows: unknown[] = []) {
+  const chamadas: Array<{ sql: string; params: unknown[] }> = [];
+  return {
+    chamadas,
+    q: {
+      query: async (sql: string, params: unknown[]) => {
+        chamadas.push({ sql, params });
+        return { rows };
+      },
+    } as never,
+  };
+}
+
+describe("a consulta dos compromissos", () => {
+  it("⭐ filtra por contact_id — e NÃO por lead_id", async () => {
+    // A armadilha da issue #509 mora aqui: no motor `leadId` É o contato, e uma
+    // consulta que confiasse no nome da variável plantaria aquele defeito dentro
+    // deste conserto.
+    const { q, chamadas } = db();
+    await compromissosDoContato(q, ORG, CONTATO, AGORA);
+
+    expect(chamadas[0]!.sql).toContain("contact_id");
+    expect(chamadas[0]!.sql).not.toMatch(/\blead_id\b/);
+    expect(chamadas[0]!.params[0]).toBe(ORG);
+    expect(chamadas[0]!.params[1]).toBe(CONTATO);
+  });
+
+  it("⭐ isola por organização — service role não tem RLS", async () => {
+    const { q, chamadas } = db();
+    await compromissosDoContato(q, ORG, CONTATO, AGORA);
+    expect(chamadas[0]!.sql).toContain("organization_id = $1");
+  });
+
+  it("⭐ exclui cancelado e passado", async () => {
+    // Compromisso cancelado no bloco faria o agente afirmar uma reunião que não
+    // existe mais — troca "não vê o que marcou" por "promete o que foi
+    // desmarcado", que é pior.
+    const { q, chamadas } = db();
+    await compromissosDoContato(q, ORG, CONTATO, AGORA);
+    expect(chamadas[0]!.sql).toContain("status <> 'cancelled'");
+    expect(chamadas[0]!.sql).toContain("ends_at >= $3");
+  });
+
+  it("pede uma linha a mais que o teto — é assim que se sabe que truncou", async () => {
+    const { q, chamadas } = db();
+    await compromissosDoContato(q, ORG, CONTATO, AGORA);
+    expect(chamadas[0]!.params[3]).toBe(MAXIMO_DE_COMPROMISSOS_NO_BLOCO + 1);
+  });
+});
+
+describe("o bloco em texto", () => {
+  const linha = (i: number) => ({
+    id: `ag-${i}`,
+    title: `Consulta ${i}`,
+    starts_at: `2026-09-0${i}T14:00:00Z`,
+    ends_at: `2026-09-0${i}T15:00:00Z`,
+    status: "confirmed",
+  });
+
+  it("⭐ traz horário e título do compromisso", () => {
+    const t = renderCompromissos([linha(4)]);
+    expect(t).toContain("2026-09-04T14:00:00Z");
+    expect(t).toContain("Consulta 4");
+  });
+
+  it("sem compromisso, o bloco é VAZIO — não custa tokens para dizer 'nenhum'", () => {
+    expect(renderCompromissos([])).toBe("");
+  });
+
+  it("⭐ quando trunca, DIZ que truncou", () => {
+    // Truncar em silêncio faria o modelo afirmar que o cliente só tem estes —
+    // a mesma classe de erro que a busca do catálogo cometia (#480).
+    const muitos = Array.from({ length: MAXIMO_DE_COMPROMISSOS_NO_BLOCO + 1 }, (_, i) => linha(i + 1));
+    const t = renderCompromissos(muitos);
+
+    expect(/NÃO diga que esta é a lista completa/i.test(t)).toBe(true);
+    expect(t.split("\n").filter((l) => l.includes("Consulta")).length).toBe(
+      MAXIMO_DE_COMPROMISSOS_NO_BLOCO,
+    );
+  });
+});
+
+describe("o bloco chega ao prompt", () => {
+  const contexto = { contact: { name: "Cliente", email: null } } as never;
+
+  it("⭐ o ritual de abertura carrega os compromissos", () => {
+    const t = ritualBlocks(null, null, contexto, "sem notas", false, "- 2026-09-04T14:00:00Z — Consulta (confirmed)").join(
+      "\n",
+    );
+    expect(t).toContain("2026-09-04T14:00:00Z");
+    expect(/compromissos/i.test(t)).toBe(true);
+  });
+
+  it("sem compromissos, nenhum cabeçalho aparece — o prompt não engorda à toa", () => {
+    const t = ritualBlocks(null, null, contexto, "sem notas", false, "").join("\n");
+    expect(/## Compromissos/i.test(t)).toBe(false);
+  });
+
+  it("controle positivo: os blocos de sempre continuam lá", () => {
+    const t = ritualBlocks(null, null, contexto, "sem notas", false, "").join("\n");
+    expect(t).toContain("## Contexto do lead");
+    expect(t).toContain("## Estado do funil");
+  });
+});


### PR DESCRIPTION
Closes #512

## O defeito

O agente marcava uma reunião e, minutos depois, agia como se ela não existisse: dizia que o horário estava ocupado por **outra** pessoa quando o ocupante era a reunião do próprio cliente, e negava o agendamento no mesmo fio.

Medido, com controle positivo na mesma sonda:

```console
$ grep -ciE "appointment|agendamento|calendar" lib/agent-engine/edge/crm/get-lead-context.ts
0
$ grep -ciE "appointment|agendamento|calendar" lib/mcp/tools/agendamento.ts
45
```

Os cinco blocos do ritual — checkpoint, resumo, funil, memória e contexto — não tinham agenda em nenhum. O agente só saberia dos compromissos **indo consultá-los**, e não tinha por que desconfiar de que precisava.

## As três decisões que o teste prende

- **Filtra por `contact_id`**, e o comentário diz por quê: no motor `leadId` **é** o contato (issue #509). Uma consulta que confiasse no *nome* da variável em vez do significado plantaria aquele defeito dentro deste conserto. Há caso de teste exatamente para isso.
- **`status <> "cancelled"` e só futuros:** um compromisso desmarcado no bloco faria o agente confirmar ao cliente uma reunião que não existe mais — troca *"não vê o que marcou"* por *"promete o que foi desmarcado"*, que é pior.
- **Teto de 5, e quando trunca ele diz que truncou.** Truncar em silêncio faria o modelo afirmar que aquela é a lista completa — a mesma classe de erro que a busca do catálogo cometia (#480).

Sem compromissos o bloco é **vazio** e o cabeçalho nem aparece: um bloco dizendo "nenhum" custaria tokens em toda conversa para informar uma ausência que o modelo não precisa saber.

## O parâmetro é opcional, e a razão é o custo

`ritualBlocks` e `buildOpening` ganham o campo **opcional e por último**. Há quatro chamadores (inbound, follow-up, resposta de caso, retomada da escalação) e o bloco é pago no **sufixo**, em toda conversa — ligar os quatro de uma vez daria tokens a turnos que talvez nunca falem de horário. Cada um decide; hoje só o inbound decidiu.

Opcional no contrato pela mesma razão que `projeta` já é: `tests/invariants/**` é congelado por hook de governança, e torná-lo obrigatório forçaria a editar um invariante existente só para satisfazer o compilador.

## Prova

```console
$ npx vitest run tests/unit/o-agente-enxerga-os-compromissos-do-contato.test.ts
  Tests  10 passed (10)
```

**Três sabotagens** — previ 1/1/1, deu 1/1/1, e cada uma acerta o caso que lhe corresponde:

```
A) reverto só a LIGAÇÃO (módulo fica)     → × o ritual de abertura carrega os compromissos
B) tiro o aviso de truncagem              → × quando trunca, DIZ que truncou
C) troco contact_id por lead_id no filtro → × filtra por contact_id — e NÃO por lead_id
```

A sabotagem C é a que importa: ela prova que o conserto não replantou o #509 dentro de si.

## Gates

```
pnpm typecheck   exit=0
pnpm lint        exit=0
pnpm test:unit   617 arquivos / 6818 testes, exit=0   (suíte COMPLETA)
```

**Nota metodológica:** uma rodada anterior desta suíte acusou 2 vermelhos (`sem-marcador-de-conflito`, `knobs-da-versao-publicada`, depois `_mapping`). Todos passam isolados no mesmo commit — a suíte estava rodando **enquanto eu sabotava arquivos no mesmo worktree**, e lia o disco no meio da edição. A rodada acima é limpa, com o disco parado.

## O que NÃO fiz

**Não liguei o bloco no follow-up, na resposta de caso nem na retomada da escalação.** É custo por turno em superfícies que talvez nunca falem de horário, e a decisão é de quem conhece o volume de cada uma. O parâmetro está pronto; ligar é uma linha por chamador.

**Não marquei em `crm_find_free_slots` que o ocupante é o próprio contato.** Sem isso, o modelo passa a ter duas fontes que podem se contradizer: o bloco diz "ele tem 10h", a tool diz "10h não está livre" **por ausência de marcação**. O bloco novo dá a informação que faltava; a segunda camada é escopo próprio, e misturá-las faria a sabotagem de uma esconder a da outra.

**Não medi o custo em tokens contra uma instalação real.** O teto de 5 é escolha, não medição.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam (suíte completa, rodada limpa)
- [x] Filtro de `organization_id` na consulta nova (caso próprio)
- [x] Sem `console.log` esquecido
- [x] Fragmento em `.changes/` (`nada_mudou` / `corrigido`)
- [ ] Schema: não toca

🤖 Generated with [Claude Code](https://claude.com/claude-code)