### PR TITLE
feat(crm): Importar leads de planilha — extraído do PR #418 (@clinicacentrodosorrisosc-code)

### DIFF
--- a/.changes/importar-leads-de-planilha.md
+++ b/.changes/importar-leads-de-planilha.md
@@ -1,0 +1,27 @@
+---
+impacto: capacidade_nova
+secao: adicionado
+titulo: Importar leads de uma planilha
+---
+
+A lista de clientes que já está no Excel agora entra no funil sem digitação. Em
+**Funis**, o botão "Importar planilha" pede um arquivo CSV e cria um negócio por
+linha, na primeira etapa do funil escolhido.
+
+O importador reconhece os cabeçalhos usuais — nome, telefone, e-mail, valor,
+origem, tags, observação — em português, com ou sem acento, e aceita o
+ponto-e-vírgula que o Excel brasileiro usa. Valor escrito como "R$ 1.200,00"
+entra certo.
+
+Quando a planilha traz telefone, o contato é criado junto e ligado ao negócio —
+e o mesmo número repetido em várias linhas vira um contato só, não vários.
+
+Nada é aceito no escuro: ao terminar, a tela mostra quantos negócios entraram,
+quantos contatos foram criados, quais colunas o importador não reconheceu e
+quais linhas foram recusadas, com o motivo e o número da linha como você a vê na
+planilha. Uma linha com erro não derruba as outras.
+
+Há uma planilha modelo para baixar, para quem prefere começar do formato certo.
+
+Isto veio da contribuição de James, da Clínica Centro do Sorriso
+(**@clinicacentrodosorrisosc-code**).

--- a/app/api/v1/leads/import/route.ts
+++ b/app/api/v1/leads/import/route.ts
@@ -1,0 +1,255 @@
+/**
+ * POST /api/v1/leads/import — o funil a partir da planilha que a empresa já tem.
+ * GET  /api/v1/leads/import — a planilha modelo, para quem não sabe por onde começar.
+ *
+ * Extraído do PR #418 (@clinicacentrodosorrisosc-code). A capacidade é dele; o
+ * que muda é ONDE ela roda e com o quê — o racional está em
+ * `lib/leads/planilha.ts`.
+ *
+ * ─── Desfecho POR LINHA, nunca do lote inteiro ─────────────────────────────
+ *
+ * Uma planilha de 400 nomes não pode morrer inteira pelo valor malformado da
+ * linha 7. Linha inválida é pulada com o motivo nominal, que volta no response
+ * e fica NA TELA — um toast que some em quatro segundos não serve para quem
+ * precisa saber quais linhas corrigir.
+ *
+ * ─── Reusa `createLeadHandler`, e paga o preço disso ───────────────────────
+ *
+ * Cada linha passa pelo MESMO caminho de um negócio criado à mão: mesma
+ * validação de etapa contra a organização, mesma `position_in_stage`, mesmo
+ * `emit_event` e mesmo audit `lead.created`. Custa consultas a mais por linha, e
+ * o teto de `CSV_MAX_DATA_ROWS` é o que torna o preço aceitável. A alternativa —
+ * um insert em lote com a regra reescrita aqui — criaria a segunda verdade sobre
+ * "como um negócio nasce", e é ela que envelhece sozinha.
+ */
+import { randomUUID } from "node:crypto";
+import { type NextRequest } from "next/server";
+
+import { ApiError } from "@/lib/api/types";
+import { ok, fail } from "@/lib/api/wrappers";
+import { audit } from "@/lib/audit";
+import { requireRole } from "@/lib/auth/require-role";
+import { phoneLookupVariants } from "@/lib/channels/phone-variants";
+import { CSV_MAX_BYTES, CSV_MAX_DATA_ROWS, decodificarCsv } from "@/lib/contacts/csv";
+import { lerPlanilhaDeLeads, type ErroDaLinha } from "@/lib/leads/planilha";
+import { createLeadHandler } from "@/app/api/v1/leads/_handler";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+interface ResumoDaImportacao {
+  total_linhas: number;
+  criados: number;
+  contatos_criados: number;
+  erros: ErroDaLinha[];
+  colunas_ignoradas: string[];
+}
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const requestId = randomUUID();
+  // Mesma régua do POST unitário de lead: escrita é `agent` para cima.
+  const authz = await requireRole("agent", { requestId, resource: "crm_leads" });
+  if (!authz.ok) return authz.response;
+  const orgId = authz.org.orgId;
+
+  let form: FormData;
+  try {
+    form = await req.formData();
+  } catch {
+    return fail("validation_failed", "Envie o arquivo como multipart/form-data.", 422, {
+      requestId,
+    });
+  }
+
+  const arquivo = form.get("file");
+  // ⚠️ POR FORMA, e não `instanceof File`, que é o que as duas rotas de
+  // importação mais antigas usam.
+  //
+  // `instanceof` compara contra o construtor do REALM em que o código roda, e
+  // aqui há três: undici (o runtime do Next), jsdom (o ambiente da suíte) e o
+  // browser. O objeto que o `formData()` devolve é um File legítimo em todos, e
+  // mesmo assim o `instanceof` é falso quando o construtor global vem de outro
+  // realm. Consequência prática: a guarda de entrada daquelas rotas NUNCA foi
+  // exercitada por teste — o único teste que as menciona lê o código-fonte
+  // delas, não o comportamento. Guarda que ninguém consegue exercitar é guarda
+  // que ninguém sabe se funciona.
+  //
+  // O que interessa é o que a rota vai FAZER com o valor: ler os bytes e o
+  // tamanho. É isso que a forma abaixo exige, e é isso que um campo de texto
+  // solto no multipart não tem.
+  const pareceArquivo =
+    typeof arquivo === "object" &&
+    arquivo !== null &&
+    typeof (arquivo as { arrayBuffer?: unknown }).arrayBuffer === "function" &&
+    typeof (arquivo as { size?: unknown }).size === "number";
+  if (!pareceArquivo) {
+    return fail("validation_failed", "Envie o arquivo no campo 'file'.", 422, { requestId });
+  }
+  const enviado = arquivo as unknown as File;
+  // ⚠️ O funil e a etapa vêm do FORM, e são conferidos contra a organização
+  // ativa logo abaixo por `createLeadHandler` — que já responde 404 para etapa
+  // de outra org e 422 para etapa que não é do funil informado. É o mesmo gate
+  // do POST unitário; reescrevê-lo aqui seria a segunda verdade.
+  const pipelineId = String(form.get("pipeline_id") ?? "");
+  const stageId = String(form.get("stage_id") ?? "");
+  if (!pipelineId || !stageId) {
+    return fail("validation_failed", "Escolha o funil e a etapa de destino.", 422, { requestId });
+  }
+
+  if (enviado.size > CSV_MAX_BYTES) {
+    return fail(
+      "validation_failed",
+      `Arquivo maior que ${Math.floor(CSV_MAX_BYTES / 1024 / 1024)}MB.`,
+      413,
+      { requestId },
+    );
+  }
+
+  const decodificado = decodificarCsv(await enviado.arrayBuffer());
+  if ("erro" in decodificado) {
+    return fail("validation_failed", decodificado.erro, 422, { requestId });
+  }
+
+  const lido = lerPlanilhaDeLeads(decodificado.texto);
+  if ("erro" in lido) {
+    return fail("validation_failed", lido.erro, 422, { requestId });
+  }
+  if (lido.leads.length > CSV_MAX_DATA_ROWS) {
+    return fail(
+      "validation_failed",
+      `A planilha tem ${lido.leads.length} linhas; o limite é ${CSV_MAX_DATA_ROWS} por importação.`,
+      422,
+      { requestId },
+    );
+  }
+
+  const supabase = await createClient();
+  const resumo: ResumoDaImportacao = {
+    total_linhas: lido.leads.length + lido.erros.length,
+    criados: 0,
+    contatos_criados: 0,
+    erros: [...lido.erros],
+    colunas_ignoradas: lido.colunasIgnoradas,
+  };
+
+  // O mesmo telefone repetido na planilha vira UM contato, não N. Sem isto, uma
+  // lista com três negócios do mesmo cliente criaria três contatos idênticos —
+  // e o produto passaria a ter duplicata que ele mesmo fabricou.
+  const contatoPorTelefone = new Map<string, string>();
+
+  for (const linha of lido.leads) {
+    try {
+      let contactId: string | null = null;
+      if (linha.telefone) {
+        contactId = contatoPorTelefone.get(linha.telefone) ?? null;
+        if (!contactId) {
+          const { data: existente } = await supabase
+            .from("contacts")
+            .select("id")
+            .eq("organization_id", orgId)
+            .in("phone_number", phoneLookupVariants(linha.telefone))
+            .limit(1)
+            .maybeSingle();
+
+          if (existente) {
+            contactId = (existente as { id: string }).id;
+          } else {
+            const { data: criado, error: erroContato } = await supabase
+              .from("contacts")
+              .insert({
+                organization_id: orgId,
+                display_name: linha.nome_do_contato ?? linha.title,
+                phone_number: linha.telefone,
+                email: linha.email,
+                source: linha.source,
+              })
+              .select("id")
+              .single();
+            if (erroContato) {
+              // Contato que não entra NÃO derruba o negócio: o card entra sem
+              // contato e a pessoa liga o telefone depois, corrigindo um card em
+              // vez de reimportar a planilha inteira.
+              resumo.erros.push({
+                linha: linha.linha,
+                motivo: "o contato não pôde ser criado — o negócio entrou sem ele",
+              });
+            } else {
+              contactId = (criado as { id: string }).id;
+              resumo.contatos_criados += 1;
+            }
+          }
+          if (contactId) contatoPorTelefone.set(linha.telefone, contactId);
+        }
+      }
+
+      await createLeadHandler(
+        supabase,
+        { organization_id: orgId, actor: { type: "user", id: authz.user.id }, requestId },
+        {
+          pipeline_id: pipelineId,
+          stage_id: stageId,
+          title: linha.title,
+          description: linha.description,
+          contact_id: contactId,
+          value_cents: linha.value_cents,
+          currency: "BRL",
+          tags: linha.tags,
+          source: linha.source,
+        },
+      );
+      resumo.criados += 1;
+    } catch (err) {
+      // A ETAPA ERRADA DERRUBA A IMPORTAÇÃO INTEIRA, e de propósito: se a etapa
+      // não é desta organização, ela não será na linha 2 nem na 300. Seguir
+      // gastaria 300 tentativas para dar o mesmo erro 300 vezes.
+      if (err instanceof ApiError && (err.status === 404 || err.status === 422)) {
+        return fail(err.code, err.message, err.status, { requestId });
+      }
+      resumo.erros.push({
+        linha: linha.linha,
+        motivo: err instanceof Error ? err.message : "linha recusada pelo banco",
+      });
+    }
+  }
+
+  await audit({
+    organizationId: orgId,
+    actorUserId: authz.user.id,
+    action: "lead.imported",
+    resourceType: "crm_leads",
+    requestId,
+    metadata: {
+      pipeline_id: pipelineId,
+      stage_id: stageId,
+      total_linhas: resumo.total_linhas,
+      criados: resumo.criados,
+      recusadas: resumo.erros.length,
+    },
+  });
+
+  return ok(resumo, { requestId });
+}
+
+export async function GET(): Promise<Response> {
+  const requestId = randomUUID();
+  const authz = await requireRole("agent", { requestId, resource: "crm_leads" });
+  if (!authz.ok) return authz.response;
+
+  // ⚠️ VALOR E TAGS ENTRE ASPAS, e não é estilo: "12.500,00" tem uma vírgula
+  // dentro, e o delimitador desta planilha É a vírgula. Sem as aspas o modelo
+  // que a gente entrega seria lido errado pelo importador que a gente escreveu —
+  // e a primeira coisa que a pessoa faz é mandar o modelo de volta.
+  const modelo = [
+    "nome,nome do contato,telefone,email,valor,origem,tags,observacao",
+    'Reforma do apartamento 402,Ana Souza,11988887777,ana@exemplo.com,"12.500,00",indicacao,"quente;retorno",Pediu orcamento para junho',
+    'Plano anual,Bruno Lima,(21) 97777-6666,,"1.200,00",site,,Veio pelo formulario',
+  ].join("\n");
+
+  return new Response(`﻿${modelo}\n`, {
+    headers: {
+      "content-type": "text/csv; charset=utf-8",
+      "content-disposition": 'attachment; filename="modelo-leads.csv"',
+      "x-request-id": requestId,
+    },
+  });
+}

--- a/app/app/kanban/_client.tsx
+++ b/app/app/kanban/_client.tsx
@@ -3,6 +3,8 @@ import { useState } from "react";
 import Link from "next/link";
 
 import { useT } from "@/hooks/i18n/useT";
+
+import { ImportarLeads } from "./_components/ImportarLeads";
 import { EmptyPipeline } from "@/components/empty";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -55,10 +57,13 @@ function textoDoErro(e: unknown, t: (texto: string) => string): string {
 export function FunisClient({
   funis: funisDoServidor,
   podeGerenciar,
+  podeImportar,
 }: {
   funis: FunilDaLista[];
   /** Espelha o `requireRole("manager")` das rotas — ver o comentário da page. */
   podeGerenciar: boolean;
+  /** Espelha o `requireRole("agent")` de `POST /api/v1/leads/import`. */
+  podeImportar: boolean;
 }) {
   const t = useT();
   /**
@@ -190,9 +195,14 @@ export function FunisClient({
 
   return (
     <div className="flex flex-col gap-4">
-      {podeGerenciar && (
-        <div className="flex sm:justify-end">
-          {novo === null ? (
+      {(podeGerenciar || podeImportar) && (
+        <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+          {/* A porta da importação fica AQUI, e não numa tela própria: é desta
+              lista que se escolhe o funil, e a planilha precisa de um destino.
+              Uma rota nova exigiria um item de menu para uma coisa que se faz
+              uma vez por mês — ruído permanente para um gesto ocasional. */}
+          {podeImportar ? <ImportarLeads funis={funis} /> : null}
+          {podeGerenciar && novo === null ? (
             <Button onClick={() => setNovo("")} disabled={ocupado} data-testid="novo-funil" className="w-full sm:w-auto">
               <Plus size={16} className="mr-2" aria-hidden /> {t("Novo funil")}
             </Button>

--- a/app/app/kanban/_components/ImportarLeads.tsx
+++ b/app/app/kanban/_components/ImportarLeads.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useT } from "@/hooks/i18n/useT";
+import { UploadSimple } from "@/lib/ui/icons";
+
+import type { FunilDaLista } from "../_client";
+
+export interface ResumoDaImportacao {
+  total_linhas: number;
+  criados: number;
+  contatos_criados: number;
+  erros: { linha: number; motivo: string }[];
+  colunas_ignoradas: string[];
+}
+
+/**
+ * IMPORTAR LEADS — a lista que a empresa já tem, para dentro do funil.
+ *
+ * Extraído do PR #418 (@clinicacentrodosorrisosc-code). Duas diferenças, e as
+ * duas são consequência de a leitura ter ido para o SERVIDOR:
+ *
+ *  1. Não há passo de MAPEAR COLUNAS. O servidor reconhece os cabeçalhos usuais
+ *     (`lib/leads/planilha.ts`) e o resumo diz, nominalmente, quais colunas ele
+ *     ignorou — então quem precisa mapear renomeia o cabeçalho no Excel, que é
+ *     um gesto que ele já sabe fazer. É o mesmo caminho por onde o catálogo da
+ *     loja já entra, e ter dois jeitos de importar planilha neste produto seria
+ *     duas verdades sobre o mesmo gesto.
+ *  2. Não há escolha de ETAPA. Planilha traz gente NOVA, e gente nova entra na
+ *     primeira etapa do funil. Perguntar seria uma pergunta a mais para uma
+ *     resposta que já é a certa — e quem quiser outra etapa arrasta os cards,
+ *     que é o gesto do quadro.
+ */
+export function ImportarLeads({ funis }: { funis: FunilDaLista[] }) {
+  const t = useT();
+  const [aberto, setAberto] = useState(false);
+  const [funilId, setFunilId] = useState(funis[0]?.id ?? "");
+  const [enviando, setEnviando] = useState(false);
+  const [resumo, setResumo] = useState<ResumoDaImportacao | null>(null);
+  const [erro, setErro] = useState<string | null>(null);
+  const arquivoRef = useRef<HTMLInputElement>(null);
+
+  async function importar(arquivo: File) {
+    setEnviando(true);
+    setErro(null);
+    setResumo(null);
+    try {
+      const form = new FormData();
+      form.append("file", arquivo);
+      form.append("pipeline_id", funilId);
+      const res = await fetch("/api/v1/leads/import", { method: "POST", body: form });
+      const json = (await res.json()) as
+        | { data: ResumoDaImportacao }
+        | { error?: { message?: string } };
+      if (!res.ok || !("data" in json)) {
+        setErro(
+          ("error" in json ? json.error?.message : undefined) ??
+            t("Não consegui ler essa planilha."),
+        );
+        return;
+      }
+      // O resumo fica NA TELA, não num toast que some em quatro segundos: quem
+      // importou 300 linhas precisa ler quais foram recusadas e por quê.
+      setResumo(json.data);
+    } catch {
+      setErro(t("Não consegui enviar o arquivo."));
+    } finally {
+      setEnviando(false);
+      if (arquivoRef.current) arquivoRef.current.value = "";
+    }
+  }
+
+  return (
+    <>
+      <Button variant="outline" onClick={() => setAberto(true)} data-testid="abrir-importar-leads">
+        {t("Importar planilha")}
+      </Button>
+
+      <Dialog open={aberto} onOpenChange={setAberto}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{t("Importar leads de uma planilha")}</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              {t(
+                "Um arquivo CSV com uma linha por lead. Os leads entram na primeira etapa do funil escolhido.",
+              )}
+            </p>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="funil-de-destino">{t("Funil de destino")}</Label>
+              <Select value={funilId} onValueChange={setFunilId}>
+                <SelectTrigger id="funil-de-destino">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {funis.map((f) => (
+                    <SelectItem key={f.id} value={f.id}>
+                      {f.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <input
+              ref={arquivoRef}
+              type="file"
+              accept=".csv,text/csv"
+              className="hidden"
+              data-testid="arquivo-de-leads"
+              onChange={(e) => {
+                const arquivo = e.target.files?.[0];
+                if (arquivo) void importar(arquivo);
+              }}
+            />
+            <Button
+              className="w-full gap-2"
+              disabled={enviando || !funilId}
+              onClick={() => arquivoRef.current?.click()}
+              data-testid="escolher-planilha"
+            >
+              <UploadSimple size={16} aria-hidden />
+              {enviando ? t("Importando…") : t("Escolher o arquivo CSV")}
+            </Button>
+
+            {/* Rota de API que devolve o arquivo com `content-disposition:
+                attachment` — é download, não navegação de página. */}
+            <a
+              href="/api/v1/leads/import"
+              download="modelo-leads.csv"
+              className="block text-xs text-muted-foreground underline"
+              data-testid="modelo-de-leads"
+            >
+              {t("Baixar planilha modelo")}
+            </a>
+
+            {erro ? (
+              <p role="alert" className="rounded bg-destructive/10 p-2 text-xs font-medium text-destructive">
+                {erro}
+              </p>
+            ) : null}
+
+            {resumo ? (
+              <div className="rounded-lg border p-3 text-sm" data-testid="resumo-da-importacao">
+                <p className="font-medium">
+                  {resumo.criados} {t("leads criados")} · {resumo.contatos_criados}{" "}
+                  {t("contatos novos")} · {resumo.total_linhas} {t("linhas na planilha")}
+                </p>
+                {resumo.colunas_ignoradas.length > 0 ? (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {t("Colunas que não reconheci:")} {resumo.colunas_ignoradas.join(", ")}
+                  </p>
+                ) : null}
+                {resumo.erros.length > 0 ? (
+                  <ul className="mt-2 max-h-40 space-y-0.5 overflow-y-auto text-xs text-muted-foreground">
+                    {resumo.erros.map((e) => (
+                      <li key={`${e.linha}-${e.motivo}`}>
+                        {t("Linha")} {e.linha}: {e.motivo}
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/app/app/kanban/page.tsx
+++ b/app/app/kanban/page.tsx
@@ -43,6 +43,9 @@ export default async function KanbanPickerPage() {
 
   const funis = (data ?? []) as FunilDaLista[];
   const podeGerenciar = ROLE_RANK[activeOrg.role] >= ROLE_RANK.manager;
+  // Importar planilha é ESCRITA DE OPERAÇÃO, não configuração: quem atende
+  // sobe a lista que recebeu. Espelha o `requireRole("agent")` da rota.
+  const podeImportar = ROLE_RANK[activeOrg.role] >= ROLE_RANK.agent;
   const idioma = user.idioma;
   const t = (texto: string) => traduzir(texto, idioma);
 
@@ -60,7 +63,7 @@ export default async function KanbanPickerPage() {
         <h1 className="text-2xl font-semibold tracking-tight">{t("Funis")}</h1>
       </header>
 
-      <FunisClient funis={funis} podeGerenciar={podeGerenciar} />
+      <FunisClient funis={funis} podeGerenciar={podeGerenciar} podeImportar={podeImportar} />
     </div>
   );
 }

--- a/lib/audit/actions.ts
+++ b/lib/audit/actions.ts
@@ -50,6 +50,10 @@ export const AUDIT_ACTIONS = [
   "lead.won",
   "lead.lost",
   "lead.bulk_action",
+  // A importação de planilha (extração do PR #418). O GESTO é auditado além dos
+  // N `lead.created`: "quem despejou 300 negócios neste funil, e quando" é a
+  // pergunta que se faz depois, e ela não se responde contando linhas soltas.
+  "lead.imported",
   "contact.created",
   "contact.updated",
   "contacts.imported",

--- a/lib/i18n/dicionario.ts
+++ b/lib/i18n/dicionario.ts
@@ -6363,6 +6363,17 @@ export const DICIONARIO: Traducoes = {
   "Salvar produto": { es: "Guardar producto" },
   "em estoque": { es: "en stock" },
   "sem controle de estoque": { es: "sin control de stock" },
+
+  // ─── Importar leads de planilha (extraído do PR #418) ───
+  "Importar leads de uma planilha": { es: "Importar leads desde una planilla" },
+  "Um arquivo CSV com uma linha por lead. Os leads entram na primeira etapa do funil escolhido.": {
+    es: "Un archivo CSV con una línea por lead. Los leads entran en la primera etapa del embudo elegido.",
+  },
+  "Funil de destino": { es: "Embudo de destino" },
+  "Escolher o arquivo CSV": { es: "Elegir el archivo CSV" },
+  "leads criados": { es: "leads creados" },
+  "contatos novos": { es: "contactos nuevos" },
+  "Colunas que não reconheci:": { es: "Columnas que no reconocí:" },
 };
 
 /**

--- a/lib/leads/planilha.ts
+++ b/lib/leads/planilha.ts
@@ -1,0 +1,188 @@
+import { normalizaTelefone, parseCsv } from "@/lib/contacts/csv";
+import { precoParaCentavos } from "@/lib/schemas/produtos";
+
+/**
+ * A PLANILHA DE LEADS — da lista que a empresa já tem para dentro do funil.
+ *
+ * Extraído do PR #418 (@clinicacentrodosorrisosc-code). O que muda é ONDE a
+ * leitura acontece e COM O QUE ela é feita.
+ *
+ * ─── Por que não veio o `xlsx` que o original usava ────────────────────────
+ *
+ * O #418 lê `.xlsx` no NAVEGADOR com `xlsx@0.18.5`. Essa é a última versão
+ * publicada no npm da SheetJS, e ela carrega CVE-2023-30533 (prototype
+ * pollution, alta) e CVE-2024-22363 (ReDoS) — a biblioteca saiu do npm e as
+ * correções vivem só no CDN próprio deles. Num produto que se instala na VPS
+ * de terceiros, entrar com uma dependência nessa situação é dívida que o
+ * cliente paga.
+ *
+ * E não era preciso: `parseCsv` já existe aqui, é RFC 4180, sem dependência,
+ * detecta o delimitador (o Excel em português exporta com `;`) e já tem
+ * `decodificarCsv` para o arquivo em Latin-1 que o Excel gera. É o mesmo
+ * caminho por onde os CONTATOS e o CATÁLOGO já entram — copiá-lo criaria a
+ * segunda verdade sobre o que é uma planilha, e a segunda envelhece sozinha.
+ *
+ * ─── Por que a leitura é no SERVIDOR ───────────────────────────────────────
+ *
+ * O original montava as linhas no browser e disparava um `POST /api/v1/leads`
+ * por linha, em lotes de 20 com `Promise.allSettled`. Três consequências: 500
+ * requisições autenticadas para uma planilha de 500 nomes; nenhuma auditoria
+ * do gesto "importei uma planilha", só 500 `lead.created` soltos; e o resultado
+ * dependendo da aba ficar aberta — fechar o navegador no meio deixa metade
+ * dentro e metade fora, sem ninguém saber qual metade.
+ *
+ * ─── A planilha vem suja, e recusar é a função ─────────────────────────────
+ *
+ * "R$ 1.200,00" e "1200", telefone com máscara, linha em branco no meio,
+ * coluna com acento. Nada disso é erro de quem mandou — é o formato real. O
+ * que NÃO se aceita em silêncio é o ambíguo: valor que não dá para ler vira
+ * linha recusada com o motivo, nunca um chute.
+ */
+
+/** Como cada coluna pode vir escrita. A primeira forma é a que a gente sugere. */
+const COLUNAS: Record<string, readonly string[]> = {
+  titulo: ["nome", "titulo", "título", "lead", "negocio", "negócio", "oportunidade", "empresa", "assunto"],
+  contato: ["nome do contato", "contato", "responsavel", "responsável", "pessoa"],
+  telefone: ["telefone", "celular", "whatsapp", "fone", "phone"],
+  email: ["email", "e-mail"],
+  descricao: ["descricao", "descrição", "observacao", "observação", "observacoes", "observações", "notas", "detalhes"],
+  valor: ["valor", "preco", "preço", "ticket", "value"],
+  origem: ["origem", "fonte", "canal", "source"],
+  etiquetas: ["tags", "etiquetas", "marcadores"],
+};
+
+function normalizarCabecalho(texto: string): string {
+  return texto
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function campoDaColuna(cabecalho: string): string | null {
+  const alvo = normalizarCabecalho(cabecalho);
+  for (const [campo, formas] of Object.entries(COLUNAS)) {
+    if (formas.some((f) => normalizarCabecalho(f) === alvo)) return campo;
+  }
+  return null;
+}
+
+export interface LinhaDeLead {
+  /** A linha como a pessoa a vê na planilha: 1 é o cabeçalho. */
+  linha: number;
+  title: string;
+  description: string | null;
+  value_cents: number | null;
+  /** Já em E.164, ou nulo quando a célula não era um telefone. */
+  telefone: string | null;
+  nome_do_contato: string | null;
+  email: string | null;
+  tags: string[];
+  source: string;
+}
+
+export interface ErroDaLinha {
+  linha: number;
+  motivo: string;
+}
+
+export interface ResultadoDaLeitura {
+  leads: LinhaDeLead[];
+  erros: ErroDaLinha[];
+  /** Colunas que a planilha trouxe e este importador não conhece. */
+  colunasIgnoradas: string[];
+}
+
+/** A origem gravada em `crm_leads.source` — vocabulário, não string solta. */
+export const ORIGEM_DA_PLANILHA = "importacao_planilha";
+
+export function lerPlanilhaDeLeads(conteudo: string): ResultadoDaLeitura | { erro: string } {
+  const linhas = parseCsv(conteudo).filter((l) => l.some((c) => c.trim() !== ""));
+  if (linhas.length === 0) return { erro: "A planilha está vazia." };
+
+  const cabecalho = linhas[0]!;
+  const mapa = new Map<number, string>();
+  const colunasIgnoradas: string[] = [];
+  cabecalho.forEach((titulo, i) => {
+    const campo = campoDaColuna(titulo);
+    if (campo && ![...mapa.values()].includes(campo)) mapa.set(i, campo);
+    else if (titulo.trim() !== "") colunasIgnoradas.push(titulo.trim());
+  });
+
+  const campos = new Set(mapa.values());
+  // Sem nada que NOMEIE o negócio não há card — e dizer isso antes de
+  // processar 300 linhas evita um relatório com 300 erros iguais.
+  if (!campos.has("titulo") && !campos.has("contato")) {
+    return {
+      erro:
+        "A planilha precisa de uma coluna com o nome do negócio ou do contato. " +
+        `Encontrei: ${cabecalho.filter((c) => c.trim()).join(", ") || "nenhuma coluna"}.`,
+    };
+  }
+
+  const leads: LinhaDeLead[] = [];
+  const erros: ErroDaLinha[] = [];
+
+  for (let i = 1; i < linhas.length; i += 1) {
+    const bruto = linhas[i]!;
+    const numeroNaPlanilha = i + 1;
+    const valor = (campo: string): string => {
+      for (const [idx, c] of mapa) if (c === campo) return (bruto[idx] ?? "").trim();
+      return "";
+    };
+
+    const nomeDoContato = valor("contato").replace(/\s+/g, " ");
+    // Sem coluna de título, o nome do contato NOMEIA o card. O original punha
+    // "Lead importado" nesse caso, e uma planilha de 300 nomes virava 300 cards
+    // com o mesmo título — indistinguíveis no funil, que é onde eles vivem.
+    const title = (valor("titulo").replace(/\s+/g, " ") || nomeDoContato).slice(0, 200);
+    if (title.length < 2) {
+      erros.push({ linha: numeroNaPlanilha, motivo: "sem nome do negócio nem do contato" });
+      continue;
+    }
+
+    const valorTexto = valor("valor");
+    const value_cents = valorTexto === "" ? null : precoParaCentavos(valorTexto);
+    if (valorTexto !== "" && value_cents === null) {
+      // O valor cru entra na mensagem: quem vai corrigir precisa achar a célula.
+      erros.push({
+        linha: numeroNaPlanilha,
+        motivo: `valor não reconhecido ("${valorTexto}") — escreva assim: 1.200,00`,
+      });
+      continue;
+    }
+
+    const telefoneTexto = valor("telefone");
+    const telefone = telefoneTexto === "" ? null : normalizaTelefone(telefoneTexto);
+    if (telefoneTexto !== "" && telefone === null) {
+      // Telefone ilegível NÃO derruba a linha: o negócio entra sem contato, e a
+      // pessoa corrige um card em vez de reimportar a planilha inteira. Mas o
+      // aviso fica, senão o número some sem ninguém saber.
+      erros.push({
+        linha: numeroNaPlanilha,
+        motivo: `telefone não reconhecido ("${telefoneTexto}") — o negócio entrou sem contato`,
+      });
+    }
+
+    const emailTexto = valor("email");
+
+    leads.push({
+      linha: numeroNaPlanilha,
+      title,
+      description: valor("descricao") || null,
+      value_cents,
+      telefone,
+      nome_do_contato: nomeDoContato || null,
+      email: emailTexto.includes("@") ? emailTexto : null,
+      tags: valor("etiquetas")
+        .split(/[,;|]/)
+        .map((t) => t.trim())
+        .filter(Boolean)
+        .slice(0, 20),
+      source: valor("origem") || ORIGEM_DA_PLANILHA,
+    });
+  }
+
+  return { leads, erros, colunasIgnoradas };
+}

--- a/tests/unit/leads-import-route.test.ts
+++ b/tests/unit/leads-import-route.test.ts
@@ -1,0 +1,213 @@
+/**
+ * A IMPORTAÇÃO DE LEADS NÃO ACEITA NADA NO ESCURO.
+ *
+ * Guarda o que a extração do PR #418 mudou de contrato:
+ *
+ *  - O funil e a etapa vêm do FORM, mas a ORGANIZAÇÃO vem da sessão. Sem isto,
+ *    uma planilha podia despejar 300 negócios no funil de outro tenant.
+ *  - Uma linha ruim não derruba as outras; uma ETAPA ruim derruba tudo, e a
+ *    diferença é o que separa "corrija a linha 7" de "300 tentativas para dar
+ *    o mesmo erro 300 vezes".
+ *  - O mesmo telefone repetido vira UM contato. O original criava um contato por
+ *    linha, e o produto passava a ter a duplicata que ele mesmo fabricou.
+ *  - `viewer` não importa.
+ */
+import { NextRequest } from "next/server";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { ApiError } from "@/lib/api/types";
+import { fail } from "@/lib/api/wrappers";
+import { audit } from "@/lib/audit";
+import { requireRole } from "@/lib/auth/require-role";
+import { ROLE_RANK, type AuthUser, type Role } from "@/lib/auth/types";
+import { createLeadHandler } from "@/app/api/v1/leads/_handler";
+import { createClient } from "@/lib/supabase/server";
+
+vi.mock("@/lib/auth/require-role", () => ({ requireRole: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("@/lib/audit", () => ({ audit: vi.fn(async () => undefined) }));
+vi.mock("@/app/api/v1/leads/_handler", () => ({ createLeadHandler: vi.fn() }));
+
+const ORG = "22222222-2222-4222-8222-222222222222";
+const ANA = "11111111-1111-4111-8111-111111111111";
+const FUNIL = "33333333-3333-4333-8333-333333333333";
+const ETAPA = "44444444-4444-4444-8444-444444444444";
+
+function sessao(papel: Role) {
+  const user: AuthUser = {
+    id: ANA,
+    email: "ana@example.com",
+    full_name: "Ana",
+    avatar_url: null,
+    is_platform_admin: false,
+    idioma: "pt-BR" as const,
+    organizations: [{ organization_id: ORG, organization_name: "Org", role: papel }],
+  };
+  vi.mocked(requireRole).mockImplementation(async (min: Role) =>
+    ROLE_RANK[papel] >= ROLE_RANK[min]
+      ? { ok: true, user, org: { orgId: ORG, name: "Org", role: papel } }
+      : { ok: false, response: fail("forbidden_role", `Requer role >= ${min}.`, 403, {}) },
+  );
+}
+
+/** Dublê de `contacts` que anota os INSERTs — é como se conta duplicata. */
+function fazerSupabase(existente: { id: string } | null) {
+  const inseridos: Record<string, unknown>[] = [];
+  const from = (tabela: string) => {
+    const elo: Record<string, unknown> = {};
+    for (const m of ["select", "eq", "in", "limit", "order"]) elo[m] = () => elo;
+    elo.insert = (linha: Record<string, unknown>) => {
+      if (tabela === "contacts") inseridos.push(linha);
+      return elo;
+    };
+    elo.single = () => Promise.resolve({ data: { id: `novo-${inseridos.length}` }, error: null });
+    elo.maybeSingle = () => Promise.resolve({ data: existente, error: null });
+    return elo;
+  };
+  vi.mocked(createClient).mockResolvedValue({ from } as never);
+  return { inseridos };
+}
+
+/**
+ * O corpo multipart é montado NA MÃO, byte a byte — e não com `new FormData()`.
+ *
+ * Medido: sob o ambiente `jsdom` da suíte, passar um `FormData` do jsdom como
+ * `body` de um `NextRequest` faz o undici (que é quem serializa) não reconhecer
+ * o `File` do jsdom e gravá-lo como a STRING "undefined". O arquivo chega à
+ * rota com 9 bytes, nome "blob" e conteúdo `undefined` — e o teste passaria a
+ * medir o realm do ambiente, não a rota.
+ *
+ * Montar o multipart à mão remove a variável: é exatamente o que o navegador
+ * põe no fio, e o `req.formData()` da rota o lê com o parser de produção.
+ */
+function pedido(csv: string, campos: Record<string, string | null> = {}) {
+  const B = "----deskcommTesteDeImportacao";
+  const parte = (nome: string, valor: string, arquivo?: string) =>
+    `--${B}\r\nContent-Disposition: form-data; name="${nome}"` +
+    (arquivo ? `; filename="${arquivo}"\r\nContent-Type: text/csv` : "") +
+    `\r\n\r\n${valor}\r\n`;
+
+  let corpo = parte("file", csv, "leads.csv");
+  const funil = campos.pipeline_id === null ? null : (campos.pipeline_id ?? FUNIL);
+  const etapa = campos.stage_id === null ? null : (campos.stage_id ?? ETAPA);
+  if (funil !== null) corpo += parte("pipeline_id", funil);
+  if (etapa !== null) corpo += parte("stage_id", etapa);
+  corpo += `--${B}--\r\n`;
+
+  return new NextRequest("http://x/api/v1/leads/import", {
+    method: "POST",
+    headers: { "content-type": `multipart/form-data; boundary=${B}` },
+    body: corpo,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessao("agent");
+  vi.mocked(createLeadHandler).mockResolvedValue({ id: "lead" } as never);
+});
+
+describe("POST /api/v1/leads/import", () => {
+  it("cria um negócio por linha, com a ORG da sessão", async () => {
+    fazerSupabase(null);
+    const { POST } = await import("@/app/api/v1/leads/import/route");
+
+    const res = await POST(pedido("nome,valor\nAna,100\nBruno,200"));
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(createLeadHandler)).toHaveBeenCalledTimes(2);
+    for (const [, ctx] of vi.mocked(createLeadHandler).mock.calls) {
+      expect((ctx as { organization_id: string }).organization_id).toBe(ORG);
+    }
+  });
+
+  it("uma linha ruim não derruba as outras — e o motivo volta com o número da linha", async () => {
+    fazerSupabase(null);
+    const { POST } = await import("@/app/api/v1/leads/import/route");
+
+    const res = await POST(pedido("nome,valor\nAna,100\nBruno,doze mil\nCarla,300"));
+    const corpo = (await res.json()) as { data: { criados: number; erros: { linha: number }[] } };
+
+    expect(corpo.data.criados).toBe(2);
+    expect(corpo.data.erros.map((e) => e.linha)).toEqual([3]);
+  });
+
+  it("uma ETAPA de outra organização derruba a importação inteira, e cedo", async () => {
+    // Se a etapa não é desta org, ela não será na linha 2 nem na 300. Seguir
+    // gastaria 300 tentativas para colher 300 vezes o mesmo erro.
+    fazerSupabase(null);
+    vi.mocked(createLeadHandler).mockRejectedValue(
+      new ApiError(404, "not_found", undefined, "rid", "Stage não encontrado."),
+    );
+    const { POST } = await import("@/app/api/v1/leads/import/route");
+
+    const res = await POST(pedido("nome\nAna\nBruno\nCarla"));
+
+    expect(res.status).toBe(404);
+    expect(vi.mocked(createLeadHandler)).toHaveBeenCalledTimes(1);
+  });
+
+  it("o mesmo telefone em três linhas vira UM contato", async () => {
+    const espiao = fazerSupabase(null);
+    const { POST } = await import("@/app/api/v1/leads/import/route");
+
+    await POST(
+      pedido(
+        "nome,telefone\nAna,11988887777\nAna (2),(11) 98888-7777\nAna (3),+5511988887777",
+      ),
+    );
+
+    expect(espiao.inseridos).toHaveLength(1);
+  });
+
+  it("contato que já existe é REUSADO, não duplicado", async () => {
+    const espiao = fazerSupabase({ id: "contato-existente" });
+    const { POST } = await import("@/app/api/v1/leads/import/route");
+
+    await POST(pedido("nome,telefone\nAna,11988887777"));
+
+    expect(espiao.inseridos).toHaveLength(0);
+    expect(vi.mocked(createLeadHandler).mock.calls[0]![2]).toMatchObject({
+      contact_id: "contato-existente",
+    });
+  });
+
+  it("audita o GESTO, não só os 300 lead.created soltos", async () => {
+    fazerSupabase(null);
+    const { POST } = await import("@/app/api/v1/leads/import/route");
+
+    await POST(pedido("nome\nAna\nBruno"));
+
+    expect(vi.mocked(audit)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "lead.imported",
+        organizationId: ORG,
+        metadata: expect.objectContaining({ criados: 2 }),
+      }),
+    );
+  });
+
+  it("sem funil escolhido, 422 antes de ler o arquivo", async () => {
+    fazerSupabase(null);
+    const { POST } = await import("@/app/api/v1/leads/import/route");
+    const res = await POST(pedido("nome\nAna", { pipeline_id: null, stage_id: null }));
+    expect(res.status).toBe(422);
+    expect(vi.mocked(createLeadHandler)).not.toHaveBeenCalled();
+  });
+
+  it("planilha sem coluna que nomeie o negócio é recusada com 422", async () => {
+    fazerSupabase(null);
+    const { POST } = await import("@/app/api/v1/leads/import/route");
+    const res = await POST(pedido("valor,origem\n100,site"));
+    expect(res.status).toBe(422);
+    expect(vi.mocked(createLeadHandler)).not.toHaveBeenCalled();
+  });
+
+  it("viewer não importa", async () => {
+    sessao("viewer");
+    fazerSupabase(null);
+    const { POST } = await import("@/app/api/v1/leads/import/route");
+    const res = await POST(pedido("nome\nAna"));
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/unit/planilha-de-leads.test.ts
+++ b/tests/unit/planilha-de-leads.test.ts
@@ -1,0 +1,107 @@
+/**
+ * A PLANILHA DE LEADS É LIDA COM O QUE JÁ EXISTE, E RECUSA O AMBÍGUO.
+ *
+ * Os casos abaixo são o que a extração do PR #418 mudou de comportamento, não
+ * uma tradução do que ele fazia:
+ *
+ *  - O original punha `"Lead importado"` quando a coluna de título faltava.
+ *    Uma lista de 300 nomes virava 300 cards indistinguíveis no funil, que é
+ *    justamente onde eles precisam ser distinguidos.
+ *  - Ele lia o valor com `Number(String(v).replace(/\./g,"").replace(",","."))`,
+ *    que devolve `NaN` em silêncio para "R$ 1.200,00" e grava o lead sem valor.
+ *    Aqui a célula ilegível vira linha recusada COM o texto cru na mensagem.
+ *  - Ele normalizava telefone com uma regra própria de +55; aqui é a MESMA de
+ *    `lib/contacts/csv.ts`, por onde os contatos já entram.
+ */
+import { describe, expect, it } from "vitest";
+
+import { lerPlanilhaDeLeads } from "@/lib/leads/planilha";
+
+function ok(conteudo: string) {
+  const r = lerPlanilhaDeLeads(conteudo);
+  if ("erro" in r) throw new Error(`esperava leitura, veio erro: ${r.erro}`);
+  return r;
+}
+
+describe("leitura da planilha de leads", () => {
+  it("planilha vazia é recusada com motivo, não devolve lista vazia", () => {
+    // Lista vazia lê-se como "importei zero leads com sucesso".
+    expect(lerPlanilhaDeLeads("")).toEqual({ erro: expect.stringContaining("vazia") });
+  });
+
+  it("sem coluna que NOMEIE o negócio, recusa ANTES de processar as linhas", () => {
+    const r = lerPlanilhaDeLeads("valor,origem\n100,site\n200,indicacao");
+    expect(r).toHaveProperty("erro");
+    // A mensagem lista o que encontrou: quem vai corrigir precisa saber o que
+    // o importador viu, não só que ele não gostou.
+    expect((r as { erro: string }).erro).toContain("valor");
+  });
+
+  it("aceita o ; do Excel em português e o cabeçalho com acento", () => {
+    const r = ok("Nome;Telefone;Observação\nAna Souza;11988887777;retorno em junho");
+    expect(r.leads).toHaveLength(1);
+    expect(r.leads[0]!.title).toBe("Ana Souza");
+    expect(r.leads[0]!.description).toBe("retorno em junho");
+  });
+
+  it("valor em moeda brasileira vira centavos; o ilegível vira linha recusada", () => {
+    const r = ok('nome,valor\nAna,"R$ 1.200,00"\nBruno,doze mil\nCarla,1200');
+    expect(r.leads.map((l) => [l.title, l.value_cents])).toEqual([
+      ["Ana", 120000],
+      ["Carla", 120000],
+    ]);
+    expect(r.erros).toHaveLength(1);
+    expect(r.erros[0]!.linha).toBe(3);
+    // O valor CRU entra na mensagem: quem corrige precisa achar a célula.
+    expect(r.erros[0]!.motivo).toContain("doze mil");
+  });
+
+  it("sem coluna de título, o nome do CONTATO nomeia o card", () => {
+    // O original punha "Lead importado" — 300 cards com o mesmo nome.
+    const r = ok("nome do contato,telefone\nAna Souza,11988887777");
+    expect(r.leads[0]!.title).toBe("Ana Souza");
+    expect(r.leads[0]!.nome_do_contato).toBe("Ana Souza");
+  });
+
+  it("linha sem nenhum nome é recusada, não vira card genérico", () => {
+    const r = ok("nome,valor\n,100\nBruno,200");
+    expect(r.leads.map((l) => l.title)).toEqual(["Bruno"]);
+    expect(r.erros[0]!.motivo).toContain("sem nome");
+  });
+
+  it("telefone com máscara vira E.164; o ilegível NÃO derruba o negócio", () => {
+    const r = ok("nome,telefone\nAna,(11) 98888-7777\nBruno,não tem");
+    expect(r.leads).toHaveLength(2);
+    expect(r.leads[0]!.telefone).toBe("+5511988887777");
+    // O negócio de Bruno entra sem contato — corrigir um card é mais barato que
+    // reimportar a planilha —, mas o aviso fica: o número não some calado.
+    expect(r.leads[1]!.telefone).toBeNull();
+    expect(r.erros.some((e) => e.motivo.includes("não tem"))).toBe(true);
+  });
+
+  it("colunas desconhecidas são NOMEADAS, não descartadas em silêncio", () => {
+    // É o que substitui o passo de mapear colunas do original: quem precisa
+    // mapear renomeia o cabeçalho, e para isso precisa saber qual foi ignorado.
+    const r = ok("nome,cpf do cliente,rating\nAna,111,5");
+    expect(r.colunasIgnoradas).toEqual(["cpf do cliente", "rating"]);
+  });
+
+  it("linha em branco no meio não vira lead nem erro", () => {
+    const r = ok("nome\nAna\n\nBruno");
+    expect(r.leads.map((l) => l.title)).toEqual(["Ana", "Bruno"]);
+    expect(r.erros).toEqual([]);
+  });
+
+  it("tags separadas por vírgula, ponto-e-vírgula ou barra viram lista", () => {
+    // A célula vem ENTRE ASPAS porque o separador das tags é o mesmo caractere
+    // que pode ser o delimitador da planilha — sem as aspas, "quente;retorno"
+    // viraria uma terceira coluna e o teste mediria o parser, não a regra.
+    const r = ok('nome,tags\nAna,"quente;retorno"');
+    expect(r.leads[0]!.tags).toEqual(["quente", "retorno"]);
+  });
+
+  it("a linha reportada é a que a pessoa VÊ na planilha (1 é o cabeçalho)", () => {
+    const r = ok("nome,valor\nAna,100\nBruno,xis");
+    expect(r.erros[0]!.linha).toBe(3);
+  });
+});


### PR DESCRIPTION
## De quem é este trabalho

A importação de leads por planilha foi construída por **James, da Clínica
Centro do Sorriso** (**@clinicacentrodosorrisosc-code**), no PR #418 — 134
commits, 100% autorais, depois de seis semanas rodando o DeskcommCRM numa
operação real. A capacidade é dele; este PR a carrega para dentro do produto
com `Co-Authored-By`.

Segundo de uma série. O primeiro é #546 (Tarefas).

## Por que extraímos em vez de mergear o #418

Duas razões medidas, e nenhuma é sobre a qualidade do que ele fez — para a
clínica dele as duas decisões eram as certas.

**1. O vocabulário é de clínica, e o núcleo é multi-nicho.** O #418 tem etapa de
funil procurada pelo NOME (`stages.find((item) => /or[cç]amento/i.test(item.name))`),
`"Paciente"` como texto padrão de contato sem nome, e `agendamento_status`,
"Consulta" e "procedimentos" no painel. Contando só linhas ADICIONADAS no diff
contra o `merge-base`: `procedimento` 109, `Orçamento` 40, `agendamento_status`
38, `Consulta` 31, `Paciente` 22. O DeskcommCRM atende e-commerce, imobiliária,
infoproduto, serviços e clínica com as mesmas telas trocando só as palavras.

**2. Colisão de tabelas de agenda que quebraria VPS instalada em silêncio.** O
#418 cria `calendar_connections`, `calendar_event_types` e `calendar_events`; a
`main` já tem as duas primeiras com formato diferente, mais cinco tabelas
`calendar_*`. Os dois lados usam `create table if not exists` — numa instalação
existente o `CREATE` não faz nada, sem erro, e as telas de agenda passam a pedir
colunas que não existem. O `update.sh` diria "pronto".

## O que este PR traz

**Importar leads de uma planilha.** Em **Funis**, um botão abre um diálogo que
pede o CSV e o funil de destino, e cria um negócio por linha na primeira etapa
daquele funil. Ao terminar, a tela mostra quantos negócios entraram, quantos
contatos foram criados, **quais colunas o importador não reconheceu** e **quais
linhas foram recusadas**, com o motivo e o número da linha como a pessoa a vê na
planilha.

- **Sem schema novo.** Nada de migration: `crm_leads` e `contacts` já existem, e
  cada linha nasce pelo MESMO `createLeadHandler` de um negócio criado à mão —
  mesma validação de etapa contra a organização, mesma `position_in_stage`,
  mesmo `emit_event` e mesmo audit `lead.created`.
- Audit do GESTO (`lead.imported`) além dos N `lead.created`: "quem despejou 300
  negócios neste funil, e quando" não se responde contando linhas soltas.
- Planilha modelo em `GET /api/v1/leads/import`, no molde do catálogo.
- Texto de tela por `t()`, com pt-BR e **es**.
- Fragmento em `.changes/`.

## O que MUDOU em relação ao original, e por quê

### 1. Sai o `xlsx@0.18.5`; entra o `parseCsv` que já existe aqui

O #418 lia `.xlsx` **no navegador** com `xlsx@0.18.5` — a última versão
publicada no npm da SheetJS. Medido na OSV, essa versão carrega duas
vulnerabilidades conhecidas:

```
$ curl -s -X POST https://api.osv.dev/v1/query \
    -d '{"package":{"name":"xlsx","ecosystem":"npm"},"version":"0.18.5"}'
GHSA-4r6h-8v6p-xvw6  CVE-2023-30533  Prototype Pollution in sheetJS
GHSA-5pgg-2g8v-p4x9  CVE-2024-22363  SheetJS ReDoS
```

A biblioteca saiu do npm e as correções vivem só no CDN próprio deles. Num
produto que se instala na VPS de terceiros, essa dependência é dívida que o
cliente paga — e ela não era necessária: `lib/contacts/csv.ts` já tem `parseCsv`
(RFC 4180, sem dependência, detecta o `;` do Excel em português) e
`decodificarCsv` (o arquivo em Latin-1 que o Excel gera). É o mesmo caminho por
onde os CONTATOS e o CATÁLOGO já entram.

**Consequência aceita e escrita:** `.xlsx` deixa de ser aceito; o formato é
`.csv`. É o mesmo que o produto já pede nas outras duas importações, e a
alternativa era manter duas verdades sobre o que é uma planilha.

### 2. A leitura vai para o SERVIDOR

O original montava as linhas no browser e disparava um `POST /api/v1/leads` por
linha, em lotes de 20. Três consequências: 500 requisições autenticadas para uma
planilha de 500 nomes; nenhuma auditoria do gesto "importei uma planilha", só
500 `lead.created` soltos; e o resultado dependendo de a aba ficar aberta —
fechar o navegador no meio deixa metade dentro e metade fora, sem ninguém saber
qual metade.

### 3. Some o passo de mapear colunas

Ele existia porque a leitura era no browser e não havia tabela de apelidos. O
servidor reconhece os cabeçalhos usuais (`lib/leads/planilha.ts`), com ou sem
acento, e o resumo **nomeia** as colunas que ignorou — quem precisa mapear
renomeia o cabeçalho no Excel, que é um gesto que já sabe fazer. Ter dois jeitos
de importar planilha neste produto seria duas verdades sobre o mesmo gesto.

### 4. `"Lead importado"` não é mais o nome de ninguém

O original punha esse título quando a planilha não tinha coluna de nome: uma
lista de 300 pessoas virava 300 cards indistinguíveis no funil, que é
justamente onde eles precisam ser distinguidos. Aqui, sem coluna de título, o
**nome do contato** nomeia o card; sem nenhum dos dois, a linha é recusada com o
motivo.

### 5. O valor deixa de virar `NaN` em silêncio

O original fazia `Number(String(v).replace(/\./g,"").replace(",","."))`, que
devolve `NaN` para "R$ 1.200,00" e grava o lead **sem valor**, sem avisar. Aqui
é o `precoParaCentavos` do catálogo, e a célula ilegível vira linha recusada com
o texto cru na mensagem — quem vai corrigir precisa achar a célula.

### 6. O mesmo telefone repetido vira UM contato

O original criava um contato por linha. Uma lista com três negócios do mesmo
cliente passava a ter três contatos idênticos — duplicata que o produto fabricou
sozinho, no mesmo sistema que tem uma tela de mesclagem para resolvê-la.

### 7. A guarda de arquivo passa a ser por FORMA, não `instanceof File`

`instanceof` compara contra o construtor do REALM em que o código roda, e aqui
há três: undici (o runtime do Next), jsdom (o ambiente da suíte) e o browser.
Medido: um File legítimo vindo do `formData()` do undici dá `instanceof File`
**falso** sob jsdom. Consequência prática nas duas rotas de importação mais
antigas — `contacts/import` e `products/import`, que usam `instanceof` — é que a
guarda de entrada delas **nunca foi exercitada por teste**: o único teste que as
menciona lê o código-fonte, não o comportamento.

Aqui a guarda exige o que a rota vai de fato usar (`arrayBuffer` e `size`), e o
teste monta o multipart **byte a byte**, que é o que o navegador põe no fio.
Isso não foi capricho: com `new FormData()` sob jsdom, o `NextRequest`
serializa o File como a **string `"undefined"`** — o arquivo chega à rota com 9
bytes e nome "blob". Um teste que não notasse isso estaria medindo o realm do
ambiente, não a rota.

## A sabotagem — previsão declarada antes de rodar

Seis sabotagens, cada uma restaurada antes da seguinte, sobre a árvore
**commitada** (a primeira tentativa rodou sobre trabalho não-commitado e o
`git checkout -- .` do próprio script o apagou; aquele resultado foi descartado
e refeito).

| # | O que foi sabotado | Previsto | Medido | Caso vermelho |
|---|---|---|---|---|
| SA | sem o memo de contato por telefone | 1 | 1 | o mesmo telefone em três linhas vira UM contato |
| SB | erro de etapa deixa de derrubar a importação | 1 | 1 | uma ETAPA de outra organização derruba a importação inteira, e cedo |
| SC | sem o audit do gesto | 1 | 1 | audita o GESTO, não só os 300 `lead.created` soltos |
| SD | volta o `"Lead importado"` do original | 2 | 2 | sem coluna de título, o nome do CONTATO nomeia o card · linha sem nenhum nome é recusada |
| SE | leitor de valor ingênuo (o do original) | 1 | 1 | valor em moeda brasileira vira centavos; o ilegível vira linha recusada |
| SF | guarda de arquivo volta a `instanceof File` | 6 | 6 | os seis casos que enviam arquivo |

**12 previstos, 12 medidos.** SF é a prova de que a troca da guarda não é
estética: com `instanceof File`, seis dos nove casos ficam vermelhos porque o
File do undici não é o File do jsdom — que é exatamente o motivo pelo qual as
duas rotas de importação mais antigas nunca tiveram essa guarda exercitada.

## Os portões, com exit code

Rodados na prévia do merge com a `main` de `4d2c71b3`, sobre a árvore commitada
e parada. O `.tsbuildinfo` foi **apagado antes** de cada `typecheck` — os dois
tsconfig têm `incremental: true`, e com cache o `tsc` responde sobre uma árvore
que pode não existir mais.

| Portão | Comando | Exit |
|---|---|---|
| typecheck | `pnpm typecheck` (= `tsc --noEmit -p tsconfig.typecheck.json`) | **0** |
| lint | `pnpm lint` | **0** (0 erros; nenhum aviso nos arquivos deste PR) |
| unit | `pnpm test:unit` (sem caminho — o repositório inteiro) | **0** na rodada das 19:30 (`639 passed (639)`); **1** na repetição das 19:37 — ver abaixo |

**O vermelho da repetição é saturação, e está medido como tal.**
`channel-health-aviso` caiu com `Error: Test timed out in 15000ms`, não com
asserção, com a máquina em `load average` 65–73. Sozinho, no mesmo commit:

```
$ npx vitest run tests/unit/channel-health-aviso.test.ts
Test Files  1 passed (1)
Tests  22 passed (22)     exit=0
```

O arquivo não é tocado por este PR (`grep` no diff devolve vazio), e a rodada
completa de sete minutos antes, sobre o mesmo código, deu `639 passed (639)`.

`pnpm test:db` **não se aplica**: este PR não tem migration nem toca
`baseline.sql`.

## NÃO MEDIDO

- **A tela, por um navegador.** Nenhum clique em `next start` contra um banco
  fresco; nenhuma evidência visual. Não sei como o diálogo se comporta com um
  resumo de 300 linhas recusadas, nem se o `<input type=file>` escondido é
  alcançável por teclado. É a DoD 12, e está em aberto.
- **A importação ponta a ponta contra um Postgres real.** Os testes de rota
  usam dublê do PostgREST: eles provam o CONTRATO (org da sessão, desfecho por
  linha, dedupe de contato, audit), não que o `insert` de `contacts` passa pelas
  policies com o JWT de um `agent`.
- **`pnpm test:e2e`** — nenhuma spec Playwright foi escrita para este fluxo.
- **`pnpm build`** (o check `build-and-size`) não foi rodado localmente.
- **Desempenho com planilha grande.** O teto é `CSV_MAX_DATA_ROWS` (500), e cada
  linha faz de 2 a 4 idas ao banco por reusar o `createLeadHandler`. Não medi o
  tempo total de uma planilha no teto.
- **A tradução em espanhol** foi escrita por mim e não revisada por quem fala a
  língua.
- **As duas rotas antigas** (`contacts/import`, `products/import`) continuam com
  `instanceof File` e continuam sem teste da guarda de entrada. Este PR não as
  toca — o achado está escrito aqui e no código, mas o conserto delas é outro
  PR.
