### PR TITLE
ci: a acolhida ao contribuidor externo sai sozinha, em minutos

### DIFF
--- a/.github/workflows/acolhida.yml
+++ b/.github/workflows/acolhida.yml
@@ -12,6 +12,23 @@
 #
 # Este workflow diz três coisas, e nada além: o `Vercel` vermelho é esperado em
 # fork; os workflows podem ficar parados esperando liberação; e quando vem o
+# O PRAZO PROMETIDO NÃO É CHUTE — foi medido antes de entrar no texto.
+#
+# A doutrina proíbe prometer o que não se cumpre, então "em até um dia útil"
+# passou pela régua. Medido em 2026-09-05, sobre os PRs de FORK dos últimos 60,
+# contando de `createdAt` até o primeiro comentário humano (descartados
+# vercel[bot], ecc-tools[bot], github-actions e o próprio autor):
+#
+#   n = 13 PRs de fork com resposta humana
+#   mediana 1,0h · p90 7,5h · máximo 10,5h · dentro de 24h: 13/13
+#
+# O pior caso tem folga de mais de 2x contra a promessa. Se um dia essa conta
+# virar, o texto aqui vira mentira ANTES de alguém notar — então refaça a
+# medição em vez de confiar nesta linha:
+#
+#   gh pr list --state all --limit 60 --json number,createdAt,author,headRepositoryOwner
+#   (filtre headRepositoryOwner != melgarafael, pegue o 1º comentário não-bot)
+#
 # veredito. O molde é `triagem/references/resposta-ao-contribuidor.md`, seção
 # "Acolhida" — mudar o texto lá sem mudar aqui faz a versão humana e a
 # automática divergirem, e `tests/unit/acolhida-nao-toca-no-fork.test.ts`

--- a/.github/workflows/acolhida.yml
+++ b/.github/workflows/acolhida.yml
@@ -1,0 +1,153 @@
+# A ACOLHIDA DE CONTRIBUIDOR EXTERNO — SEM DEPENDER DE ALGUÉM ESTAR TRIANDO.
+#
+# ## O gargalo medido
+#
+# A taxa histórica de recusa de PR de fork aqui é ZERO: o que trava não é
+# qualidade, é o tempo até alguém olhar. Três pessoas fecharam o PRÓPRIO PR
+# pedindo desculpa por "ruído" (#515, #547, #588) — nenhuma tinha errado, e a
+# última fechou 36 segundos depois de abrir, levando junto um bug de primeira
+# impressão achado com cliente real travado. Antes disso, a única coisa que este
+# projeto dizia a quem contribui era um check `Vercel` vermelho que não é culpa
+# dela.
+#
+# Este workflow diz três coisas, e nada além: o `Vercel` vermelho é esperado em
+# fork; os workflows podem ficar parados esperando liberação; e quando vem o
+# veredito. O molde é `triagem/references/resposta-ao-contribuidor.md`, seção
+# "Acolhida" — mudar o texto lá sem mudar aqui faz a versão humana e a
+# automática divergirem, e `tests/unit/acolhida-nao-toca-no-fork.test.ts`
+# reprova quando o essencial some daqui.
+#
+# ## Por que a acolhida pode ser automática: ela NÃO AVALIA
+#
+# Ela não pode estar errada sobre o mérito porque não fala do mérito. Um
+# "parece ótimo!" postado antes de medir é a semente do carimbo, e carimbo é
+# pior que silêncio — porque lava. Toda frase daqui é sobre o PROCESSO.
+#
+# ## A parte perigosa, e ela decide o desenho inteiro
+#
+# `pull_request_target` roda no contexto da BASE: com os segredos do repositório
+# e com permissão de escrita, num evento disparado por quem é de fora. É um
+# vetor de escalada conhecido, e a única defesa que não depende de vigilância é
+# o job não encostar em nada que venha do PR:
+#
+#   1. ZERO CHECKOUT, e zero `uses:`. Este job não baixa uma linha de código —
+#      nem do fork, nem da base, nem de action de terceiro. Sem `actions/checkout`
+#      não existe `npm install`, não existe script de `package.json`, não existe
+#      `.github/actions/*` do fork: não há bytes do contribuidor no runner.
+#   2. PERMISSÃO MÍNIMA E EXPLÍCITA: `pull-requests: write` e nada mais. Declarar
+#      o bloco zera todo escopo não citado — sem `contents`, sem `actions`, sem
+#      `packages`. O token deste job comenta num PR e não sabe fazer mais nada.
+#      No topo, e não por job, pela mesma razão escrita em `ci.yml`: job
+#      acrescentado depois nasce restrito em vez de herdar o default do
+#      repositório, que muda fora do repo, num clique, sem PR.
+#   3. NENHUM DADO DO PR DENTRO DE `run:`. Título, corpo e nome de branch são
+#      texto escolhido por quem abriu o PR; interpolados por `${{ }}` viram
+#      CÓDIGO no shell antes de o shell existir. O único dado que este job usa é
+#      o login, e ele entra por `env:` e é citado com aspas — nunca por `${{ }}`
+#      no corpo do `run:`.
+#   4. O texto fixo vai por heredoc COM ASPAS (`<<'MD'`). Sem as aspas, as crases
+#      da própria prosa (`` `gh pr checks` ``) viram substituição de comando.
+#
+# ## O que este workflow DELIBERADAMENTE não faz: liberar o CI sozinho
+#
+# No primeiro PR de quem nunca contribuiu, os runs ficam em `action_required` e
+# `gh pr checks` NÃO os mostra — o PR parece não ter check nenhum. Dava para
+# aprovar sozinho (`POST /actions/runs/{id}/approve`), e isso está RECUSADO:
+#
+#   - aprovar é EXECUTAR o código do fork nos nossos runners; o `verify` roda
+#     `pnpm install` (scripts de ciclo de vida) e a suíte, tudo vindo do PR. O
+#     portão do GitHub existe exatamente para uma pessoa olhar antes disso, e
+#     automatizá-lo o remove justamente para a população que ele protege;
+#   - exigiria `actions: write` aqui dentro, inflando este workflow de "sabe
+#     comentar" para "sabe aprovar e re-executar workflow" — num arquivo
+#     `pull_request_target`, que já é o alvo mais valioso do repositório;
+#   - e rodaria em `opened`, antes de qualquer humano ter visto o diff.
+#
+# Então a acolhida só AVISA que os runs estão parados. Quem tria libera com:
+#   gh api "repos/$REPO/actions/runs" --jq '.workflow_runs[]|select(.status=="action_required")|.id'
+#   gh api --method POST "repos/$REPO/actions/runs/<id>/approve"
+name: acolhida
+
+on:
+  # `opened` e só. `synchronize`/`reopened` re-disparariam a acolhida a cada push
+  # do contribuidor — e a boa-vinda que chega quatro vezes é ruído, não acolhida.
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  # `github.repository_owner` guarda o fork: este arquivo vai para a `main` de um
+  # produto self-host, e o fork de cada pessoa herda o workflow. Sem a guarda, um
+  # bot falaria pela gente no repositório de outra pessoa — prometendo o prazo de
+  # mantenedores que nunca concordaram com ele, e explicando um deploy da Vercel
+  # que não é o dela. É `repository_owner` e não `repository` porque renomear o
+  # repositório não deve calar a acolhida; mudar de dono deve.
+  acolher:
+    if: github.repository_owner == 'melgarafael' && github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Acolher quem abriu o PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          LOGIN: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+
+          # IDEMPOTÊNCIA REAL, e ela não é sobre re-execução: um humano pode ter
+          # acolhido antes (ou já ter dado o veredito). A triagem carimba TODO
+          # comentário com a âncora invisível `triagem-de-pr:v1:pass=N`; achar
+          # qualquer uma delas significa que a conversa já começou, e a boa-vinda
+          # do robô chegaria depois da pessoa.
+          #
+          # Falha aqui ABORTA de propósito. Se a listagem não respondeu, não
+          # sabemos se já há acolhida — e postar no escuro duplica. Vermelho
+          # visível vale mais que um comentário em dobro.
+          COMENTARIOS="$(mktemp)"
+          gh api --paginate "repos/${REPO}/issues/${PR}/comments" --jq '.[].body' > "${COMENTARIOS}"
+          if grep -qF 'triagem-de-pr:v1:' "${COMENTARIOS}"; then
+            echo "âncora de triagem já presente no PR #${PR} — a conversa já começou, nada a postar"
+            exit 0
+          fi
+
+          # O login é o ÚNICO dado do PR que entra no texto, e ele entra como
+          # valor, não como código. O GitHub restringe login a alfanumérico com
+          # hífen interno, no máximo 39 caracteres; qualquer coisa fora disso não
+          # é um login, e vira saudação sem nome em vez de virar conteúdo.
+          SAUDACAO="Recebido — obrigado por isto."
+          if printf '%s' "${LOGIN}" | grep -qE '^[A-Za-z0-9](-?[A-Za-z0-9]){0,38}$'; then
+            SAUDACAO="Recebido, @${LOGIN} — obrigado por isto."
+          fi
+
+          CORPO="$(mktemp)"
+          {
+            printf '<!-- triagem-de-pr:v1:pass=1 -->\n'
+            printf '%s\n\n' "${SAUDACAO}"
+            # Heredoc COM aspas: nada aqui dentro é expandido pelo shell, e as
+            # crases da prosa continuam sendo crases.
+            cat <<'MD'
+          Duas coisas que vão parecer erro seu e não são:
+
+          - O check **Vercel** vermelho ("Authorization required to deploy") é esperado em PR de fork. A
+            `main` faz deploy de produção e a Vercel se recusa a construir código de fora, o que está
+            certo. **Ele não entra no gate de merge.**
+          - No primeiro PR de quem nunca contribuiu aqui, os workflows ficam **parados esperando
+            liberação** — política do GitHub, não sua. Enquanto isso o PR parece não ter check nenhum
+            (nem o `gh pr checks` mostra os que estão nesse estado). Quem tria libera; você não precisa
+            fazer nada.
+
+          Um mantenedor vai revisar de verdade — rodando os gates e reproduzindo o comportamento, não só
+          lendo o diff — e responde aqui **em até um dia útil**, com a medição junto, nunca com um "acho
+          que".
+
+          Esta mensagem é automática e não diz nada sobre o seu PR: ela é sobre o processo. O que vem
+          depois é pessoa.
+          MD
+          } > "${CORPO}"
+
+          gh api --method POST "repos/${REPO}/issues/${PR}/comments" \
+            -F "body=@${CORPO}" --jq '.html_url'

--- a/tests/unit/acolhida-nao-toca-no-fork.test.ts
+++ b/tests/unit/acolhida-nao-toca-no-fork.test.ts
@@ -1,0 +1,252 @@
+/**
+ * A ACOLHIDA AUTOMÁTICA NÃO PODE ENCOSTAR NO CÓDIGO DE QUEM ABRIU O PR.
+ *
+ * ## O que está sendo vigiado, e por que este arquivo existe
+ *
+ * `.github/workflows/acolhida.yml` roda em `pull_request_target`. Esse gatilho é a
+ * única maneira de comentar num PR de fork — o `GITHUB_TOKEN` de `pull_request` em
+ * fork é read-only — e ele vem com o preço: o job roda no contexto da BASE, com os
+ * SEGREDOS do repositório e com permissão de escrita, disparado por quem é de fora.
+ *
+ * Todo o desenho daquele arquivo é uma única aposta: o job não encosta em NADA que
+ * venha do PR. As quatro propriedades abaixo são essa aposta escrita como gate.
+ * Nenhuma delas é opinião de estilo — cada uma corresponde a um caminho publicado
+ * de escalada em `pull_request_target`:
+ *
+ *   1. ZERO `uses:` (⇒ zero `actions/checkout`) e zero chave `ref:`. Um checkout com
+ *      `ref: github.event.pull_request.head.sha` põe a árvore do fork no runner que
+ *      já tem os segredos; a partir daí qualquer `npm install`, script de
+ *      `package.json` ou action local do fork executa com eles à mão.
+ *   2. `permissions` é EXATAMENTE `pull-requests: write`. Declarar o bloco zera todo
+ *      escopo não citado. `contents: write` aqui daria commit na `main` a um evento
+ *      disparado por terceiro; `actions: write` daria aprovar e re-executar workflow.
+ *   3. NENHUM `${{ }}` dentro de `run:`. Título, corpo e nome de branch são texto
+ *      escolhido pelo autor do PR, e a interpolação acontece ANTES de o shell
+ *      existir: `${{ github.event.pull_request.title }}` num `run:` é execução de
+ *      comando, não leitura de string. A asserção é sobre a linha CRUA, comentário
+ *      de shell incluído — o Actions interpola lá também.
+ *   4. O gatilho é só `opened`. `synchronize`/`reopened` fariam a acolhida chegar a
+ *      cada push, e ampliariam a janela em que um workflow privilegiado dispara.
+ *
+ * ## O instrumento, e por que ele começa por um controle positivo
+ *
+ * Não há parser YAML nas dependências (`yaml`/`js-yaml` não estão em `dependencies`
+ * nem `devDependencies` — js-yaml só existe como transitiva do eslint, e depender de
+ * transitiva é dívida): a mesma constatação de `tests/unit/workflows-tem-permissions.test.ts`
+ * e `tests/unit/gatilho-dos-jobs-de-entrega.test.ts`. Então: recorte por indentação
+ * + CONTROLE POSITIVO. Sem o controle, um recorte que parou de casar devolve lista
+ * vazia, "nenhum `${{ }}` em `run:`" fica verde por vacuidade, e o gate vigia nada.
+ *
+ * ## O que ele NÃO prova
+ *
+ * Nada aqui executa o workflow. Que o `gh api` responda, que o token com
+ * `pull-requests: write` consiga comentar, e que o `if:` de fork case como escrito —
+ * isso só a primeira execução real prova. O que este arquivo garante é que as
+ * propriedades de segurança do desenho não sejam apagadas por uma edição futura.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ARQUIVO = join(process.cwd(), ".github/workflows/acolhida.yml");
+const LINHAS = readFileSync(ARQUIVO, "utf8").split("\n");
+
+/**
+ * Linhas com o comentário YAML zerado, preservando a numeração.
+ *
+ * Vale para as asserções de ESTRUTURA: o cabeçalho daquele arquivo explica por
+ * escrito o que ele não faz, e cita `actions/checkout`, `actions: write` e
+ * `${{ }}`. Um `#` não pode reprovar o gate — nem satisfazê-lo.
+ */
+const EFETIVAS = LINHAS.map((l) => (l.trimStart().startsWith("#") ? "" : l));
+
+const recuo = (l: string) => l.length - l.trimStart().length;
+
+/**
+ * O conteúdo CRU de cada `run:`, comentário de shell incluído.
+ *
+ * Cru de propósito: o Actions substitui `${{ }}` no texto inteiro do script antes
+ * de entregá-lo ao shell, então um `${{ }}` dentro de um `# comentário` do bash é
+ * exatamente tão executável quanto um fora dele.
+ */
+function blocosRun(): { linha: number; conteudo: string[] }[] {
+  const blocos: { linha: number; conteudo: string[] }[] = [];
+
+  for (let i = 0; i < EFETIVAS.length; i++) {
+    const m = EFETIVAS[i]!.match(/^(\s*)(?:- )?run:(.*)$/);
+    if (!m) continue;
+
+    const dentro = recuo(EFETIVAS[i]!);
+    const resto = m[2]!.trim();
+
+    // `run: comando` numa linha só — o conteúdo é o próprio resto.
+    if (resto !== "" && !/^[|>][-+]?$/.test(resto)) {
+      blocos.push({ linha: i + 1, conteudo: [resto] });
+      continue;
+    }
+
+    // Escalar de bloco: vai até a próxima linha não-vazia com recuo <= o da chave.
+    const conteudo: string[] = [];
+    for (let j = i + 1; j < LINHAS.length; j++) {
+      const bruta = LINHAS[j]!;
+      if (bruta.trim() === "") {
+        conteudo.push(bruta);
+        continue;
+      }
+      if (recuo(bruta) <= dentro) break;
+      conteudo.push(bruta);
+    }
+    blocos.push({ linha: i + 1, conteudo });
+  }
+
+  return blocos;
+}
+
+/** As linhas do mapeamento aberto por `chave:` na coluna `col`, uma por entrada. */
+function mapeamento(chave: string, col: number): string[] {
+  const i = EFETIVAS.findIndex((l) => new RegExp(`^ {${col}}${chave}:\\s*$`).test(l));
+  if (i === -1) return [];
+  const dentro: string[] = [];
+  for (let j = i + 1; j < EFETIVAS.length; j++) {
+    const l = EFETIVAS[j]!;
+    if (l.trim() === "") continue;
+    if (recuo(l) <= col) break;
+    dentro.push(l.trim());
+  }
+  return dentro;
+}
+
+const runs = blocosRun();
+const textoDosRuns = runs.flatMap((b) => b.conteudo).join("\n");
+
+describe("acolhida: um workflow privilegiado que não toca no código do fork", () => {
+  it("o instrumento está vivo: acha o job, o `run:` e as interpolações do arquivo", () => {
+    // Controle positivo das quatro asserções seguintes. Sem ele, um recorte que
+    // parou de casar devolve lista vazia e tudo passa por vacuidade — o modo de
+    // falha mais comum desta classe de teste.
+    expect(LINHAS.length, "linhas lidas de acolhida.yml").toBeGreaterThan(50);
+    expect(runs.length, "blocos `run:` recortados").toBe(1);
+    expect(runs[0]!.conteudo.length, "linhas dentro do `run:`").toBeGreaterThan(20);
+    // E o recorte de `${{ }}` enxerga alguma coisa: o arquivo TEM interpolação —
+    // ela vive em `env:`, que é o lugar seguro. Se nem essa fosse vista, a
+    // asserção "nenhuma em `run:`" não estaria medindo nada.
+    const emEnv = mapeamento("env", 8).filter((l) => l.includes("${{"));
+    expect(emEnv.length, "interpolações lidas no bloco `env:` do passo").toBeGreaterThanOrEqual(4);
+  });
+
+  it("não baixa uma linha de código: nenhum `uses:`, nenhum `ref:`", () => {
+    const usos = EFETIVAS.map((l, i) => ({ l, i }))
+      .filter(({ l }) => /^\s*(?:- )?uses:/.test(l))
+      .map(({ i }) => `acolhida.yml:${i + 1} — ${LINHAS[i]!.trim()}`);
+
+    expect(
+      usos,
+      [
+        "Este job roda em `pull_request_target`: contexto da base, com segredos e escrita.",
+        "Ele não pode baixar NADA — nem `actions/checkout` (que traria a árvore do fork),",
+        "nem action de terceiro (que roda com o mesmo token). Zero `uses:` é a aposta inteira.",
+      ].join("\n"),
+    ).toEqual([]);
+
+    const refs = EFETIVAS.map((l, i) => ({ l, i }))
+      .filter(({ l }) => /^\s*ref:/.test(l))
+      .map(({ i }) => `acolhida.yml:${i + 1}`);
+    expect(refs, "`ref:` é a chave que aponta um checkout para o código do PR").toEqual([]);
+
+    const cabecaDoPr = EFETIVAS.map((l, i) => ({ l, i }))
+      .filter(({ l }) => /pull_request\.head\.(sha|ref)\b/.test(l))
+      .map(({ i }) => `acolhida.yml:${i + 1}`);
+    // `head.repo.full_name` PODE aparecer — é a comparação que detecta fork, e
+    // comparar não é buscar. `head.sha`/`head.ref` só servem para ir buscar.
+    expect(cabecaDoPr, "`head.sha`/`head.ref` só existem para ir buscar o código do PR").toEqual(
+      [],
+    );
+  });
+
+  it("a permissão é exatamente `pull-requests: write` — nada mais", () => {
+    const blocos = EFETIVAS.map((l, i) => ({ l, i })).filter(({ l }) => /^\s*permissions:/.test(l));
+    expect(blocos.length, "há exatamente um bloco `permissions:` (no topo do arquivo)").toBe(1);
+    expect(recuo(blocos[0]!.l), "o bloco fica no topo: job novo neste arquivo nasce restrito").toBe(
+      0,
+    );
+
+    expect(
+      mapeamento("permissions", 0),
+      [
+        "O escopo deste token mudou. Declarar o bloco zera tudo que não está citado —",
+        "então cada linha aqui é um privilégio novo dado a um evento que QUEM É DE FORA",
+        "dispara. `contents: write` = commit na main; `actions: write` = aprovar e",
+        "re-executar workflow. A acolhida só precisa comentar.",
+      ].join("\n"),
+    ).toEqual(["pull-requests: write"]);
+  });
+
+  it("nenhum dado do PR entra em `run:` — nem dentro de comentário de shell", () => {
+    const interpoladas = runs.flatMap((b) =>
+      b.conteudo
+        .map((l, k) => ({ l, k }))
+        .filter(({ l }) => l.includes("${{"))
+        .map(({ l, k }) => `acolhida.yml:${b.linha + 1 + k} — ${l.trim()}`),
+    );
+
+    expect(
+      interpoladas,
+      [
+        "`${{ }}` dentro de `run:` é substituição de TEXTO feita antes de o shell existir:",
+        "o valor vira código-fonte do script. Título, corpo e branch do PR são escolhidos",
+        "por quem o abriu. O caminho seguro é `env:` + citação com aspas — que é o que",
+        "este workflow faz com o login. Comentário de shell conta: o Actions interpola lá também.",
+      ].join("\n"),
+    ).toEqual([]);
+  });
+
+  it("dispara só em `opened`, e só em `pull_request_target`", () => {
+    expect(mapeamento("on", 0)).toEqual(["pull_request_target:", "types: [opened]"]);
+  });
+
+  it("só acolhe PR de fork, e não fala pelos forks deste repositório", () => {
+    const condicao = EFETIVAS.filter((l) => /^ {4}if:/.test(l)).join("");
+    expect(condicao).toContain(
+      "github.event.pull_request.head.repo.full_name != github.repository",
+    );
+    // Este arquivo vai para a `main` de um produto self-host: sem a guarda de dono,
+    // o fork de cada pessoa herda um bot que fala pela gente no repositório dela.
+    expect(condicao).toContain("github.repository_owner == 'melgarafael'");
+  });
+
+  it("lê os comentários e desiste se a conversa já começou — ANTES de postar", () => {
+    const conteudo = runs[0]!.conteudo;
+    const iLeitura = conteudo.findIndex((l) => /gh api .*\/comments/.test(l));
+    const iAncora = conteudo.findIndex((l) => /grep -qF 'triagem-de-pr:v1:'/.test(l));
+    const iPost = conteudo.findIndex((l) => /--method POST/.test(l));
+
+    expect(iLeitura, "o job lista os comentários existentes").toBeGreaterThanOrEqual(0);
+    expect(iAncora, "o job procura a âncora da triagem").toBeGreaterThanOrEqual(0);
+    expect(iPost, "o job posta o comentário").toBeGreaterThanOrEqual(0);
+
+    // A ordem é a propriedade — ter as três chamadas não diz nada se o POST vier
+    // primeiro. Um humano pode ter acolhido (ou já ter dado o veredito) antes.
+    expect(iLeitura, "listar vem antes de procurar a âncora").toBeLessThan(iAncora);
+    expect(iAncora, "procurar a âncora vem antes de postar").toBeLessThan(iPost);
+
+    // E a âncora postada é a canônica da triagem — é ela que a própria releitura
+    // encontra na próxima execução, e é ela que um mantenedor reconhece.
+    expect(textoDosRuns).toContain("<!-- triagem-de-pr:v1:pass=1 -->");
+  });
+
+  it("a mensagem continua dizendo as três coisas, e nenhuma delas avalia o PR", () => {
+    // O molde é `triagem/references/resposta-ao-contribuidor.md`, seção "Acolhida".
+    // A acolhida é segura de ser automática porque não fala do mérito; se alguém
+    // esvaziar o texto, ela deixa de fazer o trabalho pelo qual existe.
+    expect(textoDosRuns, "o Vercel vermelho não é culpa de quem abriu o PR").toMatch(
+      /Vercel[\s\S]*gate de merge/,
+    );
+    expect(textoDosRuns, "os workflows podem estar parados esperando liberação").toMatch(
+      /esperando[\s\S]*?libera/,
+    );
+    expect(textoDosRuns, "e quando vem o veredito — a promessa que este arquivo faz").toContain(
+      "um dia útil",
+    );
+  });
+});

--- a/tests/unit/gatilho-dos-jobs-de-entrega.test.ts
+++ b/tests/unit/gatilho-dos-jobs-de-entrega.test.ts
@@ -153,6 +153,17 @@ const GATILHO_ESPERADO: Record<string, { condicao: string | null; efeito: string
   },
 
   // --- e o que legitimamente tem interruptor -----------------------------------
+  "acolhida.yml::acolher": {
+    condicao:
+      "github.repository_owner == 'melgarafael' && " +
+      "github.event.pull_request.head.repo.full_name != github.repository",
+    efeito:
+      "Este job posta a acolhida automática em PR de fork — a resposta em minutos que existe " +
+      "porque três contribuidores fecharam o próprio PR achando que tinham errado. As duas " +
+      "condições são deliberadas e cada uma barra um caminho: sem a de fork, PR interno recebe " +
+      "boas-vindas de robô; sem a de dono, o fork de cada self-hoster herda um bot que fala pela " +
+      "gente no repositório dele, prometendo um prazo que ninguém lá concordou em cumprir.",
+  },
   "relogio.yml::tick": {
     condicao: "vars.RELOGIO_LIGADO == '1' || github.event_name == 'workflow_dispatch'",
     efeito:

--- a/tests/unit/workflows-tem-permissions.test.ts
+++ b/tests/unit/workflows-tem-permissions.test.ts
@@ -54,6 +54,9 @@ const DIR = join(process.cwd(), ".github/workflows");
 const ESCRITA_JUSTIFICADA: Record<string, string> = {
   "publish-image.yml::packages: write":
     "publica a imagem do app no GHCR — é o artefato que o self-hoster instala",
+  "acolhida.yml::pull-requests: write":
+    "comenta a acolhida no PR de fork; é o ÚNICO escopo do workflow (o bloco zera o resto), " +
+    "e o job não faz checkout nem usa action nenhuma — ver tests/unit/acolhida-nao-toca-no-fork.test.ts",
 };
 
 interface Workflow {

--- a/triagem/references/resposta-ao-contribuidor.md
+++ b/triagem/references/resposta-ao-contribuidor.md
@@ -10,6 +10,18 @@ falta — e que nada do que ela leia seja cobrança por algo que ninguém contou
 
 ## Acolhida (passe 1) — em minutos, sem uma linha de avaliação
 
+**Ela sai sozinha em PR de fork**, por `.github/workflows/acolhida.yml`, em minutos e sem depender
+de alguém estar triando — que era o gargalo real: a taxa de recusa aqui é zero, o que custava era o
+tempo até alguém olhar. O passe 1 humano só escreve isto quando o robô não escreveu (PR interno, ou
+o workflow desligado); e o robô desiste sozinho se já houver qualquer âncora `triagem-de-pr:v1:` no
+PR — inclusive a sua.
+
+Duas frases do molde abaixo o robô **não pode** dizer, e é por isso que o texto dele não é cópia
+literal: "acabei de liberar" (ele não libera — aprovar run de fork é executar código de fora nos
+nossos runners, e está recusado por escrito no cabeçalho do workflow) e um prazo negociado caso a
+caso (ele promete "em até um dia útil", fixo). Mudar o texto aqui sem mudar lá faz as duas versões
+divergirem; `tests/unit/acolhida-nao-toca-no-fork.test.ts` guarda o essencial do lado de lá.
+
 Três informações, nesta ordem. Nada além.
 
 ```markdown


### PR DESCRIPTION
O gargalo deste repositório **não é qualidade** — a taxa histórica de recusa é **zero**. O que trava é o tempo até alguém olhar. Medido esta semana:

- um contribuidor abriu um PR às 13h42 e, por horas, a única coisa que este projeto lhe disse foi um `Vercel` vermelho **que não era culpa dele**;
- **três pessoas fecharam o próprio PR** dizendo *"aberto por engano no repositório errado, desculpa o ruído"* (#515, #547, #588). **Nenhuma tinha errado.** A última fechou 36 segundos depois de abrir — e trazia um bug de primeira impressão achado com cliente real travado.

A acolhida **não avalia mérito nenhum**, e é isso que a torna segura de ser automática: ela não pode errar sobre o mérito porque não fala do mérito.

## A decisão que governa o resto: o job não baixa nada

Comentar em PR de fork exige `pull_request_target`, que roda **com segredos e permissão de escrita**. É um vetor de escalada conhecido. Então:

**Zero `uses:`. Zero checkout.** Não é só "sem checkout do head" — sem checkout de espécie alguma não existe `npm install`, não existe script do `package.json`, não existe `.github/actions/*` do fork. **Zero bytes do contribuidor entram no runner que tem os segredos.** Conferido por parse, não por grep: 0 steps com `uses:`.

Mais cinco, cada uma com razão escrita no arquivo:

| | |
|---|---|
| `permissions: pull-requests: write` **no topo** | declarar o bloco zera todo escopo não citado; no topo para que job acrescentado depois nasça restrito |
| **nenhum `${{ }}` dentro de `run:`** | o único dado do PR usado é o login, entra por `env:`, é citado, e ainda passa por `grep -qE` contra o formato real — fora do formato vira saudação sem nome |
| **heredoc com aspas** (`<<'MD'`) | sem elas, as crases da própria prosa viram substituição de comando |
| **guarda de dono** | este arquivo vai para a `main` de um produto self-host; sem ela, o fork de cada pessoa herda um bot que fala pela gente no repositório dela |
| **idempotência que falha fechado** | desiste ao achar qualquer âncora `triagem-de-pr:v1:`; se a *listagem* falhar, **aborta** — vermelho visível vale mais que comentário em dobro |

## Aprovar os runs pendentes automaticamente: recusado, com razão

Dá para fazer, e não deve: aprovar é **executar código do fork nos nossos runners** (o `verify` roda `pnpm install` com scripts de ciclo de vida). O portão do GitHub existe para uma pessoa olhar antes disso, e automatizá-lo o remove justamente para quem ele protege. A acolhida só **avisa** que os runs estão parados — e que `gh pr checks` não os mostra.

## Sabotagem: 6/6, contagem e caso

| sabotagem | previsto | medido |
|---|---|---|
| `checkout` com `ref: head.sha` | 1 | **1** |
| `+ contents: write` | 2 | **2** |
| `${{ …title }}` num `run:` | 1 | **1** |
| `types: [opened, synchronize]` | 1 | **1** |
| tirar a guarda de fork | 2 | **2** |
| postar antes de checar a âncora | 1 | **1** |

E prova **por execução**, não por leitura: o `run:` foi extraído do YAML parseado e executado com um dublê de `gh` — o markdown sai na coluna 0, âncora existente suprime o post, comentário de terceiro não suprime, e um login `$(touch /tmp/PWNED)` sai como saudação sem nome **sem criar arquivo nenhum**.

## O prazo prometido é medido

O texto promete resposta *"em até um dia útil"*, e a doutrina proíbe prometer o que não se cumpre. Medido sobre os PRs de fork dos últimos 60, de `createdAt` até o primeiro comentário humano:

```
n = 13 · mediana 1,0h · p90 7,5h · máximo 10,5h · dentro de 24h: 13/13
```

Folga de mais de 2x no pior caso — e o cabeçalho traz o comando que refaz a conta, porque ela pode virar sem ninguém notar.

## O que só a primeira execução real prova

Workflow não roda em push de branch, então **nada aqui foi executado pelo Actions**. Fica por provar: que `pull-requests: write` sozinho comenta em PR de fork; que o `if:` de fork casa como escrito; e a latência de ponta a ponta. **O primeiro PR de fork depois do merge é o teste** — e se o comentário não sair, o job fica vermelho e visível, não falha em silêncio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DC6uq5V26S13UxfaBaYKQ