### PR TITLE
fix(catalogo): count ausente deixa de virar "varri o catálogo inteiro"

### DIFF
--- a/lib/mcp/tools/comercio.ts
+++ b/lib/mcp/tools/comercio.ts
@@ -167,8 +167,22 @@ export const crmSearchProducts: McpToolDefinition<typeof produtosInputShape> = {
     // plano der, e muda com o tempo e com o vacuum. Numa loja acima do teto, o
     // produto pedido podia não estar no lote que veio, e a busca respondia "não
     // há nada com esse nome" para um produto que a loja TEM. (issue #480)
+    // ⚠️ `count` é `number | null`, e o `null` NÃO significa zero: significa que
+    // o servidor não disse quantos há (cabeçalho `Content-Range` ausente ou não
+    // parseável — proxy, gateway, versão). A versão anterior fazia
+    // `total = count ?? total` com `total` iniciado em 0, e a parada
+    // `linhas.length >= total` virava `>= 0` — verdadeira já na primeira página.
+    // Resultado: varria 1 página de uma loja de 3000, não achava, e ainda dizia
+    // "não há nada com esse nome" com `varreduraParcial` FALSO, porque
+    // `0 > 1000` é falso. O defeito da issue #480 voltava inteiro e em silêncio.
+    //
+    // Agora quem prova o fim é uma PÁGINA VAZIA, que é fato independente do
+    // count: não há linha depois de `de`. O count, quando vem, só antecipa a
+    // parada. E `varreduraParcial` passa a ser "não cheguei ao fim", em vez de
+    // uma comparação com um total que pode nunca ter existido.
     const linhas: unknown[] = [];
-    let total = 0;
+    let total: number | null = null;
+    let alcancouOFim = false;
     for (let pagina = 0; pagina < PAGINAS_MAXIMAS; pagina++) {
       const de = pagina * TAMANHO_DA_PAGINA;
       const { data: lote, error, count } = await ctx.supabase
@@ -185,18 +199,26 @@ export const crmSearchProducts: McpToolDefinition<typeof produtosInputShape> = {
         .range(de, de + TAMANHO_DA_PAGINA - 1);
 
       if (error) throw new Error(`buscar_produtos_falhou: ${error.message}`);
-      total = count ?? total;
+      if (count !== null) total = count;
       const recebidas = lote ?? [];
       linhas.push(...recebidas);
-      // Página curta significa fim do conjunto — parar aqui evita uma ida ao
-      // banco por busca em toda loja pequena, que é a esmagadora maioria.
-      if (recebidas.length === 0 || linhas.length >= total) break;
+      // Página vazia = não há mais nada. Vale mesmo sem count.
+      if (recebidas.length === 0) {
+        alcancouOFim = true;
+        break;
+      }
+      // Com count, dá para parar sem gastar a ida que confirmaria o vazio —
+      // que é o caso da esmagadora maioria das lojas, pequenas e numa página só.
+      if (total !== null && linhas.length >= total) {
+        alcancouOFim = true;
+        break;
+      }
     }
 
     const data = linhas;
     // A varredura foi parcial? Isso é o que separa "não achei no que varri" de
     // "a loja não tem" — e só a segunda pode ser dita ao cliente.
-    const varreduraParcial = total > linhas.length;
+    const varreduraParcial = !alcancouOFim;
 
     type Linha = {
       id: string;

--- a/tests/unit/catalogo-nao-corta-cego.test.ts
+++ b/tests/unit/catalogo-nao-corta-cego.test.ts
@@ -56,7 +56,7 @@ interface Chamada {
  * Um dublê que devolvesse tudo de uma vez aprovaria o código que ignora
  * paginação, que é metade do defeito.
  */
-function fakeDb(total: number, tetoDoServidor = 1000) {
+function fakeDb(total: number, tetoDoServidor = 1000, contaOculta = false) {
   const chamadas: Chamada[] = [];
   const linhas = Array.from({ length: total }, (_, i) => ({
     id: `p${i}`,
@@ -91,7 +91,7 @@ function fakeDb(total: number, tetoDoServidor = 1000) {
   (q as { then: unknown }).then = (ok: (v: unknown) => unknown) => {
     const fim = Math.min(ate + 1, de + tetoDoServidor, limite ?? Infinity, total);
     return Promise.resolve(
-      ok({ data: linhas.slice(de, fim), error: null, count: total }),
+      ok({ data: linhas.slice(de, fim), error: null, count: contaOculta ? null : total }),
     );
   };
 
@@ -181,5 +181,50 @@ describe("catálogo maior que o teto do servidor", () => {
     const paginas = db.chamadas.filter((c) => c.metodo === "range").length;
     expect(paginas, "varreu sem teto: uma busca puxaria o catálogo inteiro").toBeLessThanOrEqual(10);
     expect(paginas, "não paginou nada").toBeGreaterThan(0);
+  });
+});
+
+/**
+ * ⚠️ O RAMO EM QUE O `count` NÃO VEM — reprodução antes do conserto.
+ *
+ * `count` é `number | null` no client. Quando ele vem `null` (cabeçalho
+ * `Content-Range` ausente ou não parseável — proxy, versão, gateway), o laço
+ * fazia `total = count ?? total` com `total` iniciado em 0, e a condição de
+ * parada `linhas.length >= total` virava `>= 0`: verdadeira SEMPRE, já na
+ * primeira página.
+ *
+ * O desfecho é o defeito da issue #480 DE VOLTA, e pior: `varreduraParcial`
+ * fica `false` (0 > 1000 é falso), então a busca afirma ausência com confiança
+ * sobre uma amostra de uma página. O dublê original sempre fornece `count`, e
+ * por isso nada vigiava este ramo.
+ */
+describe("o count ausente não pode virar 'varri o catálogo inteiro'", () => {
+  it("loja de 3000 itens com count nulo: acha o produto que só existe no fim", async () => {
+    const db = fakeDb(3000, 1000, true);
+    const r = await buscar(db, "perfume importado raro");
+    expect(r.produtos.length, "parou na primeira página e não alcançou o produto").toBeGreaterThan(0);
+  });
+
+  it("varredura que ESTOURA o teto de páginas não afirma ausência, mesmo sem count", async () => {
+    // 12000 > PAGINAS_MAXIMAS × TAMANHO_DA_PAGINA (10 × 1000): a varredura é
+    // genuinamente parcial, e sem `count` ela precisa saber disso pelo fato de
+    // ter esgotado as páginas — não por uma conta com um total que não veio.
+    const db = fakeDb(12000, 1000, true);
+    const r = await buscar(db, "produto que nao existe em lugar nenhum");
+    expect(r.produtos).toHaveLength(0);
+    expect(
+      r.mensagem ?? "",
+      "afirmou 'a loja não tem' depois de varrer 10 mil de 12 mil",
+    ).not.toMatch(/não há nada com esse nome/i);
+  });
+
+  it("⚠️ CONTROLE: varredura que CHEGA ao fim sem count PODE afirmar ausência", async () => {
+    // Sem este caso, "nunca afirme ausência quando o count faltar" satisfaria o
+    // anterior — e a busca viraria eternamente evasiva numa loja pequena cujo
+    // servidor não manda `Content-Range`. A página vazia É prova de fim.
+    const db = fakeDb(2500, 1000, true);
+    const r = await buscar(db, "produto que nao existe em lugar nenhum");
+    expect(r.produtos).toHaveLength(0);
+    expect(r.mensagem ?? "").toMatch(/não há nada com esse nome/i);
   });
 });


### PR DESCRIPTION
Ramo desprotegido do #520 (já na `main`), **achado pelo Maestro na medição** e reproduzido aqui antes de virar conserto.

## O defeito

`count` é `number | null` no client do Supabase, e `null` **não significa zero** — significa que o servidor não disse quantos há (`Content-Range` ausente ou não parseável: proxy, gateway, versão).

```ts
let total = 0;
total = count ?? total;                                        // null → total segue 0
if (recebidas.length === 0 || linhas.length >= total) break;   // >= 0: verdadeiro sempre
```

A busca parava na **primeira página**. E o pior vinha depois:

```ts
const varreduraParcial = total > linhas.length;   // 0 > 1000 → false
```

Ou seja: varria 1 página de uma loja de 3000, não achava, e afirmava *"não há nada com esse nome no catálogo da loja"* **com confiança**. É o defeito da issue #480 de volta, inteiro e em silêncio.

Nada vigiava esse ramo porque o dublê do teste **sempre** fornece `count`.

## Reprodução (antes do conserto)

```
× loja de 3000 itens com count nulo: acha o produto que só existe no fim
× varredura que ESTOURA o teto de páginas não afirma ausência, mesmo sem count
  Tests  2 failed | 6 passed
```

## O conserto

Quem prova o fim passa a ser uma **página vazia** — fato que não depende do `count`: não há linha depois de `de`. O `count`, quando vem, só **antecipa** a parada, o que preserva a ida única ao banco na loja pequena (a maioria). E `varreduraParcial` vira *"não cheguei ao fim"* em vez de uma comparação com um total que pode nunca ter existido.

De quebra, conserta um caso que ninguém tinha notado: com `count` **maior que a realidade** (contagem velha), a versão anterior marcava varredura parcial mesmo tendo lido tudo.

## ⚠️ Um dos meus casos estava errado, e o conserto o denunciou

Escrevi *"com count nulo, não afirme ausência"*. Mas numa loja de 3000 a quarta página volta vazia, a varredura **é** completa, e afirmar ausência passa a ser **correto**. O caso codificava o sintoma, não o invariante.

Reescrito para 12000 itens (acima de `PAGINAS_MAXIMAS × TAMANHO_DA_PAGINA`), que é parcial de verdade — e acrescentei o **controle** de 2500 provando que a busca ainda *pode* afirmar ausência quando chega ao fim sem `count`. Sem ele, *"nunca afirme"* satisfaria o teste e a busca viraria eternamente evasiva numa loja pequena cujo servidor não manda `Content-Range`.

## A prova de que a guarda guarda

Sabotagem com a contagem **prevista antes de rodar**: previ 2 vermelhos (os dois de defeito) e o controle passando nos dois estados, que é o que faz dele controle.

```
× loja de 3000 itens com count nulo: acha o produto que só existe no fim
× varredura que ESTOURA o teto de páginas não afirma ausência, mesmo sem count
  Tests  2 failed | 7 passed (9)
```

Deu exatamente isso.

## Sem fragmento novo

`.changes/loja-grande-volta-a-achar-o-proprio-produto.md` (do #520, ainda **não lançado**) já promete ao operador exatamente o que este PR restaura: *"a busca percorre o catálogo em páginas, na ordem do código, até encontrar ou terminar"*. Essa frase não era inteiramente verdadeira no ramo sem `count`. Este PR a torna verdadeira — não há novidade a anunciar, há uma promessa a cumprir.