### PR TITLE
fix(crm): importação de leads por planilha nunca funcionava — faltava a etapa

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -295,6 +295,7 @@ jobs:
         navegacao.spec.ts
         juntar-contatos-duplicados.spec.ts
         lote-no-quadro-do-funil.spec.ts
+        importar-leads-planilha.spec.ts
         relatorio-de-atividades.spec.ts
       # ⚠️ A ORDEM DESTA LISTA NÃO DECIDE A ORDEM DE EXECUÇÃO. O Playwright
       # ordena os arquivos por CAMINHO, não pela ordem em que são passados na

--- a/app/api/v1/leads/import/route.ts
+++ b/app/api/v1/leads/import/route.ts
@@ -86,14 +86,18 @@ export async function POST(req: NextRequest): Promise<Response> {
     return fail("validation_failed", "Envie o arquivo no campo 'file'.", 422, { requestId });
   }
   const enviado = arquivo as unknown as File;
-  // ⚠️ O funil e a etapa vêm do FORM, e são conferidos contra a organização
-  // ativa logo abaixo por `createLeadHandler` — que já responde 404 para etapa
-  // de outra org e 422 para etapa que não é do funil informado. É o mesmo gate
-  // do POST unitário; reescrevê-lo aqui seria a segunda verdade.
+  // ⚠️ O funil vem do FORM, e é conferido contra a organização ativa logo
+  // abaixo por `createLeadHandler` — que já responde 404 para etapa de outra
+  // org e 422 para etapa que não é do funil informado. É o mesmo gate do POST
+  // unitário; reescrevê-lo aqui seria a segunda verdade.
   const pipelineId = String(form.get("pipeline_id") ?? "");
-  const stageId = String(form.get("stage_id") ?? "");
-  if (!pipelineId || !stageId) {
-    return fail("validation_failed", "Escolha o funil e a etapa de destino.", 422, { requestId });
+  // `stage_id` é OPCIONAL de propósito: o `ImportarLeads.tsx` nunca manda esse
+  // campo (comentário no próprio componente — planilha traz gente NOVA, e
+  // gente nova entra na primeira etapa do funil). Resolvida logo abaixo,
+  // depois que o Supabase client existir.
+  let stageId = String(form.get("stage_id") ?? "");
+  if (!pipelineId) {
+    return fail("validation_failed", "Escolha o funil de destino.", 422, { requestId });
   }
 
   if (enviado.size > CSV_MAX_BYTES) {
@@ -124,6 +128,29 @@ export async function POST(req: NextRequest): Promise<Response> {
   }
 
   const supabase = await createClient();
+
+  if (!stageId) {
+    // Primeira etapa do funil, por posição, dentro da organização ativa —
+    // nunca confia em `pipeline_id` sozinho (poderia ser de outro tenant).
+    const { data: primeiraEtapa, error: erroEtapa } = await supabase
+      .from("crm_stages")
+      .select("id")
+      .eq("pipeline_id", pipelineId)
+      .eq("organization_id", orgId)
+      .eq("is_archived", false)
+      .order("position", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    if (erroEtapa) {
+      return fail("internal_error", erroEtapa.message, 500, { requestId });
+    }
+    if (!primeiraEtapa) {
+      return fail("validation_failed", "Este funil não tem etapas.", 422, { requestId });
+    }
+    stageId = (primeiraEtapa as { id: string }).id;
+  }
+
   const resumo: ResumoDaImportacao = {
     total_linhas: lido.leads.length + lido.erros.length,
     criados: 0,

--- a/tests/e2e/importar-leads-planilha.spec.ts
+++ b/tests/e2e/importar-leads-planilha.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * IMPORTAR LEADS DE UMA PLANILHA — provado PELA TELA, com o form real.
+ *
+ * Bug medido em QA visual (sessão de tradução ao espanhol, 2026-09-05): a
+ * importação morria SEMPRE com "Elige el embudo y la etapa de destino." —
+ * mesmo com um funil válido escolhido. Causa: `ImportarLeads.tsx` só tem
+ * seletor de FUNIL (o comentário no próprio componente diz que planilha traz
+ * gente NOVA, e gente nova entra na primeira etapa — não deveria haver escolha
+ * de etapa), mas `app/api/v1/leads/import/route.ts` exigia `stage_id` sem
+ * nenhum fallback. A suíte unitária (`tests/unit/leads-import-route.test.ts`)
+ * não pegava isto porque seu helper de request mandava `stage_id` por padrão —
+ * verde medindo um caminho que o usuário real nunca percorre.
+ *
+ * Este spec dirige o FRONTEND de verdade: abre o diálogo, escolhe só o funil
+ * (nenhum seletor de etapa existe na tela, e não deveria), sobe um CSV em
+ * memória, e confirma pela TELA e pelo BANCO que o negócio nasceu na primeira
+ * etapa do funil.
+ *
+ * Pré-requisitos (banco local do baseline, app buildada):
+ *   pnpm e2e:env && pnpm e2e:build
+ *   pnpm exec playwright test tests/e2e/importar-leads-planilha.spec.ts
+ */
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { expect, test, type Page } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+
+import { carregarEnvLocal } from "../../scripts/lib/env-de-teste";
+
+const CREDS_PATH = path.join(process.cwd(), ".e2e-creds.json");
+const EVIDENCIA =
+  process.env.E2E_EVIDENCIA ?? path.join(process.cwd(), ".superpowers/evidence/importar-leads");
+
+interface Creds {
+  password: string;
+  org_id: string;
+  users: Record<string, { email: string }>;
+  kanban?: { pipeline_id: string; stage_id: string };
+}
+
+function loadCreds(): Creds {
+  const needsBase = (): boolean => {
+    if (!fs.existsSync(CREDS_PATH)) return true;
+    const c = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
+    return !c.users?.agent;
+  };
+  if (needsBase()) {
+    execFileSync("npx", ["tsx", "scripts/seed-e2e-credentials.ts"], { stdio: "inherit" });
+  }
+  let c = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
+  if (!c.kanban?.pipeline_id || !c.kanban?.stage_id) {
+    execFileSync("npx", ["tsx", "scripts/seed-e2e-kanban.ts"], { stdio: "inherit" });
+    c = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
+  }
+  return c;
+}
+
+const creds = loadCreds();
+const env = carregarEnvLocal();
+const admin = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+// Sufixo único por execução — o banco de e2e é compartilhado entre frentes.
+const SUFIXO = `${Date.now()}`.slice(-7);
+const NOME_DO_NEGOCIO = `Importado E2E ${SUFIXO}`;
+
+async function captura(page: Page, nome: string): Promise<void> {
+  fs.mkdirSync(EVIDENCIA, { recursive: true });
+  await page.screenshot({ path: path.join(EVIDENCIA, `${nome}.png`), fullPage: true });
+}
+
+async function login(page: Page, email: string): Promise<void> {
+  await page.goto("/login");
+  await page.locator("#email").fill(email);
+  await page.locator("#password").fill(creds.password);
+  await page.getByRole("button", { name: /entrar/i }).click();
+  await page.waitForURL(/\/app\//);
+}
+
+test("importa uma planilha sem escolher etapa (não há esse seletor) e o negócio nasce na primeira etapa do funil", async ({
+  page,
+}) => {
+  await login(page, creds.users.agent!.email);
+  await page.goto("/app/kanban");
+
+  await page.getByTestId("abrir-importar-leads").click();
+
+  const dialogo = page.getByRole("dialog", { name: "Importar leads de uma planilha" });
+  await expect(dialogo).toBeVisible();
+
+  // ⚠️ NÃO há campo de etapa nesta tela — só o de funil. O form real do
+  // produto nunca manda `stage_id`; é exatamente o que este spec reproduz.
+  await expect(dialogo.getByLabel("Funil de destino")).toBeVisible();
+  await expect(dialogo.getByText(/há escolha de etapa|escolha de etapa/i)).toHaveCount(0);
+
+  const csv = `nome\n${NOME_DO_NEGOCIO}\n`;
+  await dialogo.getByTestId("arquivo-de-leads").setInputFiles({
+    name: "leads.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from(csv, "utf8"),
+  });
+
+  // A confirmação NA TELA: nem toast (some em 4s) nem exceção não tratada.
+  await expect(dialogo.getByRole("alert")).toHaveCount(0);
+  const resumo = dialogo.getByTestId("resumo-da-importacao");
+  await expect(resumo).toBeVisible({ timeout: 15_000 });
+  await expect(resumo).toContainText("1");
+  await expect(resumo).toContainText("leads criados");
+  await captura(page, "resumo-da-importacao");
+
+  // A confirmação no BANCO, relida — não o que o toast prometeu.
+  const { data: negocio, error } = await admin
+    .from("crm_leads")
+    .select("id, pipeline_id, stage_id")
+    .eq("organization_id", creds.org_id)
+    .eq("title", NOME_DO_NEGOCIO)
+    .single();
+  expect(error).toBeNull();
+  expect(negocio?.pipeline_id).toBe(creds.kanban!.pipeline_id);
+  expect(negocio?.stage_id).toBe(creds.kanban!.stage_id);
+
+  // E o card aparece no board, na coluna certa — reload, não confiar no DOM
+  // que a própria ação acabou de escrever.
+  await page.goto(`/app/pipelines/${creds.kanban!.pipeline_id}`);
+  await expect(page.getByText(NOME_DO_NEGOCIO)).toBeVisible({ timeout: 15_000 });
+});

--- a/tests/unit/leads-import-route.test.ts
+++ b/tests/unit/leads-import-route.test.ts
@@ -11,6 +11,13 @@
  *  - O mesmo telefone repetido vira UM contato. O original criava um contato por
  *    linha, e o produto passava a ter a duplicata que ele mesmo fabricou.
  *  - `viewer` não importa.
+ *  - `stage_id` é OPCIONAL: o `ImportarLeads.tsx` real NUNCA manda esse campo
+ *    (só tem seletor de FUNIL). Toda suíte anterior mandava `stage_id` no
+ *    `pedido()` por padrão — verde medindo um caminho que o usuário nunca
+ *    percorre, enquanto a importação de verdade morria com 422 "Escolha o
+ *    funil e a etapa de destino" antes de ler uma linha sequer. O teste
+ *    abaixo reproduz o form real (sem `stage_id`) e prova a resolução
+ *    automática da PRIMEIRA etapa do funil.
  */
 import { NextRequest } from "next/server";
 import { describe, expect, it, vi, beforeEach } from "vitest";
@@ -62,6 +69,31 @@ function fazerSupabase(existente: { id: string } | null) {
     };
     elo.single = () => Promise.resolve({ data: { id: `novo-${inseridos.length}` }, error: null });
     elo.maybeSingle = () => Promise.resolve({ data: existente, error: null });
+    return elo;
+  };
+  vi.mocked(createClient).mockResolvedValue({ from } as never);
+  return { inseridos };
+}
+
+/**
+ * Mesmo dublê acima, mas distingue `crm_stages` de `contacts` — necessário
+ * para os testes que NÃO mandam `stage_id` e dependem da rota resolver a
+ * primeira etapa do funil consultando essa tabela.
+ */
+function fazerSupabaseComEtapa(primeiraEtapa: { id: string } | null) {
+  const inseridos: Record<string, unknown>[] = [];
+  const from = (tabela: string) => {
+    const elo: Record<string, unknown> = {};
+    for (const m of ["select", "eq", "in", "limit", "order"]) elo[m] = () => elo;
+    elo.insert = (linha: Record<string, unknown>) => {
+      if (tabela === "contacts") inseridos.push(linha);
+      return elo;
+    };
+    elo.single = () => Promise.resolve({ data: { id: `novo-${inseridos.length}` }, error: null });
+    elo.maybeSingle = () =>
+      tabela === "crm_stages"
+        ? Promise.resolve({ data: primeiraEtapa, error: null })
+        : Promise.resolve({ data: null, error: null });
     return elo;
   };
   vi.mocked(createClient).mockResolvedValue({ from } as never);
@@ -199,6 +231,30 @@ describe("POST /api/v1/leads/import", () => {
     fazerSupabase(null);
     const { POST } = await import("@/app/api/v1/leads/import/route");
     const res = await POST(pedido("valor,origem\n100,site"));
+    expect(res.status).toBe(422);
+    expect(vi.mocked(createLeadHandler)).not.toHaveBeenCalled();
+  });
+
+  it("sem stage_id no form (o caminho REAL do ImportarLeads.tsx) entra na primeira etapa do funil", async () => {
+    fazerSupabaseComEtapa({ id: ETAPA });
+    const { POST } = await import("@/app/api/v1/leads/import/route");
+
+    const res = await POST(pedido("nome\nAna", { stage_id: null }));
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(createLeadHandler)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(createLeadHandler).mock.calls[0]![2]).toMatchObject({
+      pipeline_id: FUNIL,
+      stage_id: ETAPA,
+    });
+  });
+
+  it("sem stage_id e sem etapa nenhuma no funil, 422 — nunca cai numa etapa de outro funil", async () => {
+    fazerSupabaseComEtapa(null);
+    const { POST } = await import("@/app/api/v1/leads/import/route");
+
+    const res = await POST(pedido("nome\nAna", { stage_id: null }));
+
     expect(res.status).toBe(422);
     expect(vi.mocked(createLeadHandler)).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## O bug

`ImportarLeads.tsx` (extraído do PR #418, @clinicacentrodosorrisosc-code) só tem
seletor de **funil** — de propósito, pelo comentário no próprio componente:
planilha traz gente NOVA, e gente nova entra na primeira etapa do funil, sem
pergunta a mais. Mas `app/api/v1/leads/import/route.ts` exigia `stage_id` no
form **sem nenhum fallback**:

```ts
const stageId = String(form.get("stage_id") ?? "");
if (!pipelineId || !stageId) {
  return fail("validation_failed", "Escolha o funil e a etapa de destino.", 422, { requestId });
}
```

Como o frontend nunca manda esse campo, **toda importação de leads morria com
422**, mesmo com um funil válido escolhido. A feature estava 100% quebrada
desde que entrou — achado em QA visual (Playwright + Supabase local) durante a
tradução da tela ao espanhol.

A suíte unitária existente não pegava isto: o helper de request do teste
(`pedido()`) mandava `stage_id` por padrão em toda chamada — verde medindo um
caminho que o usuário real nunca percorre.

## O conserto

Quando `stage_id` não vem no form, a rota resolve a **primeira etapa** (menor
`position`, não arquivada) do `pipeline_id` informado — filtrando pela
organização ativa (nunca só pelo pipeline, pra não cruzar tenant). Se o funil
não tiver etapa nenhuma, 422 explícito em vez de deixar `createLeadHandler`
estourar mais abaixo. `stage_id` explícito continua funcionando se algum outro
caller mandar (o gate de `createLeadHandler` valida do mesmo jeito de sempre).

## Testes

- `tests/unit/leads-import-route.test.ts` — novo caso reproduzindo o form real
  (sem `stage_id`), mais o caso de funil sem etapa nenhuma.
- `tests/e2e/importar-leads-planilha.spec.ts` (novo) — Playwright dirigindo o
  frontend de verdade: login, upload de CSV em memória sem tocar em etapa
  nenhuma (não há esse campo na tela), confirma pela TELA e pelo BANCO que o
  negócio nasce na primeira etapa do funil.

**Sabotagem confirmada nas duas suítes**: revertendo só a rota, o teste unit e
o e2e voltam a vermelho reproduzindo o 422 relatado — inclusive com screenshot
do diálogo real batendo a mensagem de erro.

## QA Visual (doutrina do repo)

Rodei contra Supabase local real + `next build && next start` (produção, não
`next dev`), login real, upload real:

- **Sem o fix**: reproduzi o 422 "Escolha o funil e a etapa de destino." com
  um funil válido ("Pedidos") já selecionado.
- **Com o fix**: "1 leads criados · 0 contatos novos · 1 linhas na planilha",
  e confirmei no banco que o lead nasceu na etapa de menor `position` do
  funil.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm lint:channels`
- [x] `pnpm test:unit` (679 arquivos, 7394 testes, verde)
- [x] `pnpm test:shell`
- [x] `pnpm build`
- [x] `pnpm exec playwright test tests/e2e/importar-leads-planilha.spec.ts` (verde com o fix, vermelho sem — sabotagem confirmada)

🤖 Generated with [Claude Code](https://claude.com/claude-code)