### PR TITLE
docs(release): fragmento retroativo — fix de fuso no contexto do agente

### DIFF
--- a/.changes/o-agente-para-de-achar-que-esta-fechado-por-causa-do-fuso.md
+++ b/.changes/o-agente-para-de-achar-que-esta-fechado-por-causa-do-fuso.md
@@ -1,0 +1,23 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O agente para de achar que está fechado por causa do fuso
+---
+
+O histórico de mensagens entregava ao agente o horário de cada mensagem em
+UTC, cru do banco — enquanto o relógio "## Agora" do mesmo prompt já mostrava
+a hora certa no fuso da organização. Um agente instruído a comparar o
+horário exato de cada mensagem contra o expediente local via uma mensagem
+enviada às 15:45 (horário de São Paulo) como "18:45" e respondia que a loja
+estava fechada dentro do próprio horário de atendimento que ele citava na
+resposta.
+
+Medido em produção em duas instalações distintas, no mesmo dia: uma cliente
+mandou uma mensagem às 15:45 e recebeu "estamos fechados" com a oficina
+ainda aberta; dois dias depois, outra cliente recebeu a mesma resposta
+errada às 13h de uma sexta-feira, dentro do horário comercial citado pelo
+próprio agente.
+
+Agora cada mensagem do histórico chega ao agente já convertida para a hora
+de parede do fuso da organização, com o mesmo relógio que o bloco "## Agora"
+usa. O agente compara maçã com maçã.


### PR DESCRIPTION
## Resumo

O commit `7d4e2cf9b` (2026-09-02, já em `main`) consertou um bug real de produção: `get-lead-context.ts` entregava o timestamp de cada mensagem em UTC cru, enquanto o bloco `## Agora` do mesmo prompt já mostrava a hora certa no fuso da organização. Um agente instruído a comparar o horário da mensagem contra o expediente local lia "18:45" para uma mensagem enviada às 15:45 (São Paulo) e respondia "estamos fechados" dentro do próprio horário comercial.

Esse commit foi feito direto (sem PR, sem fragmento em `.changes/`), então nenhuma release publicada até agora o documenta ou o inclui no CHANGELOG — apesar de já estar em `main`. Confirmado que **nenhuma tag publicada até `v1.13.0` inclui esse commit**.

## Evidência concreta

Achado investigando um relato real: a cliente **Sandra** (contato terminado em 4512, tenant YADEA) recebeu essa resposta errada numa sexta-feira às 13h — dentro do horário comercial (9h–18h) que o próprio agente citou na resposta. O cabeçalho do próprio `lib/tempo/agora.ts` já documentava um caso anterior idêntico (cliente "Regiane", 2026-09-02) que motivou o fix original.

## O que este PR faz

Só adiciona o fragmento retroativo em `.changes/` (`impacto: nada_mudou`, `secao: corrigido`), para que o próximo corte de release documente esse fix no CHANGELOG que o operador da VPS lê antes de atualizar. Não muda código.

## Por que isso é urgente

O fix já está em `main`, mas **nenhuma imagem publicada o inclui ainda** — a VPS de produção roda `1.11.0` (31/08) e mesmo a tag mais recente, `v1.13.0` (03/09), é anterior ao commit. Até que uma nova release seja cortada (workflow `release.yml`, `Run workflow` → merge do PR de release) e a VPS atualize, agentes em produção continuam respondendo "fechado" incorretamente para clientes reais em horário comercial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKPM8qVc3iw7W8THyJwgQh