### PR TITLE
fix(qa): turno vazio (HTTP 200 sem chave de IA) para de sobrescrever a medição histórica

### DIFF
--- a/tests/e2e/qa-agente-usa-as-maos.spec.ts
+++ b/tests/e2e/qa-agente-usa-as-maos.spec.ts
@@ -517,11 +517,45 @@ test.describe("QA — o agente usa as mãos que a W4 entregou?", () => {
       console.info(`[QA] status:   ${data.status} · ${data.latency_ms ?? "?"}ms`);
       console.info(`[QA] resposta: ${(data.final_text ?? "(vazia)").slice(0, 400)}`);
 
+      /**
+       * ⚠️ O TURNO SÓ SOBRESCREVE A MEDIÇÃO SE TIVER MEDIDO ALGUMA COISA.
+       *
+       * O irmão de cima já protege o caminho do HTTP != 200, e o comentário dele
+       * conta o estrago de 2026-08-08. Ficou aberto o outro caminho, e ele é mais
+       * sorrateiro: SEM CHAVE DE IA a rota responde **200**, porque o pedido foi
+       * aceito — o agente é que pula o turno (`reason='ai_gateway_key_missing'`,
+       * o aviso que `lib/env.ts` imprime em toda inicialização). `res.ok()` é
+       * verdadeiro, o gravador segue em frente, e um registro vazio cai por cima
+       * do turno REAL versionado.
+       *
+       * Aconteceu de novo em 2026-09-04, nesta máquina: 1.758 linhas apagadas
+       * dos 10 `operador__*.json`, trocadas por 80. Os testes de unidade ficaram
+       * vermelhos (o controle positivo pegou, como desenhado), e o vermelho foi
+       * lido como "os turnos foram renomeados" — o que levou a um commit que
+       * DESLIGAVA o caso. A medição histórica sobreviveu por `git checkout`; o
+       * diagnóstico errado quase não.
+       *
+       * A régua não olha `status`, olha RESULTADO: um turno que não produziu
+       * texto nem chamou ferramenta não mediu nada, seja qual for o vocabulário
+       * de status daquela versão. E ele continua sendo gravado — ao lado, como o
+       * `__falhou` —, porque cenário que some do diretório é indistinguível de
+       * cenário que nunca foi tentado.
+       */
+      const mediuAlgo = (data.final_text ?? "").trim().length > 0 || nomes.length > 0;
+      if (!mediuAlgo) {
+        console.info(
+          `[QA] ${cenario.nome}: HTTP 200 mas o turno veio VAZIO (status=${data.status}). ` +
+            `Gravando ao lado, em __sem-resposta.json — a medição versionada não é tocada. ` +
+            `Se você esperava medir de verdade, falta chave de IA.`,
+        );
+      }
+
       fs.writeFileSync(
-        dump,
+        mediuAlgo ? dump : dump.replace(/\.json$/, "__sem-resposta.json"),
         JSON.stringify(
           {
             prompt_kind: PROMPT_KIND,
+            mediu: mediuAlgo,
             cenario: cenario.nome,
             mensagem: cenario.mensagem,
             esperado: cenario.esperado,

--- a/tests/e2e/qa-agente-usa-as-maos.spec.ts
+++ b/tests/e2e/qa-agente-usa-as-maos.spec.ts
@@ -438,6 +438,14 @@ test.describe("QA — o agente usa as mãos que a W4 entregou?", () => {
     console.info(`[QA] cenários nesta corrida: ${aRodar.map((c) => c.nome).join(", ")}`);
 
     const relatorio: string[] = [];
+    /**
+     * Quantos cenarios PRODUZIRAM alguma coisa. O relatorio em markdown la
+     * embaixo tambem e artefato versionado de uma medicao real — e, ao
+     * contrario dos turnos JSON, NENHUM teste o le. Sobrescreve-lo com uma
+     * corrida vazia e destruicao que nada acusa. Medido em 2026-09-04: 507
+     * linhas de respostas reais trocadas por 35 de "NENHUMA / failed".
+     */
+    let cenariosQueMediram = 0;
     for (const cenario of aRodar) {
       const res = await page.request.post(
         `${APP_URL}/api/v1/ai/agents/${agenteId}/versions/${versaoId}/test`,
@@ -542,6 +550,7 @@ test.describe("QA — o agente usa as mãos que a W4 entregou?", () => {
        * cenário que nunca foi tentado.
        */
       const mediuAlgo = (data.final_text ?? "").trim().length > 0 || nomes.length > 0;
+      if (mediuAlgo) cenariosQueMediram += 1;
       if (!mediuAlgo) {
         console.info(
           `[QA] ${cenario.nome}: HTTP 200 mas o turno veio VAZIO (status=${data.status}). ` +
@@ -597,8 +606,21 @@ test.describe("QA — o agente usa as mãos que a W4 entregou?", () => {
       );
     }
 
+    // Mesma regra dos turnos: corrida em que NADA mediu nao encosta no artefato
+    // versionado. Ela ainda e gravada, ao lado, para a corrida ficar visivel.
+    if (cenariosQueMediram === 0) {
+      console.info(
+        "[QA] nenhum cenario produziu resposta — o relatorio versionado nao foi tocado. " +
+          "A corrida foi para qa-turnos-do-agente__sem-resposta.md.",
+      );
+    }
     fs.writeFileSync(
-      path.join(SAIDA, "qa-turnos-do-agente.md"),
+      path.join(
+        SAIDA,
+        cenariosQueMediram > 0
+          ? "qa-turnos-do-agente.md"
+          : "qa-turnos-do-agente__sem-resposta.md",
+      ),
       `# QA — o agente usando as capacidades da W4\n\n` +
         `Modelo real, dry-run, pelo endpoint do botão "Executar teste".\n\n` +
         relatorio.join("\n\n---\n\n"),


### PR DESCRIPTION
O conserto de 2026-08-08 fechou metade da porta. Esta é a outra metade, e ela é mais silenciosa.

## O caminho que ficou aberto

O ramo do `!res.ok()` já grava em `__falhou.json`, e o comentário dele conta o estrago: sem chave de IA os cenários voltavam **400** e o carimbo `rodou: false` caía por cima dos turnos reais.

Só que **sem chave de IA a rota também pode responder 200**. O pedido é aceito; quem pula o turno é o agente (`reason='ai_gateway_key_missing'` — o aviso que `lib/env.ts` imprime em toda inicialização). `res.ok()` é verdadeiro, o gravador do ramo de sucesso segue em frente, e um registro vazio sobrescreve a medição versionada.

## Aconteceu de novo, e quase virou outra coisa

2026-09-04, na minha máquina: **1.758 linhas apagadas** dos 10 `operador__*.json`, trocadas por 80.

Os testes de unidade ficaram vermelhos — o controle positivo de `projecao-conversador.test.ts` pegou, como foi desenhado para pegar. Mas eu li o vermelho como "os turnos foram renomeados" e escrevi um commit que **desligava** o caso. Foi o `25b128ff` que você derrubou no #566, com medição, e você estava certo — inclusive sobre a causa: minha `evidence/` estava diferente da do repositório.

A medição sobreviveu por `git checkout`. O diagnóstico errado quase não: ele chegou a ser publicado numa versão do meu fork antes de a sua triagem chegar.

## A régua

Não olha `status`, olha **resultado**: um turno sem texto e sem chamada de ferramenta não mediu nada, seja qual for o vocabulário de status daquela versão do runtime.

```ts
const mediuAlgo = (data.final_text ?? "").trim().length > 0 || nomes.length > 0;
```

Ele continua sendo gravado — ao lado, em `__sem-resposta.json`, mesma forma do `__falhou` —, porque cenário que some do diretório é indistinguível de cenário que nunca foi tentado. E o `console.info` diz em português o que faltou, para quem rodar local não precisar descobrir sozinho.

## Provado reproduzindo o acidente

Rodei a spec **sem chave de IA**, que é exatamente a condição que destruiu a medição:

| | antes | depois |
|---|---|---|
| Arquivos versionados alterados | 10 (−1758 linhas) | **0** |
| `unsafe_url:https_required` em `operador__7` | destruído | **32 ocorrências** |
| `projecao-conversador.test.ts` | 3 failed / 17 passed | **20 passed (20)** |
| Turnos vazios | por cima da medição | 10 arquivos `__sem-resposta` ao lado |

`pnpm typecheck` exit 0 · `pnpm lint` 0 erros.

## NÃO MEDIDO

- Não rodei a spec **com** chave de IA. O caminho feliz (`mediuAlgo === true` grava no nome canônico, como sempre) é o mesmo código de antes, com a condição na frente — mas não o exercitei com um turno real.
- Não medi se algum turno legítimo pode vir com `final_text` vazio **e** zero ferramentas. Se existir, ele passa a cair em `__sem-resposta.json` em vez do nome canônico. Achei o risco menor que o de sobrescrever a medição, mas a chamada é sua.
- Só `qa-agente-usa-as-maos.spec.ts`. Não varri outras specs que gravem em `evidence/`.

---

Obrigado pela triagem do #566 — o `--numstat` mostrando "adicionado, não renomeado" foi o que me fez ir procurar o que realmente tinha mexido nos arquivos. Sem isso eu teria consertado o sintoma de novo.
