### PR TITLE
A quebra de mensagem não corta mais preço em reais — reconciliação do #571 (@automatikpg-ux)

### DIFF
--- a/.changes/quebra-de-mensagem-nao-corta-mais-preco-em-reais.md
+++ b/.changes/quebra-de-mensagem-nao-corta-mais-preco-em-reais.md
@@ -1,0 +1,13 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A quebra de mensagem em bolhas não corta mais um valor em reais no meio
+---
+
+Com "quebrar resposta em várias mensagens" ligado, o agente tratava qualquer "." como fim de
+frase — inclusive o "." que separa milhar num preço em reais ("R$ 10.990"). O valor virava
+duas "frases" ("R$ 10." e "990 no cartão…"), que às vezes iam para bolhas de WhatsApp
+SEPARADAS (o cliente que via só a primeira lia "R$ 10" como o preço fechado de um produto de
+R$ 10.990) e às vezes eram remendadas com um espaço a mais ("R$ 7. 990").
+
+Agora um "." só conta como fim de frase quando não está entre dois dígitos.

--- a/lib/agent-engine/agent/split-message.ts
+++ b/lib/agent-engine/agent/split-message.ts
@@ -41,10 +41,40 @@ export function splitIntoBubbles(text: string, maxChars: number): string[] {
   return bubbles;
 }
 
-/** Divide em sentenças mantendo a pontuação final (. ! ?). */
+/**
+ * Divide em sentenças mantendo a pontuação final (. ! ?).
+ *
+ * O "." NÃO conta como fim de frase quando está entre dois dígitos — separador
+ * de milhar/decimal brasileiro ("R$ 10.990,00", "12.990"). Sem esta guarda,
+ * TODO preço em reais virava duas "sentenças" ("R$ 10." e "990 no cartão…"),
+ * que a bolha seguinte às vezes junta com espaço espúrio ("R$ 7. 990") e às
+ * vezes manda em bolhas do WhatsApp SEPARADAS — e um cliente que só via a
+ * primeira lia "R$ 10" como preço fechado de um produto de R$ 10.990.
+ * Medido em produção (YADEA, 2026-09-04): a moto DT3 (R$ 10.990) anunciada
+ * como "R$ 10" reais.
+ */
 function splitSentences(text: string): string[] {
-  const out = text.match(/[^.!?]+[.!?]*/g);
-  return (out ?? [text]).map((s) => s.trim()).filter((s) => s !== "");
+  const out: string[] = [];
+  let start = 0;
+  const re = /[.!?]+/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const end = m.index + m[0].length;
+    const prevChar = text[m.index - 1];
+    const nextChar = text[end];
+    const isNumeroPartido =
+      m[0] === "." &&
+      prevChar !== undefined &&
+      nextChar !== undefined &&
+      /\d/.test(prevChar) &&
+      /\d/.test(nextChar);
+    if (isNumeroPartido) continue;
+    out.push(text.slice(start, end).trim());
+    start = end;
+  }
+  const resto = text.slice(start).trim();
+  if (resto !== "") out.push(resto);
+  return out.length > 0 ? out.filter((s) => s !== "") : [text];
 }
 
 /** Última linha de defesa: agrupa palavras até maxChars; palavra atômica > max vai sozinha. */

--- a/tests/unit/agent-split-message.test.ts
+++ b/tests/unit/agent-split-message.test.ts
@@ -40,4 +40,25 @@ describe("splitIntoBubbles", () => {
     expect(out.join(" ")).toContain("149");
     expect(out.join(" ")).toContain("central");
   });
+
+  it("nunca parte um valor em reais no separador de milhar (R$ 10.990) entre bolhas", () => {
+    // Bug real (YADEA, 2026-09-04): "R$ 10.990" virava bolha "R$ 10." + bolha
+    // "990 no cartão…" — o cliente que via só a primeira lia "R$ 10" como o
+    // preço de uma moto de R$ 10.990.
+    const out = splitIntoBubbles(
+      "Temos a DT3 por R$ 9.990 à vista no Pix ou R$ 10.990 no cartão em até 12x sem juros.",
+      40,
+    );
+    for (const bubble of out) {
+      expect(bubble).not.toMatch(/\d\.\s*$/); // nenhuma bolha termina em "dígito."
+    }
+    expect(out.join(" ")).toContain("10.990");
+    expect(out.join(" ")).toContain("9.990");
+  });
+
+  it("não insere espaço espúrio dentro de um valor em reais (R$ 7. 990)", () => {
+    const out = splitIntoBubbles("O valor é R$ 7.990 à vista no Pix.", 600);
+    expect(out.join(" ")).not.toContain("7. 990");
+    expect(out.join(" ")).toContain("7.990");
+  });
 });

--- a/tests/unit/agent-split-message.test.ts
+++ b/tests/unit/agent-split-message.test.ts
@@ -57,7 +57,7 @@ describe("splitIntoBubbles", () => {
   });
 
   it("não insere espaço espúrio dentro de um valor em reais (R$ 7. 990)", () => {
-    const out = splitIntoBubbles("O valor é R$ 7.990 à vista no Pix.", 600);
+    const out = splitIntoBubbles("O valor é R$ 7.990 à vista no Pix.", 30);
     expect(out.join(" ")).not.toContain("7. 990");
     expect(out.join(" ")).toContain("7.990");
   });


### PR DESCRIPTION
O #571 do @automatikpg-ux com uma correção nossa na régua do teste. **O commit dele está preservado**, então o #571 fecha creditado.

## O defeito que ele achou

`splitSentences` tratava qualquer `.` como fim de frase, inclusive o separador de milhar. Em produção, num agente de vendas com `split_messages` ligado, `R$ 10.990` saiu em duas bolhas de WhatsApp: `R$ 10.` e `990 no cartão...`. Quem viu só a primeira leu **R$ 10** como o preço fechado. É bug de negócio, não de formatação.

## O reparo, e ele é só na régua do teste

O caso novo usava `splitIntoBubbles(frase, 600)` — e a frase tem **34 caracteres**. Com esse teto ela nunca é dividida, então o teste passava por não haver quebra nenhuma, não por a quebra estar certa. Medido nos quatro cantos:

```
fonte do PR   + teto  30 → 9 passed
fonte da MAIN + teto  30 → 2 failed | 7 passed   ← discrimina
fonte da MAIN + teto 600 → 1 failed | 8 passed   ← discrimina menos
fonte do PR   + teto  30 → 9 passed
```

Teste que não vermelha pela causa que ele nomeia não vigia a causa. Com 30 a frase é realmente dividida e o separador de milhar entra no caminho que o conserto protege.

Trabalho de @automatikpg-ux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DC6uq5V26S13UxfaBaYKQ