### PR TITLE
fix(ci): a main volta ao verde — o gate do Tailwind 4 e a tela de importar leads se cruzaram

### DIFF
--- a/.changes/a-main-volta-ao-verde.md
+++ b/.changes/a-main-volta-ao-verde.md
@@ -1,0 +1,12 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O aviso de erro da importação de planilha volta ao raio de borda do produto
+---
+
+A caixa de aviso da tela de importar leads estava com o canto arredondado pela
+metade — 4px em vez dos 8px que o resto do produto usa. É pequeno e é visível:
+ela fica ao lado de outros blocos com o raio certo.
+
+A causa é da migração para o Tailwind 4, que mudou o significado de `rounded`
+puro. Quem escreveu a tela usou o nome que valia antes.

--- a/app/app/kanban/_components/ImportarLeads.tsx
+++ b/app/app/kanban/_components/ImportarLeads.tsx
@@ -154,7 +154,7 @@ export function ImportarLeads({ funis }: { funis: FunilDaLista[] }) {
             </a>
 
             {erro ? (
-              <p role="alert" className="rounded bg-destructive/10 p-2 text-xs font-medium text-destructive">
+              <p role="alert" className="rounded-md bg-destructive/10 p-2 text-xs font-medium text-destructive">
                 {erro}
               </p>
             ) : null}


### PR DESCRIPTION
## A `main` está vermelha, e nenhum dos dois PRs que a quebraram tem defeito

O PR do **Tailwind 4** trouxe o gate `tailwind-tokens`, que proíbe `rounded` puro — no v4 ele vale `0.25rem`, e não o `--radius-md` de 8px do produto. O PR de **importar leads de planilha** trouxe uma tela que usa `rounded` puro.

Cada um passou verde no próprio CI, porque cada um foi medido contra uma `main` que não continha o outro.

## Por que é urgente

O gate roda no `verify`, que é **check obrigatório**. Com a `main` vermelha, **todo PR aberto reprova por um defeito que não é dele** — foi assim que isto apareceu: o #538 vermelhou sem ter tocado em nada relacionado.

## Medido por classe, não por instância

O regex do gate, reproduzido contra os **1.655 arquivos** de `app`/`components`/`lib`/`hooks`:

| ocorrência | veredito |
|---|---|
| `app/app/kanban/_components/ImportarLeads.tsx:157` | **real** |
| `lib/ai/cost.ts:108` | prosa — `* ... rounded up.` |
| `lib/ai/runtime/cost.ts:5` | prosa — `* ... rounded up.` |

As duas últimas são comentário, e o gate real as filtra. Não as toquei: "consertar" prosa seria mexer em texto que o gate nunca reprovou.

## Controle positivo da sonda

Um zero de instrumento morto é indistinguível de um zero de código limpo:

```
antes do conserto ............ 1 violação
depois ....................... 0
plantando `hover:rounded` .... 1   ← a sonda distingue
removendo o plantio .......... 0
```

Plantei a variante **com `:`** de propósito: o comentário do próprio gate registra que a guarda nasceu sem o lookbehind de `:` e que `hover:rounded` passava verde. Testar com `rounded` solto não provaria que a guarda em vigor é a consertada.