### PR TITLE
fix(pacing): "este número é usado desde" aceita o dia de hoje — o campo oferecia e o servidor recusava

### DIFF
--- a/.changes/o-aquecimento-aceita-a-data-de-hoje.md
+++ b/.changes/o-aquecimento-aceita-a-data-de-hoje.md
@@ -1,0 +1,24 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A proteção de envio volta a aceitar a data de hoje
+---
+
+Em **Conexões › Proteção de envio**, informar hoje em "este número é usado
+desde" era recusado durante a manhã inteira: até as 9h no relógio de quem
+opera no Brasil, salvar devolvia *"Campos inválidos."* e não gravava nada — nem
+a janela de horário, nem o intervalo entre envios, nem o teto diário que você
+tinha acabado de mudar na mesma tela.
+
+O motivo: o campo pergunta um DIA, mas a verificação o comparava com a hora
+exata em Londres. Um dia não tem hora — ele começa em horários diferentes em
+cada parte do mundo —, e por isso "hoje" só era aceito depois do meio-dia
+londrino. Agora a verificação compara dias com dias, e só recusa a data que
+ainda não chegou em canto nenhum do planeta.
+
+O calendário do campo também parou de oferecer o dia errado: depois das 21h ele
+mostrava amanhã como escolha possível.
+
+Data futura continua recusada, e data antiga continua sendo o caso normal — é
+informando a data antiga que um número usado há meses deixa de ser tratado como
+recém-criado e sai do teto de 20 envios por dia.

--- a/components/connections/AntiBanSheet.tsx
+++ b/components/connections/AntiBanSheet.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
 import { useUpdatePacingKnobs, type PacingKnobsItem } from "@/hooks/channels/usePacingKnobs";
-import { valorDeOverride } from "@/lib/ai/pacing-knobs";
+import { diaDeHojeLocal, valorDeOverride } from "@/lib/ai/pacing-knobs";
 import { ApiError } from "@/lib/api/types";
 import { nomeDoCanal } from "@/lib/channels/estado";
 import { useT } from "@/hooks/i18n/useT";
@@ -144,7 +144,9 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
             <Input
               id="numero-em-uso-desde"
               type="date"
-              max={new Date().toISOString().slice(0, 10)}
+              // O dia LOCAL, que é o que este campo fala. Com o dia UTC, às 21h
+              // em São Paulo o limite já oferecia amanhã.
+              max={diaDeHojeLocal()}
               value={form.numero_em_uso_desde}
               onChange={(e) => set({ numero_em_uso_desde: e.target.value })}
               disabled={!canWrite || form.pular_aquecimento}

--- a/docs/testing/user-journey-map.md
+++ b/docs/testing/user-journey-map.md
@@ -1613,3 +1613,37 @@ primeiro elemento com `class="border"` da tela de login é o `<input>`
 autofocado — ele casa `focus-visible:border-accent-500` e devolve a cor do
 foco. A sonda só mede elemento real, e pula elemento em foco e elemento que já
 traga classe de cor própria.
+
+---
+
+## O campo que oferecia hoje e o servidor recusava (2026-09-03)
+
+Achado de varredura adversarial contra o PR #496, no SHA `f700f3e1`. Mesma tela
+do #496 — **Conexões › Proteção de envio** —, campo ao lado do que ele acabara
+de consertar, e o mesmo desfecho para quem opera: a ficha inteira deixa de
+salvar.
+
+`<input type="date">` fala em dia LOCAL; `AntiBanSheet` encaixa o dia escolhido
+às 12h UTC (meia-noite viraria o dia anterior a oeste); e a guarda do schema
+comparava esse encaixe com `Date.now()` — um DIA contra um RELÓGIO.
+
+| régua | recusa começa | recusa para | quem sente |
+|---|---|---|---|
+| dia que a tela mostra (`America/Sao_Paulo`, UTC−3) | 03:00 UTC | 12:00 UTC | 00:00 às 09:00 no relógio de quem opera |
+| dia UTC (o que o `max` do campo oferecia, vindo de `toISOString()`) | 00:00 UTC | 12:00 UTC | as primeiras 12 horas UTC do dia |
+
+Medido varrendo as 48 meias-horas do dia com relógio falso, chamando o schema
+real com a carga exata que a tela monta — não pela tela: **NÃO MEDIDO** pelo
+browser num ambiente fresco estilo VPS. O que a varredura de horas prova é a
+fronteira; o que ela não prova é o que o operador vê quando ela dispara.
+
+**A lição, e ela não é sobre fusos.** O produto oferece o dia num campo e o
+recusa no servidor: a mesma classe do controle decorativo, ao contrário — não é
+o controle que não faz nada, é o limite do campo que promete o que a outra ponta
+nega. Toda validação de data merece a pergunta *"as duas pontas falam do mesmo
+dia, ou uma delas fala de instante?"*.
+
+**Onde mais essa pergunta cabe** (levantado, **não medido**, e fora do escopo do
+conserto): `lib/kanban/filters.ts` e `lib/automation/throttle.ts` derivam "hoje"
+de `toISOString().slice(0, 10)`, que é o dia UTC. Se algum deles compara com dia
+local, é a mesma classe.

--- a/lib/ai/pacing-knobs.ts
+++ b/lib/ai/pacing-knobs.ts
@@ -87,12 +87,17 @@ export function diaDeHojeLocal(agora: Date = new Date()): string {
  * pegar.
  *
  * A folga de até um dia é segura porque data futura **não** adianta o
- * aquecimento — ela o atrasa. `idadeEmDias` faz `Math.max(0, …)`, então futuro
- * vira idade 0, o degrau mais conservador dos `PACING_DEFAULTS` (20 envios/dia).
- * Medido em `tests/unit/aquecimento-idade-do-numero.test.ts` ("data no futuro
- * não vira idade negativa"). O comentário anterior desta guarda afirmava o
- * oposto ("ela ADIANTARIA o aquecimento") e era a justificativa de um rigor que
- * só machucava quem estava certo.
+ * aquecimento — ela o atrasa. Quem decide isso é o MOTOR, não esta guarda:
+ * `lib/agent-engine/pacing/engine.ts` faz `Math.max(0, …)` na idade, e o
+ * comentário dele já dizia por quê — "number_activated_at no futuro (typo do
+ * admin / clock skew) cai no degrau MAIS conservador — warm-up falha FECHADO".
+ * Idade 0 é o primeiro degrau dos `PACING_DEFAULTS`: 20 envios/dia. O mesmo
+ * está preso em `tests/unit/aquecimento-idade-do-numero.test.ts` ("data no
+ * futuro não vira idade negativa").
+ *
+ * O comentário anterior desta guarda afirmava o oposto ("ela ADIANTARIA o
+ * aquecimento") e era a justificativa de um rigor que só machucava quem estava
+ * certo — a razão escrita contradizia o motor que ela dizia proteger.
  */
 export function diaDeclaradoJaComecou(iso: string, agora: Date = new Date()): boolean {
   const instante = Date.parse(iso);

--- a/lib/ai/pacing-knobs.ts
+++ b/lib/ai/pacing-knobs.ts
@@ -31,6 +31,75 @@ function isValidTimezone(tz: string): boolean {
  */
 export const DAILY_LIMIT_BOUNDS = { min: 1, max: 10_000 } as const;
 
+/**
+ * O fuso mais adiantado que existe é UTC+14 (Kiritimati). Logo, o maior DIA de
+ * calendário em vigor em algum lugar do planeta é o dia UTC de `agora + 14h`.
+ */
+const MAIOR_ADIANTAMENTO_MS = 14 * 3_600_000;
+
+/** O dia do calendário (`yyyy-mm-dd`) de um instante, lido em UTC. */
+function diaEmUtc(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+/**
+ * Hoje no calendário de quem está olhando a tela (`yyyy-mm-dd`) — o mesmo espaço
+ * de valores de um `<input type="date">`, que fala em dia LOCAL.
+ *
+ * `new Date().toISOString().slice(0, 10)` dá o dia UTC, e a oeste ele adianta:
+ * às 21h em São Paulo o `max` do campo "este número é usado desde" já oferecia
+ * AMANHÃ. Limite de campo é promessa: oferecer o que o servidor recusa é o
+ * controle decorativo ao contrário.
+ */
+export function diaDeHojeLocal(agora: Date = new Date()): string {
+  const mes = String(agora.getMonth() + 1).padStart(2, "0");
+  const dia = String(agora.getDate()).padStart(2, "0");
+  return `${agora.getFullYear()}-${mes}-${dia}`;
+}
+
+/**
+ * O DIA declarado em `number_activated_at` já começou em algum lugar do mundo?
+ *
+ * ## Por que a comparação é entre DIAS, e não entre um dia e um relógio
+ *
+ * O operador não escolhe um instante: ele escolhe um DIA num `<input
+ * type="date">`, e a tela encaixa esse dia às **12h UTC** (meia-noite viraria o
+ * dia anterior em qualquer fuso a oeste — ver `AntiBanSheet`). A guarda antiga
+ * comparava esse encaixe com `Date.now()`, isto é, um DIA contra um RELÓGIO: o
+ * encaixe de hoje só "chega" às 12:00 UTC, então declarar HOJE era recusado
+ * durante toda a manhã.
+ *
+ * Medido no SHA f700f3e1, varrendo as 24 horas com o relógio falso, em
+ * `America/Sao_Paulo` (UTC−3): a recusa começava às **03:00 UTC** (00:00 BRT — o
+ * instante em que a data local vira hoje) e só parava às **12:00 UTC** (09:00
+ * BRT). Nove horas de todo dia em que o campo oferecia hoje e o servidor
+ * respondia "a data não pode estar no futuro". E a recusa derrubava a ficha
+ * INTEIRA — o schema é `.strict()` e a rota devolve 422 antes de gravar
+ * qualquer campo —, então janela, throttle e teto diário iam junto: exatamente
+ * o desfecho que o PR #496 tinha acabado de consertar para o campo em branco.
+ *
+ * ## Por que o limite é UTC+14, e por que a folga não afrouxa proteção nenhuma
+ *
+ * Um dia sem fuso não tem instante: "3 de setembro" começa em UTC+14 e termina
+ * em UTC−12, 26 horas depois. Como o payload não carrega o fuso do navegador, a
+ * única fronteira honesta é a do planeta: recusar só o dia que não começou em
+ * lugar NENHUM. Fica de fora o absurdo (2030), que é o que a guarda existe para
+ * pegar.
+ *
+ * A folga de até um dia é segura porque data futura **não** adianta o
+ * aquecimento — ela o atrasa. `idadeEmDias` faz `Math.max(0, …)`, então futuro
+ * vira idade 0, o degrau mais conservador dos `PACING_DEFAULTS` (20 envios/dia).
+ * Medido em `tests/unit/aquecimento-idade-do-numero.test.ts` ("data no futuro
+ * não vira idade negativa"). O comentário anterior desta guarda afirmava o
+ * oposto ("ela ADIANTARIA o aquecimento") e era a justificativa de um rigor que
+ * só machucava quem estava certo.
+ */
+export function diaDeclaradoJaComecou(iso: string, agora: Date = new Date()): boolean {
+  const instante = Date.parse(iso);
+  if (!Number.isFinite(instante)) return false;
+  return diaEmUtc(instante) <= diaEmUtc(agora.getTime() + MAIOR_ADIANTAMENTO_MS);
+}
+
 /** Campos editáveis pela tela — null = voltar ao default conservador do engine. */
 export const pacingKnobsUpdateSchema = z
   .object({
@@ -57,13 +126,19 @@ export const pacingKnobsUpdateSchema = z
      * O warm-up mede idade, e a idade nascia do instante em que o número era
      * pareado aqui: reconectar um número usado há meses o rebaixava a
      * recém-nascido (teto de 20 envios/dia) sem nenhum caminho para corrigir.
-     * Data futura é recusada — ela ADIANTARIA o aquecimento, que é o oposto de
-     * proteger.
+     *
+     * A guarda é de SANIDADE do dia declarado, não de proteção: só recusa o dia
+     * que ainda não começou em lugar nenhum do mundo. Ver
+     * `diaDeclaradoJaComecou` — inclusive por que comparar com `Date.now()`
+     * calava o campo durante a manhã inteira de quem está a oeste.
      */
     number_activated_at: z
       .string()
       .datetime({ offset: true })
-      .refine((iso) => new Date(iso).getTime() <= Date.now(), "a data não pode estar no futuro")
+      .refine(
+        (iso) => diaDeclaradoJaComecou(iso),
+        "a data é de um dia que ainda não começou em lugar nenhum do mundo",
+      )
       .nullable()
       .optional(),
     /**

--- a/tests/unit/aquecimento-aceita-o-dia-de-hoje.test.ts
+++ b/tests/unit/aquecimento-aceita-o-dia-de-hoje.test.ts
@@ -1,0 +1,220 @@
+/**
+ * "ESTE NÚMERO É USADO DESDE" ACEITA O DIA DE HOJE — EM TODA HORA DO DIA.
+ *
+ * Achado da varredura adversarial contra o PR #496 (já mergeado).
+ *
+ * ─── O defeito, medido no SHA f700f3e1 ────────────────────────────────────
+ *
+ * O operador não escolhe um instante: escolhe um DIA num `<input type="date">`,
+ * e `AntiBanSheet` encaixa esse dia às **12h UTC** (meia-noite viraria o dia
+ * anterior a oeste). A guarda do schema comparava esse encaixe com `Date.now()`
+ * — um DIA contra um RELÓGIO —, e o encaixe de hoje só chega às 12:00 UTC.
+ *
+ * Varrendo as 24 horas com relógio falso, em `America/Sao_Paulo` (UTC−3),
+ * declarando o dia que a tela mostra:
+ *
+ *   UTC 02:30 | BRT 23:30 | dia local=2026-09-02 | ACEITA
+ *   UTC 03:00 | BRT 00:00 | dia local=2026-09-03 | RECUSA   ← começa
+ *   ...
+ *   UTC 11:30 | BRT 08:30 | dia local=2026-09-03 | RECUSA
+ *   UTC 12:00 | BRT 09:00 | dia local=2026-09-03 | ACEITA   ← para
+ *
+ * Nove horas de todo dia — 00:00 às 09:00 no relógio de quem opera — em que a
+ * tela oferecia hoje (o `max` do campo) e o servidor respondia 422. Pela régua
+ * do dia UTC (o que aquele `max` de fato oferecia, porque ele vinha de
+ * `toISOString()`), a recusa cobria as **primeiras 12 horas UTC** do dia.
+ *
+ * E ela derrubava a ficha INTEIRA: o schema é `.strict()` e a rota devolve 422
+ * antes de gravar qualquer campo, então janela, throttle e teto diário caíam
+ * junto — o mesmo desfecho que o PR #496 tinha acabado de consertar para o
+ * campo em branco, pela porta ao lado.
+ *
+ * ─── A regra, e o PAR que ela tem de manter ───────────────────────────────
+ *
+ * Um dia sem fuso não tem instante: "3 de setembro" começa em UTC+14 e acaba em
+ * UTC−12, 26 horas depois. O payload não carrega o fuso do navegador, então a
+ * única fronteira honesta é a do planeta — recusar apenas o dia que não começou
+ * em lugar NENHUM (`agora + 14h`, UTC+14 sendo o fuso mais adiantado que
+ * existe).
+ *
+ * O par que impede "aceite tudo" de satisfazer este arquivo:
+ *   • hoje é ACEITO, em qualquer hora do dia (e o passado segue aceito — é para
+ *     isso que o campo existe);
+ *   • um dia que ainda não começou em canto nenhum segue RECUSADO.
+ *
+ * ⚠️ A polaridade desta guarda é essa mesma: ela recusa o FUTURO. "Ontem
+ * continua recusado" seria o par de uma guarda de agendamento; aqui ontem é o
+ * caso legítimo — o número É usado desde antes de hoje —, e recusá-lo é
+ * justamente o rebaixamento a 20 envios/dia que o campo existe para desfazer.
+ *
+ * ─── E a folga de até um dia não afrouxa proteção nenhuma ─────────────────
+ *
+ * Data futura não adianta o aquecimento: `idadeEmDias` faz `Math.max(0, …)`,
+ * então futuro vira idade 0 — o degrau MAIS conservador (20 envios/dia). Medido
+ * em `aquecimento-idade-do-numero.test.ts`. O comentário anterior da guarda
+ * dizia o contrário ("ela ADIANTARIA o aquecimento") e era a justificativa de
+ * um rigor que só machucava quem estava certo.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  diaDeHojeLocal,
+  diaDeclaradoJaComecou,
+  pacingKnobsUpdateSchema,
+} from "@/lib/ai/pacing-knobs";
+
+const SESSAO = "44444444-4444-4444-8444-444444444444";
+/** UTC−3: o fuso de quem opera este produto, e o `PACING_DEFAULTS.timezone`. */
+const FUSO_DO_OPERADOR = "America/Sao_Paulo";
+
+const TZ_ORIGINAL = process.env.TZ;
+
+beforeEach(() => {
+  // O `max` do campo é lido no fuso do NAVEGADOR. Sem forçar o fuso, um runner
+  // em UTC não distinguiria o conserto do defeito — os dois dias coincidem.
+  process.env.TZ = FUSO_DO_OPERADOR;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  if (TZ_ORIGINAL === undefined) delete process.env.TZ;
+  else process.env.TZ = TZ_ORIGINAL;
+});
+
+/** Congela o relógio num instante UTC. */
+function relogioEm(iso: string): void {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(iso));
+}
+
+/** O dia que o `<input type="date">` mostra a quem está neste fuso. */
+function diaNaTela(agora: Date, fuso: string): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: fuso,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(agora);
+}
+
+/** A expressão EXATA de `AntiBanSheet.handleSave`: o dia encaixado às 12h UTC. */
+function salvar(dia: string) {
+  return pacingKnobsUpdateSchema.safeParse({
+    channel_session_id: SESSAO,
+    number_activated_at: new Date(`${dia}T12:00:00.000Z`).toISOString(),
+  });
+}
+
+describe("a fronteira que recusava o dia de hoje", () => {
+  it("00:30 UTC — o dia de hoje é aceito (era a primeira hora da recusa)", () => {
+    relogioEm("2026-09-04T00:30:00.000Z");
+    // Às 00:30 UTC o dia UTC já virou; o dia de quem está em UTC−3 ainda é o 3.
+    expect(diaNaTela(new Date(), FUSO_DO_OPERADOR)).toBe("2026-09-03");
+    expect(salvar("2026-09-03").success).toBe(true);
+    // E o dia UTC — que é o que o `max` antigo oferecia nesta hora — também: era
+    // ele que caía com "a data não pode estar no futuro" até as 12:00 UTC.
+    expect(salvar("2026-09-04").success).toBe(true);
+  });
+
+  it("23:30 UTC — o dia de hoje continua aceito (a ponta oposta do dia)", () => {
+    relogioEm("2026-09-03T23:30:00.000Z");
+    expect(diaNaTela(new Date(), FUSO_DO_OPERADOR)).toBe("2026-09-03");
+    expect(salvar("2026-09-03").success).toBe(true);
+  });
+
+  it("03:30 UTC — 00:30 no relógio de quem opera, a hora em que a recusa começava", () => {
+    relogioEm("2026-09-03T03:30:00.000Z");
+    expect(diaNaTela(new Date(), FUSO_DO_OPERADOR)).toBe("2026-09-03");
+    expect(salvar("2026-09-03").success).toBe(true);
+  });
+
+  it("nenhuma das 48 meias-horas do dia recusa o dia que a tela mostra", () => {
+    const recusadas: string[] = [];
+    for (let h = 0; h < 24; h++) {
+      for (const m of [0, 30]) {
+        const hh = String(h).padStart(2, "0");
+        const mm = String(m).padStart(2, "0");
+        relogioEm(`2026-09-03T${hh}:${mm}:00.000Z`);
+        const dia = diaNaTela(new Date(), FUSO_DO_OPERADOR);
+        if (!salvar(dia).success) recusadas.push(`${hh}:${mm} UTC (dia ${dia})`);
+        vi.useRealTimers();
+      }
+    }
+    expect(recusadas).toEqual([]);
+  });
+});
+
+describe("o par — sem ele, 'aceite tudo' satisfaria o arquivo acima", () => {
+  it("o dia seguinte, quando não começou em canto nenhum, segue recusado", () => {
+    relogioEm("2026-09-04T00:30:00.000Z");
+    // 00:30 UTC + 14h (UTC+14, o fuso mais adiantado) ainda é dia 4 em todo
+    // lugar: ninguém no planeta está no dia 5.
+    expect(salvar("2026-09-05").success).toBe(false);
+  });
+
+  it("um dia depois de amanhã segue recusado em qualquer hora do dia", () => {
+    for (const hora of ["00:30", "12:30", "23:30"]) {
+      relogioEm(`2026-09-03T${hora}:00.000Z`);
+      expect(salvar("2026-09-05").success).toBe(false);
+      vi.useRealTimers();
+    }
+  });
+
+  it("o absurdo continua recusado — é para isso que a guarda existe", () => {
+    relogioEm("2026-09-03T23:30:00.000Z");
+    expect(salvar("2030-01-01").success).toBe(false);
+  });
+
+  it("o passado segue aceito — declarar número antigo é o propósito do campo", () => {
+    relogioEm("2026-09-03T00:30:00.000Z");
+    expect(salvar("2026-09-02").success).toBe(true); // ontem
+    expect(salvar("2025-09-03").success).toBe(true); // um ano atrás
+  });
+
+  it("a regra, com o relógio injetado: a fronteira é o dia UTC de agora + 14h", () => {
+    const agora = new Date("2026-09-04T00:30:00.000Z");
+    expect(diaDeclaradoJaComecou("2026-09-04T12:00:00.000Z", agora)).toBe(true);
+    expect(diaDeclaradoJaComecou("2026-09-05T12:00:00.000Z", agora)).toBe(false);
+  });
+});
+
+describe("o limite do campo não pode oferecer o que o servidor recusa", () => {
+  it("o `max` é o dia LOCAL — às 22h em São Paulo ele parava de oferecer amanhã", () => {
+    relogioEm("2026-09-04T01:00:00.000Z"); // 22:00 BRT do dia 3
+    expect(diaDeHojeLocal()).toBe("2026-09-03");
+    // O dia UTC nesta hora é o 4: era ele que o `max` oferecia, e ele é AMANHÃ
+    // para quem está olhando a tela.
+    expect(new Date().toISOString().slice(0, 10)).toBe("2026-09-04");
+  });
+
+  it("a tela não volta a calcular o `max` em UTC", () => {
+    // Sem esta linha, restaurar `max={new Date().toISOString().slice(0, 10)}`
+    // não vermelha nada: os casos acima medem `diaDeHojeLocal`, não o ponto de
+    // uso. E é o ponto de uso que o operador vê.
+    const sheet = readFileSync(
+      join(process.cwd(), "components/connections/AntiBanSheet.tsx"),
+      "utf8",
+    );
+    const maxDoCampo = /max=\{([^}]*)\}/.exec(sheet)?.[1] ?? "";
+    expect(maxDoCampo, "AntiBanSheet perdeu o `max` do campo de data").not.toBe("");
+    expect(
+      maxDoCampo.includes("diaDeHojeLocal"),
+      `o \`max\` do campo voltou a ser calculado fora do fuso local: ${maxDoCampo}`,
+    ).toBe(true);
+  });
+
+  it("o dia que o `max` oferece é aceito pelo schema em toda hora do dia", () => {
+    const recusadas: string[] = [];
+    for (let h = 0; h < 24; h++) {
+      const hh = String(h).padStart(2, "0");
+      relogioEm(`2026-09-03T${hh}:15:00.000Z`);
+      const oferecido = diaDeHojeLocal();
+      if (!salvar(oferecido).success) recusadas.push(`${hh}:15 UTC (max ${oferecido})`);
+      vi.useRealTimers();
+    }
+    expect(recusadas).toEqual([]);
+  });
+});

--- a/tests/unit/aquecimento-idade-do-numero.test.ts
+++ b/tests/unit/aquecimento-idade-do-numero.test.ts
@@ -8,7 +8,7 @@
  * Pior: a tela oferecia o teto DIÁRIO, que é outro gate. O operador subia o teto
  * para 1000, nada mudava, e a mensagem seguia falando de aquecimento.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   WARMUP_PULADO,
@@ -40,13 +40,33 @@ describe("contrato da API — os campos que faltavam", () => {
     expect(r.success).toBe(true);
   });
 
-  it("recusa data no FUTURO — adiantar o aquecimento é o oposto de proteger", () => {
-    const amanha = new Date(Date.now() + 86_400_000).toISOString();
+  it("recusa o dia que não começou em lugar nenhum do mundo", () => {
+    // ⚠️ Relógio CONGELADO de propósito. Este caso mandava `Date.now() + 24h` e
+    // media contra "instante já passou"; a guarda hoje compara DIAS (um dia sem
+    // fuso dura 26 horas — ver `diaDeclaradoJaComecou`), e `+24h` cai ora num
+    // dia que já começou em UTC+14, ora não, conforme a hora em que a suíte
+    // roda. Um caso que depende do relógio da máquina não mede regra nenhuma.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-04T00:30:00.000Z"));
     const r = pacingKnobsUpdateSchema.safeParse({
       channel_session_id: SESSAO,
-      number_activated_at: amanha,
+      number_activated_at: "2026-09-05T12:00:00.000Z",
     });
+    vi.useRealTimers();
     expect(r.success).toBe(false);
+  });
+
+  it("aceita o DIA DE HOJE — a fronteira mora em aquecimento-aceita-o-dia-de-hoje", () => {
+    // Guarda de vizinhança: recusar hoje derrubava a ficha inteira durante a
+    // manhã de quem opera a oeste (achado da varredura contra o PR #496).
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-04T00:30:00.000Z"));
+    const r = pacingKnobsUpdateSchema.safeParse({
+      channel_session_id: SESSAO,
+      number_activated_at: "2026-09-04T12:00:00.000Z",
+    });
+    vi.useRealTimers();
+    expect(r.success).toBe(true);
   });
 
   it("aceita null — volta a tratar o número como recém-criado", () => {


### PR DESCRIPTION
Achado pela varredura adversarial dos merges do próprio dia, contra o **#496** (já mergeado).

## O defeito

O campo *"este número é usado desde"* (Conexões › Proteção de envio) encaixa o dia escolhido às **12h UTC**, e a validação comparava esse encaixe com `Date.now()` — **um DIA contra um RELÓGIO**.

Varredura das 48 meias-horas com relógio falso, chamando a função real com a carga exata da tela:

| régua | recusa começa | recusa para |
|---|---|---|
| dia que a tela mostra (local, UTC−3) | **03:00 UTC** (00:00 BRT) | **12:00 UTC** (09:00 BRT) |
| dia UTC (o que o `max` do campo oferecia) | 00:00 UTC | 12:00 UTC |

**O operador brasileiro perdia as 9 primeiras horas do dia local.** A tela oferecia hoje e o servidor recusava.

## E a gravidade é maior do que "não marca hoje"

O schema é `.strict()` e a rota devolve **422 antes de gravar qualquer campo** — janela, throttle e teto diário caíam junto. É o mesmo desfecho que o #496 acabara de consertar para o campo em branco, **pela porta ao lado**.

## O conserto

`diaDeclaradoJaComecou()` compara **dia com dia**, e recusa só o dia que não começou em lugar nenhum do planeta (`agora + 14h`, UTC+14 é o fuso mais adiantado). Um dia sem fuso não tem instante — dura 26 horas — e o payload não carrega o fuso do navegador, então a única fronteira honesta é a do planeta.

**A folga não afrouxa a proteção, e a prova está no motor, não num teste:** `lib/agent-engine/pacing/engine.ts:79-84` clampa a idade em `>= 0`, então data futura vira idade 0 — o degrau **mais conservador** (20 envios/dia). O comentário anterior da guarda afirmava o oposto ("ela ADIANTARIA o aquecimento") e era a justificativa de um rigor que só machucava quem estava certo.

**Instância irmã, mesmo eixo:** `max={new Date().toISOString().slice(0,10)}` usava o dia UTC num campo cujo valor é dia local — às 21h em São Paulo já oferecia *amanhã*. Passa a `diaDeHojeLocal()`.

## Sabotagem — previsão declarada antes

| sabotagem | previsão | medido |
|---|---|---|
| guarda antiga de volta | 5 casos, nomeados | **5 falharam, exatamente esses.** A varredura nomeou 03:00→11:30 e o `max` 03:15→11:15 — a fronteira medida, duas vezes |
| `max` volta ao UTC | 1 caso, nomeado | **1 falhou, esse** |