### PR TITLE
docs(triagem): o que a fila de 18 PRs ensinou — seis passes novos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,7 +340,14 @@ Checks **obrigatórios** na branch protection da `main` (verificado na configura
 - **`verify`** (`ci.yml`) — typecheck + lint + test:unit.
 - **`invariants`** (`ci.yml`) — `pnpm test:db`: sobe `pgvector/pgvector:pg15` — o PISO que dizemos suportar, não a versão mais rica que temos à mão —, aplica `supabase/baseline.sql` em modo install (`ON_ERROR_STOP=1`) e update (idempotência), e roda os testes de invariante, incluindo o de isolamento RLS entre 2 organizações.
 - **`build-and-size`** (`perf.yml`) — `pnpm build` em Node 22.
-- **`e2e`** (`e2e.yml`) — sobe Supabase local, aplica o `baseline.sql` e roda **todas as specs Playwright menos uma**. O número saiu daqui de propósito: ele apodreceu **cinco** vezes (a quinta em 2026-08-24, quando `inbox-quem-manda.spec.ts` entrou), e a condição que o PR #242 pôs para parar de recontar já tinha vencido na quarta. Quem precisa do número roda o comando abaixo — comando não envelhece. A **única** de fora é `vps-fresh-onboarding` (precisa de WAHA + Redis + Resend + Nuvemshop) — e ela é a **P0** da doutrina de QA Visual, ou seja, `e2e` verde **não** prova a jornada de instalação fresca, que é o produto que se vende.
+- **`e2e`** (`e2e.yml`) — sobe Supabase local, aplica o `baseline.sql` e roda **todas as specs Playwright menos as que `FORA_DO_CI` declara**. O número saiu daqui de propósito: ele apodreceu **cinco** vezes (a quinta em 2026-08-24, quando `inbox-quem-manda.spec.ts` entrou), e a condição que o PR #242 pôs para parar de recontar já tinha vencido na quarta. Quem precisa do número roda o comando abaixo — comando não envelhece. Quais ficam de fora, e por quê, é o que a própria variável diz — **não confie nesta linha, leia-a**:
+
+  ```bash
+  git show origin/main:.github/workflows/e2e.yml | \
+    python3 -c "import sys,re; y=sys.stdin.read(); print(sorted({s for _,c in re.findall(r'(FORA_DO_CI):\s*>-\n((?:[ ]{8,}.*\n)+)',y) for s in re.findall(r'[a-z0-9-]+\.spec\.ts',c)}))"
+  ```
+
+  Esta frase já dizia "a **única** de fora é `vps-fresh-onboarding`" e estava errada: em 2026-09-04 a variável listava **duas** (`inbox-tempo-real` entrou depois). É o mesmo defeito que o parágrafo acima descreve — afirmação de estado que envelhece —, cometido na frase seguinte à que o denuncia. O que continua verdade e é o que importa: `vps-fresh-onboarding` é a **P0** da doutrina de QA Visual, então `e2e` verde **não** prova a jornada de instalação fresca, que é o produto que se vende.
 
   **Não confie em `grep` no arquivo inteiro.** `grep -oE '[a-z0-9-]+\.spec\.ts' .github/workflows/e2e.yml | sort -u | wc -l` conta quem é CITADO, não quem é INVOCADO: a `FORA_DO_CI` é uma variável YAML como as outras e entra na conta. (Até 2026-08-14 este parágrafo culpava "menções em comentários", e isso é falso — medido, o conjunto de specs citadas fora de variável é **vazio**.) O que roda são as `SPECS_PARTE_*`:
 

--- a/triagem/TRIAGEM.md
+++ b/triagem/TRIAGEM.md
@@ -230,6 +230,28 @@ rodar, quem cobre é este passe — à mão.
 
 ---
 
+## 3-quater. Vermelho que não é do PR — três origens, três desfechos
+
+Medido numa fila de 18 PRs em 2026-09-04: **a maioria dos vermelhos não era dos PRs.** As três
+origens leem igual no resumo do `gh pr checks` e pedem ações opostas. Distinguir é o passe, e
+o custo de errar é mandar um contribuidor consertar o que não quebrou.
+
+| origem | como ela se parece | como confirmar | o que fazer |
+|---|---|---|---|
+| **Saturação da SUA máquina** | falhas com `Test timed out in 15000ms` / `Hook timed out in 10000ms`; nunca uma asserção | rode **os mesmos arquivos isolados**. Se ficam verdes, era carga | ignorar — e não escrever "N failed" no veredito sem esta nota |
+| **Infra do runner** | `address already in use`, `failed to bind host port`, job de 2-3 min | leia o log do PASSO, não do job. Um job que morre em 2m38s não rodou teste nenhum | `gh run rerun <id> --failed` |
+| **Run anterior ao conserto** | vermelho num PR cuja causa você acabou de consertar na `main` | compare o `head_sha` do run com o head do PR | `git merge origin/main` na branch e deixe o CI remedir |
+
+O erro que isto evita tem nome: **eu rodei a suíte com build, Playwright, Supabase e seis agentes
+na mesma máquina, vi 3 vermelhos, e quase os reportei como defeito de um contribuidor.** Rodados
+isolados: `exit=0, 11 passed`. E o `ci` da `main` estava verde no mesmo SHA base — que é o
+controle mais barato de todos e leva dez segundos.
+
+> **A regra curta:** timeout não é asserção. Antes de atribuir um vermelho a um PR, pergunte
+> *quem mais estava usando esta máquina* e *este job chegou a rodar teste?*
+
+---
+
 ## 4. Complemento — o que os gates não provam
 
 `references/complemento-do-ci.md`, linha por linha, com o gatilho de cada uma no diff.
@@ -238,6 +260,31 @@ Esta é a razão de a triagem existir tecnicamente. Repetir o que o CI já faz �
 que ele **não** alcança — e a lista não é opinião, é o que foi medido: a tripla de migration é
 guardada por um hook local que fork nunca roda, o teste de RLS cobre uma lista fixa de tabelas,
 `no-console` é aviso sem `--max-warnings`, e nenhum job testa o instalador.
+
+---
+
+## 4-bis. Colisão de migration é por TIMESTAMP e por NNNN — e há um hook que sabe
+
+O `pre-commit` deste repo reprova as duas colisões, contra **todas as branches locais**, e a
+mensagem dele diz o que fazer. Ele é a régua; não tente adivinhar antes de ouvi-lo.
+
+O que ele ensina e a doutrina escrita não dizia: **renumerar só o `NNNN` fabricou 12 das colisões
+de timestamp deste repositório.** O timestamp é a PK de `supabase_migrations.schema_migrations` —
+repetido, o `db push` colide e o `db reset` quebra. Os dois têm de ser únicos, e mudam juntos.
+
+**Quem renumera, quando dois PRs colidem** — e esta é a parte que não é técnica:
+
+> **O PR aberto de um contribuidor externo mantém a numeração dele. Quem renumera é o nosso
+> lado: rascunho interno sem PR, e PR do mantenedor.**
+
+Medido nesta fila: o `0208` era do #565 (@JowaniOrantes, aberto às 04h47) e de uma branch local
+nossa sem PR. Renumerar o trabalho de quem contribui de fora para acomodar rascunho nosso é a
+troca errada — e ele nem tem como ver a nossa fila. O `CLAUDE.md` manda "veja o último em
+`ls supabase/migrations/`", ele leu, e acertou contra a `main`. **O que ele não pode ver não pode
+ser cobrado dele** (passe 10).
+
+O escape `DESKCOMM_GOV_MIGRATION_EDIT=1` existe para quando você já **decidiu** qual numeração é
+canônica — e a decisão vai escrita no corpo do commit, não fica implícita no uso do escape.
 
 ---
 
@@ -335,6 +382,30 @@ sobrevive à sua mudança?
 
 ---
 
+## 8-bis. Reconciliação de PR de fork: o merge que credita em vez de descartar
+
+Quando o PR de um contribuidor conflita, a saída **não** é fechá-lo pedindo rebase. É montar uma
+branch sua com `git merge <head-do-PR>`, resolver o conflito do **nosso** lado, e mergear a sua.
+
+O detalhe que decide o desfecho para a pessoa: se o head do PR dele virar **ancestral** da `main`,
+o GitHub fecha o PR dele como **`MERGED`**, não como `CLOSED`. A diferença é o que aparece no
+perfil dele e na contagem de contribuições.
+
+```bash
+git merge-base --is-ancestor <head-do-PR> <sua-branch> && echo "vai fechar como MERGED"
+```
+
+Isso exige **merge commit, nunca squash** — squash reescreve os commits e a autoria some junto.
+Confirmado duas vezes nesta fila (#559 pelo #566, e #565 pelo #574): os dois fecharam `MERGED`.
+
+E confira que a autoria sobreviveu, antes de empurrar:
+
+```bash
+git log --format='%an <%ae>' origin/main..HEAD | sort | uniq -c
+```
+
+---
+
 ## 9. Veredito com proveniência
 
 ```
@@ -369,6 +440,25 @@ entre abrir o PR e a primeira resposta humana**.
 
 ---
 
+## 10-bis. O crédito pode se perder na assinatura, e você é quem vê isso
+
+Um contribuidor desta fila abriu três PRs assinando como `root <root@vpsbr-…hostgator.com.br>` —
+ele commitou direto da VPS. `gh api …/pulls/<n>/commits --jq .[].author.login` devolve **`null`**:
+o GitHub não associa aquilo a conta nenhuma, e **o trabalho não aparece no perfil dele**.
+
+O `.mailmap` existe para isso, mas a regra dele exige **prova**, e `root@<host>` não a tem — o
+usuário `root` não identifica pessoa, e mapear pelo palpite de quem tinha acesso atribui trabalho
+a quem talvez não o tenha feito. Então:
+
+- **Não mapeie unilateralmente.** A regra que o projeto escreveu vale também para você.
+- **Avise a pessoa**, com o comando pronto, e ofereça mapear se ela confirmar. É trabalho de dez
+  linhas que devolve o crédito de todos os PRs seguintes.
+- Se for decisão do dono mapear retroativamente, é dele — leve como pergunta.
+
+Ninguém que contribui de graça deve descobrir sozinho que o trabalho dele não conta.
+
+---
+
 ## 11. Catraca — o passe que impede esta triagem de ser eterna
 
 Todo defeito que os gates não pegaram vira **gate novo** ou dívida com issue aberta.
@@ -376,6 +466,27 @@ Todo defeito que os gates não pegaram vira **gate novo** ou dívida com issue a
 A consequência é a parte elegante: a tabela do passe 4 é a **lista de tarefas do CI**. Cada linha que
 vira gate de verdade é uma linha que a triagem para de fazer à mão. Este procedimento deve ficar mais
 leve com o tempo. Se estiver ficando mais pesado, o passe 11 não está sendo cumprido.
+
+---
+
+## 11-bis. A conta de N vias: o gate que ninguém quebra sozinho
+
+Três PRs mexeram no mesmo invariante do menu por arquivos que **não se tocam**: um acrescentou um
+item ao registry, outro removeu um, o terceiro reescreveu a estrutura da barra lateral. **Zero
+conflito de merge. Zero gate reprovando na prévia de cada um.** O vermelho nasceu no terceiro
+merge, onde não havia PR para culpar.
+
+Quando dois ou mais PRs abertos tocam a mesma **grandeza medida** (altura de menu, tamanho de
+changelog, tempo de suíte, contagem de specs), some os deltas antes de mergear o primeiro:
+
+```bash
+for n in <prs>; do gh pr diff $n --name-only; done | sort | uniq -c | sort -rn | head
+```
+
+Arquivo repetido é aviso de ordem. Mas o caso caro é o **invariante** repetido sem arquivo comum —
+para esse, a pergunta é *"qual número este PR empurra, e quanto de folga sobra?"*, e ela se faz
+**uma vez para a fila**, não uma vez por PR. Dois orçamentos desta fila estavam simultaneamente
+em ~100% e ninguém tinha somado: o e2e a 30m00s de 30m, e o `verify` a 15m18s de 15m.
 
 ---
 
@@ -434,6 +545,21 @@ git ls-remote --tags origin 'refs/tags/vX.Y.Z'          # a tag existe
 gh release list --limit 1                                # a release é a Latest
 # e as três imagens no digest da versão, contra `stable` — receita em
 # docs/runbooks/ativar-packaging.md
+```
+---
+
+## 12-bis. Higiene de disco: um worktree por agente custa 1,2 GB
+
+A regra "um worktree por agente" (modo de falha 5) tem um custo que ninguém tinha medido: com
+`node_modules` real — obrigatório, porque symlink quebra o Turbopack —, **cada worktree pesa 1,2 a
+2,5 GB**. Quinze deles encheram o disco no meio da fila, e `ENOSPC` derruba build, agente e
+`gh` de uma vez, com mensagem que não parece falta de espaço.
+
+Remova o worktree assim que o PR dele for mergeado — não ao fim da sessão:
+
+```bash
+git worktree remove --force <caminho> && git worktree prune
+df -h /System/Volumes/Data | tail -1     # confira, não presuma
 ```
 
 ---


### PR DESCRIPTION
Escrito depois de levar uma fila inteira do primeiro comentário até a versão publicada. **Cada seção nova nasce de um erro que eu cometi ou quase cometi**, e mora ao lado do passe que ela complementa — apêndice no fim é apêndice que ninguém lê.

| passe | o que ele impede |
|---|---|
| **3-quater** | Vermelho que NÃO é do PR tem **três** origens — saturação da própria máquina, infra do runner, run anterior ao conserto. Leem igual no resumo e pedem ações opostas. Eu vi 3 vermelhos com seis agentes na mesma máquina e quase os reportei como defeito de um contribuidor; rodados isolados, `exit=0, 11 passed` |
| **4-bis** | Colisão de migration é por **timestamp E por NNNN**, o hook `pre-commit` é a régua, e **quem renumera é o nosso lado** — o PR aberto de quem contribui de fora mantém a numeração dele |
| **8-bis** | O merge de reconciliação fecha o PR do fork como **MERGED**, não CLOSED, se o head dele virar ancestral. Confirmado duas vezes hoje. Exige merge commit; squash mata a autoria |
| **10-bis** | O crédito se perde quando o contribuidor commita como `root` da VPS. O `.mailmap` exige prova — avisa-se a pessoa, não se mapeia por palpite |
| **11-bis** | A conta de N vias: três PRs empurraram o mesmo invariante do menu por arquivos que não se tocam. Zero conflito, zero gate na prévia de cada um, e o vermelho nasceu no terceiro merge, onde não havia PR para culpar |
| **12-bis** | Um worktree por agente custa 1,2 GB. Quinze encheram o disco no meio da fila, e `ENOSPC` derruba build, agente e `gh` com mensagem que não parece falta de espaço |

## E uma correção no `CLAUDE.md`

Ele afirmava que a **única** spec fora do CI era `vps-fresh-onboarding`. Medido:

```
FORA_DO_CI = ['inbox-tempo-real.spec.ts', 'vps-fresh-onboarding.spec.ts'] → 2
```

Trocado por comando — que é exatamente o que o parágrafo logo acima já mandava fazer. O defeito estava **na frase seguinte à que o denuncia**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DC6uq5V26S13UxfaBaYKQ