### PR TITLE
fix(signup): a tela manda esperar um e-mail que já não vem (@KIRAzinx566, do #588)

### DIFF
--- a/.changes/cadastro-sem-confirmar-email-ficava-sem-organizacao.md
+++ b/.changes/cadastro-sem-confirmar-email-ficava-sem-organizacao.md
@@ -1,0 +1,31 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Quem se cadastra numa instalação que não pede confirmação de e-mail para de ser mandado esperar um e-mail que não chega
+---
+
+Quem administra a instalação pode desligar a confirmação de e-mail no provedor
+de autenticação — é uma escolha comum, e às vezes é o estado em que uma VPS
+recém-montada já vem. Nesse modo, criar a conta **já entra no sistema**: não
+existe link nenhum para clicar, porque e-mail nenhum é enviado.
+
+A tela do cadastro não sabia disso e dizia assim mesmo: *"Enviamos um link de
+confirmação para o seu e-mail. Abra o e-mail e clique no link para ativar sua
+conta."* A pessoa fazia o que a tela mandou — esperava. O e-mail nunca chegava.
+Ela estava, o tempo todo, do lado de dentro, com a conta pronta e sem empresa
+nenhuma configurada, sem nenhuma razão para descobrir sozinha que bastava
+continuar.
+
+Agora, quando o sistema percebe que a pessoa já entrou, ele a leva direto ao
+passo seguinte, em vez de mandá-la esperar: quem se cadastrou por conta própria
+vai concluir a configuração da empresa, com o nome que ela mesma digitou no
+cadastro já preenchido; quem se cadastrou a partir de um convite vai aceitar o
+convite, e continua sem ganhar uma empresa própria por engano.
+
+Para quem opera uma instalação, nada muda no dia a dia: nenhuma configuração
+nova, nenhum passo de atualização. Quem já usa o sistema com confirmação de
+e-mail ligada não vê diferença nenhuma — a tela do e-mail continua igual, porque
+nesse caso o e-mail realmente vai chegar.
+
+O achado é de @KIRAzinx566, que instalou o sistema para um cliente e o encontrou
+parado nessa tela.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -112,6 +112,24 @@ jobs:
     # do gate sem razão declarada é a dívida voltando pela porta de serviço.
     # ─────────────────────────────────────────────────────────────────────────
     #
+    # ═══ `cadastro-sem-confirmacao-de-email`: A PRECONDIÇÃO É DO PROVEDOR ═══
+    #
+    # Ela mede o cadastro com "Confirm email" DESLIGADO no provedor de auth — o
+    # estado em que `signUp()` já devolve sessão e não existe link nenhum para
+    # clicar. Isso não é dado que a spec possa semear: é `GOTRUE_MAILER_AUTOCONFIRM`,
+    # fixado quando o Supabase local sobe, e o `supabase/config.toml` do repo
+    # declara `enable_confirmations = true` — que é o que `signup-journey` e
+    # `invite-lifecycle` exercitam. Ligar o autoconfirm por causa desta spec
+    # trocaria o provedor da SUÍTE INTEIRA, e as duas de cima passariam a medir
+    # outro fluxo sem que ninguém percebesse.
+    #
+    # O gate de todo dia é o par de testes de unidade, que roda no `verify`:
+    # `app/actions/auth/signUp.test.ts` (a action DIZ que a sessão veio aberta) e
+    # `tests/unit/cadastro-sem-confirmacao-nao-manda-esperar-email.test.tsx` (a
+    # tela AGE sobre isso). A spec é a prova pela tela de que os dois, juntos,
+    # resolvem a jornada — e ela CONFERE a própria precondição em `beforeAll`,
+    # falhando alto em vez de se auto-pular.
+    #
     # ═══ O 429 DE `olhar-telas-do-epico`: RESOLVIDO DUAS VEZES, EM CAMADAS DIFERENTES ═══
     #
     # A spec reprovava com **429** em TODAS as 7 telas, falha PRÉ-EXISTENTE NA MAIN (run
@@ -525,6 +543,7 @@ jobs:
       FORA_DO_CI: >-
         vps-fresh-onboarding.spec.ts
         inbox-tempo-real.spec.ts
+        cadastro-sem-confirmacao-de-email.spec.ts
     steps:
       - uses: actions/checkout@v7
 

--- a/app/actions/auth/signUp.test.ts
+++ b/app/actions/auth/signUp.test.ts
@@ -1,0 +1,100 @@
+/**
+ * O CADASTRO PRECISA DIZER QUANDO NÃO VAI EXISTIR E-MAIL PARA CLICAR.
+ *
+ * ─── O defeito, medido pela tela ────────────────────────────────────────────
+ *
+ * Provedor de auth com "Confirm email" DESLIGADO faz `signUp()` devolver uma
+ * SESSÃO junto do usuário: a pessoa já entrou. Como a action devolvia só
+ * `{ ok: true }`, a tela mostrava "Enviamos um link de confirmação para … abra
+ * o e-mail e clique no link para ativar sua conta" — uma instrução impossível
+ * de cumprir, porque e-mail nenhum foi enviado.
+ *
+ * Medido na `origin/main` @ `4d50f63f`, com `GOTRUE_MAILER_AUTOCONFIRM=true`,
+ * dirigindo a tela: o texto acima aparecia, o cookie de sessão `sb-deskcomm-auth`
+ * estava no browser, e `user_organizations` do usuário novo vinha `[]`. A pessoa
+ * ficava esperando para sempre, autenticada e sem organização, sem motivo para
+ * descobrir que a saída existe. Achado de @KIRAzinx566, com cliente real preso.
+ *
+ * ─── O que este arquivo guarda ──────────────────────────────────────────────
+ *
+ * Que `sessao_ativa` reflita a SESSÃO que o provedor devolveu — nos dois
+ * sentidos. Guardar só o caso "com sessão" deixaria verde um `sessao_ativa: true`
+ * constante, que mandaria para `/get-started` quem de fato precisa confirmar o
+ * e-mail: pessoa sem sessão nenhuma, que cairia no `requireAuth()` e voltaria
+ * para o login sem nunca ler que um e-mail a espera.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { headers } from "next/headers";
+import { createClient } from "@/lib/supabase/server";
+
+vi.mock("next/headers", () => ({ headers: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("@/lib/audit", async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  audit: vi.fn(async () => undefined),
+}));
+
+const signUpDoProvedor = vi.fn();
+
+/** Um e-mail novo por caso: o teto de `signup` é por IP e por janela. */
+let n = 0;
+const entrada = () => ({
+  org_name: "Plata Iphones",
+  email: `cadastro-${++n}-${Date.now()}@exemplo.test`,
+  password: "SenhaForte!2026",
+  password_confirm: "SenhaForte!2026",
+});
+
+describe("signUp — a tela precisa saber se a sessão já veio aberta", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    signUpDoProvedor.mockReset();
+    vi.mocked(headers).mockResolvedValue({
+      // IP diferente a cada caso, pelo mesmo motivo do e-mail.
+      get: (k: string) => (k === "x-forwarded-for" ? `198.51.100.${n % 250}` : null),
+    } as never);
+    vi.mocked(createClient).mockResolvedValue({
+      auth: { signUp: signUpDoProvedor },
+    } as never);
+  });
+
+  it('"Confirm email" DESLIGADO: o provedor devolve sessão → sessao_ativa', async () => {
+    // A forma exata que o GoTrue devolve com MAILER_AUTOCONFIRM=true.
+    signUpDoProvedor.mockResolvedValue({
+      data: { user: { id: "u-1" }, session: { access_token: "tok", refresh_token: "ref" } },
+      error: null,
+    });
+
+    const { signUp } = await import("./signUp");
+    const res = await signUp(entrada());
+
+    expect(res).toEqual({ ok: true, sessao_ativa: true });
+  });
+
+  it("CONTROLE — confirmação LIGADA: sem sessão, a tela do e-mail continua certa", async () => {
+    // Sem este caso, `sessao_ativa: true` fixo passaria — e mandaria para a
+    // recuperação quem ainda nem tem sessão.
+    signUpDoProvedor.mockResolvedValue({
+      data: { user: { id: "u-2" }, session: null },
+      error: null,
+    });
+
+    const { signUp } = await import("./signUp");
+    const res = await signUp(entrada());
+
+    expect(res).toEqual({ ok: true, sessao_ativa: false });
+  });
+
+  it("CONTROLE — o provedor recusar continua sendo erro, não sessão", async () => {
+    signUpDoProvedor.mockResolvedValue({
+      data: { user: null, session: null },
+      error: { message: "signup disabled", status: 422 },
+    });
+
+    const { signUp } = await import("./signUp");
+    const res = await signUp(entrada());
+
+    expect(res).toEqual({ ok: false, error: "signup_failed" });
+  });
+});

--- a/app/actions/auth/signUp.ts
+++ b/app/actions/auth/signUp.ts
@@ -15,7 +15,25 @@ import { authRateLimited, AUTH_LIMITS } from "@/lib/auth/rate-limit";
 import { env } from "@/lib/env";
 
 export type SignUpResult =
-  | { ok: true }
+  | {
+      ok: true;
+      /**
+       * O provedor de auth JÁ abriu a sessão neste `signUp()` — quer dizer,
+       * "Confirm email" está DESLIGADO nele e não vai existir link nenhum para
+       * clicar. Quem chama precisa saber disto: a tela de "confirme seu e-mail"
+       * é uma instrução impossível de cumprir nesse estado, e a pessoa fica
+       * esperando para sempre um e-mail que nunca sai — autenticada, sem
+       * organização, sem motivo para navegar até a saída que existe.
+       *
+       * Medido em 2026-09-05 na `origin/main` @ `4d50f63f`, com
+       * `GOTRUE_MAILER_AUTOCONFIRM=true`: a tela dizia "Enviamos um link de
+       * confirmação para …", e ao mesmo tempo o cookie `sb-deskcomm-auth`
+       * estava no browser e `user_organizations` do usuário vinha `[]`.
+       *
+       * Achado de @KIRAzinx566, com um cliente real travado nessa tela.
+       */
+      sessao_ativa: boolean;
+    }
   | {
       ok: false;
       error: "validation_error" | "rate_limited" | "signup_failed";
@@ -123,5 +141,8 @@ export async function signUp(
     userAgent,
   });
 
-  return { ok: true };
+  // `data.session` é o único sinal confiável de que o provedor não vai mandar
+  // e-mail nenhum: ele vem preenchido exatamente quando a confirmação está
+  // desligada (ou já resolvida) e o GoTrue devolveu tokens junto do usuário.
+  return { ok: true, sessao_ativa: data.session !== null };
 }

--- a/app/get-started/page.tsx
+++ b/app/get-started/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
+import { createClient } from "@/lib/supabase/server";
 import { branding } from "@/lib/branding";
 import { RecoverOrganizationForm } from "@/components/auth/RecoverOrganizationForm";
 import { traduzir } from "@/lib/i18n/dicionario";
@@ -26,6 +27,17 @@ export default async function GetStartedPage() {
   // "abra outra empresa" alcançável por quem digitasse a URL.
   if (activeOrg) redirect("/app/inbox");
 
+  // O nome da empresa que a pessoa digitou no cadastro mora no `user_metadata`,
+  // que `AuthUser` não carrega — e alargar `AuthUser` por causa de uma tela de
+  // exceção sairia mais caro que esta leitura, que só acontece aqui. Vale para
+  // quem chega pelo cadastro com confirmação de e-mail desligada: o campo já
+  // vem preenchido em vez de pedir de novo o que ela acabou de informar.
+  const supabase = await createClient();
+  const {
+    data: { user: authUser },
+  } = await supabase.auth.getUser();
+  const nomeSugerido = (authUser?.user_metadata?.org_name as string | undefined) ?? undefined;
+
   // Fora da árvore de `app/app/layout.tsx`, como as telas públicas: o idioma
   // vem do próprio usuário, e o formulário precisa do provider para o `useT()`.
   const t = (texto: string) => traduzir(texto, user.idioma);
@@ -47,7 +59,7 @@ export default async function GetStartedPage() {
               )}
             </p>
           </div>
-          <RecoverOrganizationForm />
+          <RecoverOrganizationForm nomeSugerido={nomeSugerido} />
           <p className="text-xs leading-relaxed text-muted-foreground">
             {t(
               "Se você recebeu um convite, não crie uma organização nova. Use o link do convite ou peça ao administrador para reenviá-lo.",

--- a/components/auth/RecoverOrganizationForm.tsx
+++ b/components/auth/RecoverOrganizationForm.tsx
@@ -22,9 +22,17 @@ const MENSAGENS: Record<string, string> = {
     "Não foi possível concluir a organização agora. Tente novamente ou contate o administrador da instalação.",
 };
 
-export function RecoverOrganizationForm() {
+/**
+ * `nomeSugerido` é o nome de empresa que a pessoa digitou no CADASTRO e que
+ * viajou até aqui pelo `user_metadata` — o mesmo canal que `/auth/confirm` usa
+ * para provisionar. Ele só semeia o campo: quem valida continua sendo o Zod da
+ * action, e a pessoa pode trocar antes de enviar. Sem isto, quem cai na
+ * recuperação precisa digitar de novo um dado que o sistema já tem, no momento
+ * em que ela está mais propensa a desistir.
+ */
+export function RecoverOrganizationForm({ nomeSugerido }: { nomeSugerido?: string }) {
   const t = useT();
-  const [name, setName] = useState("");
+  const [name, setName] = useState(nomeSugerido ?? "");
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useForm, type Resolver } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTransition, useState } from "react";
@@ -29,6 +30,7 @@ export interface ConviteDoSignup {
 
 export function SignupForm({ convite }: { convite?: ConviteDoSignup }) {
   const t = useT();
+  const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [serverError, setServerError] = useState<string | null>(null);
   const [sentTo, setSentTo] = useState<string | null>(null);
@@ -63,6 +65,30 @@ export function SignupForm({ convite }: { convite?: ConviteDoSignup }) {
         : values;
       const res = await signUp(entrada, convite?.token);
       if (res.ok) {
+        /**
+         * ⚠️ O PROVEDOR JÁ DEIXOU A PESSOA ENTRAR — não existe e-mail para ela
+         * esperar. Acontece quando "Confirm email" está desligado no provedor
+         * de auth, que é uma escolha do operador da instalação e não um defeito
+         * dele; o defeito é a tela abaixo, que manda "abra o e-mail e clique no
+         * link" para quem já está autenticado. Sem este desvio a pessoa fica
+         * parada nessa instrução para sempre: logada, sem organização, e sem
+         * motivo nenhum para descobrir sozinha que a saída existe em
+         * `/get-started`. Medido com um cliente real travado — achado de
+         * @KIRAzinx566.
+         *
+         * O destino separa as duas naturezas de cadastro, com o dado que esta
+         * tela já tem em mãos: quem veio de um convite vai ACEITAR o convite
+         * (dar organização própria a essa pessoa é o erro que
+         * `decidirConviteDoSignup` existe para evitar); quem se cadastrou por
+         * conta própria vai à recuperação, que é o caminho auditado e com teto
+         * de tentativas — e não uma segunda porta de provisionamento.
+         */
+        if (res.sessao_ativa) {
+          router.replace(
+            convite ? `/team/accept-invite/${convite.token}` : "/get-started",
+          );
+          return;
+        }
         setSentTo(values.email);
         return;
       }

--- a/tests/e2e/cadastro-sem-confirmacao-de-email.spec.ts
+++ b/tests/e2e/cadastro-sem-confirmacao-de-email.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * E2E — O CADASTRO QUANDO O PROVEDOR NÃO PEDE CONFIRMAÇÃO DE E-MAIL.
+ *
+ * ─── O defeito, medido pela tela ────────────────────────────────────────────
+ *
+ * Com "Confirm email" DESLIGADO no provedor de auth — escolha do operador da
+ * instalação, e o estado de muita VPS recém-montada —, `signUp()` devolve a
+ * SESSÃO junto do usuário: a pessoa já entrou. A tela, que não sabia disso,
+ * mostrava assim mesmo:
+ *
+ *     Confirme seu e-mail
+ *     Enviamos um link de confirmação para <e-mail>.
+ *     Abra o e-mail e clique no link para ativar sua conta.
+ *
+ * E-mail nenhum foi enviado. Medido na `origin/main` @ `4d50f63f`, dirigindo
+ * esta mesma jornada: o texto acima aparecia, o cookie `sb-deskcomm-auth` já
+ * estava no browser, e `user_organizations` do usuário novo vinha `[]`. A saída
+ * existe desde o PR #465 (`/get-started`), mas a pessoa não tem motivo nenhum
+ * para descobri-la: ela foi mandada esperar. Fica parada, autenticada e sem
+ * organização, até desistir.
+ *
+ * Achado de @KIRAzinx566, com um cliente real preso nessa tela.
+ *
+ * ─── Por que esta spec está FORA do CI ──────────────────────────────────────
+ *
+ * A precondição não é um dado que a spec possa semear: é a configuração do
+ * PROVEDOR (`GOTRUE_MAILER_AUTOCONFIRM`), fixada quando o Supabase local sobe,
+ * e o `supabase/config.toml` do repo declara `enable_confirmations = true` — que
+ * é o que as outras specs de cadastro exercitam. Ligar o autoconfirm para esta
+ * spec mudaria o provedor para a suíte inteira.
+ *
+ * Por isso ela vive em `FORA_DO_CI` (com o motivo escrito lá) e o gate de todo
+ * dia é o par de testes de unidade, que roda no `verify`:
+ *
+ *   - `app/actions/auth/signUp.test.ts` — a action DIZ que a sessão veio aberta
+ *   - `tests/unit/cadastro-sem-confirmacao-nao-manda-esperar-email.test.tsx`
+ *     — a tela AGE sobre isso
+ *
+ * Esta spec é a prova pela tela de que os dois, juntos, resolvem a jornada real.
+ * Para rodá-la, ligue o autoconfirm no provedor local e rode só este arquivo:
+ *
+ *   docker inspect supabase_auth_<projeto> --format '{{json .Config.Env}}'  # guarde
+ *   # recrie o container com GOTRUE_MAILER_AUTOCONFIRM=true
+ *   pnpm exec playwright test tests/e2e/cadastro-sem-confirmacao-de-email.spec.ts
+ *
+ * Ela CONFERE a precondição antes de medir e falha alto se não estiver de pé —
+ * uma spec que se auto-pula aqui leria como "a jornada está boa".
+ */
+import { randomUUID } from "node:crypto";
+
+import { test, expect } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+
+const URL_SUPABASE = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const svc = createClient(URL_SUPABASE, process.env.SUPABASE_SERVICE_ROLE_KEY!, {
+  auth: { persistSession: false },
+});
+
+const SENHA = "CadastroSemConfirmar!2026#Deskcomm";
+const NOME_DA_EMPRESA = "Plata Iphones E2E";
+
+/** Usuários e organizações criados pela jornada — limpos no fim. */
+const usuariosCriados: string[] = [];
+const orgsCriadas: string[] = [];
+
+test.beforeAll(async () => {
+  const r = await fetch(`${URL_SUPABASE}/auth/v1/settings`, {
+    headers: { apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! },
+  });
+  const settings = (await r.json()) as { mailer_autoconfirm?: boolean };
+  // Sem a precondição, TODOS os casos abaixo passariam pelo caminho de sempre e
+  // a spec ficaria verde sem ter medido nada do defeito.
+  expect(
+    settings.mailer_autoconfirm,
+    "precondição ausente: o provedor local ainda exige confirmação de e-mail " +
+      "(GOTRUE_MAILER_AUTOCONFIRM=false). Ver o cabeçalho desta spec.",
+  ).toBe(true);
+});
+
+test.afterAll(async () => {
+  for (const id of orgsCriadas) {
+    await svc.from("user_organizations").delete().eq("organization_id", id);
+    await svc.from("crm_stages").delete().eq("organization_id", id);
+    await svc.from("crm_pipelines").delete().eq("organization_id", id);
+    await svc.from("organizations").delete().eq("id", id);
+  }
+  for (const id of usuariosCriados) await svc.auth.admin.deleteUser(id);
+});
+
+async function idDoUsuario(email: string): Promise<string> {
+  const { data } = await svc.auth.admin.listUsers();
+  const u = data.users.find((x) => x.email === email);
+  if (!u) throw new Error(`usuário ${email} não chegou ao banco`);
+  usuariosCriados.push(u.id);
+  return u.id;
+}
+
+test("⭐ o cadastro não manda esperar um e-mail que não vai chegar", async ({ page }) => {
+  const email = `sem-confirmar-${randomUUID().slice(0, 8)}@qa.local`;
+
+  await page.goto("/signup");
+  await page.locator("#org_name").fill(NOME_DA_EMPRESA);
+  await page.locator("#email").fill(email);
+  await page.locator("#password").fill(SENHA);
+  await page.locator("#password_confirm").fill(SENHA);
+  await page.getByRole("button", { name: /criar conta/i }).click();
+
+  // A saída, e não a sala de espera.
+  await expect(page).toHaveURL(/\/get-started/, { timeout: 30_000 });
+  await expect(
+    page.getByText(/Enviamos um link de confirmação/i),
+    "a instrução impossível continuou na tela",
+  ).toHaveCount(0);
+
+  // O nome que ela digitou no cadastro chega preenchido — não se pede duas
+  // vezes o dado que o sistema já tem.
+  await expect(page.getByLabel(/Nome da empresa/i)).toHaveValue(NOME_DA_EMPRESA);
+
+  // E a jornada CONCLUI: chegar à tela não é o conserto, sair do beco é.
+  const idUsuario = await idDoUsuario(email);
+  await page.getByRole("button", { name: /Continuar para o onboarding/i }).click();
+  await expect(page).toHaveURL(/\/onboarding\/welcome/, { timeout: 40_000 });
+
+  const { data: vinculo } = await svc
+    .from("user_organizations")
+    .select("organization_id, role, organizations(display_name)")
+    .eq("user_id", idUsuario)
+    .maybeSingle();
+  expect(vinculo, "a tela navegou sem provisionar organização nenhuma").not.toBeNull();
+  const v = vinculo as unknown as {
+    organization_id: string;
+    role: string;
+    organizations: { display_name: string } | { display_name: string }[];
+  };
+  orgsCriadas.push(v.organization_id);
+  expect(v.role).toBe("admin");
+  const org = Array.isArray(v.organizations) ? v.organizations[0] : v.organizations;
+  expect(org?.display_name).toBe(NOME_DA_EMPRESA);
+});
+
+test("⭐ quem se cadastra POR UM CONVITE vai aceitá-lo, não abrir empresa própria", async ({
+  page,
+}) => {
+  // O contrapeso do caso acima. Um desvio que mandasse todo mundo para
+  // `/get-started` resolveria a jornada de cima e recriaria, um andar acima, o
+  // erro que `decidirConviteDoSignup` existe para evitar: dar organização
+  // própria a quem foi convidado para uma que já existe.
+  const { data: org, error } = await svc
+    .from("organizations")
+    .insert({
+      slug: `convite-sem-confirmar-${randomUUID().slice(0, 8)}`,
+      display_name: "Empresa Que Convidou",
+      legal_name: "Empresa Que Convidou",
+      status: "active",
+    })
+    .select("id")
+    .single();
+  if (error || !org) throw error ?? new Error("sem organização que convida");
+  orgsCriadas.push(org.id as string);
+
+  const email = `convidado-sem-confirmar-${randomUUID().slice(0, 8)}@qa.local`;
+  // O mesmo token que o convite real emite — assinado com o INTERNAL_SECRET do
+  // `.env.e2e`, que o runner publica no ambiente deste processo.
+  const { signInviteToken } = await import("@/lib/auth/invite-token");
+  const token = signInviteToken({
+    invite_id: randomUUID(),
+    email,
+    organization_id: org.id as string,
+    role: "agent",
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  });
+
+  await page.goto(`/signup?invite=${encodeURIComponent(token)}`);
+  await page.locator("#password").fill(SENHA);
+  await page.locator("#password_confirm").fill(SENHA);
+  await page.getByRole("button", { name: /criar conta/i }).click();
+
+  await expect(page).toHaveURL(/\/team\/accept-invite\//, { timeout: 30_000 });
+  await idDoUsuario(email);
+});

--- a/tests/unit/cadastro-sem-confirmacao-nao-manda-esperar-email.test.tsx
+++ b/tests/unit/cadastro-sem-confirmacao-nao-manda-esperar-email.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * A TELA DO CADASTRO NÃO PODE MANDAR ESPERAR UM E-MAIL QUE NÃO VAI CHEGAR.
+ *
+ * Par do `app/actions/auth/signUp.test.ts`: lá se guarda que a action DIZ que a
+ * sessão veio aberta; aqui, que a tela AGE sobre isso. Separados de propósito —
+ * a action podia devolver `sessao_ativa` certinho e o formulário continuar
+ * mostrando "confirme seu e-mail", que era exatamente o defeito medido, e um
+ * teste só do lado da action ficaria verde com a pessoa presa do mesmo jeito.
+ *
+ * Medido na `origin/main` @ `4d50f63f` com `GOTRUE_MAILER_AUTOCONFIRM=true`: a
+ * tela dizia "Enviamos um link de confirmação para …" enquanto o cookie de
+ * sessão já estava no browser e o usuário não tinha organização nenhuma.
+ * Achado de @KIRAzinx566, com um cliente real travado nessa tela.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { SignupForm } from "@/components/auth/SignupForm";
+
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace, push: vi.fn(), refresh: vi.fn() }),
+}));
+
+const signUp = vi.fn();
+vi.mock("@/app/actions/auth/signUp", () => ({ signUp: (...a: unknown[]) => signUp(...a) }));
+
+async function preencherEEnviar(comEmpresa = true) {
+  const user = userEvent.setup();
+  if (comEmpresa) await user.type(screen.getByLabelText(/Nome da empresa/i), "Plata Iphones");
+  await user.type(screen.getByLabelText(/^Email$/i), "dono@plata.test");
+  await user.type(screen.getByLabelText(/^Senha$/i), "SenhaForte!2026");
+  await user.type(screen.getByLabelText(/Confirmar senha/i), "SenhaForte!2026");
+  await user.click(screen.getByRole("button", { name: /criar conta/i }));
+}
+
+describe("cadastro quando o provedor já abriu a sessão", () => {
+  beforeEach(() => {
+    replace.mockClear();
+    signUp.mockReset();
+  });
+
+  it("⭐ sessão já aberta: leva à saída em vez de mandar abrir o e-mail", async () => {
+    signUp.mockResolvedValue({ ok: true, sessao_ativa: true });
+    render(<SignupForm />);
+    await preencherEEnviar();
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/get-started"));
+    // A instrução impossível não pode sobrar na tela junto do desvio.
+    expect(screen.queryByText(/Enviamos um link de confirmação/i)).toBeNull();
+  });
+
+  it("⭐ sessão já aberta COM convite: vai aceitar o convite, não abrir empresa", async () => {
+    // Dar organização própria a quem foi convidado é o erro que
+    // `decidirConviteDoSignup` existe para evitar. Um desvio que mandasse todo
+    // mundo para `/get-started` ficaria verde no caso acima e recriaria esse
+    // erro aqui.
+    signUp.mockResolvedValue({ ok: true, sessao_ativa: true });
+    render(<SignupForm convite={{ token: "tok-123", email: "convidado@plata.test" }} />);
+    await preencherEEnviar(false);
+
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith("/team/accept-invite/tok-123"),
+    );
+  });
+
+  it("CONTROLE — confirmação LIGADA: a tela do e-mail continua aparecendo", async () => {
+    // Sem este caso, "sempre redireciona" ficaria verde e tiraria da tela a
+    // única instrução correta para quem de fato precisa confirmar o e-mail.
+    signUp.mockResolvedValue({ ok: true, sessao_ativa: false });
+    render(<SignupForm />);
+    await preencherEEnviar();
+
+    await waitFor(() =>
+      expect(screen.getByText(/Enviamos um link de confirmação/i)).toBeTruthy(),
+    );
+    expect(replace).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Extraído do PR #588 do @KIRAzinx566 — que ele fechou 36 segundos depois de abrir, achando que tinha errado de repositório. Não tinha.

## O defeito, reproduzido na main de hoje

Com `Confirm email` **desligado** no provedor de auth (escolha comum, e estado de muita VPS recém-montada), o cadastro pela tela devolve:

```
TELA:    "Confirme seu e-mail — abra o link para ativar sua conta"
COOKIES: sb-deskcomm-auth            ← a sessão JÁ existe
BANCO:   confirmado=true, organizações=[]
/app/inbox: renderiza, "Você não tem nenhuma organização ativa"
```

Controle, a mesma jornada com a confirmação **ligada**:

```
TELA:    a MESMA
COOKIES: só os code-verifier          ← sem sessão
BANCO:   confirmado=false
/app/inbox: → /login
```

**A mesma tela para dois estados opostos.** Quem já entrou é mandado esperar um e-mail que ninguém enviou.

O beco sem saída em si **já estava fechado** pelo #465 (@prevprocesso-maker) — `recoverOrganization`, a tela `/get-started` e a spec que a prova. O que continuava aberto é a **porta de entrada**: a saída existe, mas a pessoa não tem motivo para procurá-la, porque foi instruída a aguardar. Foi por isso que o cliente dele ficou parado.

## O conserto

`signUp()` passa a devolver `sessao_ativa`, e o formulário **desvia em vez de mandar esperar** — quem veio de convite vai aceitar o convite, quem se cadastrou sozinho vai a `/get-started`, com o nome da empresa já preenchido.

**O mecanismo do autor NÃO foi trazido, e isso é deliberado:** o PR dele provisiona a organização dentro do `app/app/layout.tsx`, contornando o teto de tentativas e a auditoria de `recoverOrganization` — seria uma segunda porta de provisionamento ao lado da que a main construiu com essas duas proteções. **O diagnóstico é dele; o ponto de conserto é outro.**

## Sabotagens — seis, com a previsão declarada antes de cada uma

| sabotagem | previsto | medido |
|---|---|---|
| `sessao_ativa` fixo `false` | 1 de 3 | **1 de 3** |
| `sessao_ativa` fixo `true` | 1 de 3 | **1 de 3** |
| campo removido (*o estado da main hoje*) | 2 de 3 | **2 de 3** |
| desvio removido da tela (*idem*) | 2 de 3 | **2 de 3** |
| convite mandado para `/get-started` | 1 de 3 | **1 de 3** |
| desvia sempre, ignorando a sessão | 1 de 3 | **1 de 3** |

E pela tela: os 2 casos e2e **falharam** contra o build da main e **passaram** contra o build com o conserto.

A spec entra em `FORA_DO_CI` com motivo escrito — a precondição é `GOTRUE_MAILER_AUTOCONFIRM`, fixado quando o Supabase sobe; ligá-la trocaria o provedor da suíte inteira e faria `signup-journey`/`invite-lifecycle` medirem outro fluxo em silêncio. Ela **confere a própria precondição e falha alto** em vez de se auto-pular (provado: sem a precondição, `1 failed`, com a mensagem certa). O gate diário é o par de unidade, que roda no `verify`.

Diagnóstico de @KIRAzinx566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DC6uq5V26S13UxfaBaYKQ