### PR TITLE
fix(harness): quebra de mensagem não corta mais valor em reais no meio

### DIFF
--- a/.changes/quebra-de-mensagem-nao-corta-mais-preco-em-reais.md
+++ b/.changes/quebra-de-mensagem-nao-corta-mais-preco-em-reais.md
@@ -1,0 +1,13 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A quebra de mensagem em bolhas não corta mais um valor em reais no meio
+---
+
+Com "quebrar resposta em várias mensagens" ligado, o agente tratava qualquer "." como fim de
+frase — inclusive o "." que separa milhar num preço em reais ("R$ 10.990"). O valor virava
+duas "frases" ("R$ 10." e "990 no cartão…"), que às vezes iam para bolhas de WhatsApp
+SEPARADAS (o cliente que via só a primeira lia "R$ 10" como o preço fechado de um produto de
+R$ 10.990) e às vezes eram remendadas com um espaço a mais ("R$ 7. 990").
+
+Agora um "." só conta como fim de frase quando não está entre dois dígitos.

--- a/lib/agent-engine/agent/split-message.ts
+++ b/lib/agent-engine/agent/split-message.ts
@@ -41,10 +41,40 @@ export function splitIntoBubbles(text: string, maxChars: number): string[] {
   return bubbles;
 }
 
-/** Divide em sentenças mantendo a pontuação final (. ! ?). */
+/**
+ * Divide em sentenças mantendo a pontuação final (. ! ?).
+ *
+ * O "." NÃO conta como fim de frase quando está entre dois dígitos — separador
+ * de milhar/decimal brasileiro ("R$ 10.990,00", "12.990"). Sem esta guarda,
+ * TODO preço em reais virava duas "sentenças" ("R$ 10." e "990 no cartão…"),
+ * que a bolha seguinte às vezes junta com espaço espúrio ("R$ 7. 990") e às
+ * vezes manda em bolhas do WhatsApp SEPARADAS — e um cliente que só via a
+ * primeira lia "R$ 10" como preço fechado de um produto de R$ 10.990.
+ * Medido em produção (YADEA, 2026-09-04): a moto DT3 (R$ 10.990) anunciada
+ * como "R$ 10" reais.
+ */
 function splitSentences(text: string): string[] {
-  const out = text.match(/[^.!?]+[.!?]*/g);
-  return (out ?? [text]).map((s) => s.trim()).filter((s) => s !== "");
+  const out: string[] = [];
+  let start = 0;
+  const re = /[.!?]+/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const end = m.index + m[0].length;
+    const prevChar = text[m.index - 1];
+    const nextChar = text[end];
+    const isNumeroPartido =
+      m[0] === "." &&
+      prevChar !== undefined &&
+      nextChar !== undefined &&
+      /\d/.test(prevChar) &&
+      /\d/.test(nextChar);
+    if (isNumeroPartido) continue;
+    out.push(text.slice(start, end).trim());
+    start = end;
+  }
+  const resto = text.slice(start).trim();
+  if (resto !== "") out.push(resto);
+  return out.length > 0 ? out.filter((s) => s !== "") : [text];
 }
 
 /** Última linha de defesa: agrupa palavras até maxChars; palavra atômica > max vai sozinha. */

--- a/tests/unit/agent-split-message.test.ts
+++ b/tests/unit/agent-split-message.test.ts
@@ -40,4 +40,25 @@ describe("splitIntoBubbles", () => {
     expect(out.join(" ")).toContain("149");
     expect(out.join(" ")).toContain("central");
   });
+
+  it("nunca parte um valor em reais no separador de milhar (R$ 10.990) entre bolhas", () => {
+    // Bug real (YADEA, 2026-09-04): "R$ 10.990" virava bolha "R$ 10." + bolha
+    // "990 no cartão…" — o cliente que via só a primeira lia "R$ 10" como o
+    // preço de uma moto de R$ 10.990.
+    const out = splitIntoBubbles(
+      "Temos a DT3 por R$ 9.990 à vista no Pix ou R$ 10.990 no cartão em até 12x sem juros.",
+      40,
+    );
+    for (const bubble of out) {
+      expect(bubble).not.toMatch(/\d\.\s*$/); // nenhuma bolha termina em "dígito."
+    }
+    expect(out.join(" ")).toContain("10.990");
+    expect(out.join(" ")).toContain("9.990");
+  });
+
+  it("não insere espaço espúrio dentro de um valor em reais (R$ 7. 990)", () => {
+    const out = splitIntoBubbles("O valor é R$ 7.990 à vista no Pix.", 600);
+    expect(out.join(" ")).not.toContain("7. 990");
+    expect(out.join(" ")).toContain("7.990");
+  });
 });


### PR DESCRIPTION
## Summary
- `splitSentences` (`lib/agent-engine/agent/split-message.ts`) tratava qualquer `.` como fim de frase, inclusive o separador de milhar de um preço (`R$ 10.990` virava `R$ 10.` + `990 no cartão...`).
- Em produção (self-host, agente de vendas com `split_messages` ligado) isso mandou o preço em duas bolhas de WhatsApp separadas — quem via só a primeira lia "R$ 10" como o valor fechado de um produto de R$ 10.990.
- Corrigido: um `.` só conta como fim de frase quando não está entre dois dígitos.

## Test plan
- [x] `vitest run tests/unit/agent-split-message.test.ts` — 9/9 passando, incluindo 2 testes novos de regressão (bolha não termina em "dígito." / não insere espaço espúrio tipo "R$ 7. 990")
- [x] `tsc --noEmit -p tsconfig.typecheck.json` limpo
- [x] Fragmento `.changes/` (`impacto: nada_mudou`, `secao: corrigido`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017keqiGuQQgGfsT7FVi8wri