### PR TITLE
fix(kit): a troca de senha pela linha de comando acha o usuário — e a mensagem de erro volta a ser alcançável (@Gervanno)

### DIFF
--- a/.changes/a-troca-de-senha-pela-linha-de-comando-acha-o-usuario.md
+++ b/.changes/a-troca-de-senha-pela-linha-de-comando-acha-o-usuario.md
@@ -1,0 +1,26 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A troca de senha pela linha de comando volta a encontrar o usuário
+---
+
+Quem perde o acesso a uma instalação sem SMTP — o estado normal de um self-host
+recém-instalado — só tem um caminho de volta: o `reset-password.sh` do kit. Ele
+não funcionava para **ninguém**. Não era intermitente nem dependia do e-mail:
+qualquer endereço, existente ou não, recebia a mesma resposta seca de "usuário
+não encontrado", e a pessoa ficava trancada do lado de fora do próprio sistema.
+
+A causa era uma consulta escrita na sintaxe errada. O script pedia ao servidor de
+autenticação um filtro no formato do banco (`email.eq.<endereço>`), e esse
+servidor não fala esse formato — ele usa a expressão inteira como texto de busca.
+Como nenhum e-mail contém o pedaço `email.eq.`, a busca não achava nada, sempre.
+
+Agora a consulta vai no formato que o servidor entende. E, como a busca dele é por
+trecho do endereço, o script passou a exigir o e-mail **inteiro** antes de aceitar
+o resultado: pedir `ana@empresa.com` também traz `mariana@empresa.com`, e entregar
+a pessoa errada a um comando que TROCA SENHA seria pior que não achar ninguém. Na
+dúvida ele não devolve nada — quem chama vê "não encontrado", que é ruim mas se
+resolve; a senha de outra pessoa trocada, não.
+
+Quem opera uma VPS não precisa fazer nada além de atualizar. Nenhuma configuração
+muda, nenhum arquivo precisa ser editado à mão.

--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -641,12 +641,42 @@ set_env_var() {
 }
 
 # Resolve o UUID de um usuário pelo e-mail (admin API do Supabase).
+#
+# ── O `filter` do GoTrue é BUSCA POR SUBSTRING, não expressão ────────────────
+# Esta função pedia `?filter=email.eq.<email>` — sintaxe do PostgREST, que o
+# GoTrue não fala. Ele trata a string inteira como termo de busca, nenhum e-mail
+# contém "email.eq.", e a resposta é SEMPRE vazia. Medido em 2026-08-31 contra o
+# projeto de produção, com um e-mail que existe:
+#
+#   GET /auth/v1/admin/users?filter=email.eq.<existente>  → 200 {"users":[]}
+#   GET /auth/v1/admin/users?filter=<existente>           → 200 {"users":[<ele>]}
+#
+# Consequência: `reset-password.sh` morria com "Usuário '<email>' não
+# encontrado" para TODO e-mail — o único caminho de recuperação de senha de uma
+# instalação sem SMTP, que é o estado normal de um self-host, e o mesmo comando
+# que o CLAUDE.md do kit manda usar quando a pessoa se tranca fora.
+#
+# ── Por que o casamento tem de ser EXATO aqui ───────────────────────────────
+# Justamente por ser substring, `ana@empresa.com` casa também
+# `mariana@empresa.com`. Um `head -1` cego devolveria o UUID da outra pessoa
+# numa função cujo único consumidor TROCA SENHA. O padrão abaixo ancora no
+# prefixo do objeto de usuário (id→aud→role→email, nessa ordem), que nenhum
+# objeto aninhado de `identities` tem — e exige o e-mail inteiro, com os pontos
+# escapados (em BRE `.` casa qualquer caractere, e sem escapar
+# `elias.gervanno@x` casaria `eliasXgervanno@x`).
+#
+# Falha FECHADA: se o GoTrue mudar a ordem dos campos, o padrão não casa e a
+# função devolve vazio — quem chama morre com "não encontrado", que é ruim mas
+# recuperável. Devolver o UUID errado, não.
 owner_id_by_email() {
-  local email="$1"
-  curl -fsS "${NEXT_PUBLIC_SUPABASE_URL}/auth/v1/admin/users?filter=email.eq.${email}" \
+  local email="$1" resp esc
+  resp="$(curl -fsS "${NEXT_PUBLIC_SUPABASE_URL}/auth/v1/admin/users?filter=${email}" \
     -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
-    -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" 2>/dev/null \
-    | grep -o '"id":"[0-9a-f-]\{36\}"' | head -1 | sed 's/.*:"//;s/"//'
+    -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" 2>/dev/null)" || return 0
+  esc="$(printf '%s' "$email" | sed 's/[.[\*^$]/\\&/g')"
+  printf '%s' "$resp" \
+    | grep -o "\"id\":\"[0-9a-f-]\{36\}\",\"aud\":\"[^\"]*\",\"role\":\"[^\"]*\",\"email\":\"${esc}\"" \
+    | head -1 | sed 's/^"id":"//;s/".*//'
 }
 
 # Ativa (idempotente) o cron que dispara o drain de eventos a cada minuto. SEM

--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -668,6 +668,20 @@ set_env_var() {
 # Falha FECHADA: se o GoTrue mudar a ordem dos campos, o padrão não casa e a
 # função devolve vazio — quem chama morre com "não encontrado", que é ruim mas
 # recuperável. Devolver o UUID errado, não.
+#
+# ── Por que o `|| return 0` do fim não é enfeite ────────────────────────────
+# `_common.sh` roda sob `set -euo pipefail`, e o consumidor resolve o UUID numa
+# ATRIBUIÇÃO: `uid="$(owner_id_by_email "$EMAIL")"`. O status da atribuição é o
+# da substituição, então uma função que devolve não-zero mata o script ALI — na
+# linha de cima do `[ -n "$uid" ] || die "Usuário não encontrado."`, que nunca
+# chega a rodar. E o `grep` devolve 1 justamente quando não casa ninguém, que é
+# o caso em que a mensagem existe para falar.
+#
+# Medido em 2026-09-03 contra o GoTrue local v2.188.1, e-mail inexistente, as
+# duas linhas reais do reset-password.sh: rc=1 e NENHUMA saída — o operador que
+# erra uma letra no endereço não vê aviso nenhum, só o prompt de volta. "Não
+# encontrado" era uma mensagem inalcançável. O `|| return 0` põe a decisão onde
+# ela pertence: a função devolve VAZIO, e quem chama decide o que dizer.
 owner_id_by_email() {
   local email="$1" resp esc
   resp="$(curl -fsS "${NEXT_PUBLIC_SUPABASE_URL}/auth/v1/admin/users?filter=${email}" \
@@ -676,7 +690,7 @@ owner_id_by_email() {
   esc="$(printf '%s' "$email" | sed 's/[.[\*^$]/\\&/g')"
   printf '%s' "$resp" \
     | grep -o "\"id\":\"[0-9a-f-]\{36\}\",\"aud\":\"[^\"]*\",\"role\":\"[^\"]*\",\"email\":\"${esc}\"" \
-    | head -1 | sed 's/^"id":"//;s/".*//'
+    | head -1 | sed 's/^"id":"//;s/".*//' || return 0
 }
 
 # Ativa (idempotente) o cron que dispara o drain de eventos a cada minuto. SEM

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:journeys": "playwright test -c tests/journeys/playwright.config.ts",
     "test:unit": "vitest run",
     "test:db": "bash scripts/test-db.sh",
-    "test:shell": "bash tests/shell/update-guard.test.sh && bash tests/shell/dono-do-projeto.test.sh && bash tests/shell/scheduler-entrypoint.test.sh && bash hostgator-setup-kit/test-validators.sh",
+    "test:shell": "bash tests/shell/update-guard.test.sh && bash tests/shell/dono-do-projeto.test.sh && bash tests/shell/scheduler-entrypoint.test.sh && bash tests/shell/owner-id-por-email.test.sh && bash hostgator-setup-kit/test-validators.sh",
     "test:invariants": "bash scripts/test-db.sh",
     "lint:channels": "tsx scripts/lint-channels.ts",
     "lint:role-rank": "tsx scripts/lint-role-rank.ts",

--- a/tests/shell/owner-id-por-email.test.sh
+++ b/tests/shell/owner-id-por-email.test.sh
@@ -133,6 +133,42 @@ check "reset-password.sh resolve o uid pela função" \
 check "reset-password.sh morre quando o uid vem vazio" \
   grep -qE '\[ -n "\$uid" \] \|\| die' "$KIT_DIR/reset-password.sh"
 
+printf '\n\u25b6 o call site EXECUTADO (grep de linha nao e comportamento)\n'
+
+# Os dois greps acima provam que as linhas EXISTEM. Nenhum prova que elas RODAM,
+# e era exatamente ali que morava o residuo: `_common.sh` roda sob
+# `set -euo pipefail` e o consumidor resolve o UUID numa ATRIBUICAO —
+# `uid="$(owner_id_by_email "$EMAIL")"`. O status da atribuicao e o da
+# substituicao, entao uma funcao que devolve nao-zero mata o script NA LINHA
+# ANTERIOR ao `[ -n "$uid" ] || die`. E o `grep` devolve 1 justamente quando nao
+# casa ninguem — o unico caso em que a mensagem tem o que dizer.
+#
+# Medido em 2026-09-03 contra o GoTrue local v2.188.1, e-mail inexistente, estas
+# duas linhas reais: rc=1 e NENHUMA saida. O operador que erra uma letra no
+# endereco nao via aviso nenhum, so o prompt de volta.
+cat > "$WORK/callsite.sh" <<'CALLSITE'
+. "$1"/_common.sh
+uid="$(owner_id_by_email "$2")"
+[ -n "$uid" ] || die "Usuario '$2' nao encontrado."
+printf 'ACHOU %s\n' "$uid"
+CALLSITE
+
+callsite() {  # callsite <email> -> o que o operador ve (stdout + stderr)
+  (
+    NEXT_PUBLIC_SUPABASE_URL="https://exemplo.supabase.co" \
+    SUPABASE_SERVICE_ROLE_KEY="chave-de-teste" COLOR=0 \
+    bash "$WORK/callsite.sh" "$KIT_DIR" "$1" 2>&1
+  )
+}
+
+check "o call site chega ao uid quando o e-mail existe" \
+  test "$(callsite 'ana@empresa.com')" = "ACHOU $ANA"
+
+# A guarda do residuo. Sem o `|| return 0` no fim de `owner_id_by_email`, esta
+# saida e a string VAZIA — nao a mensagem.
+check "e-mail inexistente: o operador VE 'nao encontrado' (o die e alcancavel)" \
+  bash -c 'case "$1" in *"nao encontrado"*) exit 0 ;; *) exit 1 ;; esac' _ "$(callsite 'ninguem@empresa.com')"
+
 printf '\n'
 [ "$FAILS" -eq 0 ] && { printf '✓ owner-id-por-email: tudo verde\n'; exit 0; }
 printf '✗ owner-id-por-email: %d falha(s)\n' "$FAILS"; exit 1

--- a/tests/shell/owner-id-por-email.test.sh
+++ b/tests/shell/owner-id-por-email.test.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Prova de `owner_id_by_email` em `_common.sh` — a resolução de UUID por e-mail
+# que sustenta o `reset-password.sh`, único caminho de recuperação de senha de
+# uma instalação sem SMTP (o estado normal de um self-host).
+#
+#   bash tests/shell/owner-id-por-email.test.sh
+#
+# ── O defeito que ele guarda, medido contra um GoTrue de verdade ────────────
+#
+# A função pedia `?filter=email.eq.<email>` — sintaxe do PostgREST. O GoTrue não
+# fala essa expressão: ele trata a string INTEIRA como termo de busca por
+# substring. Nenhum e-mail contém "email.eq.", então a resposta era sempre
+# vazia. Medido em 2026-09-03, projeto de produção, e-mail existente:
+#
+#   GET /auth/v1/admin/users?filter=email.eq.<existente>  → 200 {"users":[]}
+#   GET /auth/v1/admin/users?filter=<existente>           → 200 {"users":[<ele>]}
+#
+# Consequência: `reset-password.sh` morria com "Usuário não encontrado" para
+# TODO e-mail. Não era intermitente; nunca funcionou.
+#
+# ── E por que o casamento tem de ser EXATO ──────────────────────────────────
+#
+# Justamente por ser substring, pedir `ana@empresa.com` traz também
+# `mariana@empresa.com`. Um `head -1` cego devolveria o UUID da outra pessoa
+# numa função cujo único consumidor TROCA SENHA. Medido no mesmo projeto:
+# `?filter=gmail.com` devolveu 2 de 2 usuários.
+#
+# Nada aqui toca a rede: `curl` é um dublê que devolve um corpo canônico do
+# GoTrue e registra a URL pedida.
+set -uo pipefail
+
+KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../hostgator-setup-kit" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+FAILS=0
+check() {  # check <descrição> <comando...>
+  if "${@:2}"; then printf '  ✓ %s\n' "$1"; else printf '  ✗ %s\n' "$1"; FAILS=$((FAILS + 1)); fi
+}
+
+ANA=11111111-1111-4111-8111-111111111111
+MARIANA=22222222-2222-4222-8222-222222222222
+ELIAS=33333333-3333-4333-8333-333333333333
+VIZINHO=44444444-4444-4444-8444-444444444444
+
+# ── Dublê de curl ────────────────────────────────────────────────────────────
+# Imita o GoTrue: `filter` é SUBSTRING sobre o e-mail. Devolve os usuários que
+# casam, na ordem em que estão cadastrados, com o mesmo formato de campo do
+# GoTrue real (id → aud → role → email). Registra a URL em $WORK/url.
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/curl" <<STUB
+#!/usr/bin/env bash
+url=""
+for a in "\$@"; do case "\$a" in http*) url="\$a" ;; esac; done
+printf '%s\n' "\$url" >> "$WORK/url"
+[ "\${CURL_FALHA:-0}" = "1" ] && exit 22
+termo="\${url#*filter=}"; termo="\${termo%%&*}"
+[ "\${BUSCA_FROUXA:-0}" = "1" ] && termo=""
+u() {  # u <uuid> <email>
+  case "\$2" in
+    *"\$termo"*) printf '{"id":"%s","aud":"authenticated","role":"authenticated","email":"%s"},' "\$1" "\$2" ;;
+  esac
+}
+printf '{"users":['
+# A ORDEM importa e é o miolo do caso: o GoTrue devolve por data de cadastro, e
+# o `head -1` só erra quando o INTRUSO vem antes do alvo. Com o alvo em primeiro
+# lugar, um casamento ingênuo acerta por sorte e o teste não vigia nada —
+# medido: nesta ordem invertida a sabotagem passava verde.
+u $MARIANA    "mariana@empresa.com"
+u $ANA        "ana@empresa.com"
+u $VIZINHO    "eliasXgervanno@empresa.com"
+u $ELIAS      "elias.gervanno@empresa.com"
+printf ']}'
+STUB
+chmod +x "$WORK/bin/curl"
+PATH="$WORK/bin:$PATH"
+
+# `_common.sh` roda com `set -e`; a subshell impede que um `exit` dele derrube
+# este arquivo. As duas variáveis de ambiente são o que a função lê.
+resolve() {  # resolve <email> → uuid no stdout
+  (
+    NEXT_PUBLIC_SUPABASE_URL="https://exemplo.supabase.co" \
+    SUPABASE_SERVICE_ROLE_KEY="chave-de-teste" \
+    bash -c '. "$0"/_common.sh 2>/dev/null || true
+             owner_id_by_email "$1"' "$KIT_DIR" "$1" 2>/dev/null
+  )
+}
+
+printf '\n▶ a função resolve o usuário certo\n'
+
+check "e-mail existente devolve o UUID dele" \
+  test "$(resolve 'ana@empresa.com')" = "$ANA"
+
+# O caso que o `head -1` cego errava: `ana@` é substring de `mariana@`, e a Ana
+# vem ANTES na lista — então acertar aqui não prova nada sozinho. O caso abaixo
+# é o que prova.
+check "pedir mariana@ NÃO devolve o UUID da ana@ (substring)" \
+  test "$(resolve 'mariana@empresa.com')" = "$MARIANA"
+
+# ── Ressalva honesta sobre o caso abaixo ────────────────────────────────────
+# Em BRE o `.` casa qualquer caractere, e é por isso que a função escapa o
+# e-mail antes de montar o padrão. Só que, com o GoTrue REAL, esse escape nunca
+# chega a ser exercitado: a busca dele é por substring LITERAL, então
+# `eliasXgervanno@` jamais entra numa resposta a `elias.gervanno@` e não há o
+# que confundir. Medi: com o dublê fiel, remover o escape não muda nada.
+#
+# O caso existe assim mesmo, e vale pelo que guarda: um GoTrue que afrouxe a
+# busca (outro campo, outra versão) passaria a devolver o vizinho, e aí o
+# escape é a única coisa entre a troca de senha e a pessoa errada. `BUSCA_FROUXA`
+# simula exatamente esse futuro. Não afirmo que ele detecta um defeito de hoje.
+check "com busca frouxa, o ponto do e-mail não vira coringa" \
+  test "$(BUSCA_FROUXA=1 resolve 'elias.gervanno@empresa.com')" = "$ELIAS"
+
+printf '\n▶ a URL pedida (a causa raiz)\n'
+
+: > "$WORK/url"; resolve 'ana@empresa.com' >/dev/null
+check "a query NÃO usa 'email.eq.' (sintaxe PostgREST que o GoTrue não fala)" \
+  bash -c '! grep -q "email\.eq\." "$1"' _ "$WORK/url"
+check "a query manda o e-mail cru em filter=" \
+  grep -q "filter=ana@empresa.com" "$WORK/url"
+
+printf '\n▶ falha FECHADA (o consumidor troca senha; errar a pessoa é pior que não achar)\n'
+
+check "e-mail inexistente devolve vazio" \
+  test -z "$(resolve 'ninguem@empresa.com')"
+check "curl falhando devolve vazio, sem derrubar quem chama" \
+  test -z "$(CURL_FALHA=1 resolve 'ana@empresa.com')"
+
+printf '\n▶ o call site (guardar a função não basta se ninguém a chama)\n'
+
+check "reset-password.sh resolve o uid pela função" \
+  grep -qE 'owner_id_by_email "\$EMAIL"' "$KIT_DIR/reset-password.sh"
+check "reset-password.sh morre quando o uid vem vazio" \
+  grep -qE '\[ -n "\$uid" \] \|\| die' "$KIT_DIR/reset-password.sh"
+
+printf '\n'
+[ "$FAILS" -eq 0 ] && { printf '✓ owner-id-por-email: tudo verde\n'; exit 0; }
+printf '✗ owner-id-por-email: %d falha(s)\n' "$FAILS"; exit 1


### PR DESCRIPTION
> Este PR carrega o conserto do **@Gervanno** (#552) mais um resíduo que a triagem mediu no caminho de produção. O crédito da causa raiz é dele.

## A causa raiz, que é do @Gervanno

`owner_id_by_email` pedia `?filter=email.eq.<email>` — sintaxe do **PostgREST**, que o **GoTrue** não fala. Resultado: devolvia vazio para *todo mundo*, e a troca de senha pela linha de comando nunca achava ninguém.

Reproduzido contra o GoTrue local **v2.188.1** e confirmado — inclusive a parte que o autor teve o cuidado de tratar: o `filter` do GoTrue é **substring**, então `?filter=ana@empresa.com` também traz `mariana@empresa.com`. Sem o casamento exato, o script trocaria a senha da pessoa errada.

## O resíduo que sobrou, medido no caminho de produção

`_common.sh` roda sob `set -euo pipefail`, e o consumidor resolve o UUID numa **atribuição**:

```bash
uid="$(owner_id_by_email "$EMAIL")"
[ -n "$uid" ] || die "Usuário '$EMAIL' não encontrado."
```

O status de uma atribuição é o da substituição de comando. O `grep` final devolve `1` quando não casa ninguém → a função devolvia `1` → **o `set -e` matava o script na primeira linha.** A segunda, que existe justamente para o caso do e-mail que não existe, nunca chegava a rodar.

Medido com as duas linhas reais contra o GoTrue local, e-mail inexistente: **`rc=1` e nenhuma saída**. Quem errasse uma letra no endereço via o prompt de volta e mais nada — sem erro, sem explicação, sem pista.

**Conserto:** `|| return 0` no fim do pipeline. A função devolve **vazio**, e quem chama decide o que dizer — que é exatamente o contrato que o `[ -n "$uid" ] || die` já supunha existir.

## Por que o teste do PR original não pegava isto

Ele guardava o *call site* por `grep` das duas linhas. Isso prova que **elas existem**, não que **elas rodam** — e o defeito estava precisamente em elas não rodarem.

Acrescentei dois casos que **executam** o call site sob o `set -e` real.

## Sabotagem

Revertendo **só** o `|| return 0`: **1 dos 11 casos reprova**, e é o que descreve o resíduo. Um caso, não dois — os outros exercitam a consulta ao GoTrue, que o conserto do @Gervanno já resolve e esta sabotagem não toca.