### PR TITLE
fix(crm): importar leads por planilha volta a funcionar (@JowaniOrantes, do #597)

### DIFF
--- a/.changes/importar-planilha-de-leads-volta-a-funcionar.md
+++ b/.changes/importar-planilha-de-leads-volta-a-funcionar.md
@@ -1,0 +1,32 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O botão de importar planilha volta a funcionar, e os leads entram na primeira etapa aberta do funil
+---
+
+O botão *Importar planilha*, no quadro do funil, estava morto. Quem escolhia o
+funil e mandava a planilha recebia sempre o mesmo aviso de erro — *"Escolha o
+funil e a etapa de destino"* — mesmo tendo escolhido o funil. Nenhum lead era
+criado, e não havia nada que o operador pudesse fazer para contornar: a tela não
+tem, nem deveria ter, um campo de etapa. A capacidade foi anunciada na 1.14.0 e
+seguiu assim nas duas atualizações seguintes — quem instalou a 1.14.0, a 1.15.0
+ou a 1.15.1 nunca conseguiu importar uma planilha.
+
+A causa era essa incompatibilidade mesmo: a tela pergunta só o funil, porque
+planilha traz gente nova e gente nova entra no começo do funil; o servidor, por
+outro lado, exigia que a etapa viesse junto. Agora o servidor resolve a etapa
+sozinho, que é o que a tela sempre prometeu.
+
+E ele resolve a etapa **aberta** de menos avançada — pulando as etapas de ganho
+e as de perda. Isso importa para quem reorganizou o próprio funil: numa
+instalação onde uma etapa do tipo *Pago* ou *Cancelado* foi arrastada para a
+primeira coluna, a importação teria feito a planilha inteira nascer como negócio
+já ganho, ou teria recusado todas as linhas devolvendo *"0 leads criados"* sem
+explicar por quê. Quem nunca mexeu na ordem das etapas não estava exposto a
+isso, porque o funil que vem pronto já começa com uma etapa aberta.
+
+Nada muda no dia a dia de quem opera a instalação: nenhuma configuração nova,
+nenhum passo de atualização, e nenhum lead já importado é tocado.
+
+O achado é de @JowaniOrantes, que encontrou o problema usando o sistema pela
+tela enquanto conferia a tradução para o espanhol — não lendo código.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -295,6 +295,7 @@ jobs:
         navegacao.spec.ts
         juntar-contatos-duplicados.spec.ts
         lote-no-quadro-do-funil.spec.ts
+        importar-leads-planilha.spec.ts
         relatorio-de-atividades.spec.ts
       # ⚠️ A ORDEM DESTA LISTA NÃO DECIDE A ORDEM DE EXECUÇÃO. O Playwright
       # ordena os arquivos por CAMINHO, não pela ordem em que são passados na

--- a/app/api/v1/leads/import/route.ts
+++ b/app/api/v1/leads/import/route.ts
@@ -86,14 +86,18 @@ export async function POST(req: NextRequest): Promise<Response> {
     return fail("validation_failed", "Envie o arquivo no campo 'file'.", 422, { requestId });
   }
   const enviado = arquivo as unknown as File;
-  // ⚠️ O funil e a etapa vêm do FORM, e são conferidos contra a organização
-  // ativa logo abaixo por `createLeadHandler` — que já responde 404 para etapa
-  // de outra org e 422 para etapa que não é do funil informado. É o mesmo gate
-  // do POST unitário; reescrevê-lo aqui seria a segunda verdade.
+  // ⚠️ O funil vem do FORM, e é conferido contra a organização ativa logo
+  // abaixo por `createLeadHandler` — que já responde 404 para etapa de outra
+  // org e 422 para etapa que não é do funil informado. É o mesmo gate do POST
+  // unitário; reescrevê-lo aqui seria a segunda verdade.
   const pipelineId = String(form.get("pipeline_id") ?? "");
-  const stageId = String(form.get("stage_id") ?? "");
-  if (!pipelineId || !stageId) {
-    return fail("validation_failed", "Escolha o funil e a etapa de destino.", 422, { requestId });
+  // `stage_id` é OPCIONAL de propósito: o `ImportarLeads.tsx` nunca manda esse
+  // campo (comentário no próprio componente — planilha traz gente NOVA, e
+  // gente nova entra na primeira etapa do funil). Resolvida logo abaixo,
+  // depois que o Supabase client existir.
+  let stageId = String(form.get("stage_id") ?? "");
+  if (!pipelineId) {
+    return fail("validation_failed", "Escolha o funil de destino.", 422, { requestId });
   }
 
   if (enviado.size > CSV_MAX_BYTES) {
@@ -124,6 +128,29 @@ export async function POST(req: NextRequest): Promise<Response> {
   }
 
   const supabase = await createClient();
+
+  if (!stageId) {
+    // Primeira etapa do funil, por posição, dentro da organização ativa —
+    // nunca confia em `pipeline_id` sozinho (poderia ser de outro tenant).
+    const { data: primeiraEtapa, error: erroEtapa } = await supabase
+      .from("crm_stages")
+      .select("id")
+      .eq("pipeline_id", pipelineId)
+      .eq("organization_id", orgId)
+      .eq("is_archived", false)
+      .order("position", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    if (erroEtapa) {
+      return fail("internal_error", erroEtapa.message, 500, { requestId });
+    }
+    if (!primeiraEtapa) {
+      return fail("validation_failed", "Este funil não tem etapas.", 422, { requestId });
+    }
+    stageId = (primeiraEtapa as { id: string }).id;
+  }
+
   const resumo: ResumoDaImportacao = {
     total_linhas: lido.leads.length + lido.erros.length,
     criados: 0,

--- a/app/api/v1/leads/import/route.ts
+++ b/app/api/v1/leads/import/route.ts
@@ -93,7 +93,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   const pipelineId = String(form.get("pipeline_id") ?? "");
   // `stage_id` é OPCIONAL de propósito: o `ImportarLeads.tsx` nunca manda esse
   // campo (comentário no próprio componente — planilha traz gente NOVA, e
-  // gente nova entra na primeira etapa do funil). Resolvida logo abaixo,
+  // gente nova entra na primeira etapa ABERTA do funil). Resolvida logo abaixo,
   // depois que o Supabase client existir.
   let stageId = String(form.get("stage_id") ?? "");
   if (!pipelineId) {
@@ -130,14 +130,26 @@ export async function POST(req: NextRequest): Promise<Response> {
   const supabase = await createClient();
 
   if (!stageId) {
-    // Primeira etapa do funil, por posição, dentro da organização ativa —
+    // Primeira etapa ABERTA do funil, por posição, dentro da organização ativa —
     // nunca confia em `pipeline_id` sozinho (poderia ser de outro tenant).
+    //
+    // ⚠️ `is_won`/`is_lost` fora, espelhando `funilDeEntrada` em
+    // `lib/leads/nascimento-do-lead.ts` — que é a irmã canônica desta consulta e
+    // carrega o racional: um lead não nasce fechado, e um funil mal ordenado não
+    // pode fazer alguém entrar como "Perdido". Sem os dois filtros, um funil em
+    // que "Pago" foi arrastado para a primeira coluna faz a planilha inteira
+    // nascer como negócio JÁ GANHO (o trigger `fn_crm_lead_close_on_stage`
+    // sobrescreve o `status: "open"` que o handler grava), e no caso simétrico de
+    // perda o segundo trigger aborta cada linha com `lost_reason_required` — 200
+    // na tela, zero leads criados.
     const { data: primeiraEtapa, error: erroEtapa } = await supabase
       .from("crm_stages")
       .select("id")
       .eq("pipeline_id", pipelineId)
       .eq("organization_id", orgId)
       .eq("is_archived", false)
+      .eq("is_won", false)
+      .eq("is_lost", false)
       .order("position", { ascending: true })
       .limit(1)
       .maybeSingle();
@@ -146,7 +158,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       return fail("internal_error", erroEtapa.message, 500, { requestId });
     }
     if (!primeiraEtapa) {
-      return fail("validation_failed", "Este funil não tem etapas.", 422, { requestId });
+      return fail("validation_failed", "Este funil não tem etapas abertas.", 422, { requestId });
     }
     stageId = (primeiraEtapa as { id: string }).id;
   }

--- a/app/app/kanban/_components/ImportarLeads.tsx
+++ b/app/app/kanban/_components/ImportarLeads.tsx
@@ -43,9 +43,11 @@ export interface ResumoDaImportacao {
  *     loja já entra, e ter dois jeitos de importar planilha neste produto seria
  *     duas verdades sobre o mesmo gesto.
  *  2. Não há escolha de ETAPA. Planilha traz gente NOVA, e gente nova entra na
- *     primeira etapa do funil. Perguntar seria uma pergunta a mais para uma
- *     resposta que já é a certa — e quem quiser outra etapa arrasta os cards,
- *     que é o gesto do quadro.
+ *     primeira etapa ABERTA do funil — etapa de ganho ou de perda fica de fora,
+ *     porque um lead não nasce fechado (a regra e o porquê estão em
+ *     `funilDeEntrada`, `lib/leads/nascimento-do-lead.ts`). Perguntar seria uma
+ *     pergunta a mais para uma resposta que já é a certa — e quem quiser outra
+ *     etapa arrasta os cards, que é o gesto do quadro.
  */
 export function ImportarLeads({ funis }: { funis: FunilDaLista[] }) {
   const t = useT();
@@ -101,7 +103,7 @@ export function ImportarLeads({ funis }: { funis: FunilDaLista[] }) {
           <div className="space-y-4">
             <p className="text-sm text-muted-foreground">
               {t(
-                "Um arquivo CSV com uma linha por lead. Os leads entram na primeira etapa do funil escolhido.",
+                "Um arquivo CSV com uma linha por lead. Os leads entram na primeira etapa aberta do funil escolhido.",
               )}
             </p>
 

--- a/lib/i18n/dicionario.ts
+++ b/lib/i18n/dicionario.ts
@@ -6740,8 +6740,8 @@ export const DICIONARIO: Traducoes = {
 
   // ─── Importar leads de planilha (extraído do PR #418) ───
   "Importar leads de uma planilha": { es: "Importar leads desde una planilla" },
-  "Um arquivo CSV com uma linha por lead. Os leads entram na primeira etapa do funil escolhido.": {
-    es: "Un archivo CSV con una línea por lead. Los leads entran en la primera etapa del embudo elegido.",
+  "Um arquivo CSV com uma linha por lead. Os leads entram na primeira etapa aberta do funil escolhido.": {
+    es: "Un archivo CSV con una línea por lead. Los leads entran en la primera etapa abierta del embudo elegido.",
   },
   "Funil de destino": { es: "Embudo de destino" },
   "Escolher o arquivo CSV": { es: "Elegir el archivo CSV" },

--- a/tests/e2e/importar-leads-planilha.spec.ts
+++ b/tests/e2e/importar-leads-planilha.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * IMPORTAR LEADS DE UMA PLANILHA — provado PELA TELA, com o form real.
+ *
+ * Bug medido em QA visual (sessão de tradução ao espanhol, 2026-09-05): a
+ * importação morria SEMPRE com "Elige el embudo y la etapa de destino." —
+ * mesmo com um funil válido escolhido. Causa: `ImportarLeads.tsx` só tem
+ * seletor de FUNIL (o comentário no próprio componente diz que planilha traz
+ * gente NOVA, e gente nova entra na primeira etapa — não deveria haver escolha
+ * de etapa), mas `app/api/v1/leads/import/route.ts` exigia `stage_id` sem
+ * nenhum fallback. A suíte unitária (`tests/unit/leads-import-route.test.ts`)
+ * não pegava isto porque seu helper de request mandava `stage_id` por padrão —
+ * verde medindo um caminho que o usuário real nunca percorre.
+ *
+ * Este spec dirige o FRONTEND de verdade: abre o diálogo, escolhe só o funil
+ * (nenhum seletor de etapa existe na tela, e não deveria), sobe um CSV em
+ * memória, e confirma pela TELA e pelo BANCO que o negócio nasceu na primeira
+ * etapa do funil.
+ *
+ * Pré-requisitos (banco local do baseline, app buildada):
+ *   pnpm e2e:env && pnpm e2e:build
+ *   pnpm exec playwright test tests/e2e/importar-leads-planilha.spec.ts
+ */
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { expect, test, type Page } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+
+import { carregarEnvLocal } from "../../scripts/lib/env-de-teste";
+
+const CREDS_PATH = path.join(process.cwd(), ".e2e-creds.json");
+const EVIDENCIA =
+  process.env.E2E_EVIDENCIA ?? path.join(process.cwd(), ".superpowers/evidence/importar-leads");
+
+interface Creds {
+  password: string;
+  org_id: string;
+  users: Record<string, { email: string }>;
+  kanban?: { pipeline_id: string; stage_id: string };
+}
+
+function loadCreds(): Creds {
+  const needsBase = (): boolean => {
+    if (!fs.existsSync(CREDS_PATH)) return true;
+    const c = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
+    return !c.users?.agent;
+  };
+  if (needsBase()) {
+    execFileSync("npx", ["tsx", "scripts/seed-e2e-credentials.ts"], { stdio: "inherit" });
+  }
+  let c = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
+  if (!c.kanban?.pipeline_id || !c.kanban?.stage_id) {
+    execFileSync("npx", ["tsx", "scripts/seed-e2e-kanban.ts"], { stdio: "inherit" });
+    c = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
+  }
+  return c;
+}
+
+const creds = loadCreds();
+const env = carregarEnvLocal();
+const admin = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+// Sufixo único por execução — o banco de e2e é compartilhado entre frentes.
+const SUFIXO = `${Date.now()}`.slice(-7);
+const NOME_DO_NEGOCIO = `Importado E2E ${SUFIXO}`;
+
+async function captura(page: Page, nome: string): Promise<void> {
+  fs.mkdirSync(EVIDENCIA, { recursive: true });
+  await page.screenshot({ path: path.join(EVIDENCIA, `${nome}.png`), fullPage: true });
+}
+
+async function login(page: Page, email: string): Promise<void> {
+  await page.goto("/login");
+  await page.locator("#email").fill(email);
+  await page.locator("#password").fill(creds.password);
+  await page.getByRole("button", { name: /entrar/i }).click();
+  await page.waitForURL(/\/app\//);
+}
+
+test("importa uma planilha sem escolher etapa (não há esse seletor) e o negócio nasce na primeira etapa do funil", async ({
+  page,
+}) => {
+  await login(page, creds.users.agent!.email);
+  await page.goto("/app/kanban");
+
+  await page.getByTestId("abrir-importar-leads").click();
+
+  const dialogo = page.getByRole("dialog", { name: "Importar leads de uma planilha" });
+  await expect(dialogo).toBeVisible();
+
+  // ⚠️ NÃO há campo de etapa nesta tela — só o de funil. O form real do
+  // produto nunca manda `stage_id`; é exatamente o que este spec reproduz.
+  await expect(dialogo.getByLabel("Funil de destino")).toBeVisible();
+  await expect(dialogo.getByText(/há escolha de etapa|escolha de etapa/i)).toHaveCount(0);
+
+  const csv = `nome\n${NOME_DO_NEGOCIO}\n`;
+  await dialogo.getByTestId("arquivo-de-leads").setInputFiles({
+    name: "leads.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from(csv, "utf8"),
+  });
+
+  // A confirmação NA TELA: nem toast (some em 4s) nem exceção não tratada.
+  await expect(dialogo.getByRole("alert")).toHaveCount(0);
+  const resumo = dialogo.getByTestId("resumo-da-importacao");
+  await expect(resumo).toBeVisible({ timeout: 15_000 });
+  await expect(resumo).toContainText("1");
+  await expect(resumo).toContainText("leads criados");
+  await captura(page, "resumo-da-importacao");
+
+  // A confirmação no BANCO, relida — não o que o toast prometeu.
+  const { data: negocio, error } = await admin
+    .from("crm_leads")
+    .select("id, pipeline_id, stage_id")
+    .eq("organization_id", creds.org_id)
+    .eq("title", NOME_DO_NEGOCIO)
+    .single();
+  expect(error).toBeNull();
+  expect(negocio?.pipeline_id).toBe(creds.kanban!.pipeline_id);
+  expect(negocio?.stage_id).toBe(creds.kanban!.stage_id);
+
+  // E o card aparece no board, na coluna certa — reload, não confiar no DOM
+  // que a própria ação acabou de escrever.
+  await page.goto(`/app/pipelines/${creds.kanban!.pipeline_id}`);
+  await expect(page.getByText(NOME_DO_NEGOCIO)).toBeVisible({ timeout: 15_000 });
+});

--- a/tests/unit/leads-import-route.test.ts
+++ b/tests/unit/leads-import-route.test.ts
@@ -11,6 +11,13 @@
  *  - O mesmo telefone repetido vira UM contato. O original criava um contato por
  *    linha, e o produto passava a ter a duplicata que ele mesmo fabricou.
  *  - `viewer` não importa.
+ *  - `stage_id` é OPCIONAL: o `ImportarLeads.tsx` real NUNCA manda esse campo
+ *    (só tem seletor de FUNIL). Toda suíte anterior mandava `stage_id` no
+ *    `pedido()` por padrão — verde medindo um caminho que o usuário nunca
+ *    percorre, enquanto a importação de verdade morria com 422 "Escolha o
+ *    funil e a etapa de destino" antes de ler uma linha sequer. O teste
+ *    abaixo reproduz o form real (sem `stage_id`) e prova a resolução
+ *    automática da PRIMEIRA etapa do funil.
  */
 import { NextRequest } from "next/server";
 import { describe, expect, it, vi, beforeEach } from "vitest";
@@ -62,6 +69,31 @@ function fazerSupabase(existente: { id: string } | null) {
     };
     elo.single = () => Promise.resolve({ data: { id: `novo-${inseridos.length}` }, error: null });
     elo.maybeSingle = () => Promise.resolve({ data: existente, error: null });
+    return elo;
+  };
+  vi.mocked(createClient).mockResolvedValue({ from } as never);
+  return { inseridos };
+}
+
+/**
+ * Mesmo dublê acima, mas distingue `crm_stages` de `contacts` — necessário
+ * para os testes que NÃO mandam `stage_id` e dependem da rota resolver a
+ * primeira etapa do funil consultando essa tabela.
+ */
+function fazerSupabaseComEtapa(primeiraEtapa: { id: string } | null) {
+  const inseridos: Record<string, unknown>[] = [];
+  const from = (tabela: string) => {
+    const elo: Record<string, unknown> = {};
+    for (const m of ["select", "eq", "in", "limit", "order"]) elo[m] = () => elo;
+    elo.insert = (linha: Record<string, unknown>) => {
+      if (tabela === "contacts") inseridos.push(linha);
+      return elo;
+    };
+    elo.single = () => Promise.resolve({ data: { id: `novo-${inseridos.length}` }, error: null });
+    elo.maybeSingle = () =>
+      tabela === "crm_stages"
+        ? Promise.resolve({ data: primeiraEtapa, error: null })
+        : Promise.resolve({ data: null, error: null });
     return elo;
   };
   vi.mocked(createClient).mockResolvedValue({ from } as never);
@@ -199,6 +231,30 @@ describe("POST /api/v1/leads/import", () => {
     fazerSupabase(null);
     const { POST } = await import("@/app/api/v1/leads/import/route");
     const res = await POST(pedido("valor,origem\n100,site"));
+    expect(res.status).toBe(422);
+    expect(vi.mocked(createLeadHandler)).not.toHaveBeenCalled();
+  });
+
+  it("sem stage_id no form (o caminho REAL do ImportarLeads.tsx) entra na primeira etapa do funil", async () => {
+    fazerSupabaseComEtapa({ id: ETAPA });
+    const { POST } = await import("@/app/api/v1/leads/import/route");
+
+    const res = await POST(pedido("nome\nAna", { stage_id: null }));
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(createLeadHandler)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(createLeadHandler).mock.calls[0]![2]).toMatchObject({
+      pipeline_id: FUNIL,
+      stage_id: ETAPA,
+    });
+  });
+
+  it("sem stage_id e sem etapa nenhuma no funil, 422 — nunca cai numa etapa de outro funil", async () => {
+    fazerSupabaseComEtapa(null);
+    const { POST } = await import("@/app/api/v1/leads/import/route");
+
+    const res = await POST(pedido("nome\nAna", { stage_id: null }));
+
     expect(res.status).toBe(422);
     expect(vi.mocked(createLeadHandler)).not.toHaveBeenCalled();
   });

--- a/tests/unit/leads-import-route.test.ts
+++ b/tests/unit/leads-import-route.test.ts
@@ -18,6 +18,10 @@
  *    funil e a etapa de destino" antes de ler uma linha sequer. O teste
  *    abaixo reproduz o form real (sem `stage_id`) e prova a resolução
  *    automática da PRIMEIRA etapa do funil.
+ *  - E a primeira etapa é a primeira ABERTA: etapa de ganho ou de perda com
+ *    `position` menor não pode ser escolhida, senão a planilha inteira nasce
+ *    fechada (o trigger `fn_crm_lead_close_on_stage` decide isso no banco,
+ *    contra o `status: "open"` que o handler grava).
  */
 import { NextRequest } from "next/server";
 import { describe, expect, it, vi, beforeEach } from "vitest";
@@ -75,29 +79,89 @@ function fazerSupabase(existente: { id: string } | null) {
   return { inseridos };
 }
 
+interface EtapaDoFunil {
+  id: string;
+  position: number;
+  pipeline_id: string;
+  organization_id: string;
+  is_archived: boolean;
+  is_won: boolean;
+  is_lost: boolean;
+}
+
+/** Etapa aberta, deste funil e desta org — só o que difere disso é escrito. */
+function etapa(diferente: Partial<EtapaDoFunil> & { id: string; position: number }): EtapaDoFunil {
+  return {
+    pipeline_id: FUNIL,
+    organization_id: ORG,
+    is_archived: false,
+    is_won: false,
+    is_lost: false,
+    ...diferente,
+  };
+}
+
 /**
- * Mesmo dublê acima, mas distingue `crm_stages` de `contacts` — necessário
- * para os testes que NÃO mandam `stage_id` e dependem da rota resolver a
- * primeira etapa do funil consultando essa tabela.
+ * Dublê de `crm_stages` que HONRA os `.eq()` — e essa é a diferença que importa.
+ *
+ * A versão anterior implementava `eq` como `() => elo`: o dublê ENGOLIA os
+ * filtros e devolvia a etapa fixa que o teste passasse. Consequência medida:
+ * apagar `.eq("organization_id", orgId)` da rota — a linha que o anti-pattern
+ * nº 10 da doutrina existe para exigir — deixava a suíte inteira verde. O
+ * mesmo valia para `is_won`/`is_lost`. Nenhum teste guardava a consulta;
+ * todos guardavam o dublê.
+ *
+ * Aqui a coleção é filtrada pelos pares registrados, ordenada pela coluna que a
+ * rota pediu em `order()` e cortada em `limit`. Uma etapa que o filtro deixaria
+ * passar por engano é uma etapa que ESTE dublê devolve — e é assim que a
+ * sabotagem de cada `.eq()` vira vermelho.
+ *
+ * `consultadas` existe para o caso do funil sem etapa aberta: 422 sozinho não
+ * distingue "o fallback rodou e não achou" de "o fallback nunca rodou".
  */
-function fazerSupabaseComEtapa(primeiraEtapa: { id: string } | null) {
+function fazerSupabaseComEtapas(etapas: EtapaDoFunil[]) {
   const inseridos: Record<string, unknown>[] = [];
+  const consultadas: string[] = [];
   const from = (tabela: string) => {
+    consultadas.push(tabela);
+    const filtros: [string, unknown][] = [];
+    let ordenadaPor: string | null = null;
+    let teto = Number.POSITIVE_INFINITY;
     const elo: Record<string, unknown> = {};
-    for (const m of ["select", "eq", "in", "limit", "order"]) elo[m] = () => elo;
+    for (const m of ["select", "in"]) elo[m] = () => elo;
+    elo.eq = (coluna: string, valor: unknown) => {
+      filtros.push([coluna, valor]);
+      return elo;
+    };
+    elo.order = (coluna: string) => {
+      ordenadaPor = coluna;
+      return elo;
+    };
+    elo.limit = (n: number) => {
+      teto = n;
+      return elo;
+    };
     elo.insert = (linha: Record<string, unknown>) => {
       if (tabela === "contacts") inseridos.push(linha);
       return elo;
     };
     elo.single = () => Promise.resolve({ data: { id: `novo-${inseridos.length}` }, error: null });
-    elo.maybeSingle = () =>
-      tabela === "crm_stages"
-        ? Promise.resolve({ data: primeiraEtapa, error: null })
-        : Promise.resolve({ data: null, error: null });
+    elo.maybeSingle = () => {
+      if (tabela !== "crm_stages") return Promise.resolve({ data: null, error: null });
+      const campo = (linha: EtapaDoFunil, coluna: string) =>
+        (linha as unknown as Record<string, unknown>)[coluna];
+      const restantes = etapas.filter((linha) =>
+        filtros.every(([coluna, valor]) => campo(linha, coluna) === valor),
+      );
+      const coluna = ordenadaPor;
+      if (coluna) restantes.sort((a, b) => Number(campo(a, coluna)) - Number(campo(b, coluna)));
+      const escolhida = restantes.slice(0, teto)[0];
+      return Promise.resolve({ data: escolhida ? { id: escolhida.id } : null, error: null });
+    };
     return elo;
   };
   vi.mocked(createClient).mockResolvedValue({ from } as never);
-  return { inseridos };
+  return { inseridos, consultadas };
 }
 
 /**
@@ -236,7 +300,7 @@ describe("POST /api/v1/leads/import", () => {
   });
 
   it("sem stage_id no form (o caminho REAL do ImportarLeads.tsx) entra na primeira etapa do funil", async () => {
-    fazerSupabaseComEtapa({ id: ETAPA });
+    fazerSupabaseComEtapas([etapa({ id: ETAPA, position: 1000 })]);
     const { POST } = await import("@/app/api/v1/leads/import/route");
 
     const res = await POST(pedido("nome\nAna", { stage_id: null }));
@@ -249,14 +313,73 @@ describe("POST /api/v1/leads/import", () => {
     });
   });
 
-  it("sem stage_id e sem etapa nenhuma no funil, 422 — nunca cai numa etapa de outro funil", async () => {
-    fazerSupabaseComEtapa(null);
+  it("sem stage_id e sem etapa ABERTA no funil, 422 — e o 422 é o do fallback, não o da guarda velha", async () => {
+    // ⚠️ ESTE CASO PRECISA SER DISCRIMINANTE. `status === 422` + handler não
+    // chamado é EXATAMENTE o que a guarda antiga (`if (!pipelineId || !stageId)`)
+    // também produzia — medido: sob a guarda velha este caso ficava verde,
+    // certificando o defeito que o #597 conserta. O que separa os dois mundos é
+    // a rota ter ido ao banco e a mensagem ser a do funil sem etapa aberta.
+    const espiao = fazerSupabaseComEtapas([etapa({ id: "so-ganho", position: 500, is_won: true })]);
+    const { POST } = await import("@/app/api/v1/leads/import/route");
+
+    const res = await POST(pedido("nome\nAna", { stage_id: null }));
+    const corpo = (await res.json()) as { error: { message: string } };
+
+    expect(res.status).toBe(422);
+    expect(espiao.consultadas).toContain("crm_stages");
+    expect(corpo.error.message).toBe("Este funil não tem etapas abertas.");
+    expect(vi.mocked(createLeadHandler)).not.toHaveBeenCalled();
+  });
+
+  it("etapa de OUTRA ORGANIZAÇÃO com position menor não é escolhida", async () => {
+    // A rota usa o client da sessão, mas o filtro por org é explícito (doutrina,
+    // anti-pattern nº 10) — e sem ele a planilha entraria no funil de outro
+    // tenant que por acaso tenha uma etapa mais acima.
+    fazerSupabaseComEtapas([
+      etapa({
+        id: "de-outra-org",
+        position: 100,
+        organization_id: "99999999-9999-4999-8999-999999999999",
+      }),
+      etapa({ id: ETAPA, position: 1000 }),
+    ]);
     const { POST } = await import("@/app/api/v1/leads/import/route");
 
     const res = await POST(pedido("nome\nAna", { stage_id: null }));
 
-    expect(res.status).toBe(422);
-    expect(vi.mocked(createLeadHandler)).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(vi.mocked(createLeadHandler).mock.calls[0]![2]).toMatchObject({ stage_id: ETAPA });
+  });
+
+  it("etapa de GANHO com position menor não é escolhida — a planilha não nasce vendida", async () => {
+    // Um funil com "Pago" arrastado para a primeira coluna. Sem o filtro, o
+    // trigger `fn_crm_lead_close_on_stage` sobrescreveria o `status: "open"` do
+    // handler e todo lead importado nasceria `won`.
+    fazerSupabaseComEtapas([
+      etapa({ id: "pago", position: 500, is_won: true }),
+      etapa({ id: ETAPA, position: 1000 }),
+    ]);
+    const { POST } = await import("@/app/api/v1/leads/import/route");
+
+    const res = await POST(pedido("nome\nAna", { stage_id: null }));
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(createLeadHandler).mock.calls[0]![2]).toMatchObject({ stage_id: ETAPA });
+  });
+
+  it("etapa de PERDA com position menor não é escolhida — a planilha não nasce perdida", async () => {
+    // Pior que o ganho: o trigger de perda aborta a linha com
+    // `lost_reason_required`, e a rota devolveria 200 com "0 leads criados".
+    fazerSupabaseComEtapas([
+      etapa({ id: "cancelado", position: 500, is_lost: true }),
+      etapa({ id: ETAPA, position: 1000 }),
+    ]);
+    const { POST } = await import("@/app/api/v1/leads/import/route");
+
+    const res = await POST(pedido("nome\nAna", { stage_id: null }));
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(createLeadHandler).mock.calls[0]![2]).toMatchObject({ stage_id: ETAPA });
   });
 
   it("viewer não importa", async () => {


### PR DESCRIPTION
Traz o **PR #597 do @JowaniOrantes** com os commits e a autoria dele preservados, mais o bloqueador que a triagem mediu.

## O que ele consertou

**A importação de leads por planilha estava 100% morta.** `ImportarLeads.tsx` é o único chamador da rota e manda só `file` + `pipeline_id` — de propósito, pelo comentário no próprio componente. A rota exigia `stage_id` sem fallback:

```
HTTP 422 {"code":"validation_failed","message":"Escolha o funil e a etapa de destino."}
0 leads criados — em 5 cenários
```

Reproduzido no SHA da `main` de hoje por dois agentes independentes, com o multipart exato que o componente põe no fio. **Publicado quebrado em três releases** — `v1.14.0`, `v1.15.0` e `v1.15.1`.

A suíte não pegava: o helper `pedido()` mandava `stage_id` por padrão, medindo um caminho que o usuário real nunca percorre. **Achado dele fazendo QA visual da tradução ao espanhol**, não lendo código.

## O bloqueador que entra em cima

A resolução da "primeira etapa" omitia `is_won`/`is_lost`. A irmã canônica desta mesma consulta — `funilDeEntrada`, `lib/leads/nascimento-do-lead.ts` — tem os dois filtros com o racional escrito: *um lead não nasce fechado, e um funil mal ordenado não pode fazer alguém entrar como Perdido.* Varredura por ferramenta: em produção, com `limit(1)` e para nascimento de lead, existem duas consultas — a canônica e a do PR.

Executado com um dublê que **honra** os `.eq()`:

- "Pago" (`is_won`) na primeira coluna → a rota escolhe a etapa de ganho. O handler grava `status: "open"`, **mas o trigger `fn_crm_lead_close_on_stage` (BEFORE INSERT) sobrescreve para `won` + `closed_at`** — a planilha inteira nasce como negócio já ganho.
- No caso de **perda** é pior: o segundo trigger aborta cada linha com `lost_reason_required`, e a rota devolve **200 com "0 leads criados"** e o errcode cru do Postgres na tela.

**Alcançável pela tela:** `PATCH .../stages/[stageId]` aceita `depois_de: null` ("primeira coluna") junto com `is_won` no mesmo corpo. Instalação fresca está a salvo — a primeira etapa semeada é aberta. Atinge quem reordenou o funil.

## A rede de testes

Dois buracos, medidos por sabotagem (revertendo **só o fonte**):

1. `leads-import-route.test.ts:252` afirmava só `status === 422` + handler não chamado — sinais que a **guarda antiga também produzia**. Sob sabotagem do conserto, ficava verde.
2. O dublê implementava `eq` como `() => elo`, engolindo todo filtro: **nenhum teste guardava o `.eq("organization_id", orgId)`**, a linha exigida pelo anti-pattern nº 10.

O dublê agora honra os filtros, e entram os casos de etapa de outra organização, de ganho e de perda.

## O rótulo visível

`ImportarLeads.tsx` prometia *"os leads entram na primeira etapa do funil escolhido"*. Vira **"primeira etapa aberta"** — rótulo visível é contrato. A chave do dicionário é o próprio texto em português, então ela muda junto, com o espanhol acertado.

## Fragmento

O PR não trazia — regra que quase nenhum contribuidor externo conhece, e o passe 10 proíbe cobrar como descuido gate não documentado. Escrito aqui, creditando ele. `nada_mudou` / `corrigido` → patch.

Fecha o #597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8DiyLVGChP5UaXLbMcV9J
