### PR TITLE
fix(flywheel): o juiz e o distiller usam o modelo da instalação (@maugarciasa, do #595)

### DIFF
--- a/.changes/2026-09-05-flywheel-modelo-do-painel.md
+++ b/.changes/2026-09-05-flywheel-modelo-do-painel.md
@@ -1,0 +1,13 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A avaliação automática do atendimento volta a rodar em quem não usa Anthropic
+---
+
+A rodada que revisa os atendimentos e sugere melhorias pedia um modelo pelo nome
+fixo `claude-haiku-4-5`. Esse nome só existe no vocabulário da Anthropic, então
+em instalação apontada para outro provedor (OpenRouter, por exemplo) o provedor
+recusava a chamada e a rodada morria a cada disparo, sem sugestão nenhuma
+chegando à tela de Propostas. Agora os dois pontos do flywheel usam o modelo
+escolhido no painel de provedores e, na falta dele, o padrão da organização — o
+mesmo caminho de todos os outros pontos de IA.

--- a/lib/agent-engine/flywheel/live.ts
+++ b/lib/agent-engine/flywheel/live.ts
@@ -10,11 +10,16 @@ import { runModelCall, type LlmEdgeConfig } from '../edge/llm/run-model-call';
 import type { Logger } from '../obs/logger';
 import { aggregateFollowupOutcomes, type FlowOutcomeStat } from '../../followup/outcome-stats';
 
-const JUDGE_MODEL = 'claude-haiku-4-5';
-// O distiller PRECISA de modelo próprio: o flywheel roda org-wide sem turno/agent
-// para herdar, então sem isto ele cai no settings.llm.default_model — não setado
-// em self-host configurado pela tela — e a rodada falha "modelo LLM não definido".
-const DISTILLER_MODEL = 'claude-haiku-4-5';
+// Os dois pontos do flywheel NÃO fixam modelo aqui. Fixavam `claude-haiku-4-5`,
+// e um id de modelo só é válido no vocabulário do provedor que a instalação usa:
+// numa VPS com a org apontada para OpenRouter, esse id literal voltava 400
+// `claude-haiku-4-5 is not a valid model ID` e a rodada agendada morria a cada
+// disparo (medido em produção em 2026-09-05). Sem `model`, cada ponto resolve
+// pela cadeia normal — escolha do painel de provedores, senão o padrão da
+// organização —, que é a mesma que faz todos os outros pontos funcionarem na
+// instalação. Onde não houver nenhum dos dois, o erro passa a ser o acionável
+// "modelo LLM não definido — configure o ponto no painel de provedores", em vez
+// de um 400 do provedor.
 const DIMENSION = 'memory_hygiene';
 const DATASET = 'live';
 
@@ -152,7 +157,6 @@ export async function runFlywheelOnce(
         leadId: turn.contact_id,
         jobId: turn.job_id,
         purpose: 'flywheel_judge',
-        model: JUDGE_MODEL,
         messages: [{ role: 'user', content: judgePrompt(material, optionOrder) }],
       },
       { log },
@@ -163,7 +167,7 @@ export async function runFlywheelOnce(
     const { rowCount } = await pool.query(
       `insert into flywheel_judge_verdicts
          (organization_id, dataset, trace_id, dimension, verdict, option_order, judge_family, model, provenance, run_id)
-       values ($1,$2,$3,$4,$5,$6,'anthropic',$7,$8,$9)
+       values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
        on conflict (dataset, trace_id, dimension) do nothing`,
       [
         turn.organization_id,
@@ -172,7 +176,8 @@ export async function runFlywheelOnce(
         DIMENSION,
         verdictValue,
         optionOrder,
-        JUDGE_MODEL,
+        judgedCall.provider,
+        judgedCall.model,
         JSON.stringify({ source: 'live_turn', job_id: turn.job_id, contact_id: turn.contact_id }),
         runId,
       ],
@@ -190,7 +195,6 @@ export async function runFlywheelOnce(
           leadId: turn.contact_id,
           jobId: turn.job_id,
           purpose: 'flywheel_distiller',
-          model: DISTILLER_MODEL,
           messages: [{ role: 'user', content: distillerPrompt(verdict.missing_facts ?? []) }],
         },
         { log },

--- a/tests/unit/flywheel-nao-fixa-modelo.test.ts
+++ b/tests/unit/flywheel-nao-fixa-modelo.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Os dois pontos do flywheel (`flywheel_judge` e `flywheel_distiller`) não podem
+ * fixar id de modelo no código.
+ *
+ * Fixavam `claude-haiku-4-5`, e id de modelo só vale no vocabulário do provedor
+ * que a instalação usa: numa VPS com a org apontada para OpenRouter o provedor
+ * devolvia 400 `claude-haiku-4-5 is not a valid model ID` e a rodada agendada
+ * morria a cada disparo — medido em produção em 2026-09-05. Sem `model`, o ponto
+ * resolve pela cadeia normal (painel de provedores, senão o padrão da org), que é
+ * a que faz todos os outros pontos funcionarem naquela mesma instalação.
+ */
+describe("flywheel vivo", () => {
+  const fonte = readFileSync(
+    resolve(process.cwd(), "lib/agent-engine/flywheel/live.ts"),
+    "utf-8",
+  );
+
+  it("não passa modelo fixo para runModelCall", () => {
+    const dentroDeChamada = fonte.match(/^\s*model:\s*.+$/gm) ?? [];
+    expect(dentroDeChamada).toEqual([]);
+  });
+
+  it("grava no veredito o provedor e o modelo que a chamada realmente usou", () => {
+    expect(fonte).toContain("judgedCall.provider");
+    expect(fonte).toContain("judgedCall.model");
+  });
+});

--- a/tests/unit/flywheel-nao-fixa-modelo.test.ts
+++ b/tests/unit/flywheel-nao-fixa-modelo.test.ts
@@ -1,32 +1,107 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
-
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 /**
  * Os dois pontos do flywheel (`flywheel_judge` e `flywheel_distiller`) não podem
- * fixar id de modelo no código.
+ * fixar id de modelo, e o veredito grava o provedor/modelo que a chamada
+ * REALMENTE usou.
  *
  * Fixavam `claude-haiku-4-5`, e id de modelo só vale no vocabulário do provedor
  * que a instalação usa: numa VPS com a org apontada para OpenRouter o provedor
  * devolvia 400 `claude-haiku-4-5 is not a valid model ID` e a rodada agendada
- * morria a cada disparo — medido em produção em 2026-09-05. Sem `model`, o ponto
- * resolve pela cadeia normal (painel de provedores, senão o padrão da org), que é
- * a que faz todos os outros pontos funcionarem naquela mesma instalação.
+ * morria a cada disparo — medido em produção em 2026-09-05 por @maugarciasa
+ * (PR #595). Sem `model`, o ponto resolve pela cadeia normal: painel de
+ * provedores, senão `organizations.settings.llm.default_model` — que a migration
+ * 0096 garante existir em toda organização, por backfill e por trigger.
+ *
+ * ## Por que este teste exercita a função em vez de ler o fonte
+ *
+ * A primeira versão desta guarda lia `live.ts` com `readFileSync` e afirmava que
+ * não havia linha `model:`. Presença de símbolo não é comportamento: aquela
+ * versão fica verde se alguém passar o modelo por outro nome, por uma variável,
+ * ou por um wrapper — e fica VERMELHA por um `model:` inofensivo em qualquer
+ * outro ponto do arquivo. Aqui a chamada é observada de verdade.
  */
-describe("flywheel vivo", () => {
-  const fonte = readFileSync(
-    resolve(process.cwd(), "lib/agent-engine/flywheel/live.ts"),
-    "utf-8",
-  );
 
-  it("não passa modelo fixo para runModelCall", () => {
-    const dentroDeChamada = fonte.match(/^\s*model:\s*.+$/gm) ?? [];
-    expect(dentroDeChamada).toEqual([]);
+const chamadas: Array<Record<string, unknown>> = [];
+
+vi.mock("../../lib/agent-engine/edge/llm/run-model-call", () => ({
+  runModelCall: vi.fn(async (_pool: unknown, _cfg: unknown, input: Record<string, unknown>) => {
+    chamadas.push(input);
+    const ehJuiz = input.purpose === "flywheel_judge";
+    return {
+      // O que o provedor de VERDADE devolveu — nem sempre é o que se pediu, e é
+      // justamente por isso que o veredito tem de gravar ESTES, não uma constante.
+      provider: "openrouter",
+      model: "anthropic/claude-haiku-4.5",
+      result: {
+        text: ehJuiz
+          ? '{"verdict":"no","missing_facts":["o lead tem CNPJ"]}'
+          : '{"content":"Nunca apague fato de outro assunto ao consolidar.","scope":"agent"}',
+      },
+    };
+  }),
+}));
+
+const TURNO = {
+  job_id: "0000000a-0000-4000-8000-000000000001",
+  organization_id: "org-1",
+  contact_id: "contato-1",
+};
+
+/** Responde por PADRÃO do SQL, não por ordem — ordem quebra a cada refactor. */
+function poolFalso() {
+  const inserts: Array<{ sql: string; params: unknown[] }> = [];
+  const query = vi.fn(async (sql: string, params: unknown[] = []) => {
+    if (sql.includes("from job_queue")) return { rows: [TURNO], rowCount: 1 };
+    if (sql.includes("from messages")) {
+      return { rows: [{ direction: "inbound", body: "meu CNPJ é 00.000.000/0001-00" }], rowCount: 1 };
+    }
+    if (sql.includes("from lead_notes")) return { rows: [], rowCount: 0 };
+    if (sql.includes("from lead_checkpoints")) return { rows: [], rowCount: 0 };
+    if (sql.includes("insert into flywheel_judge_verdicts")) {
+      inserts.push({ sql, params });
+      return { rows: [], rowCount: 1 };
+    }
+    if (sql.includes("insert into flywheel_distiller_proposals")) {
+      inserts.push({ sql, params });
+      return { rows: [], rowCount: 1 };
+    }
+    return { rows: [], rowCount: 0 };
+  });
+  return { pool: { query } as never, inserts };
+}
+
+const LOG = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} } as never;
+
+describe("flywheel vivo", () => {
+  it("não pede modelo nenhum: deixa a instalação resolver, nos DOIS pontos", async () => {
+    chamadas.length = 0;
+    const { pool } = poolFalso();
+    const { runFlywheelOnce } = await import("../../lib/agent-engine/flywheel/live");
+
+    await runFlywheelOnce(pool, {} as never, { limit: 1, log: LOG });
+
+    // Controle positivo: se os dois pontos não foram exercitados, a asserção de
+    // ausência abaixo seria satisfeita por um array vazio — que é o modo clássico
+    // desta guarda morrer sem avisar.
+    expect(chamadas.map((c) => c.purpose)).toEqual(["flywheel_judge", "flywheel_distiller"]);
+    for (const c of chamadas) {
+      expect(c.model, `o ponto ${String(c.purpose)} fixou modelo`).toBeUndefined();
+    }
   });
 
-  it("grava no veredito o provedor e o modelo que a chamada realmente usou", () => {
-    expect(fonte).toContain("judgedCall.provider");
-    expect(fonte).toContain("judgedCall.model");
+  it("grava no veredito o provedor e o modelo que a chamada realmente usou", async () => {
+    chamadas.length = 0;
+    const { pool, inserts } = poolFalso();
+    const { runFlywheelOnce } = await import("../../lib/agent-engine/flywheel/live");
+
+    await runFlywheelOnce(pool, {} as never, { limit: 1, log: LOG });
+
+    const veredito = inserts.find((i) => i.sql.includes("flywheel_judge_verdicts"));
+    expect(veredito, "nenhum veredito foi gravado").toBeDefined();
+    // `judge_family` e `model` são o 7º e o 8º parâmetros do INSERT. O 'anthropic'
+    // que estava fixo ali mentia sobre a instalação inteira que não usa Anthropic.
+    expect(veredito?.params[6]).toBe("openrouter");
+    expect(veredito?.params[7]).toBe("anthropic/claude-haiku-4.5");
   });
 });


### PR DESCRIPTION
Recupera o **PR #595 do @maugarciasa**, que ele fechou duas horas depois de abrir, sem ter recebido nenhuma resposta nossa. O commit dele vem com a autoria preservada.

## O defeito, ainda vivo na `main`

```
$ git grep -n "claude-haiku-4-5" origin/main -- lib/agent-engine/flywheel
lib/agent-engine/flywheel/live.ts:13:const JUDGE_MODEL = 'claude-haiku-4-5';
lib/agent-engine/flywheel/live.ts:17:const DISTILLER_MODEL = 'claude-haiku-4-5';
```

Id de modelo só vale no vocabulário do provedor que a instalação usa. Numa VPS apontada para OpenRouter, esse literal volta `400 claude-haiku-4-5 is not a valid model ID` e **a rodada agendada do flywheel morre a cada disparo** — nenhuma sugestão chega à tela de Propostas. Medido em produção pelo autor, nas duas rodadas do dia 05/09.

## Por que não regride quem usa Anthropic

O comentário que justificava o modelo fixo dizia que sem ele a rodada cairia em `settings.llm.default_model`, *"não setado em self-host configurado pela tela"*. Era a única razão para segurar este PR — e ela **venceu**: a migration `0096` instalou as duas metades que a desmentem.

- o backfill curou toda organização existente — `where coalesce(o.settings->'llm'->>'default_model','') = ''`;
- o trigger `fn_seed_org_llm_defaults` faz organização nova **nascer** com `provider` e `default_model`.

Prosa de estado que estava certa quando foi escrita e que ninguém releu.

## O que o PR ganha de brinde

O `INSERT` em `flywheel_judge_verdicts` gravava o literal `'anthropic'` em `judge_family`. Passa a gravar o provedor e o modelo que a chamada **realmente** usou — o log deixa de mentir sobre toda instalação que não usa Anthropic.

## O que eu mudei em cima

A guarda que ele trouxe lia `live.ts` com `readFileSync` e afirmava não haver linha `model:`. Presença de símbolo não é comportamento: fica verde se alguém passar o modelo por outro nome ou por um wrapper, e vermelha por um `model:` inofensivo em qualquer outro ponto do arquivo. Troquei por um teste que **roda `runFlywheelOnce`** com `runModelCall` dublado e observa o que a função faz.

Discriminância medida, com a contagem prevista antes de rodar:

| sabotagem | previsto | observado |
|---|---|---|
| `model: 'claude-haiku-4-5'` de volta no juiz | 1 vermelho | 1 — *"o ponto flywheel_judge fixou modelo"* |
| literal `'anthropic'` de volta no INSERT | 1 vermelho | 1 — *"expected 'anthropic' to be 'openrouter'"* |

Nunca os dois: cada asserção guarda uma coisa.

Fragmento de versão: o autor escreveu, e escreveu certo — impacto declarado, número nenhum digitado. `nada_mudou` / `corrigido` → patch.

Fecha o #595.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8DiyLVGChP5UaXLbMcV9J
