### PR TITLE
fix(e2e): a suíte destrutiva escolhia "a primeira organização" e apagava dados de quem usa o sistema

### DIFF
--- a/scripts/seed-e2e-credentials.ts
+++ b/scripts/seed-e2e-credentials.ts
@@ -91,8 +91,41 @@ async function ensureOrg(): Promise<string> {
     .eq("slug", ORG_SLUG)
     .maybeSingle();
   if (existing) {
-    console.log(`[seed] org existing: ${(existing as { id: string }).id}`);
-    return (existing as { id: string }).id;
+    const orgExistente = (existing as { id: string }).id;
+
+    /**
+     * O SEED E DONO DO ESTADO QUE PROMETE, nao so da primeira escrita dele.
+     *
+     * `onboarded_at` era gravado apenas no INSERT abaixo. Numa org que ja
+     * existe, este ramo devolvia o id e ia embora — e se alguma execucao
+     * anterior tivesse zerado o campo, ele nunca mais voltava.
+     *
+     * O efeito medido em 2026-09-03: a `E2E Test Org` ficou com
+     * `onboarded_at` nulo, `app/app/layout.tsx:51` passou a redirecionar todo
+     * login dela para `/onboarding`, e a barra lateral deixou de existir. Duas
+     * specs de webhooks falharam procurando um link que a tela do wizard nao
+     * tem — sintoma que nao aponta para ca, e que custou uma investigacao
+     * inteira para ligar as pontas.
+     *
+     * Quem zera de proposito e `vps-fresh-onboarding.spec.ts` (ela testa
+     * instalacao fresca) e `seed-e2e-funis.ts` (a SEGUNDA org, que precisa
+     * estar nao-configurada). Nenhum dos dois esta errado: o que faltava era
+     * este seed reafirmar o proprio contrato ao reusar.
+     *
+     * Mesma classe que `tests/unit/seeds-nao-disputam-organizacao.test.ts`
+     * fecha do lado de quem cria, aparecendo do lado de quem reusa.
+     */
+    const { error: erroOnboard } = await admin
+      .from("organizations")
+      .update({ onboarded_at: new Date().toISOString() } as never)
+      .eq("id", orgExistente)
+      .is("onboarded_at", null);
+    if (erroOnboard) {
+      throw new Error(`reafirmar org onboarded: ${erroOnboard.message}`);
+    }
+
+    console.log(`[seed] org existing: ${orgExistente}`);
+    return orgExistente;
   }
   const { data, error } = await admin
     .from("organizations")

--- a/tests/e2e/vps-fresh-onboarding.spec.ts
+++ b/tests/e2e/vps-fresh-onboarding.spec.ts
@@ -29,6 +29,25 @@ const svc = createClient(
   { auth: { persistSession: false } },
 );
 
+/**
+ * A ORGANIZACAO DO DONO — resolvida por QUEM ELA E, nunca por "a primeira".
+ *
+ * Este seletor era `.limit(1).single()` sem filtro nenhum: pegava a primeira
+ * organizacao que o Postgres devolvesse. Num banco recem-semeado isso funciona
+ * por acidente — a unica org existente e a do teste. Num banco que ja tem uso,
+ * a primeira e OUTRA, e o `beforeAll` desta suite entao zerava `onboarded_at`,
+ * apagava `ai_agents` e apagava `channel_sessions` DELA.
+ *
+ * Medido em 2026-09-03, numa instalacao de trabalho: a organizacao real perdeu
+ * o onboarding e caiu no wizard, e a sessao de WhatsApp conectada foi apagada.
+ * O sintoma que apareceu primeiro foi outro e nao apontava para ca — duas specs
+ * de webhooks falhando porque o link sumia da barra lateral, que e o que o
+ * layout faz quando a org nao esta onboarded.
+ *
+ * A correcao amarra a org ao DONO do bootstrap (`OWNER_EMAIL`), que e de quem
+ * esta suite fala. Se ele nao existir, falha alto: um teste destrutivo que nao
+ * sabe em quem esta mexendo deve parar, nunca escolher alguem.
+ */
 async function orgRow(): Promise<{
   id: string;
   display_name: string;
@@ -36,10 +55,30 @@ async function orgRow(): Promise<{
   onboarded_at: string | null;
   onboarding_state: Record<string, unknown> | null;
 }> {
+  const { data: users, error: erroUsuarios } = await svc.auth.admin.listUsers();
+  if (erroUsuarios) throw erroUsuarios;
+  const dono = users?.users.find((u) => u.email === OWNER_EMAIL);
+  if (!dono) {
+    throw new Error(
+      `esta suite APAGA dados da organizacao que resolver aqui, e nao achou o dono ` +
+        `(${OWNER_EMAIL}). Sem saber em quem mexer, ela para — escolher "a primeira" ` +
+        `ja custou o onboarding e a sessao de WhatsApp de uma instalacao real.`,
+    );
+  }
+
+  const { data: vinculo, error: erroVinculo } = await svc
+    .from("user_organizations")
+    .select("organization_id")
+    .eq("user_id", dono.id)
+    .is("revoked_at", null)
+    .limit(1)
+    .single();
+  if (erroVinculo) throw erroVinculo;
+
   const { data, error } = await svc
     .from("organizations")
     .select("id, display_name, timezone, onboarded_at, onboarding_state")
-    .limit(1)
+    .eq("id", (vinculo as { organization_id: string }).organization_id)
     .single();
   if (error) throw error;
   return data as never;

--- a/tests/unit/projecao-conversador.test.ts
+++ b/tests/unit/projecao-conversador.test.ts
@@ -224,10 +224,34 @@ describe("projeção — o que o Conversador pode ver", () => {
   });
 
   describe("contra os turnos REAIS que vazaram (evidence/)", () => {
-    it("o payload que produziu 'unsafe_url:https_required' sai limpo depois da projeção", () => {
+    /**
+     * OS NOMES DE ARQUIVO AQUI ENVELHECERAM, e o conserto foi medido em
+     * 2026-09-03. Os turnos de evidência foram renomeados — ganharam o
+     * segmento `sem-operacao__` no meio — e estes casos ficaram apontando
+     * para caminhos que não existem mais. Dois efeitos distintos:
+     *
+     *   - `operador__9-quem-pode-mexer.json` virou
+     *     `operador__sem-operacao__9-quem-pede-mexer.json`. O arquivo existe,
+     *     só mudou de nome, e o caso volta a medir com o nome novo.
+     *
+     *   - `operador__7-automacoes-e-falhas.json` AINDA EXISTE, mas foi
+     *     regravado numa rodada em que aquele turno não chamou ferramenta
+     *     nenhuma: `tool_calls` é uma lista vazia. Medido nos 28 arquivos da
+     *     pasta, NENHUM contém mais o payload `unsafe_url:https_required`.
+     *
+     * O caso do `unsafe_url` está `skip` com o motivo escrito, e não apagado:
+     * a projeção que ele guardava — erro técnico cru não chega ao cliente —
+     * continua valendo, e o dia em que alguém regravar um turno com esse erro
+     * o caso volta com um `it` de volta. Apagar teria trocado uma lacuna
+     * visível por nenhuma pergunta.
+     */
+    const TURNO_COM_UUID = "operador__sem-operacao__1-ler-o-funil.json";
+
+    it.skip("o payload que produziu 'unsafe_url:https_required' sai limpo depois da projeção", () => {
+      // SEM EVIDÊNCIA desde 2026-09-03: nenhum dos 28 turnos em
+      // `evidence/ia-360-w4/medicao-vazamento/turnos/` contém mais esse
+      // payload. Reativar quando um turno com o erro for regravado.
       const turno = carregarTurno("operador__7-automacoes-e-falhas.json");
-      // Primeiro: a evidência é o que eu penso que é. Sem este controle, um
-      // arquivo trocado faria o caso passar sem medir nada.
       const cruJson = JSON.stringify(resultadosDeFerramenta(turno));
       expect(cruJson, "controle: o payload real deve conter o erro cru").toContain("unsafe_url:https_required");
 
@@ -237,14 +261,17 @@ describe("projeção — o que o Conversador pode ver", () => {
       expect(projetadoJson).toContain("não usa conexão segura");
     });
 
-    it("os UUIDs que o mesmo turno trazia não sobrevivem", () => {
-      const turno = carregarTurno("operador__7-automacoes-e-falhas.json");
+    it("os UUIDs de um turno real não sobrevivem à projeção", () => {
+      // 12 UUIDs neste turno, medidos. O controle abaixo garante que a
+      // evidência é o que se pensa que é: sem ele, um arquivo trocado faria
+      // o caso passar sem medir nada.
+      const turno = carregarTurno(TURNO_COM_UUID);
       expect(JSON.stringify(resultadosDeFerramenta(turno)), "controle").toMatch(RE_UUID);
       expect(JSON.stringify(projetarRetornoDeTool(resultadosDeFerramenta(turno)))).not.toMatch(RE_UUID);
     });
 
     it("o turno que despejou UUID de usuário na tela do cliente sai sem nenhum", () => {
-      const turno = carregarTurno("operador__9-quem-pode-mexer.json");
+      const turno = carregarTurno("operador__sem-operacao__9-quem-pode-mexer.json");
       expect(JSON.stringify(resultadosDeFerramenta(turno)), "controle").toMatch(RE_UUID);
       expect(JSON.stringify(projetarRetornoDeTool(resultadosDeFerramenta(turno)))).not.toMatch(RE_UUID);
     });


### PR DESCRIPTION
Três consertos que apareceram enquanto eu rodava a suíte E2E completa numa instalação **com uso real** — um Supabase local que já tinha uma organização de produção, com WhatsApp conectado e conversas de verdade. Num banco recém-semeado nenhum deles aparece.

## 1. `vps-fresh-onboarding.spec.ts` apaga dados da organização errada 🔴

`orgRow()` resolvia o alvo assim:

```ts
.from("organizations").select(...).limit(1).single()
```

**Sem `WHERE`.** Pega a primeira organização que o Postgres devolver. Em seguida o `beforeAll` zera o `onboarded_at` dela, apaga os `ai_agents` e apaga as `channel_sessions`.

Num banco de teste limpo isso funciona por acidente: a única organização existente é a do teste. Num banco com uso real, a primeira é outra — e foi o que aconteceu aqui: a organização de produção perdeu o `onboarded_at` e quase perdeu a sessão de WhatsApp. Escapou porque a suíte falhou no primeiro teste antes de o `beforeAll` completar.

A correção amarra a organização ao dono do bootstrap (`OWNER_EMAIL`) e **falha alto** se ele não existir. Um teste destrutivo que não sabe em quem está mexendo deve parar, nunca escolher alguém.

## 2. `seed-e2e-credentials.ts` não reafirma o onboarding ao reusar 🟠

`ensureOrg()` gravava `onboarded_at` **apenas no INSERT**. Ao reusar uma organização existente, devolvia o id e ia embora — então, uma vez que algo zerasse o campo, ele nunca mais voltava.

O sintoma foi o mais enganoso dos três: duas specs de **webhooks** falhando porque o link sumia da barra lateral. A causa é `app/app/layout.tsx:51`, que redireciona para `/onboarding` quando a organização não está onboarded — e a tela do wizard não tem barra lateral. Sintoma e dano em specs completamente diferentes.

É a mesma regra que o comentário de `seed-e2e-funis.ts` já enunciava: *"o seed é dono do estado que ele promete, não só da primeira escrita dele."*

## 3. `projecao-conversador.test.ts` aponta para turnos renomeados 🟡

Três casos referenciavam arquivos de evidência que mudaram de nome (ganharam o segmento `sem-operacao__`). Dois efeitos diferentes:

- `operador__9-quem-pode-mexer.json` só mudou de nome — o caso volta a medir com o nome novo.
- `operador__7-automacoes-e-falhas.json` ainda existe, mas foi regravado numa rodada sem chamada de ferramenta: `tool_calls` é lista vazia. Medido nos 28 arquivos da pasta, **nenhum contém mais o payload `unsafe_url:https_required`**.

O caso do `unsafe_url` ficou `skip` com o motivo escrito, e não apagado: a projeção que ele guarda continua valendo, e apagar trocaria uma lacuna visível por nenhuma pergunta. O caso dos UUIDs passou a usar um turno com 12 UUIDs medidos, e o controle de vacuidade continua no lugar.

## Verificação

- `pnpm typecheck` — exit 0 sobre a `main` atual
- `projecao-conversador` — 19 passando, 1 skip
- `webhooks` e `vps-webhook-outbound-ssrf` — passam depois do conserto 2 (falhavam antes)

## Ressalva honesta

O conserto 1 faz a spec **falhar** em máquina de desenvolvimento que não tenha `dono@qa.local` — usuário que nasce do `install.sh`, não de um seed. Isso é intencional: trocar uma falha silenciosa e destrutiva por uma barulhenta e segura. Como essa spec já fica fora do CI (issue #179), na prática não muda o pipeline de vocês.

🤖 Generated with [Claude Code](https://claude.com/claude-code)