### PR TITLE
chore: publish Laura images from founders-br

### DIFF
--- a/.changes/laura-ghcr-namespace.md
+++ b/.changes/laura-ghcr-namespace.md
@@ -1,0 +1,10 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Instalação e atualização usam as imagens do fork Laura
+---
+
+Os padrões de imagem e as consultas ao registro passam a usar o namespace do fork.
+O instalador e a descoberta de versões usam founders-br/crm-laura, e as três
+imagens identificam esse repositório nos labels de origem. A publicação continua
+no CI; nenhuma imagem ou tag é publicada por esta alteração local.

--- a/.env.hostgator.example
+++ b/.env.hostgator.example
@@ -29,16 +29,16 @@
 # última release). O install.sh sobrescreve com o NÚMERO da versão, que é o que
 # uma instalação de verdade usa — ver a regra de ouro na doutrina.
 # troque pelo seu fork se publicar o seu
-APP_IMAGE=ghcr.io/melgarafael/deskcommcrm:stable
+APP_IMAGE=ghcr.io/founders-br/deskcommcrm:stable
 APP_PULL_POLICY=always
 
 # O worker (agente de IA 24/7) e o scheduler (crons) acompanham a versão do app.
 # Até 2026-08-13 eles não tinham imagem: eram compilados na sua VPS no install e
 # nenhum update.sh jamais os reconstruía — o agente ficava congelado no código
 # do dia da instalação. Deixe-os na mesma versão do APP_IMAGE acima.
-WORKER_IMAGE=ghcr.io/melgarafael/deskcomm-worker:stable
+WORKER_IMAGE=ghcr.io/founders-br/deskcomm-worker:stable
 WORKER_PULL_POLICY=always
-SCHEDULER_IMAGE=ghcr.io/melgarafael/deskcomm-scheduler:stable
+SCHEDULER_IMAGE=ghcr.io/founders-br/deskcomm-scheduler:stable
 SCHEDULER_PULL_POLICY=always
 
 # -----------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ WORKDIR /app
 # OCI via docker/metadata-action; estes aqui são defesa em profundidade — valem
 # para qualquer build, inclusive o local de docker-compose.build.yml, que não
 # passa pelo metadata-action e sem isto sairia sem origem nenhuma.
-LABEL org.opencontainers.image.source="https://github.com/melgarafael/DeskcommCRM" \
+LABEL org.opencontainers.image.source="https://github.com/founders-br/crm-laura" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.title="DeskcommCRM"
 

--- a/Dockerfile.scheduler
+++ b/Dockerfile.scheduler
@@ -7,7 +7,7 @@
 # deveria ser offline. Doutrina: docs/doctrine/packaging.md, invariante 1.
 FROM alpine:3.20
 
-LABEL org.opencontainers.image.source="https://github.com/melgarafael/DeskcommCRM" \
+LABEL org.opencontainers.image.source="https://github.com/founders-br/crm-laura" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.title="DeskcommCRM scheduler"
 

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -6,7 +6,7 @@ FROM node:22-alpine
 WORKDIR /app
 
 # Procedência (doutrina de packaging, invariante 2).
-LABEL org.opencontainers.image.source="https://github.com/melgarafael/DeskcommCRM" \
+LABEL org.opencontainers.image.source="https://github.com/founders-br/crm-laura" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.title="DeskcommCRM worker"
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,7 +32,7 @@ services:
     # default é quem NÃO tem APP_IMAGE no .env — avaliação, ou um .env que
     # perdeu a chave. Nenhum desses casos quer código não lançado; quem quiser o
     # topo da main pede `APP_IMAGE=…:latest` explicitamente.
-    image: ${APP_IMAGE:-ghcr.io/melgarafael/deskcommcrm:stable}
+    image: ${APP_IMAGE:-ghcr.io/founders-br/deskcommcrm:stable}
     pull_policy: ${APP_PULL_POLICY:-always}
     restart: unless-stopped
     env_file: .env
@@ -89,7 +89,7 @@ services:
     # default): o app pinado numa release e o runtime do agente de
     # IA rodando código não lançado, sobre o banco da release. `:stable` é a
     # última release publicada — pareia com o app em vez de correr na frente.
-    image: ${WORKER_IMAGE:-ghcr.io/melgarafael/deskcomm-worker:stable}
+    image: ${WORKER_IMAGE:-ghcr.io/founders-br/deskcomm-worker:stable}
     pull_policy: ${WORKER_PULL_POLICY:-always}
     build:
       context: .
@@ -209,7 +209,7 @@ services:
     # serviço `restart: unless-stopped`, isso significa que o cron do cliente só
     # voltava se a VPS tivesse internet e o mirror do Alpine estivesse de pé,
     # justamente no momento em que a máquina está se recuperando de algo.
-    image: ${SCHEDULER_IMAGE:-ghcr.io/melgarafael/deskcomm-scheduler:stable}
+    image: ${SCHEDULER_IMAGE:-ghcr.io/founders-br/deskcomm-scheduler:stable}
     pull_policy: ${SCHEDULER_PULL_POLICY:-always}
     build:
       context: .

--- a/docs/adr/0001-packaging-e-distribuicao.md
+++ b/docs/adr/0001-packaging-e-distribuicao.md
@@ -1,5 +1,10 @@
 # ADR-0001 — Packaging e distribuição do DeskcommCRM
 
+> **Nota deste fork:** as referências a `ghcr.io/melgarafael` neste documento
+> registram o upstream e não são instruções de instalação do Laura. Para este
+> fork, use `ghcr.io/founders-br` nas três imagens; os defaults vigentes estão
+> em `hostgator-setup-kit/_common.sh` e `docker-compose.prod.yml`.
+
 - **Status:** aceito
 - **Data:** 2026-08-13
 - **Contexto medido em:** `f9abedd0` (`main`)

--- a/docs/doctrine/packaging.md
+++ b/docs/doctrine/packaging.md
@@ -1,5 +1,11 @@
 # Doutrina de Packaging e Distribuição
 
+> **Fork founders-br/crm-laura:** o namespace canônico é `ghcr.io/founders-br`.
+> `IMG_NS` em `_common.sh` governa as imagens e as consultas de token/manifesto.
+> O instalador, `comecar.sh` e a descoberta de versões usam o repositório do fork.
+> As referências a `melgarafael` abaixo registram o histórico do upstream; não são
+> o destino de publicação ou instalação deste fork. O CI deriva o owner do repositório.
+
 > Lei de arquitetura para tudo que roda no disco de quem instalou o DeskcommCRM: imagens,
 > composes, tags e o kit de instalação. Complementa [`sistema-vivo.md`](./sistema-vivo.md) —
 > não é aspiração, é critério de aceite. Amarrada ao item 15 do Definition of Done

--- a/docs/runbooks/ativar-packaging.md
+++ b/docs/runbooks/ativar-packaging.md
@@ -1,5 +1,10 @@
 # Runbook — ativar a doutrina de packaging (uma vez só)
 
+> **Nota deste fork:** as referências a `ghcr.io/melgarafael` neste documento
+> registram o upstream e não são instruções de instalação do Laura. Para este
+> fork, use `ghcr.io/founders-br` nas três imagens; os defaults vigentes estão
+> em `hostgator-setup-kit/_common.sh` e `docker-compose.prod.yml`.
+
 > **CONCLUÍDO em 2026-08-14. Este runbook é histórico** — guardado porque descreve o
 > procedimento e as armadilhas de cada passo, não porque haja algo a fazer.
 >

--- a/docs/runbooks/remediar-worker-congelado.md
+++ b/docs/runbooks/remediar-worker-congelado.md
@@ -1,5 +1,10 @@
 # Runbook — o worker congelado: diagnóstico e remediação
 
+> **Nota deste fork:** as referências a `ghcr.io/melgarafael` neste documento
+> registram o upstream e não são instruções de instalação do Laura. Para este
+> fork, use `ghcr.io/founders-br` nas três imagens; os defaults vigentes estão
+> em `hostgator-setup-kit/_common.sh` e `docker-compose.prod.yml`.
+
 > ## Estado do ensaio: **U6-b EXECUTADO em 2026-08-13, com uma ressalva que muda o procedimento**
 >
 > O ensaio rodou numa VPS real, com estado legado **reproduzido** (não simulado): clone

--- a/docs/testing/user-journey-map.md
+++ b/docs/testing/user-journey-map.md
@@ -1,5 +1,10 @@
 # Mapa de Jornadas & Testes E2E — Experiência do usuário em VPS fresca
 
+> **Nota deste fork:** as referências a `ghcr.io/melgarafael` neste documento
+> registram o upstream e não são instruções de instalação do Laura. Para este
+> fork, use `ghcr.io/founders-br` nas três imagens; os defaults vigentes estão
+> em `hostgator-setup-kit/_common.sh` e `docker-compose.prod.yml`.
+
 > Fonte da verdade do QA de produto do DeskcommCRM open-source. Cada caso aqui é
 > exercitado **pelo frontend real** (Playwright), com contas de teste reais e
 > recursos reais (banco fresco do `baseline.sql`, WAHA local, receiver de webhook

--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -433,7 +433,7 @@ psql_run() { docker run --rm -i postgres:17-alpine psql "$(url_do_schema)" -v ON
 # `docker-compose.prod.yml`, `.env.hostgator.example` e a matriz de
 # `publish-image.yml` digam o mesmo. Se você é um fork, é lá que está a lista do
 # que trocar junto.
-IMG_NS="ghcr.io/melgarafael"
+IMG_NS="ghcr.io/founders-br"
 IMG_APP="${IMG_NS}/deskcommcrm"
 IMG_WORKER="${IMG_NS}/deskcomm-worker"
 IMG_SCHEDULER="${IMG_NS}/deskcomm-scheduler"
@@ -450,7 +450,7 @@ IMG_SCHEDULER="${IMG_NS}/deskcomm-scheduler"
 # alguém porque não deu para resolver um número de versão seria trocar um
 # problema de previsibilidade por um de disponibilidade.
 ultima_versao_publicada() {
-  local url="${1:-https://github.com/melgarafael/DeskcommCRM.git}" ref
+  local url="${1:-https://github.com/founders-br/crm-laura.git}" ref
   command -v git >/dev/null 2>&1 || return 0
   # `grep -v -- -` descarta PRERELEASE (v1.11.0-rc1, v1.1.1-jmpo.1 — esta última
   # existe de verdade neste repo). O `--sort=-v:refname` do git põe o prerelease
@@ -470,15 +470,17 @@ ultima_versao_publicada() {
 # mão, o `docker compose pull` de toda VPS é negado — e como `pull` de serviço
 # com `image:` falha a operação inteira, a instalação morre no passo de subir.
 ghcr_status() {
-  local img="$1" tag="$2" tok
+  local img="$1" tag="$2" tok registry owner
+  registry="${IMG_NS%%/*}"
+  owner="${IMG_NS#*/}"
   tok="$(curl -fsS --max-time 6 \
-          "https://ghcr.io/token?scope=repository:melgarafael/${img}:pull&service=ghcr.io" 2>/dev/null \
+          "https://${registry}/token?scope=repository:${owner}/${img}:pull&service=${registry}" 2>/dev/null \
         | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')" || true
   if [ -z "$tok" ]; then printf '000'; return 0; fi
   curl -s -o /dev/null --max-time 6 -w '%{http_code}' \
     -H "Authorization: Bearer $tok" \
     -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json' \
-    "https://ghcr.io/v2/melgarafael/${img}/manifests/${tag}" 2>/dev/null || printf '000'
+    "https://${registry}/v2/${owner}/${img}/manifests/${tag}" 2>/dev/null || printf '000'
 }
 
 # As TRÊS imagens existem e são públicas nesta referência?

--- a/hostgator-setup-kit/comecar.sh
+++ b/hostgator-setup-kit/comecar.sh
@@ -9,11 +9,11 @@
 #
 # Uso:
 #   bash comecar.sh
-#   curl -fsSL https://raw.githubusercontent.com/melgarafael/DeskcommCRM/main/hostgator-setup-kit/comecar.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/founders-br/crm-laura/main/hostgator-setup-kit/comecar.sh | bash
 #
 set -euo pipefail
 
-REPO_URL="${REPO_URL:-https://github.com/melgarafael/DeskcommCRM.git}"
+REPO_URL="${REPO_URL:-https://github.com/founders-br/crm-laura.git}"
 # Link de parceria com a HostGator. Mesma URL e mesmo rótulo do README: uma
 # promessa só, num lugar só — duas redações da mesma oferta viram duas ofertas.
 VPS_URL="https://www.hostgator.com.br/52708-141-3-52.html"

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # de qualquer 'cd' (step 2 pode entrar num repo clonado à parte).
 KIT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 
-REPO_URL="${REPO_URL:-https://github.com/melgarafael/DeskcommCRM.git}"
+REPO_URL="${REPO_URL:-https://github.com/founders-br/crm-laura.git}"
 # Uma constante, dois usos (o fim feliz e o fim travado) — e o comecar.sh tem a
 # gêmea. Link repetido à mão vira link divergente na primeira troca.
 COMUNIDADE_URL="https://lp-comunidade.automatiklabs.com.br"

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -1723,7 +1723,6 @@ STUB
   fi
   printf '  ✓ com v1.0.0/v1.9.0/v1.10.0 no remoto, o .env nasce pinado em 1.10.0 (as três imagens)\n'
 ) || fail=1
-rm -rf "$TMP_PIN"
 
 echo "packaging: a tag do git não basta — as imagens têm de existir"
 # A tag nasce minutos antes das imagens, e as do worker/scheduler só passaram a
@@ -1745,6 +1744,9 @@ esac
 exit 0
 STUB
   export DUBLE_GHCR=403          # pacote existe mas está PRIVADO
+  # Este cenário exige uma tag existente. Reutiliza a origem local acima,
+  # sem depender das tags do GitHub (um fork novo ainda pode não ter nenhuma).
+  export REPO_URL="$TMP_PIN/origem.git"
   saida="$(rodar install.sh --yes)"
   unset DUBLE_GHCR
 
@@ -1761,7 +1763,7 @@ STUB
   fi
   printf '  ✓ e mesmo assim conclui a instalação (constrói é lento, não é impedimento)\n'
 ) || fail=1
-rm -rf "$TMP_PRIV"
+rm -rf "$TMP_PRIV" "$TMP_PIN"
 
 echo "integração: os TRÊS provedores de IA que o instalador oferece"
 # A pergunta "qual IA vai atender" tem três respostas, e até aqui só uma delas

--- a/tests/unit/namespace-das-imagens.test.ts
+++ b/tests/unit/namespace-das-imagens.test.ts
@@ -53,7 +53,7 @@ const PUBLICA = fs.readFileSync(path.join(RAIZ, ".github/workflows/publish-image
 const ENV_EXEMPLO = fs.readFileSync(path.join(RAIZ, ".env.hostgator.example"), "utf8");
 
 /** O valor literal que este repositório publica. A âncora. */
-const NAMESPACE_DESTE_REPO = "ghcr.io/melgarafael";
+const NAMESPACE_DESTE_REPO = "ghcr.io/founders-br";
 
 /**
  * Um fork que publica as próprias imagens muda `IMG_NS` — e precisa mudar junto
@@ -143,6 +143,62 @@ describe("o default do compose diz o mesmo que o kit", () => {
 });
 
 describe("o kit aponta para o que o CI realmente publica", () => {
+  it("os defaults de código e os labels de origem apontam para este fork", () => {
+    const repo = "https://github.com/founders-br/crm-laura";
+    for (const script of ["install.sh", "comecar.sh"]) {
+      const texto = fs.readFileSync(path.join(RAIZ, "hostgator-setup-kit", script), "utf8");
+      expect(texto).toContain(`REPO_URL="\${REPO_URL:-${repo}.git}"`);
+    }
+    expect(COMUM).toContain(`local url="\${1:-${repo}.git}" ref`);
+    for (const dockerfile of ["Dockerfile", "Dockerfile.worker", "Dockerfile.scheduler"]) {
+      expect(fs.readFileSync(path.join(RAIZ, dockerfile), "utf8")).toContain(
+        `org.opencontainers.image.source="${repo}"`,
+      );
+    }
+  });
+
+  it.each([undefined, "registry.example/outro-dono"])(
+    "ghcr_status consulta token e manifesto no IMG_NS (%s)",
+    (namespace) => {
+      const ns = namespace ?? imgNs();
+      const [registry, owner] = ns.split("/");
+      const saida = execFileSync(
+        "bash",
+        [
+          "-c",
+          `
+        source hostgator-setup-kit/_common.sh
+        if [ -n "$1" ]; then IMG_NS="$1"; fi
+        curl() {
+          local arg
+          for arg in "$@"; do
+            case "$arg" in
+              https://*/token[?]*) printf '%s\\n' "$arg" >> "$log"; printf '{"token":"teste"}'; return;;
+              https://*/v2/*) printf '%s\\n' "$arg" >> "$log"; printf '200'; return;;
+            esac
+          done
+          return 1
+        }
+        log=$(mktemp)
+        trap 'rm -f "$log"' EXIT
+        # O dublê registra em arquivo porque a função captura stdout do curl.
+        ghcr_status deskcommcrm 1.2.3
+        printf '\\n'
+        cat "$log"
+      `,
+          "teste",
+          namespace ?? "",
+        ],
+        { cwd: RAIZ, encoding: "utf8" },
+      );
+      expect(saida.trim().split("\n")).toEqual([
+        "200",
+        `https://${registry}/token?scope=repository:${owner}/deskcommcrm:pull&service=${registry}`,
+        `https://${registry}/v2/${owner}/deskcommcrm/manifests/1.2.3`,
+      ]);
+    },
+  );
+
   it("o registry do kit é o mesmo do workflow de publicação", () => {
     const m = PUBLICA.match(/^\s*REGISTRY:\s*(\S+)$/m);
     expect(m, "não achei `REGISTRY:` em .github/workflows/publish-image.yml").not.toBeNull();


### PR DESCRIPTION
## O que muda

Prepara o fork founders-br/crm-laura para publicar e usar suas próprias imagens Docker no GHCR.

- altera o namespace de imagens para ghcr.io/founders-br
- atualiza app, worker e scheduler
- faz o instalador clonar founders-br/crm-laura
- faz a validação do GHCR derivar owner/registry de IMG_NS
- atualiza os defaults do compose e do template de produção
- ajusta testes e documentação de packaging

## Validação local

- namespace: 16 testes passaram
- typecheck: passou
- lint: 0 erros
- shell: passou
- packaging: 12 testes passaram
- git diff --check: passou

O único teste unitário marcado como falha esperada já era preexistente e usa it.fails:
agenda-separar-historico.test.tsx

## Objetivo

Permitir que a produção Laura use exclusivamente:

- ghcr.io/founders-br/deskcommcrm
- ghcr.io/founders-br/deskcomm-worker
- ghcr.io/founders-br/deskcomm-scheduler