### PR TITLE
test(followup): a fiação do rascunho ganha guarda — ela entrou na main sem uma

### DIFF
--- a/tests/unit/o-fluxo-publicado-nao-abre-vazio.test.ts
+++ b/tests/unit/o-fluxo-publicado-nao-abre-vazio.test.ts
@@ -108,3 +108,59 @@ describe("o rascunho que a tela desenha", () => {
     ).resolves.toBeNull();
   });
 });
+
+/**
+ * ═══ A REGRA ESTÁ GUARDADA; A FIAÇÃO NÃO ESTAVA ═════════════════════════════
+ *
+ * ⚠️ Achado por revisão adversarial deste PR, e reproduzido: removendo a fiação
+ * dos DOIS call sites — o import, o `const draft_graph = await rascunhoDoFluxo(…)`
+ * e a linha `draft_graph,` do objeto — mas deixando `lib/followup/rascunho.ts`
+ * intacto, o defeito volta INTEIRO (o GET devolve `draft_graph: null` e a tela
+ * abre em branco sobre o fluxo que está no ar) e a suíte fica 100% verde: 617
+ * arquivos, 6812 casos, zero falhas.
+ *
+ * Os casos acima exercitam só a função pura com um dublê de PostgREST. O único
+ * teste que importa a rota monta a linha com `active_version_id: null`, ou seja,
+ * nunca entra no ramo novo. E os e2e de follow-up gravam `draft_graph` por PATCH
+ * antes de abrir o construtor, então o estado "rascunho nulo com versão ativa"
+ * não ocorre lá.
+ *
+ * O risco não é teórico: o conserto mora numa LINHA SOLTA dentro de um object
+ * literal em cada arquivo — a forma exata que um revert ou uma resolução de
+ * merge derruba sem ninguém ver. E o que se perde junto é a proteção contra
+ * salvar-por-cima, que este PR descreve como o dano maior.
+ *
+ * Varredura de fonte, no padrão de `provedores-x-registry.test.ts`: não prova
+ * comportamento — prova que a fiação continua lá, que é o que some.
+ */
+describe("os dois lugares que abriam a tela continuam perguntando ao rascunho", () => {
+  const ler = async (p: string) => (await import("node:fs")).readFileSync(p, "utf8");
+
+  it("a rota GET resolve o rascunho pela regra, não pela coluna crua", async () => {
+    const fonte = await ler("app/api/v1/ai/followup-flows/[id]/route.ts");
+    expect(fonte, "a rota parou de importar a regra").toMatch(
+      /import \{ rascunhoDoFluxo \} from "@\/lib\/followup\/rascunho"/,
+    );
+    expect(fonte, "o call site da rota sumiu — o GET volta a devolver draft_graph nulo").toMatch(
+      /const draft_graph = await rascunhoDoFluxo\(/,
+    );
+    expect(
+      fonte,
+      "o resultado deixou de entrar na resposta: a regra roda e ninguém usa",
+    ).toMatch(/\n\s*draft_graph,/);
+  });
+
+  it("a página do construtor resolve o rascunho pela regra", async () => {
+    const fonte = await ler("app/app/ai/followups/[id]/page.tsx");
+    expect(fonte, "a página parou de importar a regra").toMatch(
+      /import \{ rascunhoDoFluxo \} from "@\/lib\/followup\/rascunho"/,
+    );
+    expect(fonte, "o call site da página sumiu — o canvas volta a abrir em branco").toMatch(
+      /const draft_graph = await rascunhoDoFluxo\(/,
+    );
+    expect(
+      fonte,
+      "o resultado deixou de ser passado adiante: o canvas lê `initialData.draft_graph`",
+    ).toMatch(/\n\s*draft_graph,/);
+  });
+});


### PR DESCRIPTION
Acompanhamento do #495, que **já está na `main`** (merge `2517d016`). O conserto entrou; a rede que o vigia não — empurrei três minutos depois do merge.

## O que está desprotegido na `main` agora

Removendo a fiação dos **dois** call sites — o import, o `const draft_graph = await rascunhoDoFluxo(…)` e a linha `draft_graph,` do objeto — mas deixando `lib/followup/rascunho.ts` intacto:

- `GET /api/v1/ai/followup-flows/[id]` volta a devolver `draft_graph: null`;
- o construtor abre **em branco** sobre o fluxo que está no ar;
- volta junto o caminho de **salvar-por-cima**, que o #495 nomeia como o dano maior;
- **e a suíte fica verde.**

## Por que nada pegava

Os casos existentes exercitam só a função pura com um dublê de PostgREST. O único teste que importa a rota monta a linha com `active_version_id: null` — nunca entra no ramo novo. Os e2e de follow-up gravam `draft_graph` por PATCH antes de abrir o construtor, então o estado "rascunho nulo com versão ativa" não ocorre lá.

É a lição que o repo já pagou: **teste guarda a função, não o call site**. Uma regra correta que ninguém chama é uma regra que não existe — e o conserto mora numa linha solta dentro de um object literal em cada arquivo, que é a forma que uma resolução de merge derruba sem ninguém ver.

## Como isto foi achado

Revisão adversarial do diff do #495 antes do merge. O achado foi **reproduzido** antes de virar código: sabotagem aplicada, suíte inteira rodada, 617 arquivos e 6812 casos verdes com o defeito de volta.

## A prova de que a guarda guarda

Sabotagem com a contagem **prevista antes de rodar**: previ 2 vermelhos, um por arquivo, com os 5 casos originais verdes.

```
× a rota GET resolve o rascunho pela regra, não pela coluna crua
× a página do construtor resolve o rascunho pela regra
  Tests  2 failed | 5 passed (7)
```

Deu exatamente isso — e os 5 originais verdes são a prova de que eles eram cegos à fiação, que é o achado.

## Escopo

Só teste. Sem fragmento em `.changes/`: não muda comportamento para quem opera uma VPS.