### PR TITLE
docs: o espelho também mentia — o AGENTS.md repetia a contagem de specs vencida

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,11 +82,19 @@ mudança toca schema, RLS ou UI, `gov:verify` verde **não** é prova — rode `
 **O que o CI cobre.** `.github/workflows/ci.yml`: `verify` = typecheck + lint + test:unit;
 `invariants` = `pnpm test:db` (isolamento RLS + invariantes de governança contra Postgres
 efêmero pg15). `.github/workflows/perf.yml`: `build-and-size` = `pnpm build`.
-`.github/workflows/e2e.yml` roda **45 das 46 specs** Playwright contra um Supabase local de
-verdade com o `baseline.sql` aplicado — o mesmo banco que o self-hoster tem. **É check
-obrigatório desde 2026-08-08.** A **única** de fora é `vps-fresh-onboarding` (WAHA + Redis +
-Resend + Nuvemshop; é a P0 da doutrina de QA) — ou seja, `e2e` verde não prova a jornada de
-instalação fresca. `followup-journey`, `webhooks` e `capacidades-do-agente` estiveram fora e
+`.github/workflows/e2e.yml` roda as specs Playwright contra um Supabase local de verdade com
+o `baseline.sql` aplicado — o mesmo banco que o self-hoster tem. **É check obrigatório desde
+2026-08-08.** **Não há número aqui de propósito**: esta linha já afirmou uma contagem exata
+de specs e "a única de fora", e as duas envelheceram — a suíte cresce toda semana e a lista de
+exceções muda com ela. Quem fica de fora é o que a própria variável declara; leia, não confie:
+
+```bash
+git show origin/main:.github/workflows/e2e.yml | grep -A4 'FORA_DO_CI:'
+```
+
+O que continua verdade e é o que importa: `vps-fresh-onboarding` está entre elas (WAHA + Redis
++ Resend + Nuvemshop) e é a **P0** da doutrina de QA — ou seja, `e2e` verde não prova a jornada
+de instalação fresca. `followup-journey`, `webhooks` e `capacidades-do-agente` estiveram fora e
 **voltaram**: rodam hoje (`e2e.yml`, listas `SPECS_PARTE_1`/`SPECS_PARTE_2`).
 
 `.github/workflows/publish-image.yml`: `imagens-ok` = as três imagens Docker constroem. **Obrigatório
@@ -172,9 +180,11 @@ Medido em 2026-08-14 @ `741c4ec8`, com o comando ao lado de cada número:
 - Arquivos de invariante de banco em `tests/invariants/` — RLS/isolamento cross-tenant, RBAC,
   governança (G1–G6). Excluídos do `test:unit` de propósito; rodam via `pnpm test:db` **e no job
   `invariants` do CI**. Quantos: `git ls-files 'tests/invariants/*.test.ts' | wc -l`.
-- Specs Playwright em `tests/e2e/`, **todas no CI menos uma** (via `e2e.yml`, **obrigatório**). A
-  única de fora é `vps-fresh-onboarding`, por dependência de serviço externo
-  (WAHA/Redis/Resend/Nuvemshop). Ver issue #63. Quantas: `ls tests/e2e/*.spec.ts | wc -l`.
+- Specs Playwright em `tests/e2e/`, quase todas no CI (via `e2e.yml`, **obrigatório**). As que
+  ficam de fora estão declaradas em `FORA_DO_CI`, **com o motivo escrito ao lado**. Esta linha
+  já afirmou "menos uma" depois de deixarem de ser uma — por isso não conta mais. Ver issue #63.
+  Quantas existem: `ls tests/e2e/*.spec.ts | wc -l`. Quantas ficam fora:
+  `git show origin/main:.github/workflows/e2e.yml | grep -A4 'FORA_DO_CI:'`.
 
 > **Os dois números saíram daqui, e é decisão, não descuido.** Estavam em 102 e 46/45 quando o
 > medido era 114 e 51/50 — envelheceram porque toda entrega que acrescenta um teste os falsifica,


### PR DESCRIPTION
Corrigi essa afirmação no `CLAUDE.md` hoje (PR #578) e **não olhei o espelho**. O próprio `CLAUDE.md` manda olhar: *"ao mudar doutrina aqui, verifique se `AGENTS.md` desatualizou"*. Conserto por instância onde cabia conserto por classe — e o arquivo derivado ficou mentindo sozinho.

Duas afirmações, as duas vencidas:

- **"45 das 46 specs"** — o disco já passou de oitenta;
- **"a única de fora é `vps-fresh-onboarding`"** — `FORA_DO_CI` lista mais de uma.

Trocadas por comando, que é o que o resto da doutrina já faz.

## E uma armadilha em que eu caí no meio do próprio conserto

A primeira versão deste texto citava os números que eu tinha **acabado de medir** — *"quando o disco tinha 78"*, *"quando listava duas"*. Entre a medição e o commit, uma spec nova entrou (a do #591) e os dois viraram outros.

**Corrigir uma afirmação vencida escrevendo outra afirmação com prazo é o mesmo defeito.** O texto final não afirma contagem nenhuma — só diz onde ler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DC6uq5V26S13UxfaBaYKQ