### PR TITLE
fix(i18n): varredura de cobertura do espanhol (@JowaniOrantes, do #600)

### DIFF
--- a/.changes/espanhol-cobre-mais-telas-e-mensagens-de-erro.md
+++ b/.changes/espanhol-cobre-mais-telas-e-mensagens-de-erro.md
@@ -1,0 +1,15 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O espanhol cobre mais telas e mais mensagens de erro
+---
+
+Várias telas e mensagens de erro apareciam em português mesmo com a
+organização configurada para espanhol: o badge de status de um agente de
+IA, o painel de Segurança (STOP, LGPD, ritmo de envio…), os avisos de
+provedores de IA, os erros de verificação em duas etapas, os avisos de
+número/conta do WhatsApp na Central, o resumo de impacto ao excluir um
+número, e toda a mensagem de erro do módulo de Tarefas. Numa tela de
+Agenda da organização, o nome que o próprio operador deu a um tipo de
+atendimento chegou a ser traduzido por engano, trocando "Retorno" por
+"Seguimiento". Todos os casos foram corrigidos.

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,12 @@ evidence/.sonda-score-residuo.json
 # role key, secrets de webhook e a chave de cifra dos tokens. O padrão `.env*`
 # acima não os alcança porque eles vivem num diretório, com outro prefixo.
 backups/
+
+# Dump de banco de QA. A doutrina já estava escrita duas linhas acima e só o
+# PADRÃO faltava: `backups/` não casa com `.qa-backups/`, e um dump de 1,1 MB de
+# um Supabase local chegou a um PR de contribuidor por causa disso (#600). O
+# conteúdo daquele era sintético, mas um dump carrega hash de senha, refresh
+# token e o jwt_secret da instância — e história de git público é PERMANENTE:
+# commit posterior de remoção não tira o blob.
+.qa-backups/
+*.dump

--- a/app/admin/(protected)/google/_form.tsx
+++ b/app/admin/(protected)/google/_form.tsx
@@ -84,7 +84,7 @@ export function FormularioDoGoogle({
         </div>
 
         <div className="flex flex-col gap-1.5">
-          <Label htmlFor="client-secret">Chave secreta do cliente</Label>
+          <Label htmlFor="client-secret">{t("Chave secreta do cliente")}</Label>
           <Input
             id="client-secret"
             data-testid="google-client-secret"
@@ -144,10 +144,10 @@ export function FormularioDoGoogle({
                   ...(clientSecret.trim() ? { client_secret: clientSecret.trim() } : {}),
                 });
                 if (!r.ok) {
-                  toast.error(r.error);
+                  toast.error(t(r.error));
                   return;
                 }
-                toast.success("Credenciais do Google salvas.");
+                toast.success(t("Credenciais do Google salvas."));
                 setClientSecret("");
                 router.refresh();
               })

--- a/app/api/v1/agenda/agendamentos/route.ts
+++ b/app/api/v1/agenda/agendamentos/route.ts
@@ -31,6 +31,7 @@ type AgendamentoDaResposta = AgendamentoListado & { origem?: "google_sync" };
 import { ApiError } from "@/lib/api/types";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 import {
   alterarAgendamentoHandler,
@@ -138,6 +139,7 @@ export async function GET(req: NextRequest): Promise<Response> {
   // `viewer`: olhar a agenda é o menor privilégio desta feature.
   const authz = await requireRole("viewer", { requestId, resource: "agenda" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const url = new URL(req.url);
@@ -152,7 +154,7 @@ export async function GET(req: NextRequest): Promise<Response> {
     limite: url.searchParams.get("limite") ?? undefined,
   });
   if (!parsed.success) {
-    return fail("validation_failed", "Consulta inválida.", 422, {
+    return fail("validation_failed", t("Consulta inválida."), 422, {
       details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
       requestId,
     });
@@ -173,7 +175,7 @@ export async function GET(req: NextRequest): Promise<Response> {
   if (!resultado.ok) {
     return fail(
       resultado.codigo === "sem_alvo" ? "agenda_listagem_sem_recorte" : "internal_error",
-      resultado.motivoParaOperador,
+      t(resultado.motivoParaOperador),
       resultado.codigo === "sem_alvo" ? 422 : 500,
       { requestId },
     );
@@ -279,11 +281,12 @@ async function despachar<T>(
 
   const authz = await requireRole("agent", { requestId, resource: "agenda" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg, user } = authz;
 
   const parsed = schema.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
-    return fail("validation_failed", "Dados inválidos.", 422, {
+    return fail("validation_failed", t("Dados inválidos."), 422, {
       details: (parsed.error as z.ZodError).flatten().fieldErrors as Record<string, unknown>,
       requestId,
     });
@@ -306,7 +309,7 @@ async function despachar<T>(
     return ok(resultado, { requestId, status });
   } catch (err) {
     if (err instanceof ApiError) {
-      return fail(err.code, err.message, err.status, {
+      return fail(err.code, t(err.message), err.status, {
         details: err.details as Record<string, unknown> | undefined,
         requestId,
       });

--- a/app/api/v1/agenda/google/desconectar/route.ts
+++ b/app/api/v1/agenda/google/desconectar/route.ts
@@ -50,6 +50,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { PROVEDOR_GOOGLE } from "@/lib/agenda/tipos";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -63,13 +64,14 @@ export async function DELETE(req: NextRequest): Promise<Response> {
 
   const autorizado = await requireRole("agent", { requestId, resource: "calendar_connections" });
   if (!autorizado.ok) return autorizado.response;
+  const t = (texto: string) => traduzir(texto, autorizado.user.idioma);
   const { user, org } = autorizado;
 
   let alvo = user.id;
   const bruto = await req.json().catch(() => ({}));
   const lido = corpo.safeParse(bruto);
   if (!lido.success) {
-    return fail("validation_failed", "Corpo inválido para desconectar.", 422, { requestId });
+    return fail("validation_failed", t("Corpo inválido para desconectar."), 422, { requestId });
   }
   if (lido.data.user_id && lido.data.user_id !== user.id) {
     // Desconectar a agenda de OUTRA pessoa é ato de gestão, não de uso.
@@ -97,7 +99,7 @@ export async function DELETE(req: NextRequest): Promise<Response> {
   if (!conexoes || conexoes.length === 0) {
     // 404 e não 200: dizer "desconectei" sobre o que não existe é a mesma
     // família de mentira que o "Marcado ✓" sem linha no banco.
-    return fail("not_found", "Não há agenda do Google conectada para esta pessoa.", 404, {
+    return fail("not_found", t("Não há agenda do Google conectada para esta pessoa."), 404, {
       requestId,
     });
   }

--- a/app/api/v1/agenda/horarios-livres/route.ts
+++ b/app/api/v1/agenda/horarios-livres/route.ts
@@ -45,6 +45,7 @@ import {
 import { fail, ok } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 const querySchema = z.object({
   event_type_id: z.string().uuid(),
@@ -58,6 +59,7 @@ export async function GET(req: NextRequest): Promise<Response> {
 
   const authz = await requireRole("viewer", { requestId, resource: "agenda" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const url = new URL(req.url);
@@ -68,7 +70,7 @@ export async function GET(req: NextRequest): Promise<Response> {
     ate: url.searchParams.get("ate") ?? undefined,
   });
   if (!parsed.success) {
-    return fail("validation_failed", "Consulta inválida.", 422, {
+    return fail("validation_failed", t("Consulta inválida."), 422, {
       details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
       requestId,
     });
@@ -77,12 +79,12 @@ export async function GET(req: NextRequest): Promise<Response> {
   const de = new Date(parsed.data.de);
   const ate = new Date(parsed.data.ate);
   if (ate.getTime() <= de.getTime()) {
-    return fail("validation_failed", "O fim do período precisa ser depois do começo.", 422, {
+    return fail("validation_failed", t("O fim do período precisa ser depois do começo."), 422, {
       requestId,
     });
   }
   if (ate.getTime() - de.getTime() > MAXIMO_DE_DIAS * 86_400_000) {
-    return fail("validation_failed", `O período não pode passar de ${MAXIMO_DE_DIAS} dias.`, 422, {
+    return fail("validation_failed", t(`O período não pode passar de ${MAXIMO_DE_DIAS} dias.`), 422, {
       requestId,
     });
   }
@@ -113,7 +115,7 @@ export async function GET(req: NextRequest): Promise<Response> {
       erro_interno: { codigo: "internal_error", http: 500 },
     };
     const { codigo, http } = status[consulta.codigo];
-    return fail(codigo, consulta.motivoParaOperador, http, { requestId });
+    return fail(codigo, t(consulta.motivoParaOperador), http, { requestId });
   }
 
   return ok(

--- a/app/api/v1/agenda/tipos/route.ts
+++ b/app/api/v1/agenda/tipos/route.ts
@@ -26,6 +26,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { listaTiposDeAtendimento } from "@/lib/agenda/consulta";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -128,10 +129,11 @@ export async function POST(req: NextRequest): Promise<Response> {
   const requestId = req.headers.get("x-request-id") ?? undefined;
   const autorizado = await requireRole("manager", { requestId, resource: "calendar_event_types" });
   if (!autorizado.ok) return autorizado.response;
+  const t = (texto: string) => traduzir(texto, autorizado.user.idioma);
 
   const lido = criarSchema.safeParse(await req.json().catch(() => ({})));
   if (!lido.success) {
-    return fail("validation_failed", lido.error.issues[0]?.message ?? "corpo inválido", 422, { requestId });
+    return fail("validation_failed", lido.error.issues[0]?.message ?? t("corpo inválido"), 422, { requestId });
   }
 
   const admin = createAdminClient();
@@ -163,16 +165,17 @@ export async function PATCH(req: NextRequest): Promise<Response> {
   const requestId = req.headers.get("x-request-id") ?? undefined;
   const autorizado = await requireRole("manager", { requestId, resource: "calendar_event_types" });
   if (!autorizado.ok) return autorizado.response;
+  const t = (texto: string) => traduzir(texto, autorizado.user.idioma);
 
   const lido = alterarSchema.safeParse(await req.json().catch(() => ({})));
   if (!lido.success) {
-    return fail("validation_failed", lido.error.issues[0]?.message ?? "corpo inválido", 422, { requestId });
+    return fail("validation_failed", lido.error.issues[0]?.message ?? t("corpo inválido"), 422, { requestId });
   }
   const { id, ...campos } = lido.data;
   if (Object.keys(campos).length === 0) {
     // Recusa em vez de UPDATE vazio: "alterei" sobre nada é a mesma família de
     // mentira que o "Marcado ✓" sem linha no banco.
-    return fail("validation_failed", "Nenhum campo para alterar.", 422, { requestId });
+    return fail("validation_failed", t("Nenhum campo para alterar."), 422, { requestId });
   }
 
   const admin = createAdminClient();
@@ -185,7 +188,7 @@ export async function PATCH(req: NextRequest): Promise<Response> {
     .maybeSingle();
 
   if (error) return fail("internal_error", error.message, 500, { requestId });
-  if (!data) return fail("not_found", "Tipo de agendamento não encontrado.", 404, { requestId });
+  if (!data) return fail("not_found", t("Tipo de agendamento não encontrado."), 404, { requestId });
 
   await audit({
     action: "agenda.tipo_alterado",
@@ -201,9 +204,10 @@ export async function DELETE(req: NextRequest): Promise<Response> {
   const requestId = req.headers.get("x-request-id") ?? undefined;
   const autorizado = await requireRole("manager", { requestId, resource: "calendar_event_types" });
   if (!autorizado.ok) return autorizado.response;
+  const t = (texto: string) => traduzir(texto, autorizado.user.idioma);
 
   const lido = desativarSchema.safeParse(await req.json().catch(() => ({})));
-  if (!lido.success) return fail("validation_failed", "corpo inválido", 422, { requestId });
+  if (!lido.success) return fail("validation_failed", t("corpo inválido"), 422, { requestId });
 
   const admin = createAdminClient();
   const { data, error } = await admin
@@ -215,7 +219,7 @@ export async function DELETE(req: NextRequest): Promise<Response> {
     .maybeSingle();
 
   if (error) return fail("internal_error", error.message, 500, { requestId });
-  if (!data) return fail("not_found", "Tipo de agendamento não encontrado.", 404, { requestId });
+  if (!data) return fail("not_found", t("Tipo de agendamento não encontrado."), 404, { requestId });
 
   await audit({
     action: "agenda.tipo_desativado",

--- a/app/api/v1/ai/agents/[id]/duplicate/route.ts
+++ b/app/api/v1/ai/agents/[id]/duplicate/route.ts
@@ -15,6 +15,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { duplicateAgentWithVersion } from "@/lib/ai/agents/duplicate";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -29,6 +30,7 @@ export async function POST(_req: NextRequest, ctx: Ctx): Promise<Response> {
 
   const authz = await requireRole("admin", { requestId, resource: "ai_agents" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   const admin = createAdminClient();
@@ -44,14 +46,14 @@ export async function POST(_req: NextRequest, ctx: Ctx): Promise<Response> {
 
   if (!result.ok) {
     if (result.error === "not_found") {
-      return fail("not_found", "Agent não encontrado.", 404, { requestId });
+      return fail("not_found", t("Agent não encontrado."), 404, { requestId });
     }
     if (result.error === "no_version_to_duplicate") {
-      return fail("state_conflict", "Agent não tem versão para duplicar.", 409, { requestId });
+      return fail("state_conflict", t("Agent não tem versão para duplicar."), 409, { requestId });
     }
     return fail(
       "internal_error",
-      result.error === "version_insert_failed" ? "Erro ao duplicar versão." : "Erro ao duplicar agent.",
+      result.error === "version_insert_failed" ? t("Erro ao duplicar versão.") : "Erro ao duplicar agent.",
       500,
       { requestId },
     );

--- a/app/api/v1/ai/agents/[id]/pause/route.ts
+++ b/app/api/v1/ai/agents/[id]/pause/route.ts
@@ -12,6 +12,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -26,6 +27,7 @@ export async function POST(_req: NextRequest, ctx: Ctx): Promise<Response> {
 
   const authz = await requireRole("admin", { requestId, resource: "ai_agents" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   const admin = createAdminClient();
@@ -36,7 +38,7 @@ export async function POST(_req: NextRequest, ctx: Ctx): Promise<Response> {
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
 
-  if (!existing) return fail("not_found", "Agent não encontrado.", 404, { requestId });
+  if (!existing) return fail("not_found", t("Agent não encontrado."), 404, { requestId });
   if (existing.archived_at) {
     return fail("state_conflict", "Agent arquivado.", 409, { requestId });
   }

--- a/app/api/v1/ai/agents/[id]/proposals/route.ts
+++ b/app/api/v1/ai/agents/[id]/proposals/route.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -29,13 +30,14 @@ export async function GET(req: NextRequest, ctx: Ctx): Promise<Response> {
 
   const authz = await requireRole("agent", { requestId, resource: "flywheel_proposals" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
 
   const parsed = querySchema.safeParse(
     Object.fromEntries(new URL(req.url).searchParams.entries()),
   );
   if (!parsed.success) {
-    return fail("validation_failed", "Query inválida.", 422, {
+    return fail("validation_failed", t("Query inválida."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -51,7 +53,7 @@ export async function GET(req: NextRequest, ctx: Ctx): Promise<Response> {
     .eq("organization_id", org.orgId)
     .maybeSingle();
   if (!agent) {
-    return fail("not_found", "Agente não encontrado nesta organização.", 404, { requestId });
+    return fail("not_found", t("Agente não encontrado nesta organização."), 404, { requestId });
   }
 
   let query = admin
@@ -67,7 +69,7 @@ export async function GET(req: NextRequest, ctx: Ctx): Promise<Response> {
 
   const { data, error } = await query;
   if (error) {
-    return fail("internal_error", "Falha ao carregar as propostas.", 500, { requestId });
+    return fail("internal_error", t("Falha ao carregar as propostas."), 500, { requestId });
   }
   return ok({ items: data ?? [] }, { requestId });
 }

--- a/app/api/v1/ai/agents/[id]/publish/route.ts
+++ b/app/api/v1/ai/agents/[id]/publish/route.ts
@@ -20,6 +20,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { publishSchema, PUBLISH_ERROR_CODES } from "@/lib/ai/agents/validation";
 import { VALID_TOOL_IDS } from "@/lib/mcp/tools";
 import { publishAgentVersion } from "@/lib/ai/agents/publish";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 const VALID_TOOL_IDS_RUNTIME = new Set<string>(VALID_TOOL_IDS as readonly string[]);
 
@@ -38,18 +39,19 @@ export async function POST(req: NextRequest, ctx: Ctx): Promise<Response> {
 
   const authz = await requireRole("admin", { requestId, resource: "ai_agents" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   let raw: unknown;
   try {
     raw = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
 
   const parsed = publishSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -67,13 +69,13 @@ export async function POST(req: NextRequest, ctx: Ctx): Promise<Response> {
     .maybeSingle();
 
   if (!targetV || targetV.agent_id !== id) {
-    return fail("version_not_found", "Version não encontrada.", 404, { requestId });
+    return fail("version_not_found", t("Version não encontrada."), 404, { requestId });
   }
 
   const tools = (targetV.tool_ids ?? []) as string[];
   const invalid = tools.filter((t) => !VALID_TOOL_IDS_RUNTIME.has(t));
   if (invalid.length > 0) {
-    return fail("tool_id_invalid", "tool_ids contém ids inexistentes no catálogo MCP.", 422, {
+    return fail("tool_id_invalid", t("tool_ids contém ids inexistentes no catálogo MCP."), 422, {
       requestId,
       details: { invalid },
     });
@@ -90,7 +92,7 @@ export async function POST(req: NextRequest, ctx: Ctx): Promise<Response> {
       const status = result.code === "agent_not_found" || result.code === "version_not_found"
         ? 404
         : 422;
-      return fail(result.code, "Validação de publish falhou.", status, { requestId });
+      return fail(result.code, t("Validação de publish falhou."), status, { requestId });
     }
     return fail("internal_error", "Erro ao publicar.", 500, { requestId });
   }

--- a/app/api/v1/ai/agents/[id]/route.ts
+++ b/app/api/v1/ai/agents/[id]/route.ts
@@ -13,6 +13,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 import {
   agentPatchSchema,
   AGENT_CONFIG_DEFAULTS,
@@ -42,6 +43,7 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
 
   const authz = await requireRole("manager", { requestId, resource: "ai_agents" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const supabase = await createClient();
@@ -56,7 +58,7 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
     return fail("internal_error", "Erro ao buscar agent.", 500, { requestId });
   }
   if (!data) {
-    return fail("not_found", "Agent não encontrado.", 404, { requestId });
+    return fail("not_found", t("Agent não encontrado."), 404, { requestId });
   }
 
   return ok(data, { requestId });
@@ -76,13 +78,14 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
 
   const authz = await requireRole("admin", { requestId, resource: "ai_agents" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   let rawBody: unknown;
   try {
     rawBody = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
 
   // Extract priority (mcp_agent-only) before strict-schema parse so we don't
@@ -96,7 +99,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
       p < 0 ||
       p > 1000
     ) {
-      return fail("validation_failed", "priority inválido (0..1000).", 422, { requestId });
+      return fail("validation_failed", t("priority inválido (0..1000)."), 422, { requestId });
     }
     priorityPatch = p;
     delete (rawBody as Record<string, unknown>).priority;
@@ -104,7 +107,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
 
   const parsed = agentPatchSchema.safeParse(rawBody);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -125,7 +128,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
     return fail("internal_error", "Erro ao carregar agent.", 500, { requestId });
   }
   if (!existing) {
-    return fail("not_found", "Agent não encontrado.", 404, { requestId });
+    return fail("not_found", t("Agent não encontrado."), 404, { requestId });
   }
 
   // ─── CONTEÚDO DE VERSÃO PUBLICADA NÃO SE EDITA PELO CADASTRO ───────────
@@ -211,6 +214,7 @@ export async function DELETE(_req: NextRequest, ctx: RouteCtx): Promise<Response
 
   const authz = await requireRole("admin", { requestId, resource: "ai_agents" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   const admin = createAdminClient();
@@ -226,12 +230,12 @@ export async function DELETE(_req: NextRequest, ctx: RouteCtx): Promise<Response
     return fail("internal_error", "Erro ao carregar agent.", 500, { requestId });
   }
   if (!existing) {
-    return fail("not_found", "Agent não encontrado.", 404, { requestId });
+    return fail("not_found", t("Agent não encontrado."), 404, { requestId });
   }
   if (existing.is_default) {
     return fail(
       "state_conflict",
-      "Não é possível desativar o agent default da organização.",
+      t("Não é possível desativar o agent default da organização."),
       409,
       { requestId },
     );

--- a/app/api/v1/ai/agents/[id]/runs/route.ts
+++ b/app/api/v1/ai/agents/[id]/runs/route.ts
@@ -47,6 +47,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 import { runsListQuerySchema } from "@/lib/ai/agents/validation";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -153,6 +154,7 @@ export async function GET(req: NextRequest, ctx: Ctx): Promise<Response> {
 
   const authz = await requireRole("manager", { requestId, resource: "ai_agents" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const sp = req.nextUrl.searchParams;
@@ -162,7 +164,7 @@ export async function GET(req: NextRequest, ctx: Ctx): Promise<Response> {
     status: sp.get("status") ?? undefined,
   });
   if (!parsed.success) {
-    return fail("validation_failed", "Query inválida.", 422, {
+    return fail("validation_failed", t("Query inválida."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -187,7 +189,7 @@ export async function GET(req: NextRequest, ctx: Ctx): Promise<Response> {
 
   if (q.cursor) {
     const c = decodeCursor(q.cursor);
-    if (!c) return fail("invalid_request", "cursor inválido.", 400, { requestId });
+    if (!c) return fail("invalid_request", t("cursor inválido."), 400, { requestId });
     // Tuple-aware seek: created_at < c.started_at OR (=, id < c.id).
     query = query.or(
       `created_at.lt.${c.started_at},and(created_at.eq.${c.started_at},id.lt.${c.id})`,
@@ -195,7 +197,7 @@ export async function GET(req: NextRequest, ctx: Ctx): Promise<Response> {
   }
 
   const { data, error } = await query;
-  if (error) return fail("internal_error", "Erro ao listar execuções.", 500, { requestId });
+  if (error) return fail("internal_error", t("Erro ao listar execuções."), 500, { requestId });
 
   const rows = ((data ?? []) as unknown as LlmCallRow[]).map(paraLinhaDeExecucao);
   const hasMore = rows.length > q.limit;

--- a/app/api/v1/ai/agents/[id]/tool-usage/route.ts
+++ b/app/api/v1/ai/agents/[id]/tool-usage/route.ts
@@ -32,6 +32,7 @@ import {
   type LinhaDeUso,
 } from "@/lib/ai/agents/uso-de-capacidades";
 import { TOOL_CATALOG } from "@/lib/mcp/tools/catalog";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -50,13 +51,14 @@ export async function GET(req: NextRequest, ctx: Ctx): Promise<Response> {
 
   const authz = await requireRole("manager", { requestId, resource: "ai_agents" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const parsed = querySchema.safeParse({
     days: req.nextUrl.searchParams.get("days") ?? undefined,
   });
   if (!parsed.success) {
-    return fail("validation_failed", "Janela inválida.", 422, {
+    return fail("validation_failed", t("Janela inválida."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -75,7 +77,7 @@ export async function GET(req: NextRequest, ctx: Ctx): Promise<Response> {
     .eq("id", id)
     .maybeSingle();
   if (erroAgente) return fail("internal_error", "Erro ao carregar o agente.", 500, { requestId });
-  if (!agente) return fail("not_found", "Agente não encontrado.", 404, { requestId });
+  if (!agente) return fail("not_found", t("Agente não encontrado."), 404, { requestId });
 
   // O que está VALENDO: a versão publicada. Sem publicada, o rascunho mais
   // recente — é o que o humano tem na frente na aba de configuração.

--- a/app/api/v1/ai/agents/[id]/versions/[vid]/route.ts
+++ b/app/api/v1/ai/agents/[id]/versions/[vid]/route.ts
@@ -13,6 +13,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { versionPatchSchema } from "@/lib/ai/agents/validation";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -32,6 +33,7 @@ export async function GET(_req: NextRequest, ctx: Ctx): Promise<Response> {
 
   const authz = await requireRole("manager", { requestId, resource: "ai_agents" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const supabase = await createClient();
@@ -44,7 +46,7 @@ export async function GET(_req: NextRequest, ctx: Ctx): Promise<Response> {
     .maybeSingle();
 
   if (error) return fail("internal_error", "Erro ao buscar version.", 500, { requestId });
-  if (!data) return fail("not_found", "Version não encontrada.", 404, { requestId });
+  if (!data) return fail("not_found", t("Version não encontrada."), 404, { requestId });
   return ok(data, { requestId });
 }
 
@@ -57,17 +59,18 @@ export async function PATCH(req: NextRequest, ctx: Ctx): Promise<Response> {
 
   const authz = await requireRole("admin", { requestId, resource: "ai_agents" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   let raw: unknown;
   try {
     raw = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
   const parsed = versionPatchSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -86,9 +89,9 @@ export async function PATCH(req: NextRequest, ctx: Ctx): Promise<Response> {
     .eq("agent_id", id)
     .maybeSingle();
 
-  if (!existing) return fail("not_found", "Version não encontrada.", 404, { requestId });
+  if (!existing) return fail("not_found", t("Version não encontrada."), 404, { requestId });
   if (existing.status !== "draft") {
-    return fail("version_immutable", "Apenas versões 'draft' podem ser editadas.", 409, {
+    return fail("version_immutable", t("Apenas versões 'draft' podem ser editadas."), 409, {
       requestId,
       details: { current_status: existing.status },
     });

--- a/app/api/v1/ai/agents/[id]/versions/[vid]/test/route.ts
+++ b/app/api/v1/ai/agents/[id]/versions/[vid]/test/route.ts
@@ -25,6 +25,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { testRunSchema } from "@/lib/ai/agents/validation";
 import { avaliarRespostaDeTeste } from "@/lib/ai/agents/avaliar-resposta-de-teste";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -41,17 +42,18 @@ export async function POST(req: NextRequest, ctx: Ctx): Promise<Response> {
 
   const authz = await requireRole("admin", { requestId, resource: "ai_agents" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   let raw: unknown;
   try {
     raw = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
   const parsed = testRunSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -69,7 +71,7 @@ export async function POST(req: NextRequest, ctx: Ctx): Promise<Response> {
     .eq("agent_id", id)
     .maybeSingle();
 
-  if (!version) return fail("not_found", "Version não encontrada.", 404, { requestId });
+  if (!version) return fail("not_found", t("Version não encontrada."), 404, { requestId });
 
   const startedAt = new Date();
 

--- a/app/api/v1/ai/agents/[id]/versions/route.ts
+++ b/app/api/v1/ai/agents/[id]/versions/route.ts
@@ -17,6 +17,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { mensagemDoEscopo, validarEscopoDaVersao } from "@/lib/ai/agents/escopo";
 import { versionCreateSchema } from "@/lib/ai/agents/validation";
 import { lerAmbiente } from "@/lib/instalacao/ambiente";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -70,18 +71,19 @@ export async function POST(req: NextRequest, ctx: Ctx): Promise<Response> {
 
   const authz = await requireRole("admin", { requestId, resource: "ai_agents" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   let raw: unknown;
   try {
     raw = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
 
   const parsed = versionCreateSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -90,7 +92,7 @@ export async function POST(req: NextRequest, ctx: Ctx): Promise<Response> {
 
   const agentCheck = await assertAgentInOrg(id, activeOrg.orgId);
   if (!agentCheck.ok) {
-    return fail("not_found", "Agent não encontrado.", 404, { requestId });
+    return fail("not_found", t("Agent não encontrado."), 404, { requestId });
   }
 
   const admin = createAdminClient();

--- a/app/api/v1/ai/agents/route.ts
+++ b/app/api/v1/ai/agents/route.ts
@@ -22,6 +22,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { mensagemDoEscopo, validarEscopoDaVersao } from "@/lib/ai/agents/escopo";
 import { agentCreateSchema } from "@/lib/ai/guardrails-schema";
 import { agentMcpCreateSchema } from "@/lib/ai/agents/validation";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -85,13 +86,14 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   const authz = await requireRole("admin", { requestId, resource: "ai_agents" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   let rawBody: unknown;
   try {
     rawBody = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
 
   const wantsMcp =
@@ -104,7 +106,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   if (wantsMcp) {
     const parsed = agentMcpCreateSchema.safeParse(rawBody);
     if (!parsed.success) {
-      return fail("validation_failed", "Campos inválidos.", 422, {
+      return fail("validation_failed", t("Campos inválidos."), 422, {
         requestId,
         details: parsed.error.flatten(),
       });
@@ -191,7 +193,7 @@ export async function POST(req: NextRequest): Promise<Response> {
         .from("ai_agents")
         .update({ archived_at: new Date().toISOString() })
         .eq("id", agentRow.id);
-      return fail("internal_error", "Erro ao criar versão inicial.", 500, {
+      return fail("internal_error", t("Erro ao criar versão inicial."), 500, {
         requestId,
         details: { agent_rolled_back: true, db_error: versionErr?.message },
       });
@@ -213,7 +215,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   // Legacy path — kind='rag_bot' (default DB constraint).
   const parsed = agentCreateSchema.safeParse(rawBody);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });

--- a/app/api/v1/ai/budget/route.ts
+++ b/app/api/v1/ai/budget/route.ts
@@ -41,6 +41,7 @@ import {
 } from "@/lib/agent-engine/edge/llm/orcamento";
 import { logger } from "@/lib/logger";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -98,18 +99,19 @@ export async function PATCH(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("admin", { requestId, resource: "ai_budget" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   let body: unknown;
   try {
     body = await req.json();
   } catch {
-    return fail("validation_failed", "JSON inválido.", 422, { requestId });
+    return fail("validation_failed", t("JSON inválido."), 422, { requestId });
   }
 
   const parsed = patchSchema.safeParse(body);
   if (!parsed.success) {
-    return fail("validation_failed", "Payload inválido.", 422, {
+    return fail("validation_failed", t("Payload inválido."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -128,7 +130,7 @@ export async function PATCH(req: NextRequest): Promise<Response> {
       request_id: requestId,
       causa: readErr.message,
     });
-    return fail("internal_error", "Erro ao ler o orçamento.", 500, { requestId });
+    return fail("internal_error", t("Erro ao ler o orçamento."), 500, { requestId });
   }
 
   const modoAntes = normalizarModoDeOrcamento(existing?.enforcement_mode ?? null);
@@ -154,8 +156,8 @@ export async function PATCH(req: NextRequest): Promise<Response> {
     // matar. Quem garante o tempo é a CARÊNCIA de 72h, e é dela que a frase fala.
     return fail(
       "invalid_state_transition",
-      'Antes de fazer a IA parar no limite, salve "Me avisar" — assim o aviso já ' +
-        "está de pé quando a parada começar a valer, 72 horas depois de você armá-la.",
+      t('Antes de fazer a IA parar no limite, salve "Me avisar" — assim o aviso já ') +
+        t("está de pé quando a parada começar a valer, 72 horas depois de você armá-la."),
       422,
       { requestId, details: { de: modoAntes, para: modoDepois, degrau_faltante: "avisar" } },
     );
@@ -226,7 +228,7 @@ export async function PATCH(req: NextRequest): Promise<Response> {
         request_id: requestId,
         causa: updErr.message,
       });
-      return fail("internal_error", "Erro ao atualizar orçamento.", 500, { requestId });
+      return fail("internal_error", t("Erro ao atualizar orçamento."), 500, { requestId });
     }
   } else {
     const { error: insErr } = await admin.from("ai_budgets").insert({
@@ -242,7 +244,7 @@ export async function PATCH(req: NextRequest): Promise<Response> {
         request_id: requestId,
         causa: insErr.message,
       });
-      return fail("internal_error", "Erro ao criar orçamento.", 500, { requestId });
+      return fail("internal_error", t("Erro ao criar orçamento."), 500, { requestId });
     }
   }
 

--- a/app/api/v1/ai/cases/[id]/reply/route.ts
+++ b/app/api/v1/ai/cases/[id]/reply/route.ts
@@ -40,6 +40,7 @@ import { enqueueJob } from "@/lib/agent-engine/queue/queue";
 import { audit } from "@/lib/audit";
 import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -73,6 +74,7 @@ export async function POST(req: NextRequest, { params }: RouteParams): Promise<R
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "agent_cases" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org, user } = authz;
   const { id: caseId } = await params;
 
@@ -80,11 +82,11 @@ export async function POST(req: NextRequest, { params }: RouteParams): Promise<R
   try {
     payload = await req.json();
   } catch {
-    return fail("invalid_request", "Body inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body inválido."), 400, { requestId });
   }
   const parsed = bodySchema.safeParse(payload);
   if (!parsed.success) {
-    return fail("validation_failed", "Body inválido.", 422, {
+    return fail("validation_failed", t("Body inválido."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -95,7 +97,7 @@ export async function POST(req: NextRequest, { params }: RouteParams): Promise<R
   try {
     pool = getRequestPool();
   } catch {
-    return fail("unavailable", "Resposta ao caso indisponível (config).", 503, { requestId });
+    return fail("unavailable", t("Resposta ao caso indisponível (config)."), 503, { requestId });
   }
 
   const { rows } = await pool.query<CaseRow>(
@@ -108,18 +110,18 @@ export async function POST(req: NextRequest, { params }: RouteParams): Promise<R
   );
   const caseRow = rows[0];
   if (caseRow === undefined) {
-    return fail("not_found", "Caso não encontrado.", 404, { requestId });
+    return fail("not_found", t("Caso não encontrado."), 404, { requestId });
   }
   if (caseRow.status !== "awaiting_human") {
     return fail(
       "invalid_state",
-      "O caso não está aguardando resposta do atendente (awaiting_human).",
+      t("O caso não está aguardando resposta do atendente (awaiting_human)."),
       409,
       { requestId },
     );
   }
   if (caseRow.contact_id === null) {
-    return fail("unprocessable_entity", "Conversa do caso sem contato associado.", 422, {
+    return fail("unprocessable_entity", t("Conversa do caso sem contato associado."), 422, {
       requestId,
     });
   }
@@ -165,7 +167,7 @@ export async function POST(req: NextRequest, { params }: RouteParams): Promise<R
       // Corrida perdida entre a leitura e o update. O handoff já aconteceu (e é
       // idempotente), então não mentimos dizendo que escalamos: devolvemos o
       // conflito para a UI reler o caso.
-      return fail("invalid_state", "Este caso já foi respondido por outra pessoa.", 409, {
+      return fail("invalid_state", t("Este caso já foi respondido por outra pessoa."), 409, {
         requestId,
       });
     }
@@ -199,7 +201,7 @@ export async function POST(req: NextRequest, { params }: RouteParams): Promise<R
       client.release();
     }
     if (!transitioned) {
-      return fail("invalid_state", "Este caso já foi respondido por outra pessoa.", 409, {
+      return fail("invalid_state", t("Este caso já foi respondido por outra pessoa."), 409, {
         requestId,
       });
     }

--- a/app/api/v1/ai/cases/[id]/route.ts
+++ b/app/api/v1/ai/cases/[id]/route.ts
@@ -12,6 +12,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { lerChamado } from "@/lib/escalacao/chamados";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -23,6 +24,7 @@ export async function GET(_req: NextRequest, { params }: RouteParams): Promise<R
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "agent_cases" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
   const { id } = await params;
 
@@ -30,9 +32,9 @@ export async function GET(_req: NextRequest, { params }: RouteParams): Promise<R
   try {
     chamado = await lerChamado(createAdminClient(), org.orgId, id);
   } catch {
-    return fail("internal_error", "Falha ao carregar o caso.", 500, { requestId });
+    return fail("internal_error", t("Falha ao carregar o caso."), 500, { requestId });
   }
-  if (!chamado) return fail("not_found", "Caso não encontrado.", 404, { requestId });
+  if (!chamado) return fail("not_found", t("Caso não encontrado."), 404, { requestId });
 
   return ok(chamado, { requestId });
 }

--- a/app/api/v1/ai/cases/route.ts
+++ b/app/api/v1/ai/cases/route.ts
@@ -15,6 +15,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { listarChamados } from "@/lib/escalacao/chamados";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -26,13 +27,14 @@ export async function GET(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "agent_cases" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
 
   const parsed = querySchema.safeParse(
     Object.fromEntries(new URL(req.url).searchParams.entries()),
   );
   if (!parsed.success) {
-    return fail("validation_failed", "Query inválida.", 422, {
+    return fail("validation_failed", t("Query inválida."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -44,6 +46,6 @@ export async function GET(req: NextRequest): Promise<Response> {
     });
     return ok({ cases: chamados, open_count: abertos }, { requestId });
   } catch {
-    return fail("internal_error", "Falha ao carregar os casos.", 500, { requestId });
+    return fail("internal_error", t("Falha ao carregar os casos."), 500, { requestId });
   }
 }

--- a/app/api/v1/ai/credentials/[id]/revalidate/route.ts
+++ b/app/api/v1/ai/credentials/[id]/revalidate/route.ts
@@ -14,6 +14,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { byteaToBuffer, decryptKey } from "@/lib/crypto/aes_gcm";
 import { validateProviderKey } from "@/lib/ai/provider-validators";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -29,6 +30,7 @@ export async function POST(
 
   const authz = await requireRole("admin", { requestId, resource: "ai_credentials" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   const admin = createAdminClient();
@@ -47,10 +49,10 @@ export async function POST(
     return fail("internal_error", "Erro ao consultar credential.", 500, { requestId });
   }
   if (!row || row.organization_id !== activeOrg.orgId) {
-    return fail("not_found", "Credential não encontrada.", 404, { requestId });
+    return fail("not_found", t("Credential não encontrada."), 404, { requestId });
   }
   if (!row.is_active) {
-    return fail("credential_inactive", "Credential desativada.", 409, { requestId });
+    return fail("credential_inactive", t("Credential desativada."), 409, { requestId });
   }
 
   // Leitura direta + decifragem (sem passar pelo gate `validated_at` do
@@ -64,7 +66,7 @@ export async function POST(
     });
   } catch (err) {
     console.error("[ai.credentials] decrypt failed during revalidate", err);
-    return fail("decrypt_failed", "Falha ao decifrar credential.", 500, { requestId });
+    return fail("decrypt_failed", t("Falha ao decifrar credential."), 500, { requestId });
   }
 
   const result = await validateProviderKey(row.provider, apiKey);

--- a/app/api/v1/ai/credentials/[id]/route.ts
+++ b/app/api/v1/ai/credentials/[id]/route.ts
@@ -14,6 +14,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { contarUsoPublicado, type VersaoVinculada } from "@/lib/ai/credenciais/uso";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -26,6 +27,7 @@ export async function DELETE(
 
   const authz = await requireRole("admin", { requestId, resource: "ai_credentials" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   const admin = createAdminClient();
@@ -40,7 +42,7 @@ export async function DELETE(
     return fail("internal_error", "Erro ao consultar credential.", 500, { requestId });
   }
   if (!cred || cred.organization_id !== activeOrg.orgId) {
-    return fail("not_found", "Credential não encontrada.", 404, { requestId });
+    return fail("not_found", t("Credential não encontrada."), 404, { requestId });
   }
 
   // Está referenciada por alguma versão que é published_version_id de agent ativo?
@@ -61,7 +63,7 @@ export async function DELETE(
   if (inUse) {
     return fail(
       "credential_in_use",
-      "Credential é usada por uma versão publicada de agent. Despublique antes de deletar.",
+      t("Credential é usada por uma versão publicada de agent. Despublique antes de deletar."),
       409,
       { requestId },
     );
@@ -77,7 +79,7 @@ export async function DELETE(
     if (delErr.code === "23503") {
       return fail(
         "credential_in_use",
-        "Credential referenciada (FK ON DELETE RESTRICT). Remova as versões antes.",
+        t("Credential referenciada (FK ON DELETE RESTRICT). Remova as versões antes."),
         409,
         { requestId },
       );

--- a/app/api/v1/ai/credentials/route.ts
+++ b/app/api/v1/ai/credentials/route.ts
@@ -20,6 +20,7 @@ import { guardarCredencial } from "@/lib/ai/credenciais/guardar";
 import { IDS_DE_PROVEDOR } from "@/lib/ai/pontos/provedores";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -59,18 +60,19 @@ export async function POST(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("admin", { requestId, resource: "ai_credentials" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   let rawBody: unknown;
   try {
     rawBody = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
 
   const parsed = createSchema.safeParse(rawBody);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -96,7 +98,7 @@ export async function POST(req: NextRequest): Promise<Response> {
     if (guardado.motivo === "label_em_uso") {
       return fail(
         "label_already_used",
-        "Já existe uma credential com este label e provider.",
+        t("Já existe uma credential com este label e provider."),
         409,
         { requestId },
       );

--- a/app/api/v1/ai/evolution/route.test.ts
+++ b/app/api/v1/ai/evolution/route.test.ts
@@ -74,7 +74,7 @@ function fakeDb(
 beforeEach(() => {
   requireRole.mockReset();
   from.mockReset();
-  requireRole.mockResolvedValue({ ok: true, org: { orgId: 'org-1' } });
+  requireRole.mockResolvedValue({ ok: true, org: { orgId: 'org-1' }, user: { idioma: 'pt-BR' } });
   fakeDb();
 });
 

--- a/app/api/v1/ai/evolution/route.ts
+++ b/app/api/v1/ai/evolution/route.ts
@@ -23,6 +23,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 import { aggregateEvolution, type EvolutionInput } from "@/lib/ai/evolution/aggregate";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -60,11 +61,12 @@ export async function GET(req: NextRequest): Promise<Response> {
 
   const authz = await requireRole("manager", { requestId, resource: "ai_evolution" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const orgId = authz.org.orgId;
 
   const parsed = querySchema.safeParse(Object.fromEntries(req.nextUrl.searchParams.entries()));
   if (!parsed.success) {
-    return fail("validation_failed", "Filtros inválidos.", 422, {
+    return fail("validation_failed", t("Filtros inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });

--- a/app/api/v1/ai/followup-flows/[id]/disable/route.ts
+++ b/app/api/v1/ai/followup-flows/[id]/disable/route.ts
@@ -9,6 +9,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -25,6 +26,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
 
   const authz = await requireRole("manager", { requestId, resource: "followup_flows" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org: activeOrg } = authz;
 
   const supabase = await createClient();
@@ -35,7 +37,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
   if (fetchErr) return fail("internal_error", fetchErr.message, 500, { requestId });
-  if (!existing) return fail("not_found", "Fluxo não encontrado.", 404, { requestId });
+  if (!existing) return fail("not_found", t("Fluxo não encontrado."), 404, { requestId });
 
   if (existing.status === "disabled") {
     return ok({ id, status: "disabled" }, { requestId });

--- a/app/api/v1/ai/followup-flows/[id]/publish/route.ts
+++ b/app/api/v1/ai/followup-flows/[id]/publish/route.ts
@@ -20,6 +20,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { validateFlowForPublish } from "@/lib/followup/validate-publish";
 import { publishFollowupFlowVersion } from "@/lib/followup/publish";
 import type { FlowGraph } from "@/lib/followup/graph-schema";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -36,6 +37,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
 
   const authz = await requireRole("manager", { requestId, resource: "followup_flows" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org: activeOrg } = authz;
 
   const admin = createAdminClient();
@@ -46,7 +48,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
   if (fetchErr) return fail("internal_error", fetchErr.message, 500, { requestId });
-  if (!pointer) return fail("not_found", "Fluxo não encontrado.", 404, { requestId });
+  if (!pointer) return fail("not_found", t("Fluxo não encontrado."), 404, { requestId });
 
   // ⚠️ ALLOWLIST, NÃO DENYLIST — e a diferença não é estilo.
   //
@@ -85,7 +87,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
     if (!stageId || !UUID_RX.test(stageId)) {
       return fail(
         "trigger_stage_missing",
-        "Escolha a etapa do funil que dispara este fluxo antes de publicar.",
+        t("Escolha a etapa do funil que dispara este fluxo antes de publicar."),
         422,
         { requestId },
       );
@@ -100,7 +102,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
     if (!stage) {
       return fail(
         "trigger_stage_not_found",
-        "A etapa escolhida para o gatilho não existe mais neste funil — escolha outra.",
+        t("A etapa escolhida para o gatilho não existe mais neste funil — escolha outra."),
         422,
         { requestId },
       );
@@ -116,14 +118,14 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
   }
 
   if (!pointer.draft_graph) {
-    return fail("validation_failed", "Fluxo não tem rascunho pronto para publicar.", 422, {
+    return fail("validation_failed", t("Fluxo não tem rascunho pronto para publicar."), 422, {
       requestId,
       details: {
         errors: [
           {
             node_id: null,
             code: "no_trigger",
-            message: "draft_graph ausente — monte o fluxo antes de publicar.",
+            message: t("draft_graph ausente — monte o fluxo antes de publicar."),
           },
         ],
       },
@@ -133,7 +135,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
   const graph = pointer.draft_graph as unknown as FlowGraph;
   const validation = validateFlowForPublish(graph);
   if (!validation.ok) {
-    return fail("validation_failed", "Fluxo reprovado na validação de publish.", 422, {
+    return fail("validation_failed", t("Fluxo reprovado na validação de publish."), 422, {
       requestId,
       details: { errors: validation.errors },
     });
@@ -147,7 +149,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
   });
   if (!result.ok) {
     if (result.code === "pointer_not_found") {
-      return fail("not_found", "Fluxo não encontrado.", 404, { requestId });
+      return fail("not_found", t("Fluxo não encontrado."), 404, { requestId });
     }
     return fail("internal_error", result.message, 500, { requestId });
   }

--- a/app/api/v1/ai/followup-flows/[id]/rollback/route.ts
+++ b/app/api/v1/ai/followup-flows/[id]/rollback/route.ts
@@ -19,6 +19,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 import { rollbackFollowupFlowSchema } from "@/lib/followup/api-schemas";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -35,18 +36,19 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
 
   const authz = await requireRole("manager", { requestId, resource: "followup_flows" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org: activeOrg } = authz;
 
   let raw: unknown;
   try {
     raw = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
 
   const parsed = rollbackFollowupFlowSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -60,7 +62,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
   if (fetchErr) return fail("internal_error", fetchErr.message, 500, { requestId });
-  if (!pointer) return fail("not_found", "Fluxo não encontrado.", 404, { requestId });
+  if (!pointer) return fail("not_found", t("Fluxo não encontrado."), 404, { requestId });
 
   const { data: version, error: versionErr } = await supabase
     .from("followup_flow_versions")
@@ -70,7 +72,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     .eq("pointer_id", id)
     .maybeSingle();
   if (versionErr) return fail("internal_error", versionErr.message, 500, { requestId });
-  if (!version) return fail("not_found", "Version não encontrada.", 404, { requestId });
+  if (!version) return fail("not_found", t("Version não encontrada."), 404, { requestId });
 
   const { data: updated, error: updErr } = await supabase
     .from("followup_flow_pointers")

--- a/app/api/v1/ai/followup-flows/[id]/route.ts
+++ b/app/api/v1/ai/followup-flows/[id]/route.ts
@@ -16,6 +16,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 import { patchFollowupFlowSchema } from "@/lib/followup/api-schemas";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -35,6 +36,7 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
 
   const authz = await requireRole("viewer", { requestId, resource: "followup_flows" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const supabase = await createClient();
@@ -45,7 +47,7 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
   if (error) return fail("internal_error", error.message, 500, { requestId });
-  if (!data) return fail("not_found", "Fluxo não encontrado.", 404, { requestId });
+  if (!data) return fail("not_found", t("Fluxo não encontrado."), 404, { requestId });
 
   // Linhagem de versions (Task 6.2 — builder): o PublishBar precisa saber se
   // existe versão anterior pra habilitar Rollback. `.limit()` deliberadamente
@@ -89,18 +91,19 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
 
   const authz = await requireRole("manager", { requestId, resource: "followup_flows" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org: activeOrg } = authz;
 
   let raw: unknown;
   try {
     raw = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
 
   const parsed = patchFollowupFlowSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -114,7 +117,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
   if (fetchErr) return fail("internal_error", fetchErr.message, 500, { requestId });
-  if (!existing) return fail("not_found", "Fluxo não encontrado.", 404, { requestId });
+  if (!existing) return fail("not_found", t("Fluxo não encontrado."), 404, { requestId });
 
   const patch = parsed.data;
   if (Object.keys(patch).length === 0) {
@@ -142,7 +145,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
 
   if (updErr || !updated) {
     if (updErr?.code === "23505") {
-      return fail("conflict", "Já existe um fluxo com este nome.", 409, { requestId });
+      return fail("conflict", t("Já existe um fluxo com este nome."), 409, { requestId });
     }
     return fail("internal_error", updErr?.message ?? "followup_flow_update_failed", 500, {
       requestId,
@@ -171,6 +174,7 @@ export async function DELETE(_req: NextRequest, ctx: RouteCtx): Promise<Response
 
   const authz = await requireRole("manager", { requestId, resource: "followup_flows" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org: activeOrg } = authz;
 
   const supabase = await createClient();
@@ -181,7 +185,7 @@ export async function DELETE(_req: NextRequest, ctx: RouteCtx): Promise<Response
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
   if (fetchErr) return fail("internal_error", fetchErr.message, 500, { requestId });
-  if (!existing) return fail("not_found", "Fluxo não encontrado.", 404, { requestId });
+  if (!existing) return fail("not_found", t("Fluxo não encontrado."), 404, { requestId });
 
   // Enrollment referencia version_id; pointer referencia active_version_id.
   // Soltar o relógio nessa ordem evita 23503 no Postgres.

--- a/app/api/v1/ai/followup-flows/route.ts
+++ b/app/api/v1/ai/followup-flows/route.ts
@@ -11,6 +11,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 import { createFollowupFlowSchema } from "@/lib/followup/api-schemas";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -36,18 +37,19 @@ export async function POST(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "followup_flows" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org: activeOrg } = authz;
 
   let raw: unknown;
   try {
     raw = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
 
   const parsed = createFollowupFlowSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -62,7 +64,7 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   if (insErr || !created) {
     if (insErr?.code === "23505") {
-      return fail("conflict", "Já existe um fluxo com este nome.", 409, { requestId });
+      return fail("conflict", t("Já existe um fluxo com este nome."), 409, { requestId });
     }
     return fail("internal_error", insErr?.message ?? "followup_flow_insert_failed", 500, {
       requestId,

--- a/app/api/v1/ai/followups/enrollments/[id]/cancel/route.ts
+++ b/app/api/v1/ai/followups/enrollments/[id]/cancel/route.ts
@@ -16,6 +16,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { logger } from "@/lib/logger";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -36,6 +37,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
 
   const authz = await requireRole("manager", { requestId, resource: "followup_enrollments" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org: activeOrg } = authz;
 
   const supabase = await createClient();
@@ -46,10 +48,10 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
   if (fetchErr) return fail("internal_error", fetchErr.message, 500, { requestId });
-  if (!existing) return fail("not_found", "Enrollment não encontrado.", 404, { requestId });
+  if (!existing) return fail("not_found", t("Enrollment não encontrado."), 404, { requestId });
 
   if (!LIVE_STATUSES.includes(existing.status)) {
-    return fail("already_terminal", "Enrollment já está encerrado.", 409, { requestId });
+    return fail("already_terminal", t("Enrollment já está encerrado."), 409, { requestId });
   }
 
   const { data: updated, error: updErr } = await supabase

--- a/app/api/v1/ai/followups/enrollments/[id]/pause/route.ts
+++ b/app/api/v1/ai/followups/enrollments/[id]/pause/route.ts
@@ -14,6 +14,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { pausaEnrollment } from "@/lib/followup/intervencao";
 import { respostaDaFalha } from "@/lib/followup/intervencao-resposta";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
 
@@ -32,12 +33,13 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
   const authz = await requireRole("manager", { requestId, resource: "followup_enrollments" });
   if (!authz.ok) return authz.response;
   const { user, org } = authz;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   const resultado = await pausaEnrollment(
     { supabase: await createClient(), admin: createAdminClient(), orgId: org.orgId, userId: user.id, requestId },
     id,
   );
-  if (!resultado.ok) return respostaDaFalha(resultado, requestId);
+  if (!resultado.ok) return respostaDaFalha(resultado, requestId, t);
 
   void audit({
     action: "followup_enrollment.paused",

--- a/app/api/v1/ai/followups/enrollments/[id]/resume/route.ts
+++ b/app/api/v1/ai/followups/enrollments/[id]/resume/route.ts
@@ -15,6 +15,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { retomaEnrollment } from "@/lib/followup/intervencao";
 import { respostaDaFalha } from "@/lib/followup/intervencao-resposta";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
 
@@ -33,12 +34,13 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
   const authz = await requireRole("manager", { requestId, resource: "followup_enrollments" });
   if (!authz.ok) return authz.response;
   const { user, org } = authz;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   const resultado = await retomaEnrollment(
     { supabase: await createClient(), admin: createAdminClient(), orgId: org.orgId, userId: user.id, requestId },
     id,
   );
-  if (!resultado.ok) return respostaDaFalha(resultado, requestId);
+  if (!resultado.ok) return respostaDaFalha(resultado, requestId, t);
 
   void audit({
     action: "followup_enrollment.resumed",

--- a/app/api/v1/ai/followups/enrollments/[id]/route.ts
+++ b/app/api/v1/ai/followups/enrollments/[id]/route.ts
@@ -34,6 +34,7 @@ import {
 import { leituraDoPlano, type TimingPlan } from "@/lib/followup/plano-de-tempo";
 import { flowGraphSchema } from "@/lib/followup/graph-schema";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -140,6 +141,7 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
 
   const authz = await requireRole("viewer", { requestId, resource: "followup_enrollments" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
 
   const supabase = await createClient();
@@ -159,7 +161,7 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
     .maybeSingle();
 
   if (error) return fail("internal_error", error.message, 500, { requestId });
-  if (!row) return fail("not_found", "Follow-up não encontrado.", 404, { requestId });
+  if (!row) return fail("not_found", t("Follow-up não encontrado."), 404, { requestId });
 
   const { data: eventos, error: evErr } = await supabase
     .from("followup_enrollment_events")

--- a/app/api/v1/ai/followups/enrollments/[id]/skip/route.ts
+++ b/app/api/v1/ai/followups/enrollments/[id]/skip/route.ts
@@ -21,6 +21,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
 
 import { validaIdDaRota } from "../_id";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -36,6 +37,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
 
   const authz = await requireRole("manager", { requestId, resource: "followup_enrollments" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org } = authz;
 
   // Body ausente é legítimo aqui (nó de saída única não precisa de escolha), então
@@ -48,7 +50,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   }
   const parsed = bodySchema.safeParse(raw ?? {});
   if (!parsed.success) {
-    return fail("validation_failed", "Caminho inválido.", 422, {
+    return fail("validation_failed", t("Caminho inválido."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -59,7 +61,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     id,
     parsed.data.edge_id ?? null,
   );
-  if (!resultado.ok) return respostaDaFalha(resultado, requestId);
+  if (!resultado.ok) return respostaDaFalha(resultado, requestId, t);
 
   void audit({
     action: "followup_enrollment.step_skipped",

--- a/app/api/v1/ai/followups/enrollments/[id]/snooze/route.ts
+++ b/app/api/v1/ai/followups/enrollments/[id]/snooze/route.ts
@@ -19,6 +19,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
 
 import { validaIdDaRota } from "../_id";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -34,17 +35,18 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
 
   const authz = await requireRole("manager", { requestId, resource: "followup_enrollments" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org } = authz;
 
   let raw: unknown;
   try {
     raw = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
   const parsed = bodySchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("validation_failed", "Informe o novo horário.", 422, {
+    return fail("validation_failed", t("Informe o novo horário."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -55,7 +57,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     id,
     parsed.data.next_eval_at,
   );
-  if (!resultado.ok) return respostaDaFalha(resultado, requestId);
+  if (!resultado.ok) return respostaDaFalha(resultado, requestId, t);
 
   void audit({
     action: "followup_enrollment.snoozed",

--- a/app/api/v1/ai/followups/enrollments/route.ts
+++ b/app/api/v1/ai/followups/enrollments/route.ts
@@ -12,6 +12,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 import { createFollowupEnrollmentSchema } from "@/lib/followup/api-schemas";
 import { ENROLLMENT_LIST_COLUMNS, enrollFollowupFlow } from "@/lib/followup/enroll";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -29,11 +30,12 @@ export async function GET(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("viewer", { requestId, resource: "followup_enrollments" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const status = req.nextUrl.searchParams.get("status");
   if (status !== null && !ENROLLMENT_STATUSES.includes(status)) {
-    return fail("invalid_request", "status inválido.", 400, { requestId });
+    return fail("invalid_request", t("status inválido."), 400, { requestId });
   }
 
   const supabase = await createClient();
@@ -53,18 +55,19 @@ export async function POST(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "followup_enrollments" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org: activeOrg } = authz;
 
   let raw: unknown;
   try {
     raw = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
 
   const parsed = createFollowupEnrollmentSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });

--- a/app/api/v1/ai/followups/promises/[id]/cancel/route.ts
+++ b/app/api/v1/ai/followups/promises/[id]/cancel/route.ts
@@ -23,6 +23,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { cancelaRetornoNoCrm } from "@/lib/followup/retorno-crm";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -39,6 +40,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
 
   const authz = await requireRole("manager", { requestId, resource: "followup_promises" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org } = authz;
 
   // Admin client porque a operação compartilhada escreve atividade e lê o
@@ -59,9 +61,9 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
 
   if (!resultado.ok) {
     if (resultado.codigo === "nao_encontrado") {
-      return fail("not_found", "Retorno não encontrado.", 404, { requestId });
+      return fail("not_found", t("Retorno não encontrado."), 404, { requestId });
     }
-    return fail("already_terminal", "Este retorno já aconteceu ou já foi cancelado.", 409, {
+    return fail("already_terminal", t("Este retorno já aconteceu ou já foi cancelado."), 409, {
       requestId,
     });
   }

--- a/app/api/v1/ai/followups/queue/route.ts
+++ b/app/api/v1/ai/followups/queue/route.ts
@@ -29,6 +29,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { situacaoDoRetorno } from "@/lib/followup/retorno";
 import { createClient } from "@/lib/supabase/server";
 import { rotuloDoContato } from "@/lib/contacts/rotulo-do-contato";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -133,23 +134,24 @@ export async function GET(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("viewer", { requestId, resource: "followup_queue" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const sp = req.nextUrl.searchParams;
   const status = sp.get("status");
   if (status !== null && !ENROLLMENT_STATUSES.includes(status as (typeof ENROLLMENT_STATUSES)[number])) {
-    return fail("invalid_request", "status inválido.", 400, { requestId });
+    return fail("invalid_request", t("status inválido."), 400, { requestId });
   }
   const pointerId = sp.get("pointer_id");
   const UUID_RX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   if (pointerId !== null && !UUID_RX.test(pointerId)) {
-    return fail("invalid_request", "pointer_id inválido.", 400, { requestId });
+    return fail("invalid_request", t("pointer_id inválido."), 400, { requestId });
   }
   const q = sp.get("q")?.trim() || null;
   const cursorRaw = sp.get("cursor");
   const cursor = cursorRaw ? decodeCursor(cursorRaw) : null;
   if (cursorRaw && !cursor) {
-    return fail("invalid_request", "cursor inválido.", 400, { requestId });
+    return fail("invalid_request", t("cursor inválido."), 400, { requestId });
   }
   const limitParam = Number(sp.get("limit") ?? "20");
   const limit = Number.isFinite(limitParam) ? Math.min(100, Math.max(1, Math.trunc(limitParam))) : 20;

--- a/app/api/v1/ai/guardrail-layers/route.ts
+++ b/app/api/v1/ai/guardrail-layers/route.ts
@@ -33,6 +33,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { roleAtLeast } from "@/lib/auth/types";
 import { CAMADAS_SEMANTICAS } from "@/lib/agent-engine/guardrails/camadas-da-org";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -90,11 +91,12 @@ const corpoDoPut = z.object({
 export async function PUT(req: NextRequest): Promise<Response> {
   const authz = await requireRole("admin", { resource: "ai_guardrail_layers" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org } = authz;
 
   const parsed = corpoDoPut.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
-    return fail("invalid_body", "corpo inválido", 422, { details: parsed.error.issues });
+    return fail("invalid_body", t("corpo inválido"), 422, { details: parsed.error.issues });
   }
   const corpo = parsed.data;
 
@@ -117,7 +119,7 @@ export async function PUT(req: NextRequest): Promise<Response> {
   if (!gravado) {
     // Upsert que casa zero linhas devolve sucesso no PostgREST — a tela diria
     // "salvo" sem nada ter sido gravado. Mesmo cuidado da rota de provedores.
-    return fail("save_failed", "nada foi gravado — verifique as permissões da organização", 500);
+    return fail("save_failed", t("nada foi gravado — verifique as permissões da organização"), 500);
   }
 
   void audit({

--- a/app/api/v1/ai/inbox/[id]/route.ts
+++ b/app/api/v1/ai/inbox/[id]/route.ts
@@ -11,6 +11,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -28,17 +29,18 @@ export async function PATCH(req: NextRequest, ctx: Ctx): Promise<Response> {
 
   const authz = await requireRole("agent", { requestId, resource: "agent_inbox_items" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org } = authz;
 
   let raw: unknown;
   try {
     raw = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
   const parsed = bodySchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -53,10 +55,10 @@ export async function PATCH(req: NextRequest, ctx: Ctx): Promise<Response> {
     .select("id, kind, severity, title, body, ref_kind, ref_id, status, created_at")
     .maybeSingle();
   if (error) {
-    return fail("internal_error", "Falha ao atualizar o aviso.", 500, { requestId });
+    return fail("internal_error", t("Falha ao atualizar o aviso."), 500, { requestId });
   }
   if (!data) {
-    return fail("not_found", "Aviso não encontrado nesta organização.", 404, { requestId });
+    return fail("not_found", t("Aviso não encontrado nesta organização."), 404, { requestId });
   }
 
   await audit({

--- a/app/api/v1/ai/inbox/route.ts
+++ b/app/api/v1/ai/inbox/route.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -23,13 +24,14 @@ export async function GET(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "agent_inbox_items" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
 
   const parsed = querySchema.safeParse(
     Object.fromEntries(new URL(req.url).searchParams.entries()),
   );
   if (!parsed.success) {
-    return fail("validation_failed", "Query inválida.", 422, {
+    return fail("validation_failed", t("Query inválida."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -48,7 +50,7 @@ export async function GET(req: NextRequest): Promise<Response> {
   }
   const { data, error } = await query;
   if (error) {
-    return fail("internal_error", "Falha ao carregar os avisos.", 500, { requestId });
+    return fail("internal_error", t("Falha ao carregar os avisos."), 500, { requestId });
   }
 
   const { count: openCount } = await admin

--- a/app/api/v1/ai/knowledge/sources/[id]/reindex/route.ts
+++ b/app/api/v1/ai/knowledge/sources/[id]/reindex/route.ts
@@ -18,6 +18,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -37,6 +38,7 @@ export async function POST(
 
   const authz = await requireRole("manager", { requestId, resource: "ai_knowledge" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   // Body é opcional; se vier, valida.
@@ -50,7 +52,7 @@ export async function POST(
     if (raw !== undefined && raw !== null) {
       const parsed = reindexBodySchema.safeParse(raw);
       if (!parsed.success) {
-        return fail("validation_failed", "Campos inválidos.", 422, {
+        return fail("validation_failed", t("Campos inválidos."), 422, {
           requestId,
           details: parsed.error.flatten(),
         });
@@ -72,7 +74,7 @@ export async function POST(
     return fail("internal_error", "Erro ao verificar fonte.", 500, { requestId });
   }
   if (!existing) {
-    return fail("not_found", "Fonte de conhecimento não encontrada.", 404, { requestId });
+    return fail("not_found", t("Fonte de conhecimento não encontrada."), 404, { requestId });
   }
 
   const ksRow = existing as { id: string; agent_id: string; source_type: string };

--- a/app/api/v1/ai/knowledge/sources/[id]/trechos/route.ts
+++ b/app/api/v1/ai/knowledge/sources/[id]/trechos/route.ts
@@ -19,6 +19,7 @@ import { randomUUID } from "node:crypto";
 import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -34,6 +35,7 @@ export async function GET(
 
   const authz = await requireRole("manager", { requestId, resource: "ai_knowledge" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const supabase = await createClient();
@@ -50,7 +52,7 @@ export async function GET(
     return fail("internal_error", "Erro ao ler o material.", 500, { requestId });
   }
   if (!fonte) {
-    return fail("not_found", "Material não encontrado.", 404, { requestId });
+    return fail("not_found", t("Material não encontrado."), 404, { requestId });
   }
 
   const versaoAtiva = (fonte as { active_kb_version_id: string | null }).active_kb_version_id;

--- a/app/api/v1/ai/knowledge/sources/route.ts
+++ b/app/api/v1/ai/knowledge/sources/route.ts
@@ -28,6 +28,7 @@ import {
   rotuloDoTipo,
 } from "@/lib/ai/rag/tipos-de-fonte";
 import { BUCKET_DE_CONHECIMENTO } from "@/lib/ai/rag/ingest/documento";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -107,18 +108,19 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   const authz = await requireRole("manager", { requestId, resource: "ai_knowledge" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   let rawBody: unknown;
   try {
     rawBody = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
 
   const parsed = createSourceSchema.safeParse(rawBody);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -167,7 +169,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       return fail("internal_error", "Erro ao validar agent_id.", 500, { requestId });
     }
     if (!agent) {
-      return fail("not_found", "Assistente não encontrado nesta organização.", 404, { requestId });
+      return fail("not_found", t("Assistente não encontrado nesta organização."), 404, { requestId });
     }
   }
 
@@ -186,13 +188,13 @@ export async function POST(req: NextRequest): Promise<Response> {
       if (faqItems.length === 0) {
         return fail(
           "invalid_request",
-          "Não achei nenhum par pergunta/resposta no texto. Use uma linha ## Pergunta: e uma ## Resposta: por item.",
+          t("Não achei nenhum par pergunta/resposta no texto. Use uma linha ## Pergunta: e uma ## Resposta: por item."),
           400,
           { requestId },
         );
       }
     } else {
-      return fail("invalid_request", "Cole o conteúdo do material antes de criar.", 400, {
+      return fail("invalid_request", t("Cole o conteúdo do material antes de criar."), 400, {
         requestId,
       });
     }
@@ -227,7 +229,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       });
     if (upErr) {
       console.error("[ai-knowledge-sources] guardar o texto falhou:", upErr.message);
-      return fail("internal_error", "Erro ao guardar o conteúdo do material.", 500, { requestId });
+      return fail("internal_error", t("Erro ao guardar o conteúdo do material."), 500, { requestId });
     }
     metadata = { ...metadata, blob_path: blobPath, ext: "md", origem: "texto_colado" };
   }
@@ -284,7 +286,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       // linha que promete conteúdo e nunca vai indexar nada.
       await admin.from("ai_knowledge_sources").delete().eq("id", ksId);
       console.error("[ai-knowledge-sources] insert dos itens falhou:", itemsErr.message);
-      return fail("internal_error", "Erro ao gravar o conteúdo do material.", 500, { requestId });
+      return fail("internal_error", t("Erro ao gravar o conteúdo do material."), 500, { requestId });
     }
     itemsCount = rows.length;
   }

--- a/app/api/v1/ai/knowledge/sources/upload/route.ts
+++ b/app/api/v1/ai/knowledge/sources/upload/route.ts
@@ -31,6 +31,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { temChaveDeEmbedding } from "@/lib/ai/embeddings/chave";
+import { traduzir } from "@/lib/i18n/dicionario";
 import {
   BUCKET_DE_CONHECIMENTO,
   ErroDeExtracao,
@@ -50,13 +51,14 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   const authz = await requireRole("manager", { requestId, resource: "ai_knowledge" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   let formData: FormData;
   try {
     formData = await req.formData();
   } catch {
-    return fail("invalid_request", "Falha ao processar o envio do arquivo.", 400, { requestId });
+    return fail("invalid_request", t("Falha ao processar o envio do arquivo."), 400, { requestId });
   }
 
   const fileEntry = formData.get("file");
@@ -64,13 +66,13 @@ export async function POST(req: NextRequest): Promise<Response> {
   const nameRaw = formData.get("name");
 
   if (!(fileEntry instanceof File)) {
-    return fail("invalid_request", "Nenhum arquivo foi enviado.", 400, { requestId });
+    return fail("invalid_request", t("Nenhum arquivo foi enviado."), 400, { requestId });
   }
   const file = fileEntry;
 
   const nameParsed = nameSchema.safeParse(nameRaw);
   if (!nameParsed.success) {
-    return fail("validation_failed", "Dê um nome ao material (2 a 120 caracteres).", 422, {
+    return fail("validation_failed", t("Dê um nome ao material (2 a 120 caracteres)."), 422, {
       requestId,
     });
   }
@@ -83,7 +85,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   if (agentIdRaw !== null && String(agentIdRaw).length > 0) {
     const agentIdParsed = agentIdSchema.safeParse(agentIdRaw);
     if (!agentIdParsed.success) {
-      return fail("validation_failed", "Campo 'agent_id' deve ser UUID válido.", 422, { requestId });
+      return fail("validation_failed", t("Campo 'agent_id' deve ser UUID válido."), 422, { requestId });
     }
     const supabase = await createClient();
     const { data: agent, error: agentErr } = await supabase
@@ -97,7 +99,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       return fail("internal_error", "Erro ao validar agent_id.", 500, { requestId });
     }
     if (!agent) {
-      return fail("not_found", "Assistente não encontrado nesta organização.", 404, { requestId });
+      return fail("not_found", t("Assistente não encontrado nesta organização."), 404, { requestId });
     }
     agentId = agentIdParsed.data;
   }
@@ -110,7 +112,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   if (!ext) {
     return fail(
       "unsupported_media_type",
-      "Não sei ler esse tipo de arquivo. Envie PDF, Markdown (.md) ou texto (.txt).",
+      t("Não sei ler esse tipo de arquivo. Envie PDF, Markdown (.md) ou texto (.txt)."),
       415,
       { requestId },
     );
@@ -150,7 +152,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   } catch (err) {
     await admin.storage.from(BUCKET_DE_CONHECIMENTO).remove([blobPath]);
     if (err instanceof ErroDeExtracao) {
-      return fail("unprocessable_entity", err.message, 422, { requestId });
+      return fail("unprocessable_entity", t(err.message), 422, { requestId });
     }
     console.error("[conhecimento-upload] extração falhou:", err);
     return fail("internal_error", "Erro ao ler o arquivo.", 500, { requestId });

--- a/app/api/v1/ai/memory/entries/[id]/route.ts
+++ b/app/api/v1/ai/memory/entries/[id]/route.ts
@@ -11,6 +11,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -28,12 +29,13 @@ export async function PATCH(req: NextRequest, ctx: Ctx): Promise<Response> {
 
   const authz = await requireRole("manager", { requestId, resource: "org_memory" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org } = authz;
 
   const body = await req.json().catch(() => null);
   const parsed = patchSchema.safeParse(body);
   if (!parsed.success) {
-    return fail("validation_failed", "status inválido.", 422, {
+    return fail("validation_failed", t("status inválido."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -48,7 +50,7 @@ export async function PATCH(req: NextRequest, ctx: Ctx): Promise<Response> {
     .select("id, status")
     .single();
   if (error || !data) {
-    return fail("not_found", "Entrada de memória não encontrada nesta organização.", 404, {
+    return fail("not_found", t("Entrada de memória não encontrada nesta organização."), 404, {
       requestId,
     });
   }

--- a/app/api/v1/ai/memory/entries/route.ts
+++ b/app/api/v1/ai/memory/entries/route.ts
@@ -11,6 +11,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -23,12 +24,13 @@ export async function POST(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "org_memory" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org } = authz;
 
   const body = await req.json().catch(() => null);
   const parsed = postSchema.safeParse(body);
   if (!parsed.success) {
-    return fail("validation_failed", "title e body são obrigatórios.", 422, {
+    return fail("validation_failed", t("title e body são obrigatórios."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -48,7 +50,7 @@ export async function POST(req: NextRequest): Promise<Response> {
     .select("id")
     .single();
   if (error || !data) {
-    return fail("internal_error", "Erro ao criar entrada de memória.", 500, { requestId });
+    return fail("internal_error", t("Erro ao criar entrada de memória."), 500, { requestId });
   }
 
   await audit({

--- a/app/api/v1/ai/memory/route.ts
+++ b/app/api/v1/ai/memory/route.ts
@@ -16,6 +16,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { publicarMemoriaDaOrg } from "@/lib/ai/memoria-da-org";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -25,6 +26,7 @@ export async function GET(_req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "org_memory" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
 
   const admin = createAdminClient();
@@ -65,7 +67,7 @@ export async function GET(_req: NextRequest): Promise<Response> {
     .eq("organization_id", org.orgId)
     .order("version_number", { ascending: false });
   if (versionsErr) {
-    return fail("internal_error", "Erro ao carregar versões da memória.", 500, { requestId });
+    return fail("internal_error", t("Erro ao carregar versões da memória."), 500, { requestId });
   }
 
   const { data: entries, error: entriesErr } = await admin
@@ -75,7 +77,7 @@ export async function GET(_req: NextRequest): Promise<Response> {
     .neq("status", "proposed")
     .order("created_at", { ascending: false });
   if (entriesErr) {
-    return fail("internal_error", "Erro ao carregar entradas da memória.", 500, { requestId });
+    return fail("internal_error", t("Erro ao carregar entradas da memória."), 500, { requestId });
   }
 
   return ok({ document, versions: versions ?? [], entries: entries ?? [] }, { requestId });
@@ -85,12 +87,13 @@ export async function POST(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("admin", { requestId, resource: "org_memory" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org } = authz;
 
   const body = await req.json().catch(() => null);
   const parsed = postSchema.safeParse(body);
   if (!parsed.success) {
-    return fail("validation_failed", "content é obrigatório.", 422, {
+    return fail("validation_failed", t("content é obrigatório."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -103,8 +106,8 @@ export async function POST(req: NextRequest): Promise<Response> {
     return fail(
       "internal_error",
       pub.erro === "versao"
-        ? "Erro ao publicar versão da memória."
-        : "Erro ao ativar a versão da memória.",
+        ? t("Erro ao publicar versão da memória.")
+        : t("Erro ao ativar a versão da memória."),
       500,
       { requestId },
     );

--- a/app/api/v1/ai/memory/versions/[id]/route.ts
+++ b/app/api/v1/ai/memory/versions/[id]/route.ts
@@ -8,6 +8,7 @@ import { type NextRequest } from "next/server";
 import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -24,6 +25,7 @@ export async function GET(_req: NextRequest, ctx: Ctx): Promise<Response> {
 
   const authz = await requireRole("agent", { requestId, resource: "org_memory" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
 
   const admin = createAdminClient();
@@ -34,10 +36,10 @@ export async function GET(_req: NextRequest, ctx: Ctx): Promise<Response> {
     .eq("organization_id", org.orgId)
     .maybeSingle();
   if (error) {
-    return fail("internal_error", "Erro ao carregar a versão da memória.", 500, { requestId });
+    return fail("internal_error", t("Erro ao carregar a versão da memória."), 500, { requestId });
   }
   if (!data) {
-    return fail("not_found", "Versão não encontrada nesta organização.", 404, { requestId });
+    return fail("not_found", t("Versão não encontrada nesta organização."), 404, { requestId });
   }
 
   return ok(data, { requestId });

--- a/app/api/v1/ai/operator-metrics/route.ts
+++ b/app/api/v1/ai/operator-metrics/route.ts
@@ -30,6 +30,7 @@
 import { fail, ok } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -39,6 +40,7 @@ const DIAS = 30;
 export async function GET(): Promise<Response> {
   const authz = await requireRole("manager", { resource: "ai_operator_metrics" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
 
   const db = await createClient();
@@ -84,6 +86,6 @@ export async function GET(): Promise<Response> {
       quisAgirENaoPode: semFerramenta,
     });
   } catch (err) {
-    return fail("read_failed", err instanceof Error ? err.message : "falha ao ler", 500);
+    return fail("read_failed", err instanceof Error ? err.message : t("falha ao ler"), 500);
   }
 }

--- a/app/api/v1/ai/pacing/route.ts
+++ b/app/api/v1/ai/pacing/route.ts
@@ -14,6 +14,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 import {
   pacingKnobsUpdateSchema,
   knobsView,
@@ -32,6 +33,7 @@ export async function GET(): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "channel_knobs" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
 
   const admin = createAdminClient();
@@ -49,7 +51,7 @@ export async function GET(): Promise<Response> {
       .eq("organization_id", org.orgId),
   ]);
   if (sErr || kErr) {
-    return fail("internal_error", "Falha ao carregar conexões/knobs.", 500, { requestId });
+    return fail("internal_error", t("Falha ao carregar conexões/knobs."), 500, { requestId });
   }
 
   const byuSession = new Map<string, ChannelKnobsRow>(
@@ -66,17 +68,18 @@ export async function PUT(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "channel_knobs" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org } = authz;
 
   let raw: unknown;
   try {
     raw = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
   const parsed = pacingKnobsUpdateSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -119,7 +122,7 @@ export async function PUT(req: NextRequest): Promise<Response> {
     .is("archived_at", null)
     .maybeSingle();
   if (!session) {
-    return fail("session_not_found", "Conexão não encontrada nesta organização.", 404, {
+    return fail("session_not_found", t("Conexão não encontrada nesta organização."), 404, {
       requestId,
     });
   }
@@ -167,7 +170,7 @@ export async function PUT(req: NextRequest): Promise<Response> {
       // O motivo cru vai em `details`, não na `message` que o operador lê: foi a
       // ausência dele que transformou um `not null` num diagnóstico de horas —
       // nem a tela nem o log diziam QUAL campo o banco recusou.
-      return fail("internal_error", "Falha ao salvar os knobs.", 500, {
+      return fail("internal_error", t("Falha ao salvar os knobs."), 500, {
         requestId,
         details: { motivo: upErr.message },
       });
@@ -181,7 +184,7 @@ export async function PUT(req: NextRequest): Promise<Response> {
       .eq("id", channel_session_id)
       .eq("organization_id", org.orgId);
     if (dlErr) {
-      return fail("internal_error", "Falha ao salvar o teto diário.", 500, { requestId });
+      return fail("internal_error", t("Falha ao salvar o teto diário."), 500, { requestId });
     }
   }
 

--- a/app/api/v1/ai/providers/route.ts
+++ b/app/api/v1/ai/providers/route.ts
@@ -30,6 +30,7 @@ import { PAPEIS, PONTOS_DE_IA, PONTO_POR_ID } from "@/lib/ai/pontos/registro";
 import { PROVEDORES, ehProvedorSuportado } from "@/lib/ai/pontos/provedores";
 import { validarBinding } from "@/lib/ai/pontos/validar-binding";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -47,6 +48,7 @@ interface ModeloDoCatalogo {
 export async function GET(): Promise<Response> {
   const authz = await requireRole("manager", { resource: "ai_providers" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
 
   const db = await createClient();
@@ -174,7 +176,7 @@ export async function GET(): Promise<Response> {
         // catálogo; o resolvedor puro não consulta banco.
         ...(capacidade && ponto.exige.tools === true && !capacidade.supports_tools
           ? [
-              `O modelo em uso não sabe usar as ferramentas do CRM — o agente conversa, mas não registra nada no funil.`,
+              t(`O modelo em uso não sabe usar as ferramentas do CRM — o agente conversa, mas não registra nada no funil.`),
             ]
           : []),
       ],
@@ -215,11 +217,12 @@ const corpoDoPut = z.object({
 export async function PUT(req: NextRequest): Promise<Response> {
   const authz = await requireRole("admin", { resource: "ai_providers" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org } = authz;
 
   const parsed = corpoDoPut.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
-    return fail("invalid_body", "corpo inválido", 422, { details: parsed.error.issues });
+    return fail("invalid_body", t("corpo inválido"), 422, { details: parsed.error.issues });
   }
   const corpo = parsed.data;
 
@@ -268,7 +271,7 @@ export async function PUT(req: NextRequest): Promise<Response> {
       .eq("id", corpo.credential_id)
       .eq("organization_id", org.orgId)
       .maybeSingle();
-    if (!cred) return fail("credencial_invalida", "chave não encontrada nesta organização", 422);
+    if (!cred) return fail("credencial_invalida", t("chave não encontrada nesta organização"), 422);
     if (cred.provider !== corpo.provider) {
       return fail(
         "credencial_de_outro_provedor",
@@ -300,7 +303,7 @@ export async function PUT(req: NextRequest): Promise<Response> {
   if (!gravado) {
     // Upsert que casa zero linhas devolve sucesso no PostgREST — a tela diria
     // "salvo" sem nada ter sido gravado.
-    return fail("save_failed", "nada foi gravado — verifique as permissões da organização", 500);
+    return fail("save_failed", t("nada foi gravado — verifique as permissões da organização"), 500);
   }
 
   void audit({

--- a/app/api/v1/ai/routers/[id]/members/route.ts
+++ b/app/api/v1/ai/routers/[id]/members/route.ts
@@ -11,6 +11,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -38,18 +39,19 @@ export async function PUT(req: NextRequest, ctx: RouteCtx): Promise<Response> {
 
   const authz = await requireRole("admin", { requestId, resource: "ai_routers" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org } = authz;
 
   let rawBody: unknown;
   try {
     rawBody = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
 
   const parsed = membersPutSchema.safeParse(rawBody);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -68,7 +70,7 @@ export async function PUT(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     return fail("internal_error", "Erro ao carregar router.", 500, { requestId });
   }
   if (!router) {
-    return fail("not_found", "Router não encontrado.", 404, { requestId });
+    return fail("not_found", t("Router não encontrado."), 404, { requestId });
   }
 
   // Substitui a lista inteira: apaga os membros atuais (filtrando org) e
@@ -96,7 +98,7 @@ export async function PUT(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     const { error: insErr } = await admin.from("ai_router_members").insert(rows);
     if (insErr) {
       if (insErr.code === "23505") {
-        return fail("duplicate_intent_name", "Duas intenções não podem ter o mesmo nome no router.", 409, {
+        return fail("duplicate_intent_name", t("Duas intenções não podem ter o mesmo nome no router."), 409, {
           requestId,
         });
       }

--- a/app/api/v1/ai/routers/[id]/route.ts
+++ b/app/api/v1/ai/routers/[id]/route.ts
@@ -14,6 +14,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -44,6 +45,7 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
 
   const authz = await requireRole("agent", { requestId, resource: "ai_routers" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
 
   const admin = createAdminClient();
@@ -58,7 +60,7 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
     return fail("internal_error", "Erro ao buscar router.", 500, { requestId });
   }
   if (!router) {
-    return fail("not_found", "Router não encontrado.", 404, { requestId });
+    return fail("not_found", t("Router não encontrado."), 404, { requestId });
   }
 
   const { data: members, error: membersErr } = await admin
@@ -87,18 +89,19 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
 
   const authz = await requireRole("admin", { requestId, resource: "ai_routers" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org } = authz;
 
   let rawBody: unknown;
   try {
     rawBody = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
 
   const parsed = patchRouterSchema.safeParse(rawBody);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -117,7 +120,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
     return fail("internal_error", "Erro ao carregar router.", 500, { requestId });
   }
   if (!existing) {
-    return fail("not_found", "Router não encontrado.", 404, { requestId });
+    return fail("not_found", t("Router não encontrado."), 404, { requestId });
   }
 
   const update: Record<string, unknown> = {};
@@ -140,7 +143,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
     .eq("organization_id", org.orgId);
   if (updErr) {
     if (updErr.code === "23505") {
-      return fail("router_already_exists", "Este número já tem um roteador ativo.", 409, { requestId });
+      return fail("router_already_exists", t("Este número já tem um roteador ativo."), 409, { requestId });
     }
     return fail("internal_error", "Erro ao atualizar router.", 500, { requestId });
   }
@@ -171,6 +174,7 @@ export async function DELETE(_req: NextRequest, ctx: RouteCtx): Promise<Response
 
   const authz = await requireRole("admin", { requestId, resource: "ai_routers" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org } = authz;
 
   const admin = createAdminClient();
@@ -185,7 +189,7 @@ export async function DELETE(_req: NextRequest, ctx: RouteCtx): Promise<Response
     return fail("internal_error", "Erro ao carregar router.", 500, { requestId });
   }
   if (!existing) {
-    return fail("not_found", "Router não encontrado.", 404, { requestId });
+    return fail("not_found", t("Router não encontrado."), 404, { requestId });
   }
 
   const { error: delErr } = await admin

--- a/app/api/v1/ai/routers/[id]/test/route.ts
+++ b/app/api/v1/ai/routers/[id]/test/route.ts
@@ -26,6 +26,7 @@ import { llmEdgeConfigFromEnv } from "@/lib/agent-engine/edge/llm/credentials";
 import { createLogger } from "@/lib/agent-engine/obs/logger";
 import { loadActiveRouter } from "@/lib/agent-engine/agent/router-config";
 import { classifyIntent } from "@/lib/agent-engine/agent/intent-classifier";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -46,18 +47,19 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
 
   const authz = await requireRole("manager", { requestId, resource: "ai_routers" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
 
   let rawBody: unknown;
   try {
     rawBody = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
 
   const parsed = testSchema.safeParse(rawBody);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -74,7 +76,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     return fail("internal_error", "Erro ao carregar router.", 500, { requestId });
   }
   if (!router) {
-    return fail("not_found", "Router não encontrado.", 404, { requestId });
+    return fail("not_found", t("Router não encontrado."), 404, { requestId });
   }
 
   const pool = getSkillsPool();
@@ -82,7 +84,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   if (!loaded || loaded.id !== id) {
     return fail(
       "state_conflict",
-      "O router precisa estar ativo (is_active=true) para ser testado.",
+      t("O router precisa estar ativo (is_active=true) para ser testado."),
       409,
       { requestId },
     );

--- a/app/api/v1/ai/routers/route.ts
+++ b/app/api/v1/ai/routers/route.ts
@@ -16,6 +16,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { ARCHIVED_AT, queryTolerantToMissingArchived } from "@/lib/channels/archived";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -75,18 +76,19 @@ export async function POST(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("admin", { requestId, resource: "ai_routers" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org } = authz;
 
   let rawBody: unknown;
   try {
     rawBody = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
 
   const parsed = createRouterSchema.safeParse(rawBody);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -115,10 +117,10 @@ export async function POST(req: NextRequest): Promise<Response> {
     () => base().maybeSingle(),
   );
   if (sessionErr) {
-    return fail("internal_error", "Erro ao verificar o número de WhatsApp.", 500, { requestId });
+    return fail("internal_error", t("Erro ao verificar o número de WhatsApp."), 500, { requestId });
   }
   if (!session) {
-    return fail("channel_session_not_found", "Número de WhatsApp não encontrado nesta organização.", 404, {
+    return fail("channel_session_not_found", t("Número de WhatsApp não encontrado nesta organização."), 404, {
       requestId,
     });
   }
@@ -138,7 +140,7 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   if (insErr || !created) {
     if (insErr?.code === "23505") {
-      return fail("router_already_exists", "Este número já tem um roteador ativo.", 409, { requestId });
+      return fail("router_already_exists", t("Este número já tem um roteador ativo."), 409, { requestId });
     }
     return fail("internal_error", "Erro ao criar router.", 500, { requestId });
   }

--- a/app/api/v1/ai/runs/route.ts
+++ b/app/api/v1/ai/runs/route.ts
@@ -16,6 +16,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { PONTO_POR_ID } from "@/lib/ai/pontos/registro";
 import { EXPLICACAO_DA_ORIGEM, type OrigemDaEscolha } from "@/lib/ai/pontos/resolver";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -74,6 +75,7 @@ const filtrosDaQuery = z.object({
 export async function GET(req: NextRequest): Promise<Response> {
   const authz = await requireRole("manager", { resource: "ai_runs" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
 
   // Zod na query string, como a rota irmã de uso já faz. `Math.min(Number(…))`
@@ -82,7 +84,7 @@ export async function GET(req: NextRequest): Promise<Response> {
   // crua no corpo — resposta de servidor para um erro do cliente.
   const filtros = filtrosDaQuery.safeParse(Object.fromEntries(new URL(req.url).searchParams));
   if (!filtros.success) {
-    return fail("invalid_query", "filtros inválidos", 422, { details: filtros.error.issues });
+    return fail("invalid_query", t("filtros inválidos"), 422, { details: filtros.error.issues });
   }
   const { purpose, status, limit: limite } = filtros.data;
 

--- a/app/api/v1/ai/skills/[name]/install/route.ts
+++ b/app/api/v1/ai/skills/[name]/install/route.ts
@@ -17,6 +17,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getSkillsPool } from "@/lib/ai/skills/db";
 import { installPlatformSkill } from "@/lib/ai/skills/install";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -30,12 +31,13 @@ export async function POST(
 
   const authz = await requireRole("manager", { requestId, resource: "ai_skills" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org } = authz;
 
   const { name: rawName } = await ctx.params;
   const nameParsed = nameSchema.safeParse(decodeURIComponent(rawName));
   if (!nameParsed.success) {
-    return fail("validation_failed", "Nome de skill inválido.", 422, { requestId });
+    return fail("validation_failed", t("Nome de skill inválido."), 422, { requestId });
   }
   const name = nameParsed.data;
 
@@ -51,7 +53,7 @@ export async function POST(
     .eq("name", name)
     .maybeSingle();
   if (!platformSkill) {
-    return fail("not_found", "Skill não encontrada no catálogo de plataforma.", 404, { requestId });
+    return fail("not_found", t("Skill não encontrada no catálogo de plataforma."), 404, { requestId });
   }
 
   const db = getSkillsPool();

--- a/app/api/v1/ai/skills/[name]/route.ts
+++ b/app/api/v1/ai/skills/[name]/route.ts
@@ -16,6 +16,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -29,12 +30,13 @@ export async function DELETE(
 
   const authz = await requireRole("manager", { requestId, resource: "ai_skills" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org } = authz;
 
   const { name: rawName } = await ctx.params;
   const nameParsed = nameSchema.safeParse(decodeURIComponent(rawName));
   if (!nameParsed.success) {
-    return fail("validation_failed", "Nome de skill inválido.", 422, { requestId });
+    return fail("validation_failed", t("Nome de skill inválido."), 422, { requestId });
   }
   const name = nameParsed.data;
 
@@ -50,7 +52,7 @@ export async function DELETE(
     return fail("internal_error", "Erro ao desinstalar a skill.", 500, { requestId });
   }
   if (!deleted || deleted.length === 0) {
-    return fail("not_found", "Skill não está instalada nesta organização.", 404, { requestId });
+    return fail("not_found", t("Skill não está instalada nesta organização."), 404, { requestId });
   }
 
   await audit({

--- a/app/api/v1/ai/skills/import/route.ts
+++ b/app/api/v1/ai/skills/import/route.ts
@@ -19,6 +19,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { getSkillsPool } from "@/lib/ai/skills/db";
 import { parseSkillPackage } from "@/lib/ai/skills/package";
 import { importSkillPackage } from "@/lib/ai/skills/install";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -27,6 +28,7 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   const authz = await requireRole("manager", { requestId, resource: "ai_skills" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org } = authz;
 
   // Guard against large uploads before buffering into memory. `parseSkillPackage`'s
@@ -35,19 +37,19 @@ export async function POST(req: NextRequest): Promise<Response> {
   const MAX_UPLOAD_BYTES = 6 * 1024 * 1024; // 6MB: teto do envelope multipart (5MB skill + overhead)
   const contentLength = Number(req.headers.get("content-length") ?? "0");
   if (contentLength > MAX_UPLOAD_BYTES) {
-    return fail("skill_upload_too_large", "O arquivo enviado é grande demais (máx. 5 MB por skill).", 413, { requestId });
+    return fail("skill_upload_too_large", t("O arquivo enviado é grande demais (máx. 5 MB por skill)."), 413, { requestId });
   }
 
   let formData: FormData;
   try {
     formData = await req.formData();
   } catch {
-    return fail("invalid_request", "Falha ao processar multipart/form-data.", 400, { requestId });
+    return fail("invalid_request", t("Falha ao processar multipart/form-data."), 400, { requestId });
   }
 
   const fileEntry = formData.get("file");
   if (!(fileEntry instanceof File)) {
-    return fail("invalid_request", "Campo 'file' ausente ou inválido.", 400, { requestId });
+    return fail("invalid_request", t("Campo 'file' ausente ou inválido."), 400, { requestId });
   }
 
   const zipBytes = new Uint8Array(await fileEntry.arrayBuffer());

--- a/app/api/v1/ai/skills/route.ts
+++ b/app/api/v1/ai/skills/route.ts
@@ -19,6 +19,7 @@ import { type NextRequest } from "next/server";
 import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -39,6 +40,7 @@ export async function GET(_req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "ai_skills" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
 
   const admin = createAdminClient();
@@ -56,7 +58,7 @@ export async function GET(_req: NextRequest): Promise<Response> {
     .select("name, version_id")
     .is("organization_id", null);
   if (platErr) {
-    return fail("internal_error", "Erro ao carregar catálogo de skills.", 500, { requestId });
+    return fail("internal_error", t("Erro ao carregar catálogo de skills."), 500, { requestId });
   }
 
   const orgRows = (orgPointers ?? []) as OrgPointerRow[];
@@ -70,7 +72,7 @@ export async function GET(_req: NextRequest): Promise<Response> {
       .select("id, description, forked_from_version_id")
       .in("id", versionIds);
     if (verErr) {
-      return fail("internal_error", "Erro ao carregar descrição das skills.", 500, { requestId });
+      return fail("internal_error", t("Erro ao carregar descrição das skills."), 500, { requestId });
     }
     versions = (versionRows ?? []) as VersionRow[];
   }

--- a/app/api/v1/ai/usage/route.ts
+++ b/app/api/v1/ai/usage/route.ts
@@ -18,6 +18,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 import { aggregateUsage, type InvocationRow } from "@/lib/ai/usage/aggregate";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -64,13 +65,14 @@ export async function GET(req: NextRequest): Promise<Response> {
 
   const authz = await requireRole("manager", { requestId, resource: "ai_usage" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const parsed = querySchema.safeParse(
     Object.fromEntries(req.nextUrl.searchParams.entries()),
   );
   if (!parsed.success) {
-    return fail("validation_failed", "Filtros inválidos.", 422, {
+    return fail("validation_failed", t("Filtros inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });

--- a/app/api/v1/attendants/availability/[user_id]/route.ts
+++ b/app/api/v1/attendants/availability/[user_id]/route.ts
@@ -23,6 +23,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { roleAtLeast } from "@/lib/auth/types";
 import { availabilityPatchSchema, validateRequest } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -38,6 +39,7 @@ export async function PATCH(
 
   const authz = await requireRole("agent", { requestId, resource: "attendant_availability" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   const isSelf = targetUserId === authUser.id;
@@ -45,7 +47,7 @@ export async function PATCH(
   if (!isSelf && !isManager) {
     return fail(
       "forbidden_role",
-      "Só o próprio atendente ou um manager pode alterar esta disponibilidade.",
+      t("Só o próprio atendente ou um manager pode alterar esta disponibilidade."),
       403,
       { requestId },
     );
@@ -77,7 +79,7 @@ export async function PATCH(
       .is("revoked_at", null)
       .maybeSingle();
     if (memberErr) return fail("internal_error", memberErr.message, 500, { requestId });
-    if (!member) return fail("not_found", "Atendente não encontrado na organização.", 404, { requestId });
+    if (!member) return fail("not_found", t("Atendente não encontrado na organização."), 404, { requestId });
   }
 
   const now = new Date().toISOString();

--- a/app/api/v1/audit/export/route.ts
+++ b/app/api/v1/audit/export/route.ts
@@ -10,6 +10,7 @@ import { fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 import { auditQuerySchema } from "@/lib/schemas/audit";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -40,13 +41,14 @@ export async function GET(req: NextRequest): Promise<Response> {
     allowPlatformAdmin: true,
   });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const params = Object.fromEntries(new URL(req.url).searchParams.entries());
   // Force a high limit for export, ignore caller's `limit`.
   const parsed = auditQuerySchema.safeParse({ ...params, limit: undefined });
   if (!parsed.success) {
-    return fail("validation_failed", "Query inválida.", 422, {
+    return fail("validation_failed", t("Query inválida."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });

--- a/app/api/v1/audit/route.ts
+++ b/app/api/v1/audit/route.ts
@@ -12,6 +12,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 import { auditQuerySchema, decodeAuditCursor, encodeAuditCursor } from "@/lib/schemas/audit";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -23,12 +24,13 @@ export async function GET(req: NextRequest): Promise<Response> {
     allowPlatformAdmin: true,
   });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const params = Object.fromEntries(new URL(req.url).searchParams.entries());
   const parsed = auditQuerySchema.safeParse(params);
   if (!parsed.success) {
-    return fail("validation_failed", "Query inválida.", 422, {
+    return fail("validation_failed", t("Query inválida."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -54,7 +56,7 @@ export async function GET(req: NextRequest): Promise<Response> {
 
   if (q.cursor) {
     const c = decodeAuditCursor(q.cursor);
-    if (!c) return fail("invalid_cursor", "Cursor inválido.", 400, { requestId });
+    if (!c) return fail("invalid_cursor", t("Cursor inválido."), 400, { requestId });
     // (created_at, id) < (cursor.created_at, cursor.id) — keyset DESC
     query = query.or(
       `created_at.lt.${c.created_at},and(created_at.eq.${c.created_at},id.lt.${c.id})`,

--- a/app/api/v1/automation-rules/[id]/route.ts
+++ b/app/api/v1/automation-rules/[id]/route.ts
@@ -13,6 +13,7 @@ import { updateAutomationRuleSchema } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { encryptRuleActionSecrets } from "@/lib/webhooks/secrets";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -25,6 +26,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
   const { id } = await ctx.params;
   const authz = await requireRole("manager", { requestId, resource: "automation_rules" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org: activeOrg } = authz;
 
   let raw: unknown = {};
@@ -35,7 +37,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
   }
   const parsed = updateAutomationRuleSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("invalid_request", "Dados inválidos.", 400, {
+    return fail("invalid_request", t("Dados inválidos."), 400, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -49,7 +51,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
   if (fetchErr) return fail("internal_error", fetchErr.message, 500, { requestId });
-  if (!existing) return fail("not_found", "Regra não encontrada.", 404, { requestId });
+  if (!existing) return fail("not_found", t("Regra não encontrada."), 404, { requestId });
 
   // Secrets de call_webhook nunca ficam em claro no jsonb (migration 0041);
   // secret_enc existente (round-trip do editor) passa intacto.
@@ -66,7 +68,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
     if (safeActions === null) {
       return fail(
         "encryption_unavailable",
-        "Não foi possível guardar o segredo do webhook com segurança: a chave de cifra desta instalação não está ativa. Quem administra o servidor resolve rodando o update.sh, que gera e ativa a chave.",
+        t("Não foi possível guardar o segredo do webhook com segurança: a chave de cifra desta instalação não está ativa. Quem administra o servidor resolve rodando o update.sh, que gera e ativa a chave."),
         422,
         { requestId },
       );
@@ -102,6 +104,7 @@ export async function DELETE(_req: NextRequest, ctx: RouteCtx): Promise<Response
   const { id } = await ctx.params;
   const authz = await requireRole("manager", { requestId, resource: "automation_rules" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org: activeOrg } = authz;
 
   const supabase = await createClient();
@@ -112,7 +115,7 @@ export async function DELETE(_req: NextRequest, ctx: RouteCtx): Promise<Response
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
   if (fetchErr) return fail("internal_error", fetchErr.message, 500, { requestId });
-  if (!existing) return fail("not_found", "Regra não encontrada.", 404, { requestId });
+  if (!existing) return fail("not_found", t("Regra não encontrada."), 404, { requestId });
 
   const { error: delErr } = await supabase.from("automation_rules").delete().eq("id", id);
   if (delErr) return fail("internal_error", delErr.message, 500, { requestId });

--- a/app/api/v1/automation-rules/route.ts
+++ b/app/api/v1/automation-rules/route.ts
@@ -13,6 +13,7 @@ import { createAutomationRuleSchema } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { encryptRuleActionSecrets } from "@/lib/webhooks/secrets";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -36,6 +37,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "automation_rules" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org: activeOrg } = authz;
 
   let raw: unknown = {};
@@ -46,7 +48,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   }
   const parsed = createAutomationRuleSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("invalid_request", "Dados inválidos.", 400, {
+    return fail("invalid_request", t("Dados inválidos."), 400, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -57,7 +59,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   if (safeActions === null) {
     return fail(
       "encryption_unavailable",
-      "Não foi possível guardar o segredo do webhook com segurança: a chave de cifra desta instalação não está ativa. Quem administra o servidor resolve rodando o update.sh, que gera e ativa a chave. Enquanto isso, você pode criar a ação sem segredo.",
+      t("Não foi possível guardar o segredo do webhook com segurança: a chave de cifra desta instalação não está ativa. Quem administra o servidor resolve rodando o update.sh, que gera e ativa a chave. Enquanto isso, você pode criar a ação sem segredo."),
       422,
       { requestId },
     );

--- a/app/api/v1/automation-rules/runs/[runId]/resend/route.ts
+++ b/app/api/v1/automation-rules/runs/[runId]/resend/route.ts
@@ -16,6 +16,7 @@ import { buildContext } from "@/lib/automation/engine";
 import { executeCallWebhook } from "@/lib/automation/actions/call-webhook";
 import type { ActionCtx, ActionResultDetail } from "@/lib/automation/types";
 import type { EventRow } from "@/lib/event-log/dispatcher";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -33,6 +34,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
   const { runId } = await ctx.params;
   const authz = await requireRole("manager", { requestId, resource: "automation_rules" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org: activeOrg } = authz;
 
   const supabase = await createClient();
@@ -44,10 +46,10 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
   if (runErr) return fail("internal_error", runErr.message, 500, { requestId });
-  if (!run) return fail("not_found", "Run não encontrado.", 404, { requestId });
+  if (!run) return fail("not_found", t("Run não encontrado."), 404, { requestId });
 
   if (!run.event_id) {
-    return fail("event_gone", "O evento original deste run foi removido.", 409, { requestId });
+    return fail("event_gone", t("O evento original deste run foi removido."), 409, { requestId });
   }
 
   const { data: rule, error: ruleErr } = await supabase
@@ -57,7 +59,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
   if (ruleErr) return fail("internal_error", ruleErr.message, 500, { requestId });
-  if (!rule) return fail("not_found", "Regra do run não encontrada.", 404, { requestId });
+  if (!rule) return fail("not_found", t("Regra do run não encontrada."), 404, { requestId });
 
   const { data: eventRow, error: eventErr } = await supabase
     .from("event_log")
@@ -67,7 +69,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
     .maybeSingle();
   if (eventErr) return fail("internal_error", eventErr.message, 500, { requestId });
   if (!eventRow) {
-    return fail("event_gone", "O evento original deste run foi removido.", 409, { requestId });
+    return fail("event_gone", t("O evento original deste run foi removido."), 409, { requestId });
   }
 
   const typedEvent = eventRow as unknown as EventRow;
@@ -94,7 +96,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
   if (callWebhookActions.length === 0) {
     return fail(
       "no_actions_to_resend",
-      "Esta automação não tem mais nenhuma ação de webhook — não há o que reenviar.",
+      t("Esta automação não tem mais nenhuma ação de webhook — não há o que reenviar."),
       409,
       { requestId },
     );

--- a/app/api/v1/channel-sessions/[id]/reconnect/route.ts
+++ b/app/api/v1/channel-sessions/[id]/reconnect/route.ts
@@ -40,6 +40,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { ARCHIVED_AT, queryTolerantToMissingArchived } from "@/lib/channels/archived";
 import { createClient } from "@/lib/supabase/server";
 import { getWahaClient, wahaFriendlyError } from "@/lib/waha/client";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -67,6 +68,7 @@ export async function POST(
     allowPlatformAdmin: true,
   });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org: activeOrg } = authz;
 
   const supabase = await createClient();
@@ -89,11 +91,11 @@ export async function POST(
     waha_session_name: string | null;
     archived_at?: string | null;
   } | null;
-  if (!session) return fail("not_found", "Canal não encontrado.", 404, { requestId });
+  if (!session) return fail("not_found", t("Canal não encontrado."), 404, { requestId });
   if (session.archived_at) {
     return fail(
       "channel_archived",
-      "Este número foi excluído da Central de Conexões — reconectar não o traz de volta. Conecte um número para voltar a atender.",
+      t("Este número foi excluído da Central de Conexões — reconectar não o traz de volta. Conecte um número para voltar a atender."),
       409,
       { requestId },
     );
@@ -107,7 +109,7 @@ export async function POST(
   if (!nomeSessao) {
     return fail(
       "channel_without_session",
-      "Este canal é o oficial (API da plataforma): ele não tem sessão de WhatsApp para reiniciar. Se parou de entregar, atualize a credencial na tela do canal oficial.",
+      t("Este canal é o oficial (API da plataforma): ele não tem sessão de WhatsApp para reiniciar. Se parou de entregar, atualize a credencial na tela do canal oficial."),
       422,
       { requestId },
     );
@@ -117,7 +119,7 @@ export async function POST(
   if (!waha) {
     return fail(
       "waha_not_configured",
-      "O WhatsApp (WAHA) não está configurado neste ambiente: faltam WAHA_API_BASE_URL e/ou WAHA_API_KEY. Configure-as e tente de novo.",
+      t("O WhatsApp (WAHA) não está configurado neste ambiente: faltam WAHA_API_BASE_URL e/ou WAHA_API_KEY. Configure-as e tente de novo."),
       503,
       { requestId },
     );

--- a/app/api/v1/channel-sessions/[id]/route.ts
+++ b/app/api/v1/channel-sessions/[id]/route.ts
@@ -30,6 +30,7 @@ import { isChannelStatus } from "@/lib/schemas/channels";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
 import { getWahaClient, wahaFriendlyError } from "@/lib/waha/client";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -286,6 +287,7 @@ export async function DELETE(
     allowPlatformAdmin: true,
   });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org: activeOrg } = authz;
 
   const supabase = await createClient();
@@ -295,7 +297,7 @@ export async function DELETE(
     .eq("organization_id", activeOrg.orgId)
     .eq("id", id)
     .maybeSingle();
-  if (!session) return fail("not_found", "Canal não encontrado.", 404, { requestId });
+  if (!session) return fail("not_found", t("Canal não encontrado."), 404, { requestId });
 
   const impact = await loadDeletionImpact(activeOrg.orgId, id);
   const arquivar = impact.outcome === "archive";
@@ -312,7 +314,7 @@ export async function DELETE(
     if (!waha) {
       return fail(
         "waha_not_configured",
-        "O WhatsApp (WAHA) não está configurado neste ambiente (faltam WAHA_API_BASE_URL e/ou WAHA_API_KEY) — sem ele o número não pode ser desconectado do aparelho.",
+        t("O WhatsApp (WAHA) não está configurado neste ambiente (faltam WAHA_API_BASE_URL e/ou WAHA_API_KEY) — sem ele o número não pode ser desconectado do aparelho."),
         503,
         { requestId },
       );

--- a/app/api/v1/channel-sessions/route.ts
+++ b/app/api/v1/channel-sessions/route.ts
@@ -17,6 +17,7 @@ import { ARCHIVED_AT, queryTolerantToMissingArchived } from "@/lib/channels/arch
 import { createChannelSchema } from "@/lib/schemas/channels";
 import { createClient } from "@/lib/supabase/server";
 import { getWahaClient, wahaFriendlyError } from "@/lib/waha/client";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -64,13 +65,14 @@ export async function POST(req: NextRequest): Promise<Response> {
     allowPlatformAdmin: true,
   });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org: activeOrg } = authz;
 
   const waha = getWahaClient();
   if (!waha) {
     return fail(
       "waha_not_configured",
-      "O WhatsApp (WAHA) não está configurado neste ambiente: faltam WAHA_API_BASE_URL e/ou WAHA_API_KEY. Configure-as e tente de novo.",
+      t("O WhatsApp (WAHA) não está configurado neste ambiente: faltam WAHA_API_BASE_URL e/ou WAHA_API_KEY. Configure-as e tente de novo."),
       503,
       { requestId },
     );
@@ -84,7 +86,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   }
   const parsed = createChannelSchema.safeParse(raw ?? {});
   if (!parsed.success) {
-    return fail("validation_failed", "Dados inválidos.", 422, {
+    return fail("validation_failed", t("Dados inválidos."), 422, {
       requestId,
       details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
     });

--- a/app/api/v1/channels/official/route.ts
+++ b/app/api/v1/channels/official/route.ts
@@ -33,6 +33,7 @@ import { reactivateChannelSession } from "@/lib/channels/reactivate";
 import { env } from "@/lib/env";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { encryptWebhookSecret } from "@/lib/webhooks/secrets";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -110,12 +111,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const requestId = randomUUID();
   const authz = await requireRole("admin", { requestId, resource: "channels_official" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const orgId = authz.org.orgId;
   const userId = authz.user.id;
 
   const parsed = conectarSchema.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
-    return fail("invalid_request", "phone_number_id, waba_id e token são obrigatórios", 422, {
+    return fail("invalid_request", t("phone_number_id, waba_id e token são obrigatórios"), 422, {
       requestId,
     });
   }
@@ -135,7 +137,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     // recusar. O operador precisa saber que falta uma configuração de servidor.
     return fail(
       "invalid_request",
-      "cifra indisponível nesta instalação (GUC app.nuvemshop_oauth_key ausente) — o token não foi gravado",
+      t("cifra indisponível nesta instalação (GUC app.nuvemshop_oauth_key ausente) — o token não foi gravado"),
       422,
       { requestId },
     );

--- a/app/api/v1/channels/partner/route.ts
+++ b/app/api/v1/channels/partner/route.ts
@@ -31,6 +31,7 @@ import {
 import { env } from "@/lib/env";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { encryptWebhookSecret } from "@/lib/webhooks/secrets";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -99,11 +100,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   // dono, não de quem atende.
   const authz = await requireRole("admin", { requestId, resource: "channels_partner" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const orgId = authz.org.orgId;
 
   const parsed = conectarSchema.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
-    return fail("invalid_request", "account_id e api_key são obrigatórios", 422, { requestId });
+    return fail("invalid_request", t("account_id e api_key são obrigatórios"), 422, { requestId });
   }
 
   // A rota não sabe com quem fala: pergunta se a credencial presta e o canal responde.
@@ -125,7 +127,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     // operador precisa saber que falta configuração de servidor.
     return fail(
       "invalid_request",
-      "cifra indisponível nesta instalação — a chave não foi gravada",
+      t("cifra indisponível nesta instalação — a chave não foi gravada"),
       422,
       { requestId },
     );

--- a/app/api/v1/channels/partner/templates/media/route.ts
+++ b/app/api/v1/channels/partner/templates/media/route.ts
@@ -27,6 +27,7 @@ import type { NextRequest } from "next/server";
 
 import { fail, ok } from "@/lib/api/wrappers";
 import { loadAuthUser, resolveActiveOrg } from "@/lib/auth/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { logger } from "@/lib/logger";
 import { createAdminClient } from "@/lib/supabase/admin";
 
@@ -50,26 +51,27 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   const user = await loadAuthUser();
   if (!user) return fail("unauthenticated", "Faça login.", 401, { requestId });
+  const t = (texto: string) => traduzir(texto, user.idioma);
   const org = await resolveActiveOrg(user);
-  if (!org) return fail("forbidden", "Sem organização ativa.", 403, { requestId });
+  if (!org) return fail("forbidden", t("Sem organização ativa."), 403, { requestId });
 
   const form = await req.formData().catch(() => null);
   const file = form?.get("file");
   if (!(file instanceof File)) {
-    return fail("validation_failed", "Campo 'file' (multipart) obrigatório.", 422, { requestId });
+    return fail("validation_failed", t("Campo 'file' (multipart) obrigatório."), 422, { requestId });
   }
 
   const mime = file.type || "application/octet-stream";
   if (!TIPOS.has(mime)) {
     return fail(
       "unsupported_media_type",
-      "O cabeçalho aceita imagem JPG ou PNG.",
+      t("O cabeçalho aceita imagem JPG ou PNG."),
       415,
       { requestId },
     );
   }
   if (file.size > TAMANHO_MAX) {
-    return fail("payload_too_large", "A imagem precisa ter até 5 MB.", 413, { requestId });
+    return fail("payload_too_large", t("A imagem precisa ter até 5 MB."), 413, { requestId });
   }
 
   const ext = mime === "image/png" ? "png" : "jpg";

--- a/app/api/v1/channels/partner/templates/route.ts
+++ b/app/api/v1/channels/partner/templates/route.ts
@@ -38,6 +38,8 @@ import {
   type ChannelSessionRef,
 } from "@/lib/channels";
 import { findPartnerSession } from "@/lib/channels/connect";
+import { traduzir } from "@/lib/i18n/dicionario";
+import type { Idioma } from "@/lib/i18n/idiomas";
 import { logger } from "@/lib/logger";
 import { createAdminClient } from "@/lib/supabase/admin";
 
@@ -48,6 +50,7 @@ interface Contexto {
   sessionId: string;
   sessionRef: string;
   provider: ChannelProvider;
+  idioma: Idioma;
 }
 
 /**
@@ -61,15 +64,16 @@ async function contexto(
 ): Promise<{ ok: true; ctx: Contexto } | { ok: false; res: Response }> {
   const user = await loadAuthUser();
   if (!user) return { ok: false, res: fail("unauthenticated", "Faça login.", 401, { requestId }) };
+  const t = (texto: string) => traduzir(texto, user.idioma);
   const org = await resolveActiveOrg(user);
-  if (!org) return { ok: false, res: fail("forbidden", "Sem organização ativa.", 403, { requestId }) };
+  if (!org) return { ok: false, res: fail("forbidden", t("Sem organização ativa."), 403, { requestId }) };
 
   const admin = createAdminClient();
   const sessao = await findPartnerSession(admin, org.orgId);
   if (!sessao || sessao.archivedAt) {
     return {
       ok: false,
-      res: fail("not_found", "Nenhuma conexão de parceiro ativa.", 404, { requestId }),
+      res: fail("not_found", t("Nenhuma conexão de parceiro ativa."), 404, { requestId }),
     };
   }
 
@@ -87,11 +91,14 @@ async function contexto(
   if (!sessionRef) {
     return {
       ok: false,
-      res: fail("failed_precondition", "Conexão sem identificador utilizável.", 409, { requestId }),
+      res: fail("failed_precondition", t("Conexão sem identificador utilizável."), 409, { requestId }),
     };
   }
 
-  return { ok: true, ctx: { orgId: org.orgId, sessionId: sessao.id, sessionRef, provider } };
+  return {
+    ok: true,
+    ctx: { orgId: org.orgId, sessionId: sessao.id, sessionRef, provider, idioma: user.idioma },
+  };
 }
 
 /** Lista o que está ESPELHADO. Rápido, e é o que a tela mostra. */
@@ -140,10 +147,11 @@ export async function POST(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const r = await contexto(requestId);
   if (!r.ok) return r.res;
+  const t = (texto: string) => traduzir(texto, r.ctx.idioma);
 
   const adapter = getAdapter(r.ctx.provider);
   if (!adapter.templates) {
-    return fail("not_implemented", "Este canal não gerencia definições.", 501, { requestId });
+    return fail("not_implemented", t("Este canal não gerencia definições."), 501, { requestId });
   }
 
   const corpo = (await req.json().catch(() => ({}))) as {
@@ -157,7 +165,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   try {
     if (corpo.acao === "criar") {
       if (!corpo.name || !corpo.language || !Array.isArray(corpo.components)) {
-        return fail("invalid_request", "Faltam nome, idioma ou conteúdo.", 400, { requestId });
+        return fail("invalid_request", t("Faltam nome, idioma ou conteúdo."), 400, { requestId });
       }
       // A plataforma valida o formato do nome e devolve o motivo com código. Não
       // duplicamos a regra: regra copiada envelhece separado da fonte.

--- a/app/api/v1/contacts/[id]/proposals/[proposal_id]/route.ts
+++ b/app/api/v1/contacts/[id]/proposals/[proposal_id]/route.ts
@@ -31,6 +31,7 @@ import { fail, ok } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -59,12 +60,13 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   // editar a ficha, e editar ficha é trabalho de quem atende.
   const guard = await requireRole("agent", { requestId });
   if (!guard.ok) return guard.response;
+  const t = (texto: string) => traduzir(texto, guard.user.idioma);
   const orgId = guard.org.orgId;
   const userId = guard.user.id;
 
   const parsed = Body.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
-    return fail("invalid_body", "decision é obrigatório (accept | dismiss).", 400, { requestId });
+    return fail("invalid_body", t("decision é obrigatório (accept | dismiss)."), 400, { requestId });
   }
   const { decision, motivo } = parsed.data;
 
@@ -101,12 +103,12 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
       const st = (existe as { status: string }).status;
       return fail(
         "proposal_not_pending",
-        st === "expired" ? "Esta sugestão venceu pelo prazo." : "Esta sugestão já foi decidida.",
+        st === "expired" ? t("Esta sugestão venceu pelo prazo.") : t("Esta sugestão já foi decidida."),
         409,
         { requestId },
       );
     }
-    return fail("not_found", "Sugestão não encontrada.", 404, { requestId });
+    return fail("not_found", t("Sugestão não encontrada."), 404, { requestId });
   }
 
   const p = decidida as PropostaDecidida;
@@ -164,9 +166,9 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
       // decisão humana, e ela é fato mesmo que a escrita tenha sido barrada.
       // Reverter para `pending` reapresentaria o botão e convidaria ao mesmo
       // clique, sem que nada tivesse mudado.
-      return fail(err.code, err.message ?? "Não foi possível gravar.", err.status, { requestId });
+      return fail(err.code, err.message ?? t("Não foi possível gravar."), err.status, { requestId });
     }
-    return fail("internal_error", "Não foi possível gravar o dado.", 500, { requestId });
+    return fail("internal_error", t("Não foi possível gravar o dado."), 500, { requestId });
   }
 
   await audit({

--- a/app/api/v1/contacts/[id]/route.ts
+++ b/app/api/v1/contacts/[id]/route.ts
@@ -12,6 +12,7 @@ import { ApiError } from "@/lib/api/types";
 import { ok, fail, noContent } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { loadAuthUser, resolveActiveOrg } from "@/lib/auth/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { contactPatchSchema, validateRequest } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
 
@@ -36,9 +37,10 @@ export async function GET(
   }
 
   const authUser = await loadAuthUser();
+  const t = (texto: string) => traduzir(texto, authUser?.idioma ?? "pt-BR");
   const activeOrg = authUser ? await resolveActiveOrg(authUser) : null;
   if (!activeOrg) {
-    return fail("no_active_org", "No active organization.", 403, { requestId });
+    return fail("no_active_org", t("No active organization."), 403, { requestId });
   }
 
   const decryptPurpose = req.headers.get("x-decrypt-purpose");
@@ -50,6 +52,7 @@ export async function GET(
         organization_id: activeOrg.orgId,
         actor: { type: "user", id: user.id },
         requestId,
+        idioma: authUser?.idioma,
       },
       { contactId: id, decryptPurpose },
     );
@@ -96,6 +99,7 @@ export async function PATCH(
         organization_id: activeOrg.orgId,
         actor: { type: "user", id: user.id },
         requestId,
+        idioma: user.idioma,
       },
       id,
       input,
@@ -130,6 +134,7 @@ export async function DELETE(
         organization_id: activeOrg.orgId,
         actor: { type: "user", id: user.id },
         requestId,
+        idioma: user.idioma,
       },
       id,
     );

--- a/app/api/v1/contacts/[id]/timeline/route.ts
+++ b/app/api/v1/contacts/[id]/timeline/route.ts
@@ -21,6 +21,8 @@ import { randomUUID } from "node:crypto";
 import { type NextRequest } from "next/server";
 
 import { ok, fail } from "@/lib/api/wrappers";
+import { loadAuthUser } from "@/lib/auth/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { createClient } from "@/lib/supabase/server";
 import type { TimelineItem } from "@/lib/types/contacts";
 import {
@@ -48,6 +50,8 @@ export async function GET(
   if (authErr || !user) {
     return fail("unauthenticated", "Auth required.", 401, { requestId });
   }
+  const authUser = await loadAuthUser();
+  const t = (texto: string) => traduzir(texto, authUser?.idioma ?? "pt-BR");
 
   const url = new URL(req.url);
   const types = url.searchParams.getAll("type").filter(Boolean);
@@ -59,7 +63,7 @@ export async function GET(
   if (cursorRaw) {
     cursor = decodeCursor(cursorRaw);
     if (!cursor) {
-      return fail("invalid_cursor", "Cursor inválido.", 400, { requestId });
+      return fail("invalid_cursor", t("Cursor inválido."), 400, { requestId });
     }
   }
 
@@ -70,7 +74,7 @@ export async function GET(
     .eq("id", contactId)
     .maybeSingle();
   if (cErr) return fail("internal_error", cErr.message, 500, { requestId });
-  if (!contactRow) return fail("not_found", "Contato não encontrado.", 404, { requestId });
+  if (!contactRow) return fail("not_found", t("Contato não encontrado."), 404, { requestId });
 
   // Resolve owned lead ids first.
   const { data: leadRows, error: lErr } = await supabase

--- a/app/api/v1/contacts/_handler.ts
+++ b/app/api/v1/contacts/_handler.ts
@@ -11,6 +11,8 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { ApiError } from "@/lib/api/types";
 import type { Actor, HandlerCtx } from "@/lib/api/handlers/types";
 import { audit } from "@/lib/audit";
+import { traduzir } from "@/lib/i18n/dicionario";
+import type { Idioma } from "@/lib/i18n/idiomas";
 import { roleAtLeast } from "@/lib/auth/types";
 import { canonicalPhoneBR, phoneLookupVariants } from "@/lib/channels/phone-variants";
 import { hashCpf, encryptCpfSql } from "@/lib/contacts/cpf";
@@ -164,7 +166,13 @@ export async function listContactsHandler(
   if (q.cursor) {
     const c = decodeCursor(q.cursor);
     if (!c) {
-      throw new ApiError(400, "invalid_cursor", undefined, ctx.requestId, "Cursor inválido.");
+      throw new ApiError(
+        400,
+        "invalid_cursor",
+        undefined,
+        ctx.requestId,
+        traduzir("Cursor inválido.", ctx.idioma ?? "pt-BR"),
+      );
     }
     const op = asc ? "gt" : "lt";
     if (c.sort) {
@@ -280,7 +288,13 @@ export async function getContactHandler(
     throw new ApiError(500, "internal_error", undefined, ctx.requestId, error.message);
   }
   if (!data) {
-    throw new ApiError(404, "not_found", undefined, ctx.requestId, "Contato não encontrado.");
+    throw new ApiError(
+      404,
+      "not_found",
+      undefined,
+      ctx.requestId,
+      traduzir("Contato não encontrado.", ctx.idioma ?? "pt-BR"),
+    );
   }
   const contact = data as Contact;
 
@@ -459,7 +473,13 @@ export async function patchContactHandler(
     throw new ApiError(500, "internal_error", undefined, ctx.requestId, selErr.message);
   }
   if (!existing) {
-    throw new ApiError(404, "not_found", undefined, ctx.requestId, "Contato não encontrado.");
+    throw new ApiError(
+      404,
+      "not_found",
+      undefined,
+      ctx.requestId,
+      traduzir("Contato não encontrado.", ctx.idioma ?? "pt-BR"),
+    );
   }
   if (existing.is_anonymized) {
     throw new ApiError(
@@ -467,7 +487,7 @@ export async function patchContactHandler(
       "lgpd_anonymization_irreversible",
       undefined,
       ctx.requestId,
-      "Contato anonimizado — edição bloqueada (LGPD).",
+      traduzir("Contato anonimizado — edição bloqueada (LGPD).", ctx.idioma ?? "pt-BR"),
     );
   }
 
@@ -523,7 +543,7 @@ export async function patchContactHandler(
       "invalid_request",
       undefined,
       ctx.requestId,
-      "Nenhum campo para atualizar.",
+      traduzir("Nenhum campo para atualizar.", ctx.idioma ?? "pt-BR"),
     );
   }
 
@@ -545,7 +565,7 @@ export async function patchContactHandler(
       "not_found",
       undefined,
       ctx.requestId,
-      "Contato não encontrado após update.",
+      traduzir("Contato não encontrado após update.", ctx.idioma ?? "pt-BR"),
     );
   }
 
@@ -630,6 +650,7 @@ export async function patchContactHandler(
 function throwOnDbError(
   err: { code?: string; message: string } | null,
   requestId: string,
+  idioma: Idioma = "pt-BR",
 ): void {
   if (!err) return;
   // conversations/messages apontam para contacts com ON DELETE RESTRICT.
@@ -639,7 +660,7 @@ function throwOnDbError(
       "state_conflict",
       undefined,
       requestId,
-      "Não foi possível excluir: o contato ainda tem registros vinculados.",
+      traduzir("Não foi possível excluir: o contato ainda tem registros vinculados.", idioma),
     );
   }
   throw new ApiError(500, "internal_error", undefined, requestId, err.message);
@@ -661,7 +682,13 @@ export async function deleteContactHandler(
     throw new ApiError(500, "internal_error", undefined, ctx.requestId, selErr.message);
   }
   if (!existing) {
-    throw new ApiError(404, "not_found", undefined, ctx.requestId, "Contato não encontrado.");
+    throw new ApiError(
+      404,
+      "not_found",
+      undefined,
+      ctx.requestId,
+      traduzir("Contato não encontrado.", ctx.idioma ?? "pt-BR"),
+    );
   }
 
   // Mensagens e conversas RESTRICT no contato: apagar primeiro, senão o DELETE
@@ -671,14 +698,14 @@ export async function deleteContactHandler(
     .delete()
     .eq("contact_id", contactId)
     .eq("organization_id", ctx.organization_id);
-  throwOnDbError(msgErr, ctx.requestId);
+  throwOnDbError(msgErr, ctx.requestId, ctx.idioma);
 
   const { error: convErr } = await supabase
     .from("conversations")
     .delete()
     .eq("contact_id", contactId)
     .eq("organization_id", ctx.organization_id);
-  throwOnDbError(convErr, ctx.requestId);
+  throwOnDbError(convErr, ctx.requestId, ctx.idioma);
 
   const { data: deleted, error: delErr } = await supabase
     .from("contacts")
@@ -687,9 +714,15 @@ export async function deleteContactHandler(
     .eq("organization_id", ctx.organization_id)
     .select("id")
     .maybeSingle();
-  throwOnDbError(delErr, ctx.requestId);
+  throwOnDbError(delErr, ctx.requestId, ctx.idioma);
   if (!deleted) {
-    throw new ApiError(404, "not_found", undefined, ctx.requestId, "Contato não encontrado.");
+    throw new ApiError(
+      404,
+      "not_found",
+      undefined,
+      ctx.requestId,
+      traduzir("Contato não encontrado.", ctx.idioma ?? "pt-BR"),
+    );
   }
 
   const a = actorAuditPayload(ctx.actor);

--- a/app/api/v1/contacts/duplicates/route.ts
+++ b/app/api/v1/contacts/duplicates/route.ts
@@ -22,6 +22,7 @@ import {
   principalSugerido,
   type ContatoParaDeduplicar,
 } from "@/lib/contacts/duplicados";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -46,7 +47,8 @@ export async function GET(): Promise<Response> {
   }
   const org = await resolveActiveOrg(user);
   if (!org) {
-    return fail("forbidden_tenant", "Organização ativa não resolvida.", 403, { requestId });
+    const t = (texto: string) => traduzir(texto, user.idioma);
+    return fail("forbidden_tenant", t("Organização ativa não resolvida."), 403, { requestId });
   }
 
   const supabase = await createClient();

--- a/app/api/v1/contacts/import/route.ts
+++ b/app/api/v1/contacts/import/route.ts
@@ -24,6 +24,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { audit } from "@/lib/audit";
 import { encryptCpfSql, hashCpf } from "@/lib/contacts/cpf";
+import { traduzir } from "@/lib/i18n/dicionario";
 import {
   CSV_MAX_BYTES,
   CSV_MAX_DATA_ROWS,
@@ -60,6 +61,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   if (!authz.ok) return authz.response;
   const user = authz.user;
   const orgId = authz.org.orgId;
+  const t = (texto: string) => traduzir(texto, user.idioma);
 
   let file: File;
   try {
@@ -68,9 +70,12 @@ export async function POST(req: NextRequest): Promise<Response> {
     if (!(f instanceof File)) throw new Error("sem arquivo");
     file = f;
   } catch {
-    return fail("validation_failed", "Envie o arquivo como multipart/form-data no campo 'file'.", 422, {
-      requestId,
-    });
+    return fail(
+      "validation_failed",
+      t("Envie o arquivo como multipart/form-data no campo 'file'."),
+      422,
+      { requestId },
+    );
   }
 
   const nome = file.name ?? "";
@@ -81,32 +86,35 @@ export async function POST(req: NextRequest): Promise<Response> {
   if (!tipoOk) {
     return fail(
       "validation_failed",
-      "Formato não suportado — envie um arquivo .csv. No Excel use 'Salvar como' → 'CSV UTF-8'.",
+      t("Formato não suportado — envie um arquivo .csv. No Excel use 'Salvar como' → 'CSV UTF-8'."),
       422,
       { requestId },
     );
   }
   if (file.size > CSV_MAX_BYTES) {
-    return fail("validation_failed", `Arquivo maior que ${Math.floor(CSV_MAX_BYTES / 1024 / 1024)}MB.`, 413, {
-      requestId,
-    });
+    return fail(
+      "validation_failed",
+      t("Arquivo maior que ") + `${Math.floor(CSV_MAX_BYTES / 1024 / 1024)}MB.`,
+      413,
+      { requestId },
+    );
   }
 
   // ─── Parse + validação de linhas (puro; nada tocou no banco ainda) ───────
   // Os BYTES, não `file.text()` — ver `decodificarCsv` (#483).
   const decodificado = decodificarCsv(await file.arrayBuffer());
   if ("erro" in decodificado) {
-    return fail("validation_failed", decodificado.erro, 422, { requestId });
+    return fail("validation_failed", t(decodificado.erro), 422, { requestId });
   }
   const text = decodificado.texto;
   const rows = parseCsv(text);
   if (rows.length < 2) {
-    return fail("validation_failed", "CSV vazio ou sem linhas de dados.", 422, { requestId });
+    return fail("validation_failed", t("CSV vazio ou sem linhas de dados."), 422, { requestId });
   }
   const header = rows[0]!;
-  const mapeado = mapHeader(header);
+  const mapeado = mapHeader(header, t);
   if (mapeado.motivo !== null) {
-    return fail("validation_failed", `Cabeçalho inválido: ${mapeado.motivo}.`, 422, {
+    return fail("validation_failed", `${t("Cabeçalho inválido:")} ${mapeado.motivo}.`, 422, {
       details: { header: header.join(", ") },
       requestId,
     });
@@ -117,7 +125,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   if (dataRows.length > CSV_MAX_DATA_ROWS) {
     return fail(
       "validation_failed",
-      `Máximo de ${CSV_MAX_DATA_ROWS} linhas por importação — divida a planilha.`,
+      `${t("Máximo de")} ${CSV_MAX_DATA_ROWS} ${t("linhas por importação — divida a planilha.")}`,
       422,
       { requestId },
     );
@@ -129,13 +137,13 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   for (let i = 0; i < dataRows.length; i++) {
     const linha = i + 2; // 1-based contando o cabeçalho — bate com o editor de planilhas.
-    const { contato, motivo } = mapLinha(dataRows[i]!, indices);
+    const { contato, motivo } = mapLinha(dataRows[i]!, indices, t);
     if (motivo !== null) {
       errors.push({ linha, motivo });
       continue;
     }
     if (contato.cpf && !isValidCpf(contato.cpf)) {
-      errors.push({ linha, motivo: `CPF inválido: "${contato.cpf}"` });
+      errors.push({ linha, motivo: t("CPF inválido: ") + `"${contato.cpf}"` });
       continue;
     }
     const chave = contato.phone_number ?? `email:${(contato.email as string).toLowerCase()}`;
@@ -147,7 +155,7 @@ export async function POST(req: NextRequest): Promise<Response> {
     const parsed = contactCreateSchema.safeParse({ ...contato, source: SOURCE_IMPORT_CSV });
     if (!parsed.success) {
       const primeiro = parsed.error.issues[0];
-      errors.push({ linha, motivo: primeiro?.message ?? "dados inválidos" });
+      errors.push({ linha, motivo: primeiro?.message ?? t("dados inválidos") });
       continue;
     }
     candidatos.push({ linha, contato: parsed.data as Record<string, unknown> });

--- a/app/api/v1/contacts/route.ts
+++ b/app/api/v1/contacts/route.ts
@@ -11,6 +11,7 @@ import { ApiError } from "@/lib/api/types";
 import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { loadAuthUser, resolveActiveOrg } from "@/lib/auth/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 import {
   contactCreateSchema,
   contactListQuerySchema,
@@ -33,6 +34,8 @@ export async function GET(req: NextRequest): Promise<Response> {
   if (authErr || !user) {
     return fail("unauthenticated", "Auth required.", 401, { requestId });
   }
+  const authUser = await loadAuthUser();
+  const t = (texto: string) => traduzir(texto, authUser?.idioma ?? "pt-BR");
 
   const url = new URL(req.url);
   const qsParsed = contactListQuerySchema.safeParse({
@@ -45,13 +48,12 @@ export async function GET(req: NextRequest): Promise<Response> {
     order_dir: url.searchParams.get("order_dir") ?? undefined,
   });
   if (!qsParsed.success) {
-    return fail("validation_failed", "Query inválida.", 422, {
+    return fail("validation_failed", t("Query inválida."), 422, {
       details: qsParsed.error.flatten().fieldErrors as Record<string, unknown>,
       requestId,
     });
   }
 
-  const authUser = await loadAuthUser();
   const orgId = authUser ? (await resolveActiveOrg(authUser))?.orgId : undefined;
 
   try {
@@ -61,6 +63,7 @@ export async function GET(req: NextRequest): Promise<Response> {
         organization_id: orgId ?? "",
         actor: { type: "user", id: user.id },
         requestId,
+        idioma: authUser?.idioma,
       },
       qsParsed.data,
     );
@@ -102,6 +105,7 @@ export async function POST(req: NextRequest): Promise<Response> {
         organization_id: activeOrg.orgId,
         actor: { type: "user", id: user.id },
         requestId,
+        idioma: user.idioma,
       },
       input as ContactCreate,
     );

--- a/app/api/v1/conversations/[id]/claim/route.ts
+++ b/app/api/v1/conversations/[id]/claim/route.ts
@@ -24,6 +24,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { claimConversationSchema, validateRequest } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
 import type { Conversation } from "@/lib/types/messaging";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -39,6 +40,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   // spec 13 §4: escrita é agent+ (viewer é read-only).
   const authz = await requireRole("agent", { requestId, resource: "conversations" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const user = authz.user;
 
   let input;
@@ -70,7 +72,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   }
   const row = data?.[0];
   if (!row) {
-    return fail("state_conflict", "Outro atendente já assumiu.", 409, { requestId });
+    return fail("state_conflict", t("Outro atendente já assumiu."), 409, { requestId });
   }
 
   const conv = row as unknown as Conversation;
@@ -107,7 +109,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     contactId: conv.contact_id,
     tipo: "conversation_claimed",
     actor: { type: "user", id: user.id, role: authz.org.role },
-    motivo: "Assumiu o atendimento desta conversa",
+    motivo: t("Assumiu o atendimento desta conversa"),
   });
 
   return ok(conv, { requestId });

--- a/app/api/v1/conversations/[id]/claim/route.ts
+++ b/app/api/v1/conversations/[id]/claim/route.ts
@@ -109,7 +109,9 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     contactId: conv.contact_id,
     tipo: "conversation_claimed",
     actor: { type: "user", id: user.id, role: authz.org.role },
-    motivo: t("Assumiu o atendimento desta conversa"),
+    // Canônico em português: quem traduz é a LEITURA (`t(item.reason)`). Ver o
+    // bloco "vocabulario de dominio persistido" em `lib/i18n/dicionario.ts`.
+    motivo: "Assumiu o atendimento desta conversa",
   });
 
   return ok(conv, { requestId });

--- a/app/api/v1/conversations/[id]/close/route.ts
+++ b/app/api/v1/conversations/[id]/close/route.ts
@@ -12,6 +12,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { logger } from "@/lib/logger";
 import { createClient } from "@/lib/supabase/server";
 import type { Conversation } from "@/lib/types/messaging";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -35,6 +36,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
   // spec 13 §4: escrita é agent+ (viewer é read-only).
   const authz = await requireRole("agent", { requestId, resource: "conversations" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const user = authz.user;
 
   const now = new Date().toISOString();
@@ -73,7 +75,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
     return fail("internal_error", error.message, 500, { requestId });
   }
   if (!data) {
-    return fail("not_found", "Conversa não encontrada.", 404, { requestId });
+    return fail("not_found", t("Conversa não encontrada."), 404, { requestId });
   }
 
   const conv = data as unknown as Conversation;

--- a/app/api/v1/conversations/[id]/draft-reply/route.ts
+++ b/app/api/v1/conversations/[id]/draft-reply/route.ts
@@ -20,6 +20,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { env } from "@/lib/env";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -41,6 +42,7 @@ export async function POST(_req: NextRequest, { params }: RouteParams): Promise<
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "conversations" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
   const { id } = await params;
 
@@ -51,16 +53,16 @@ export async function POST(_req: NextRequest, { params }: RouteParams): Promise<
     .eq("id", id)
     .eq("organization_id", org.orgId)
     .maybeSingle();
-  if (!conv) return fail("not_found", "Conversa não encontrada.", 404, { requestId });
+  if (!conv) return fail("not_found", t("Conversa não encontrada."), 404, { requestId });
   if (!conv.contact_id || !conv.channel_session_id) {
-    return fail("unprocessable", "Conversa sem contato/canal.", 422, { requestId });
+    return fail("unprocessable", t("Conversa sem contato/canal."), 422, { requestId });
   }
 
   let pool;
   try {
     pool = getRequestPool();
   } catch {
-    return fail("unavailable", "Rascunho da IA indisponível (config).", 503, { requestId });
+    return fail("unavailable", t("Rascunho da IA indisponível (config)."), 503, { requestId });
   }
 
   // Falha controlada (getLeadContext ok:false) volta como reason:'error' e vira
@@ -84,7 +86,7 @@ export async function POST(_req: NextRequest, { params }: RouteParams): Promise<
 
   if (!result.ok) {
     const [code, message, status] = REASON_TO_RESPONSE[result.reason];
-    return fail(code, message, status, { requestId });
+    return fail(code, t(message), status, { requestId });
   }
   return ok({ draft: result.draft }, { requestId });
 }

--- a/app/api/v1/conversations/[id]/mark-read/route.ts
+++ b/app/api/v1/conversations/[id]/mark-read/route.ts
@@ -35,6 +35,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
         organization_id: authz.org.orgId,
         actor: { type: "user", id: authz.user.id },
         requestId,
+        idioma: authz.user.idioma,
       },
       id,
     );

--- a/app/api/v1/conversations/[id]/media/route.ts
+++ b/app/api/v1/conversations/[id]/media/route.ts
@@ -14,6 +14,7 @@ import { validateOutboundMedia } from "@/lib/messaging/media/upload-validation";
 import { transcodificarNotaDeVoz } from "@/lib/messaging/media/voice-transcode";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -33,10 +34,11 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   // claim/route.ts:35 é o modelo literal.
   const authz = await requireRole("agent", { requestId, resource: "conversation_media" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const user = authz.user;
   const authUser = await loadAuthUser();
   const activeOrg = authUser ? await resolveActiveOrg(authUser) : null;
-  if (!activeOrg) return fail("no_active_org", "No active organization.", 403, { requestId });
+  if (!activeOrg) return fail("no_active_org", t("No active organization."), 403, { requestId });
 
   // RLS + filtro explícito: a conversa precisa ser da org ativa.
   const { data: conv, error: convErr } = await supabase
@@ -45,21 +47,21 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     .eq("id", conversationId)
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
-  if (convErr) return fail("internal_error", "Erro ao validar conversa.", 500, { requestId });
-  if (!conv) return fail("not_found", "Conversa não encontrada.", 404, { requestId });
+  if (convErr) return fail("internal_error", t("Erro ao validar conversa."), 500, { requestId });
+  if (!conv) return fail("not_found", t("Conversa não encontrada."), 404, { requestId });
 
   // Guard de DoS: rejeita pelo Content-Length declarado ANTES de bufferizar
   // o corpo inteiro. 1MB de slack pro overhead de multipart; o check
   // autoritativo continua o file.size pós-parse (Content-Length pode mentir).
   const declared = Number(req.headers.get("content-length") ?? 0);
   if (declared > MAX_MEDIA_BYTES + 1_048_576) {
-    return fail("payload_too_large", "Arquivo acima de 50MB.", 413, { requestId });
+    return fail("payload_too_large", t("Arquivo acima de 50MB."), 413, { requestId });
   }
 
   const form = await req.formData().catch(() => null);
   const file = form?.get("file");
   if (!(file instanceof File)) {
-    return fail("validation_failed", "Campo 'file' (multipart) obrigatório.", 422, { requestId });
+    return fail("validation_failed", t("Campo 'file' (multipart) obrigatório."), 422, { requestId });
   }
 
   const mime = file.type || "application/octet-stream";
@@ -88,7 +90,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     .upload(storagePath, buffer, { contentType: mimeFinal, upsert: false });
   if (upErr) {
     console.error("[conversations.media] upload failed", upErr.message);
-    return fail("internal_error", "Erro ao subir o arquivo.", 500, { requestId });
+    return fail("internal_error", t("Erro ao subir o arquivo."), 500, { requestId });
   }
 
   return ok(

--- a/app/api/v1/conversations/[id]/messages/route.ts
+++ b/app/api/v1/conversations/[id]/messages/route.ts
@@ -8,6 +8,7 @@ import { type NextRequest } from "next/server";
 import { ApiError } from "@/lib/api/types";
 import { fail, ok } from "@/lib/api/wrappers";
 import { loadAuthUser, resolveActiveOrg } from "@/lib/auth/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { listMessagesQuerySchema } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
 
@@ -33,9 +34,10 @@ export async function GET(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   }
 
   const authUser = await loadAuthUser();
+  const t = (texto: string) => traduzir(texto, authUser?.idioma ?? "pt-BR");
   const activeOrg = authUser ? await resolveActiveOrg(authUser) : null;
   if (!activeOrg) {
-    return fail("no_active_org", "No active organization.", 403, { requestId });
+    return fail("no_active_org", t("No active organization."), 403, { requestId });
   }
 
   const url = new URL(req.url);
@@ -44,7 +46,7 @@ export async function GET(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     limit: url.searchParams.get("limit") ?? undefined,
   });
   if (!qsParsed.success) {
-    return fail("validation_failed", "Query inválida.", 422, {
+    return fail("validation_failed", t("Query inválida."), 422, {
       details: qsParsed.error.flatten().fieldErrors as Record<string, unknown>,
       requestId,
     });
@@ -57,6 +59,7 @@ export async function GET(req: NextRequest, ctx: RouteCtx): Promise<Response> {
         organization_id: activeOrg.orgId,
         actor: { type: "user", id: user.id },
         requestId,
+        idioma: authUser?.idioma,
       },
       conversationId,
       qsParsed.data,

--- a/app/api/v1/conversations/[id]/notes/[noteId]/route.ts
+++ b/app/api/v1/conversations/[id]/notes/[noteId]/route.ts
@@ -10,6 +10,7 @@ import { fail, noContent } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { roleAtLeast } from "@/lib/auth/types";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -21,6 +22,7 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams): Promis
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "conversation_notes" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org } = authz;
   const { id, noteId } = await params;
 
@@ -35,10 +37,10 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams): Promis
     .eq("conversation_id", id)
     .eq("organization_id", org.orgId)
     .maybeSingle();
-  if (!note) return fail("not_found", "Nota não encontrada.", 404, { requestId });
+  if (!note) return fail("not_found", t("Nota não encontrada."), 404, { requestId });
 
   if (note.created_by_user_id !== user.id && !roleAtLeast(org.role, "manager")) {
-    return fail("forbidden", "Só o autor ou manager+ pode apagar esta nota.", 403, { requestId });
+    return fail("forbidden", t("Só o autor ou manager+ pode apagar esta nota."), 403, { requestId });
   }
 
   const { data: deleted, error } = await supabase
@@ -50,7 +52,7 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams): Promis
     .select("id")
     .maybeSingle();
   if (error) return fail("internal_error", "Erro ao excluir nota.", 500, { requestId });
-  if (!deleted) return fail("not_found", "Nota não encontrada.", 404, { requestId });
+  if (!deleted) return fail("not_found", t("Nota não encontrada."), 404, { requestId });
 
   void audit({
     action: "conversation.note_deleted",

--- a/app/api/v1/conversations/[id]/notes/route.ts
+++ b/app/api/v1/conversations/[id]/notes/route.ts
@@ -15,6 +15,7 @@ import { mencaoAtingeUsuario, tokensDeMencao } from "@/lib/notifications/mention
 import { createNoteSchema } from "@/lib/schemas/notes";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 const COLS = "id, conversation_id, body, created_by_user_id, created_by_name, created_at";
@@ -27,6 +28,7 @@ export async function GET(_req: NextRequest, { params }: RouteParams): Promise<R
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "conversation_notes" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
   const { id } = await params;
 
@@ -37,7 +39,7 @@ export async function GET(_req: NextRequest, { params }: RouteParams): Promise<R
     .eq("id", id)
     .eq("organization_id", org.orgId)
     .maybeSingle();
-  if (!conversation) return fail("not_found", "Conversa não encontrada.", 404, { requestId });
+  if (!conversation) return fail("not_found", t("Conversa não encontrada."), 404, { requestId });
 
   const { data, error } = await supabase
     .from("conversation_notes")
@@ -53,6 +55,7 @@ export async function POST(req: NextRequest, { params }: RouteParams): Promise<R
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "conversation_notes" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org } = authz;
   const { id } = await params;
 
@@ -63,12 +66,12 @@ export async function POST(req: NextRequest, { params }: RouteParams): Promise<R
     .eq("id", id)
     .eq("organization_id", org.orgId)
     .maybeSingle();
-  if (!conversation) return fail("not_found", "Conversa não encontrada.", 404, { requestId });
+  if (!conversation) return fail("not_found", t("Conversa não encontrada."), 404, { requestId });
 
   const raw = await req.json().catch(() => null);
   const parsed = createNoteSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("validation_failed", "Dados inválidos.", 422, {
+    return fail("validation_failed", t("Dados inválidos."), 422, {
       requestId,
       details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
     });

--- a/app/api/v1/conversations/[id]/pause-ai/route.ts
+++ b/app/api/v1/conversations/[id]/pause-ai/route.ts
@@ -39,6 +39,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { registrarTrocaDeComando } from "@/lib/inbox/atividade-de-comando";
 import { createClient } from "@/lib/supabase/server";
 import type { Conversation } from "@/lib/types/messaging";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -56,6 +57,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
 
   const authz = await requireRole("agent", { requestId, resource: "conversations" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org } = authz;
 
   const supabase = await createClient();
@@ -70,7 +72,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
     .eq("organization_id", org.orgId)
     .maybeSingle();
   if (convErr) return fail("internal_error", convErr.message, 500, { requestId });
-  if (!convData) return fail("not_found", "Conversa não encontrada.", 404, { requestId });
+  if (!convData) return fail("not_found", t("Conversa não encontrada."), 404, { requestId });
 
   const conv = convData as unknown as {
     id: string;
@@ -83,7 +85,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
   if (conv.status === "closed" || conv.status === "archived") {
     return fail(
       "state_conflict",
-      "Esta conversa está encerrada — não há atendimento automático a pausar.",
+      t("Esta conversa está encerrada — não há atendimento automático a pausar."),
       409,
       { requestId },
     );
@@ -104,7 +106,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
     });
     if (rpcErr) return fail("internal_error", rpcErr.message, 500, { requestId });
     if (!atribuida || (atribuida as unknown[]).length === 0) {
-      return fail("state_conflict", "Outro atendente assumiu esta conversa agora.", 409, {
+      return fail("state_conflict", t("Outro atendente assumiu esta conversa agora."), 409, {
         requestId,
       });
     }
@@ -127,7 +129,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
     .select("id, contact_id, organization_id, status, assigned_to_user_id, bot_silenced_until")
     .maybeSingle();
   if (updErr) return fail("internal_error", updErr.message, 500, { requestId });
-  if (!atualizada) return fail("not_found", "Conversa não encontrada.", 404, { requestId });
+  if (!atualizada) return fail("not_found", t("Conversa não encontrada."), 404, { requestId });
 
   const final = atualizada as unknown as Conversation;
 
@@ -151,7 +153,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
     tipo: "conversation_ai_paused",
     actor: { type: "user", id: user.id, role: org.role },
     motivo: assumiu
-      ? "Assumiu a conversa e pausou o atendimento automático"
+      ? t("Assumiu a conversa e pausou o atendimento automático")
       : MOTIVO,
     payload: { assumiu_ao_pausar: assumiu },
   });

--- a/app/api/v1/conversations/[id]/pause-ai/route.ts
+++ b/app/api/v1/conversations/[id]/pause-ai/route.ts
@@ -152,9 +152,9 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
     contactId: conv.contact_id,
     tipo: "conversation_ai_paused",
     actor: { type: "user", id: user.id, role: org.role },
-    motivo: assumiu
-      ? t("Assumiu a conversa e pausou o atendimento automático")
-      : MOTIVO,
+    // Canônico em português: quem traduz é a LEITURA (`t(item.reason)`). Ver o
+    // bloco "vocabulario de dominio persistido" em `lib/i18n/dicionario.ts`.
+    motivo: assumiu ? "Assumiu a conversa e pausou o atendimento automático" : MOTIVO,
     payload: { assumiu_ao_pausar: assumiu },
   });
 

--- a/app/api/v1/conversations/[id]/reactivate-bot/route.ts
+++ b/app/api/v1/conversations/[id]/reactivate-bot/route.ts
@@ -24,6 +24,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { devolverAtendimentoAoAgente } from "@/lib/escalacao/retomada";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -37,6 +38,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
 
   const authz = await requireRole("agent", { requestId, resource: "conversations" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   const supabase = await createClient();
@@ -53,12 +55,12 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
 
   if (!resultado.ok) {
     if (resultado.erro === "conversation_not_found") {
-      return fail("not_found", "Conversa não encontrada.", 404, { requestId });
+      return fail("not_found", t("Conversa não encontrada."), 404, { requestId });
     }
     if (resultado.erro === "assignment_conflict") {
       return fail(
         "state_conflict",
-        "Alguém assumiu esta conversa agora — recarregue e tente de novo.",
+        t("Alguém assumiu esta conversa agora — recarregue e tente de novo."),
         409,
         { requestId },
       );
@@ -67,7 +69,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
     // acompanhamento pausado. Repetir a chamada é seguro (tudo é idempotente).
     return fail(
       "internal_error",
-      "Atendimento devolvido, mas o sinal de retomada do acompanhamento falhou — tente de novo.",
+      t("Atendimento devolvido, mas o sinal de retomada do acompanhamento falhou — tente de novo."),
       500,
       { requestId },
     );

--- a/app/api/v1/conversations/[id]/release/route.ts
+++ b/app/api/v1/conversations/[id]/release/route.ts
@@ -18,6 +18,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 import type { Conversation } from "@/lib/types/messaging";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -33,6 +34,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
   // spec 13 §4: escrita é agent+ (viewer é read-only).
   const authz = await requireRole("agent", { requestId, resource: "conversations" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const user = authz.user;
 
   const { data, error } = await supabase.rpc("fn_conversation_assign", {
@@ -50,7 +52,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
   }
   const row = data?.[0];
   if (!row) {
-    return fail("state_conflict", "Você não está atribuído a essa conversa.", 409, { requestId });
+    return fail("state_conflict", t("Você não está atribuído a essa conversa."), 409, { requestId });
   }
 
   const conv = row as unknown as Conversation;
@@ -74,7 +76,7 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
     contactId: conv.contact_id,
     tipo: "conversation_released",
     actor: { type: "user", id: user.id, role: authz.org.role },
-    motivo: "Liberou a conversa de volta para a fila",
+    motivo: t("Liberou a conversa de volta para a fila"),
   });
 
   return ok(conv, { requestId });

--- a/app/api/v1/conversations/[id]/release/route.ts
+++ b/app/api/v1/conversations/[id]/release/route.ts
@@ -76,7 +76,9 @@ export async function POST(_req: NextRequest, ctx: RouteCtx): Promise<Response> 
     contactId: conv.contact_id,
     tipo: "conversation_released",
     actor: { type: "user", id: user.id, role: authz.org.role },
-    motivo: t("Liberou a conversa de volta para a fila"),
+    // Canônico em português: quem traduz é a LEITURA (`t(item.reason)`). Ver o
+    // bloco "vocabulario de dominio persistido" em `lib/i18n/dicionario.ts`.
+    motivo: "Liberou a conversa de volta para a fila",
   });
 
   return ok(conv, { requestId });

--- a/app/api/v1/conversations/[id]/retention/route.ts
+++ b/app/api/v1/conversations/[id]/retention/route.ts
@@ -10,6 +10,7 @@ import { type NextRequest } from "next/server";
 import { PACING_DEFAULTS } from "@/lib/agent-engine/pacing/defaults";
 import { ok, fail } from "@/lib/api/wrappers";
 import { loadAuthUser, resolveActiveOrg } from "@/lib/auth/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -35,9 +36,10 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
   }
 
   const authUser = await loadAuthUser();
+  const t = (texto: string) => traduzir(texto, authUser?.idioma ?? "pt-BR");
   const activeOrg = authUser ? await resolveActiveOrg(authUser) : null;
   if (!activeOrg) {
-    return fail("no_active_org", "No active organization.", 403, { requestId });
+    return fail("no_active_org", t("No active organization."), 403, { requestId });
   }
 
   const { data: conv, error: convErr } = await supabase
@@ -47,10 +49,10 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
     .eq("id", id)
     .maybeSingle();
   if (convErr) {
-    return fail("internal_error", "Failed to load conversation.", 500, { requestId });
+    return fail("internal_error", t("Failed to load conversation."), 500, { requestId });
   }
   if (!conv) {
-    return fail("not_found", "Conversation not found.", 404, { requestId });
+    return fail("not_found", t("Conversation not found."), 404, { requestId });
   }
 
   const since = new Date(Date.now() - RETENTION_LOOKBACK_MS).toISOString();
@@ -64,7 +66,7 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
     .order("created_at", { ascending: false })
     .limit(5);
   if (traceErr) {
-    return fail("internal_error", "Failed to load retention traces.", 500, { requestId });
+    return fail("internal_error", t("Failed to load retention traces."), 500, { requestId });
   }
 
   // Knobs do número (coluna NULL = default conservador do engine) — a UI usa o

--- a/app/api/v1/conversations/[id]/route.ts
+++ b/app/api/v1/conversations/[id]/route.ts
@@ -9,6 +9,7 @@ import { ApiError } from "@/lib/api/types";
 import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { loadAuthUser, resolveActiveOrg } from "@/lib/auth/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { patchConversationSchema, validateRequest } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
 import { comNomeDoAtendente } from "@/lib/users/com-nome-do-atendente";
@@ -35,9 +36,10 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
   }
 
   const authUser = await loadAuthUser();
+  const t = (texto: string) => traduzir(texto, authUser?.idioma ?? "pt-BR");
   const activeOrg = authUser ? await resolveActiveOrg(authUser) : null;
   if (!activeOrg) {
-    return fail("no_active_org", "No active organization.", 403, { requestId });
+    return fail("no_active_org", t("No active organization."), 403, { requestId });
   }
 
   try {
@@ -47,6 +49,7 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
         organization_id: activeOrg.orgId,
         actor: { type: "user", id: user.id },
         requestId,
+        idioma: authUser?.idioma,
       },
       id,
     );
@@ -93,6 +96,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
         organization_id: activeOrg.orgId,
         actor: { type: "user", id: user.id },
         requestId,
+        idioma: user.idioma,
       },
       id,
       input,

--- a/app/api/v1/conversations/[id]/snooze/route.ts
+++ b/app/api/v1/conversations/[id]/snooze/route.ts
@@ -20,6 +20,7 @@ import { fail, ok, noContent } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { snoozeSchema } from "@/lib/schemas/snooze";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -31,13 +32,14 @@ export async function POST(req: NextRequest, { params }: RouteParams): Promise<R
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "conversations" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org } = authz;
   const { id } = await params;
 
   const raw = await req.json().catch(() => null);
   const parsed = snoozeSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("validation_failed", "Dados inválidos.", 422, {
+    return fail("validation_failed", t("Dados inválidos."), 422, {
       requestId,
       details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
     });
@@ -56,7 +58,7 @@ export async function POST(req: NextRequest, { params }: RouteParams): Promise<R
     .select("id")
     .maybeSingle();
   if (error) return fail("internal_error", error.message, 500, { requestId });
-  if (!data) return fail("not_found", "Conversa não encontrada.", 404, { requestId });
+  if (!data) return fail("not_found", t("Conversa não encontrada."), 404, { requestId });
 
   void audit({
     action: "conversation.snoozed",
@@ -74,6 +76,7 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams): Promis
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "conversations" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org } = authz;
   const { id } = await params;
 
@@ -86,7 +89,7 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams): Promis
     .select("id")
     .maybeSingle();
   if (error) return fail("internal_error", error.message, 500, { requestId });
-  if (!data) return fail("not_found", "Conversa não encontrada.", 404, { requestId });
+  if (!data) return fail("not_found", t("Conversa não encontrada."), 404, { requestId });
 
   void audit({
     action: "conversation.snooze_cancelled",

--- a/app/api/v1/conversations/[id]/transfer/route.ts
+++ b/app/api/v1/conversations/[id]/transfer/route.ts
@@ -20,6 +20,7 @@ import { transferConversationSchema, validateRequest } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import type { Conversation } from "@/lib/types/messaging";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -35,6 +36,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   // spec 13 §4: escrita é agent+ (viewer é read-only).
   const authz = await requireRole("agent", { requestId, resource: "conversations" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const user = authz.user;
   const orgId = authz.org.orgId; // fonte confiável (cookie validado), nunca o body
 
@@ -67,7 +69,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
       return fail("internal_error", memberErr.message, 500, { requestId });
     }
     if (!member || member.role === "viewer") {
-      return fail("unprocessable_entity", "Destino não é um atendente desta organização.", 422, {
+      return fail("unprocessable_entity", t("Destino não é um atendente desta organização."), 422, {
         requestId,
       });
     }
@@ -87,7 +89,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   }
   const row = data?.[0];
   if (!row) {
-    return fail("not_found", "Conversa não encontrada.", 404, { requestId });
+    return fail("not_found", t("Conversa não encontrada."), 404, { requestId });
   }
 
   const conv = row as unknown as Conversation;
@@ -133,7 +135,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     actor: { type: "user", id: user.id, role: authz.org.role },
     motivo: input.reason?.trim()
       ? `Transferiu a conversa: ${input.reason.trim()}`
-      : "Transferiu a conversa para outro atendente",
+      : t("Transferiu a conversa para outro atendente"),
     payload: { to_user_id: input.to_user_id },
   });
 

--- a/app/api/v1/conversations/[id]/transfer/route.ts
+++ b/app/api/v1/conversations/[id]/transfer/route.ts
@@ -133,9 +133,11 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     contactId: conv.contact_id,
     tipo: "conversation_transferred",
     actor: { type: "user", id: user.id, role: authz.org.role },
+    // Canônico em português: quem traduz é a LEITURA (`t(item.reason)`). Ver o
+    // bloco "vocabulario de dominio persistido" em `lib/i18n/dicionario.ts`.
     motivo: input.reason?.trim()
       ? `Transferiu a conversa: ${input.reason.trim()}`
-      : t("Transferiu a conversa para outro atendente"),
+      : "Transferiu a conversa para outro atendente",
     payload: { to_user_id: input.to_user_id },
   });
 

--- a/app/api/v1/conversations/[id]/usable-for-rag/route.ts
+++ b/app/api/v1/conversations/[id]/usable-for-rag/route.ts
@@ -18,6 +18,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { validateRequest } from "@/lib/schemas/_validate";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -33,6 +34,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
 
   const authz = await requireRole("agent", { requestId, resource: "conversations" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   let input;
@@ -87,7 +89,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     return fail("internal_error", error.message, 500, { requestId });
   }
   if (!data) {
-    return fail("not_found", "Conversa não encontrada.", 404, { requestId });
+    return fail("not_found", t("Conversa não encontrada."), 404, { requestId });
   }
 
   await audit({

--- a/app/api/v1/conversations/_handler.ts
+++ b/app/api/v1/conversations/_handler.ts
@@ -8,6 +8,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { ApiError } from "@/lib/api/types";
 import type { Actor, HandlerCtx } from "@/lib/api/handlers/types";
 import { audit } from "@/lib/audit";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { CONVERSATION_TERMINAL_STATUSES } from "@/lib/schemas";
 import type {
   ListConversationsQuery,
@@ -313,7 +314,13 @@ export async function listConversationsHandler(
   if (q.cursor) {
     const c = decodeCursor(q.cursor);
     if (!c) {
-      throw new ApiError(400, "invalid_cursor", undefined, ctx.requestId, "Cursor inválido.");
+      throw new ApiError(
+        400,
+        "invalid_cursor",
+        undefined,
+        ctx.requestId,
+        traduzir("Cursor inválido.", ctx.idioma ?? "pt-BR"),
+      );
     }
     const op = asc ? "gt" : "lt";
     if (c.sort) {
@@ -364,7 +371,13 @@ export async function getConversationHandler(
     throw new ApiError(500, "internal_error", undefined, ctx.requestId, error.message);
   }
   if (!data) {
-    throw new ApiError(404, "not_found", undefined, ctx.requestId, "Conversa não encontrada.");
+    throw new ApiError(
+      404,
+      "not_found",
+      undefined,
+      ctx.requestId,
+      traduzir("Conversa não encontrada.", ctx.idioma ?? "pt-BR"),
+    );
   }
   return data as unknown as Conversation;
 }
@@ -435,7 +448,13 @@ export async function patchConversationHandler(
     throw new ApiError(500, "internal_error", undefined, ctx.requestId, error.message);
   }
   if (!data) {
-    throw new ApiError(404, "not_found", undefined, ctx.requestId, "Conversa não encontrada.");
+    throw new ApiError(
+      404,
+      "not_found",
+      undefined,
+      ctx.requestId,
+      traduzir("Conversa não encontrada.", ctx.idioma ?? "pt-BR"),
+    );
   }
 
   const conv = data as unknown as Conversation;
@@ -509,7 +528,13 @@ export async function markConversationReadHandler(
     throw new ApiError(500, "internal_error", undefined, ctx.requestId, error.message);
   }
   if (!data) {
-    throw new ApiError(404, "not_found", undefined, ctx.requestId, "Conversa não encontrada.");
+    throw new ApiError(
+      404,
+      "not_found",
+      undefined,
+      ctx.requestId,
+      traduzir("Conversa não encontrada.", ctx.idioma ?? "pt-BR"),
+    );
   }
   return data as unknown as Conversation;
 }

--- a/app/api/v1/conversations/counts/route.ts
+++ b/app/api/v1/conversations/counts/route.ts
@@ -10,6 +10,7 @@ import { randomUUID } from "node:crypto";
 
 import { fail, ok } from "@/lib/api/wrappers";
 import { loadAuthUser, resolveActiveOrg } from "@/lib/auth/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { CONVERSATION_TERMINAL_STATUSES } from "@/lib/schemas";
 import { orgTemAutomatico } from "@/lib/ai/agents/org-tem-automatico";
 import { comandosDaFila } from "@/lib/inbox/comando-da-conversa";
@@ -32,7 +33,12 @@ export async function GET(): Promise<Response> {
   const authUser = await loadAuthUser();
   const activeOrg = authUser ? await resolveActiveOrg(authUser) : null;
   if (!activeOrg) {
-    return fail("no_active_org", "No active organization.", 403, { requestId });
+    return fail(
+      "no_active_org",
+      traduzir("No active organization.", authUser?.idioma ?? "pt-BR"),
+      403,
+      { requestId },
+    );
   }
 
   const org = activeOrg.orgId;

--- a/app/api/v1/conversations/open-with-contact/route.ts
+++ b/app/api/v1/conversations/open-with-contact/route.ts
@@ -13,6 +13,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { openSharedContactConversation } from "@/lib/messaging/open-shared-contact-conversation";
 import { openConversationWithContactSchema, validateRequest } from "@/lib/schemas";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -21,6 +22,7 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   const authz = await requireRole("agent", { requestId, resource: "conversations" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   let input;
   try {
@@ -42,13 +44,13 @@ export async function POST(req: NextRequest): Promise<Response> {
   } catch (err) {
     const msg = err instanceof Error ? err.message : "open_failed";
     if (msg === "contact_not_found") {
-      return fail("not_found", "Contato não encontrado.", 404, { requestId });
+      return fail("not_found", t("Contato não encontrado."), 404, { requestId });
     }
     if (msg === "session_not_found") {
-      return fail("not_found", "Sessão de canal não encontrada.", 404, { requestId });
+      return fail("not_found", t("Sessão de canal não encontrada."), 404, { requestId });
     }
     if (msg === "invalid_phone") {
-      return fail("validation_error", "Telefone inválido.", 422, { requestId });
+      return fail("validation_error", t("Telefone inválido."), 422, { requestId });
     }
     return fail("internal_error", msg, 500, { requestId });
   }

--- a/app/api/v1/conversations/route.ts
+++ b/app/api/v1/conversations/route.ts
@@ -7,6 +7,7 @@ import { type NextRequest } from "next/server";
 import { ApiError } from "@/lib/api/types";
 import { fail, ok } from "@/lib/api/wrappers";
 import { loadAuthUser, resolveActiveOrg } from "@/lib/auth/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { listConversationsQuerySchema } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
 import { comNomeDoAtendente } from "@/lib/users/com-nome-do-atendente";
@@ -28,9 +29,10 @@ export async function GET(req: NextRequest): Promise<Response> {
   }
 
   const authUser = await loadAuthUser();
+  const t = (texto: string) => traduzir(texto, authUser?.idioma ?? "pt-BR");
   const activeOrg = authUser ? await resolveActiveOrg(authUser) : null;
   if (!activeOrg) {
-    return fail("no_active_org", "No active organization.", 403, { requestId });
+    return fail("no_active_org", t("No active organization."), 403, { requestId });
   }
 
   const url = new URL(req.url);
@@ -59,7 +61,7 @@ export async function GET(req: NextRequest): Promise<Response> {
     limit: url.searchParams.get("limit") ?? undefined,
   });
   if (!qsParsed.success) {
-    return fail("validation_failed", "Query inválida.", 422, {
+    return fail("validation_failed", t("Query inválida."), 422, {
       details: qsParsed.error.flatten().fieldErrors as Record<string, unknown>,
       requestId,
     });
@@ -72,6 +74,7 @@ export async function GET(req: NextRequest): Promise<Response> {
         organization_id: activeOrg.orgId,
         actor: { type: "user", id: user.id },
         requestId,
+        idioma: authUser?.idioma,
       },
       qsParsed.data,
     );

--- a/app/api/v1/demandas/[id]/route.ts
+++ b/app/api/v1/demandas/[id]/route.ts
@@ -34,6 +34,7 @@ import { audit } from "@/lib/audit";
 import { fail, ok } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -52,19 +53,20 @@ export async function PATCH(
 
   const authz = await requireRole("agent", { requestId, resource: "demandas" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg, user } = authz;
 
   let corpo: unknown;
   try {
     corpo = await req.json();
   } catch {
-    return fail("validation_failed", "Corpo inválido.", 422, { requestId });
+    return fail("validation_failed", t("Corpo inválido."), 422, { requestId });
   }
   const parsed = patchSchema.safeParse(corpo);
   if (!parsed.success) {
     return fail(
       "validation_failed",
-      "O próximo passo precisa ter de 3 a 500 caracteres.",
+      t("O próximo passo precisa ter de 3 a 500 caracteres."),
       422,
       { details: parsed.error.flatten().fieldErrors as Record<string, unknown>, requestId },
     );
@@ -94,7 +96,7 @@ export async function PATCH(
   // `organizations` engana exatamente assim. Aqui o `select` de volta é o que
   // separa "gravou" de "não achou/já fechada".
   if (!data) {
-    return fail("not_found", "Demanda não encontrada, ou já encerrada.", 404, { requestId });
+    return fail("not_found", t("Demanda não encontrada, ou já encerrada."), 404, { requestId });
   }
 
   void audit({

--- a/app/api/v1/lead-captures/route.ts
+++ b/app/api/v1/lead-captures/route.ts
@@ -15,6 +15,7 @@ import type { NextRequest } from "next/server";
 import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 import {
   decodeLeadCaptureCursor,
   encodeLeadCaptureCursor,
@@ -35,12 +36,13 @@ export async function GET(req: NextRequest): Promise<Response> {
     allowPlatformAdmin: true,
   });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const params = Object.fromEntries(new URL(req.url).searchParams.entries());
   const parsed = leadCapturesQuerySchema.safeParse(params);
   if (!parsed.success) {
-    return fail("validation_failed", "Query inválida.", 422, {
+    return fail("validation_failed", t("Query inválida."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -74,7 +76,7 @@ export async function GET(req: NextRequest): Promise<Response> {
 
   if (q.cursor) {
     const c = decodeLeadCaptureCursor(q.cursor);
-    if (!c) return fail("invalid_cursor", "Cursor inválido.", 400, { requestId });
+    if (!c) return fail("invalid_cursor", t("Cursor inválido."), 400, { requestId });
     query = query.or(
       `received_at.lt.${c.received_at},and(received_at.eq.${c.received_at},id.lt.${c.id})`,
     );

--- a/app/api/v1/leads/[id]/lose/route.ts
+++ b/app/api/v1/leads/[id]/lose/route.ts
@@ -16,6 +16,7 @@ import { ApiError } from "@/lib/api/types";
 import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { encerraDemanda } from "@/lib/leads/encerramento";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { loseLeadSchema, validateRequest } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
 
@@ -32,6 +33,7 @@ export async function POST(
   // spec 13 §4: escrita é agent+ (viewer é read-only).
   const authz = await requireRole("agent", { requestId, resource: "crm_leads" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   try {
     const input = await validateRequest(loseLeadSchema, req);
@@ -41,6 +43,7 @@ export async function POST(
         organization_id: authz.org.orgId,
         actor: { type: "user", id: authz.user.id },
         requestId,
+        idioma: authz.user.idioma,
       },
       { leadId, desfecho: "lost", motivo: input.lost_reason },
     );
@@ -49,7 +52,7 @@ export async function POST(
     if (err instanceof ApiError) {
       const fieldErrors = (err.details as { fieldErrors?: Record<string, unknown> } | undefined)?.fieldErrors;
       if (err.code === "validation_error" && fieldErrors && "lost_reason" in fieldErrors) {
-        return fail("lost_reason_required", "Informe o motivo da perda.", 422, { requestId });
+        return fail("lost_reason_required", t("Informe o motivo da perda."), 422, { requestId });
       }
       return fail(err.code, err.message, err.status, {
         details: err.details as Record<string, unknown> | undefined,

--- a/app/api/v1/leads/[id]/move/route.ts
+++ b/app/api/v1/leads/[id]/move/route.ts
@@ -18,6 +18,7 @@ import { moveLeadSchema, validateRequest } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
 import { emitLeadActivity, stageChangeReason } from "@/lib/leads/activity-emitter";
 import { registraFalhaDeAtividade } from "@/lib/leads/activity-write-failure";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -32,6 +33,7 @@ export async function POST(
   // spec 13 §4: escrita é agent+ (viewer é read-only).
   const authz = await requireRole("agent", { requestId, resource: "crm_leads" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const user = authz.user;
 
   let input;
@@ -58,7 +60,7 @@ export async function POST(
     return fail("internal_error", selErr.message, 500, { requestId });
   }
   if (!lead) {
-    return fail("not_found", "Lead não encontrado.", 404, { requestId });
+    return fail("not_found", t("Lead não encontrado."), 404, { requestId });
   }
 
   // Fetch target stage to validate same pipeline (P-01).
@@ -72,12 +74,12 @@ export async function POST(
     return fail("internal_error", stageErr.message, 500, { requestId });
   }
   if (!stage) {
-    return fail("not_found", "Stage não encontrado.", 404, { requestId });
+    return fail("not_found", t("Stage não encontrado."), 404, { requestId });
   }
   if (stage.pipeline_id !== lead.pipeline_id) {
     return fail(
       "pipeline_immutable_use_clone",
-      "Move cross-pipeline não é permitido. Clone o lead para o pipeline alvo.",
+      t("Move cross-pipeline não é permitido. Clone o lead para o pipeline alvo."),
       422,
       { requestId },
     );
@@ -109,7 +111,7 @@ export async function POST(
       .maybeSingle();
     return fail(
       "lead_stage_changed_concurrent",
-      "Lead foi modificado por outro usuário. Recarregue e tente novamente.",
+      t("Lead foi modificado por outro usuário. Recarregue e tente novamente."),
       409,
       {
         details: { current_updated_at: current?.updated_at ?? null },

--- a/app/api/v1/leads/[id]/next-action/route.ts
+++ b/app/api/v1/leads/[id]/next-action/route.ts
@@ -20,6 +20,7 @@ import { fail, ok } from "@/lib/api/wrappers";
 import { createClient } from "@/lib/supabase/server";
 import { requireRole } from "@/lib/auth/require-role";
 import { emitLeadActivity } from "@/lib/leads/activity-emitter";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -47,13 +48,14 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   // `viewer` lê o board e vê a proposta, mas não aprova nem descarta.
   const authz = await requireRole("agent", { requestId, resource: "crm_leads" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user } = authz;
 
   const supabase = await createClient();
 
   const parsed = Body.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
-    return fail("validation_failed", "Corpo inválido.", 422, {
+    return fail("validation_failed", t("Corpo inválido."), 422, {
       requestId,
       details: { issues: parsed.error.issues },
     });
@@ -67,7 +69,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     .eq("id", leadId)
     .maybeSingle();
   if (leadErr) return fail("internal_error", leadErr.message, 500, { requestId });
-  if (!lead) return fail("not_found", "Lead não encontrado.", 404, { requestId });
+  if (!lead) return fail("not_found", t("Lead não encontrado."), 404, { requestId });
 
   const row = lead as {
     id: string;
@@ -78,7 +80,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   if (!row.contact_id) {
     return fail(
       "next_action_absent",
-      "Este negócio não tem contato, então não há proposta do agente.",
+      t("Este negócio não tem contato, então não há proposta do agente."),
       409,
       { requestId },
     );
@@ -95,7 +97,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   const linha = estado as { next_action: string | null; next_action_seq: number } | null;
   const atual = linha?.next_action?.trim() ?? null;
   if (!atual) {
-    return fail("next_action_absent", "Não há proposta pendente para este negócio.", 409, {
+    return fail("next_action_absent", t("Não há proposta pendente para este negócio."), 409, {
       requestId,
     });
   }
@@ -105,7 +107,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     // identidade e não texto é o que pega a reescrita com as mesmas palavras.
     return fail(
       "next_action_changed",
-      "A proposta mudou desde que você a leu. Confira a nova antes de decidir.",
+      t("A proposta mudou desde que você a leu. Confira a nova antes de decidir."),
       409,
       { requestId, details: { current_text: atual, current_seq: linha!.next_action_seq } },
     );

--- a/app/api/v1/leads/[id]/reactivation/route.ts
+++ b/app/api/v1/leads/[id]/reactivation/route.ts
@@ -24,6 +24,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { emitLeadActivity } from "@/lib/leads/activity-emitter";
 import { registraFalhaDeAtividade } from "@/lib/leads/activity-write-failure";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -43,12 +44,13 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
 
   const guard = await requireRole("agent", { requestId });
   if (!guard.ok) return guard.response;
+  const t = (texto: string) => traduzir(texto, guard.user.idioma);
   const orgId = guard.org.orgId;
   const userId = guard.user.id;
 
   const parsed = Body.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
-    return fail("invalid_body", "decision e proposal_id são obrigatórios.", 400, { requestId });
+    return fail("invalid_body", t("decision e proposal_id são obrigatórios."), 400, { requestId });
   }
   const { decision, proposal_id } = parsed.data;
 
@@ -84,14 +86,14 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     if (existe) {
       return fail(
         "reactivation_not_pending",
-        `Esta sugestão já foi ${
-          (existe as { status: string }).status === "expired" ? "encerrada pelo prazo" : "decidida"
+        `${t("Esta sugestão já foi")} ${
+          (existe as { status: string }).status === "expired" ? t("encerrada pelo prazo") : t("decidida")
         }.`,
         409,
         { requestId },
       );
     }
-    return fail("not_found", "Sugestão não encontrada.", 404, { requestId });
+    return fail("not_found", t("Sugestão não encontrada."), 404, { requestId });
   }
 
   const { data: lead } = await supabase
@@ -158,8 +160,8 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     // Nomeia a decisão, nunca o conteúdo da proposta nem dado do negócio.
     reason:
       decision === "accept"
-        ? "Retomada de contato aprovada"
-        : "Retomada de contato descartada — decisão registrada",
+        ? t("Retomada de contato aprovada")
+        : t("Retomada de contato descartada — decisão registrada"),
     payload: { proposal_id },
   });
   if (!atividade.ok) {
@@ -176,7 +178,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     });
     return fail(
       "activity_write_failed",
-      "A decisão não pôde ser registrada. Nada foi enviado ao cliente.",
+      t("A decisão não pôde ser registrada. Nada foi enviado ao cliente."),
       500,
       { requestId },
     );

--- a/app/api/v1/leads/[id]/reactivation/route.ts
+++ b/app/api/v1/leads/[id]/reactivation/route.ts
@@ -158,10 +158,12 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     sourceId: leadId,
     actor: { type: "user", id: userId },
     // Nomeia a decisão, nunca o conteúdo da proposta nem dado do negócio.
+    // Canônico em português: quem traduz é a LEITURA (`t(item.reason)`). Ver o
+    // bloco "vocabulario de dominio persistido" em `lib/i18n/dicionario.ts`.
     reason:
       decision === "accept"
-        ? t("Retomada de contato aprovada")
-        : t("Retomada de contato descartada — decisão registrada"),
+        ? "Retomada de contato aprovada"
+        : "Retomada de contato descartada — decisão registrada",
     payload: { proposal_id },
   });
   if (!atividade.ok) {

--- a/app/api/v1/leads/[id]/route.ts
+++ b/app/api/v1/leads/[id]/route.ts
@@ -48,6 +48,7 @@ export async function PATCH(
         organization_id: activeOrg.orgId,
         actor: { type: "user", id: user.id },
         requestId,
+        idioma: user.idioma,
       },
       leadId,
       input,

--- a/app/api/v1/leads/[id]/timeline/route.ts
+++ b/app/api/v1/leads/[id]/timeline/route.ts
@@ -35,6 +35,8 @@ import { randomUUID } from "node:crypto";
 import { type NextRequest } from "next/server";
 
 import { ok, fail } from "@/lib/api/wrappers";
+import { loadAuthUser } from "@/lib/auth/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { createClient } from "@/lib/supabase/server";
 import {
   TIMELINE_COLS,
@@ -63,6 +65,8 @@ export async function GET(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   if (authErr || !user) {
     return fail("unauthenticated", "Auth required.", 401, { requestId });
   }
+  const authUser = await loadAuthUser();
+  const t = (texto: string) => traduzir(texto, authUser?.idioma ?? "pt-BR");
 
   const url = new URL(req.url);
   const types = url.searchParams.getAll("type").filter(Boolean);
@@ -71,7 +75,7 @@ export async function GET(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   const cursorRaw = url.searchParams.get("cursor");
   const cursor = cursorRaw ? decodeCursor(cursorRaw) : null;
   if (cursorRaw && !cursor) {
-    return fail("invalid_cursor", "Cursor inválido.", 400, { requestId });
+    return fail("invalid_cursor", t("Cursor inválido."), 400, { requestId });
   }
 
   // O lead vem pela RLS do caller — é ele que prova a org, nunca o body.
@@ -81,7 +85,7 @@ export async function GET(req: NextRequest, ctx: RouteCtx): Promise<Response> {
     .eq("id", leadId)
     .maybeSingle();
   if (leadErr) return fail("internal_error", leadErr.message, 500, { requestId });
-  if (!lead) return fail("not_found", "Negócio não encontrado.", 404, { requestId });
+  if (!lead) return fail("not_found", t("Negócio não encontrado."), 404, { requestId });
 
   const contactId = (lead as { contact_id: string | null }).contact_id;
 

--- a/app/api/v1/leads/[id]/win/route.ts
+++ b/app/api/v1/leads/[id]/win/route.ts
@@ -39,6 +39,7 @@ export async function POST(
         organization_id: authz.org.orgId,
         actor: { type: "user", id: authz.user.id },
         requestId,
+        idioma: authz.user.idioma,
       },
       { leadId, desfecho: "won" },
     );

--- a/app/api/v1/leads/_handler.ts
+++ b/app/api/v1/leads/_handler.ts
@@ -9,6 +9,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { ApiError } from "@/lib/api/types";
 import type { Actor, HandlerCtx } from "@/lib/api/handlers/types";
 import { audit } from "@/lib/audit";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { resolveOwnerPatch, type OwnerPatch, type OwnerPatchInput } from "@/lib/leads/owner-patch";
 import { emitLeadActivity, stageChangeReason } from "@/lib/leads/activity-emitter";
 import { listaLegivel } from "@/lib/leads/activity-vocabulary";
@@ -40,7 +41,7 @@ async function ownerPatchOrThrow(
       "validation_failed",
       undefined,
       ctx.requestId,
-      "Um lead tem um dono: informe owner_user_id OU owner_agent_id.",
+      traduzir("Um lead tem um dono: informe owner_user_id OU owner_agent_id.", ctx.idioma ?? "pt-BR"),
     );
   }
   if (!result.patch) return null;
@@ -63,7 +64,7 @@ async function ownerPatchOrThrow(
         "validation_failed",
         undefined,
         ctx.requestId,
-        "Agente não encontrado nesta organização.",
+        traduzir("Agente não encontrado nesta organização.", ctx.idioma ?? "pt-BR"),
       );
     }
   }
@@ -160,7 +161,13 @@ export async function listLeadsHandler(
   if (q.cursor) {
     const c = decLeadCursor(q.cursor);
     if (!c) {
-      throw new ApiError(400, "invalid_cursor", undefined, ctx.requestId, "Cursor inválido.");
+      throw new ApiError(
+        400,
+        "invalid_cursor",
+        undefined,
+        ctx.requestId,
+        traduzir("Cursor inválido.", ctx.idioma ?? "pt-BR"),
+      );
     }
     query = query.or(
       `created_at.lt.${c.created_at},and(created_at.eq.${c.created_at},id.lt.${c.id})`,
@@ -210,7 +217,13 @@ export async function getLeadHandler(
   if (!data) {
     // 404, e não 403: dizer "existe, mas não é seu" confirmaria a existência de
     // um recurso alheio a quem tentou adivinhar o id.
-    throw new ApiError(404, "not_found", undefined, ctx.requestId, "Lead não encontrado.");
+    throw new ApiError(
+      404,
+      "not_found",
+      undefined,
+      ctx.requestId,
+      traduzir("Lead não encontrado.", ctx.idioma ?? "pt-BR"),
+    );
   }
   return data as Record<string, unknown>;
 }
@@ -240,7 +253,13 @@ export async function createLeadHandler(
     throw new ApiError(500, "internal_error", undefined, ctx.requestId, stageErr.message);
   }
   if (!stage || stage.organization_id !== ctx.organization_id) {
-    throw new ApiError(404, "not_found", undefined, ctx.requestId, "Stage não encontrado.");
+    throw new ApiError(
+      404,
+      "not_found",
+      undefined,
+      ctx.requestId,
+      traduzir("Stage não encontrado.", ctx.idioma ?? "pt-BR"),
+    );
   }
   if (stage.pipeline_id !== input.pipeline_id) {
     throw new ApiError(
@@ -248,7 +267,7 @@ export async function createLeadHandler(
       "stage_pipeline_mismatch",
       undefined,
       ctx.requestId,
-      "Stage não pertence ao pipeline informado.",
+      traduzir("Stage não pertence ao pipeline informado.", ctx.idioma ?? "pt-BR"),
     );
   }
 
@@ -305,7 +324,7 @@ export async function createLeadHandler(
       "internal_error",
       undefined,
       ctx.requestId,
-      insErr?.message ?? "Falha ao criar lead.",
+      insErr?.message ?? traduzir("Falha ao criar lead.", ctx.idioma ?? "pt-BR"),
     );
   }
 
@@ -375,7 +394,13 @@ export async function updateLeadHandler(
     throw new ApiError(500, "internal_error", undefined, ctx.requestId, selErr.message);
   }
   if (!existing) {
-    throw new ApiError(404, "not_found", undefined, ctx.requestId, "Lead não encontrado.");
+    throw new ApiError(
+      404,
+      "not_found",
+      undefined,
+      ctx.requestId,
+      traduzir("Lead não encontrado.", ctx.idioma ?? "pt-BR"),
+    );
   }
 
   const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
@@ -420,7 +445,13 @@ export async function updateLeadHandler(
     throw new ApiError(500, "internal_error", undefined, ctx.requestId, updErr.message);
   }
   if (!updated) {
-    throw new ApiError(404, "not_found", undefined, ctx.requestId, "Lead não encontrado.");
+    throw new ApiError(
+      404,
+      "not_found",
+      undefined,
+      ctx.requestId,
+      traduzir("Lead não encontrado.", ctx.idioma ?? "pt-BR"),
+    );
   }
 
   const a = actorAuditPayload(ctx.actor);
@@ -551,7 +582,13 @@ export async function moveLeadHandler(
     throw new ApiError(500, "internal_error", undefined, ctx.requestId, selErr.message);
   }
   if (!lead || lead.organization_id !== ctx.organization_id) {
-    throw new ApiError(404, "not_found", undefined, ctx.requestId, "Lead não encontrado.");
+    throw new ApiError(
+      404,
+      "not_found",
+      undefined,
+      ctx.requestId,
+      traduzir("Lead não encontrado.", ctx.idioma ?? "pt-BR"),
+    );
   }
 
   const { data: stage, error: stageErr } = await supabase
@@ -563,7 +600,13 @@ export async function moveLeadHandler(
     throw new ApiError(500, "internal_error", undefined, ctx.requestId, stageErr.message);
   }
   if (!stage || stage.organization_id !== ctx.organization_id) {
-    throw new ApiError(404, "not_found", undefined, ctx.requestId, "Stage não encontrado.");
+    throw new ApiError(
+      404,
+      "not_found",
+      undefined,
+      ctx.requestId,
+      traduzir("Stage não encontrado.", ctx.idioma ?? "pt-BR"),
+    );
   }
   if (stage.pipeline_id !== lead.pipeline_id) {
     throw new ApiError(
@@ -571,7 +614,7 @@ export async function moveLeadHandler(
       "pipeline_immutable_use_clone",
       undefined,
       ctx.requestId,
-      "Move cross-pipeline não é permitido.",
+      traduzir("Move cross-pipeline não é permitido.", ctx.idioma ?? "pt-BR"),
     );
   }
 
@@ -609,7 +652,7 @@ export async function moveLeadHandler(
       "lead_stage_changed_concurrent",
       undefined,
       ctx.requestId,
-      "Lead foi modificado concorrentemente.",
+      traduzir("Lead foi modificado concorrentemente.", ctx.idioma ?? "pt-BR"),
     );
   }
 

--- a/app/api/v1/leads/at-risk/route.ts
+++ b/app/api/v1/leads/at-risk/route.ts
@@ -19,6 +19,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { carregaRadarDeRisco, RADAR_MIN_HOURS_PADRAO } from "@/lib/leads/radar-de-risco";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -33,13 +34,14 @@ export async function GET(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "leads_at_risk" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
 
   const parsed = querySchema.safeParse(
     Object.fromEntries(new URL(req.url).searchParams.entries()),
   );
   if (!parsed.success) {
-    return fail("validation_failed", "Query inválida.", 422, {
+    return fail("validation_failed", t("Query inválida."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -54,6 +56,6 @@ export async function GET(req: NextRequest): Promise<Response> {
     });
     return ok(radar, { requestId });
   } catch {
-    return fail("internal_error", "Falha ao carregar o radar.", 500, { requestId });
+    return fail("internal_error", t("Falha ao carregar o radar."), 500, { requestId });
   }
 }

--- a/app/api/v1/leads/bulk/route.ts
+++ b/app/api/v1/leads/bulk/route.ts
@@ -20,6 +20,7 @@ import { registraFalhaDeAtividade } from "@/lib/leads/activity-write-failure";
 import { bulkLeadActionSchema, validateRequest } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -39,6 +40,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   // spec 13 §4: escrita é agent+ (viewer é read-only).
   const authz = await requireRole("agent", { requestId, resource: "crm_leads" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const user = authz.user;
 
   let input;
@@ -55,7 +57,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   }
 
   if (input.lead_ids.length > MAX_BULK) {
-    return fail("bulk_too_large", `Máximo ${MAX_BULK} leads por bulk.`, 422, { requestId });
+    return fail("bulk_too_large", `${t("Máximo")} ${MAX_BULK} ${t("leads por bulk.")}`, 422, { requestId });
   }
 
   // G3-04: assign é reatribuição de dono em lote → piso ≥manager (spec 04 §6.5,
@@ -78,7 +80,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       if (!isServiceRoleConfigured()) {
         return fail(
           "owner_validation_unavailable",
-          "Não foi possível validar o responsável agora. Tente novamente em instantes.",
+          t("Não foi possível validar o responsável agora. Tente novamente em instantes."),
           422,
           { requestId },
         );
@@ -95,7 +97,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       if (!member || member.role === "viewer") {
         return fail(
           "invalid_owner",
-          "Responsável não é um atendente ativo desta organização.",
+          t("Responsável não é um atendente ativo desta organização."),
           422,
           { requestId },
         );
@@ -119,7 +121,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   if (!first) {
     return fail(
       "not_found",
-      "Nenhum lead acessível na operação.",
+      t("Nenhum lead acessível na operação."),
       404,
       { requestId },
     );
@@ -247,7 +249,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       if (!owner.ok || !owner.patch) {
         return fail(
           "validation_failed",
-          "Um lead tem um dono: informe owner_user_id OU owner_agent_id.",
+          t("Um lead tem um dono: informe owner_user_id OU owner_agent_id."),
           422,
           { requestId },
         );

--- a/app/api/v1/leads/import/route.ts
+++ b/app/api/v1/leads/import/route.ts
@@ -31,6 +31,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { phoneLookupVariants } from "@/lib/channels/phone-variants";
 import { CSV_MAX_BYTES, CSV_MAX_DATA_ROWS, decodificarCsv } from "@/lib/contacts/csv";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { lerPlanilhaDeLeads, type ErroDaLinha } from "@/lib/leads/planilha";
 import { createLeadHandler } from "@/app/api/v1/leads/_handler";
 import { createClient } from "@/lib/supabase/server";
@@ -51,12 +52,13 @@ export async function POST(req: NextRequest): Promise<Response> {
   const authz = await requireRole("agent", { requestId, resource: "crm_leads" });
   if (!authz.ok) return authz.response;
   const orgId = authz.org.orgId;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   let form: FormData;
   try {
     form = await req.formData();
   } catch {
-    return fail("validation_failed", "Envie o arquivo como multipart/form-data.", 422, {
+    return fail("validation_failed", t("Envie o arquivo como multipart/form-data."), 422, {
       requestId,
     });
   }
@@ -83,7 +85,7 @@ export async function POST(req: NextRequest): Promise<Response> {
     typeof (arquivo as { arrayBuffer?: unknown }).arrayBuffer === "function" &&
     typeof (arquivo as { size?: unknown }).size === "number";
   if (!pareceArquivo) {
-    return fail("validation_failed", "Envie o arquivo no campo 'file'.", 422, { requestId });
+    return fail("validation_failed", t("Envie o arquivo no campo 'file'."), 422, { requestId });
   }
   const enviado = arquivo as unknown as File;
   // ⚠️ O funil e a etapa vêm do FORM, e são conferidos contra a organização
@@ -93,13 +95,13 @@ export async function POST(req: NextRequest): Promise<Response> {
   const pipelineId = String(form.get("pipeline_id") ?? "");
   const stageId = String(form.get("stage_id") ?? "");
   if (!pipelineId || !stageId) {
-    return fail("validation_failed", "Escolha o funil e a etapa de destino.", 422, { requestId });
+    return fail("validation_failed", t("Escolha o funil e a etapa de destino."), 422, { requestId });
   }
 
   if (enviado.size > CSV_MAX_BYTES) {
     return fail(
       "validation_failed",
-      `Arquivo maior que ${Math.floor(CSV_MAX_BYTES / 1024 / 1024)}MB.`,
+      t("Arquivo maior que ") + `${Math.floor(CSV_MAX_BYTES / 1024 / 1024)}MB.`,
       413,
       { requestId },
     );
@@ -107,17 +109,17 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   const decodificado = decodificarCsv(await enviado.arrayBuffer());
   if ("erro" in decodificado) {
-    return fail("validation_failed", decodificado.erro, 422, { requestId });
+    return fail("validation_failed", t(decodificado.erro), 422, { requestId });
   }
 
-  const lido = lerPlanilhaDeLeads(decodificado.texto);
+  const lido = lerPlanilhaDeLeads(decodificado.texto, t);
   if ("erro" in lido) {
     return fail("validation_failed", lido.erro, 422, { requestId });
   }
   if (lido.leads.length > CSV_MAX_DATA_ROWS) {
     return fail(
       "validation_failed",
-      `A planilha tem ${lido.leads.length} linhas; o limite é ${CSV_MAX_DATA_ROWS} por importação.`,
+      `${t("A planilha tem")} ${lido.leads.length} ${t("linhas; o limite é")} ${CSV_MAX_DATA_ROWS} ${t("por importação.")}`,
       422,
       { requestId },
     );
@@ -171,7 +173,7 @@ export async function POST(req: NextRequest): Promise<Response> {
               // vez de reimportar a planilha inteira.
               resumo.erros.push({
                 linha: linha.linha,
-                motivo: "o contato não pôde ser criado — o negócio entrou sem ele",
+                motivo: t("o contato não pôde ser criado — o negócio entrou sem ele"),
               });
             } else {
               contactId = (criado as { id: string }).id;
@@ -207,7 +209,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       }
       resumo.erros.push({
         linha: linha.linha,
-        motivo: err instanceof Error ? err.message : "linha recusada pelo banco",
+        motivo: err instanceof Error ? err.message : t("linha recusada pelo banco"),
       });
     }
   }

--- a/app/api/v1/leads/proposals/route.ts
+++ b/app/api/v1/leads/proposals/route.ts
@@ -29,6 +29,7 @@ import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { isServiceRoleConfigured } from "@/lib/audit";
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -63,7 +64,7 @@ export async function GET(req: NextRequest): Promise<Response> {
   const user = await requireAuth();
   const activeOrg = await resolveActiveOrg(user);
   if (!activeOrg) {
-    return fail("forbidden", "sem organização ativa", 403, { requestId });
+    return fail("forbidden", traduzir("sem organização ativa", user.idioma), 403, { requestId });
   }
   const orgId = activeOrg.orgId;
   const supabase = await createClient();
@@ -117,7 +118,7 @@ export async function GET(req: NextRequest): Promise<Response> {
       if (!proposta) continue;
       pendentes.push({
         lead_id: l.id,
-        lead_title: l.title ?? "(sem título)",
+        lead_title: l.title ?? traduzir("(sem título)", user.idioma),
         stage_name: l.crm_stages?.name ?? null,
         contact_name: l.contacts?.display_name ?? null,
         next_action: proposta.label,
@@ -180,7 +181,7 @@ export async function GET(req: NextRequest): Promise<Response> {
   const historico: DecisaoPassada[] = linhas.map((d) => ({
     activity_id: d.id,
     lead_id: d.lead_id ?? "",
-    lead_title: d.crm_leads?.title ?? "(negócio removido)",
+    lead_title: d.crm_leads?.title ?? traduzir("(negócio removido)", user.idioma),
     decision: d.type === "next_action_approved" ? "approve" : "dismiss",
     next_action: d.payload?.next_action ?? "",
     decided_by: d.performed_by_user_id ? (nomes.get(d.performed_by_user_id) ?? null) : null,

--- a/app/api/v1/leads/route.ts
+++ b/app/api/v1/leads/route.ts
@@ -44,6 +44,7 @@ export async function POST(req: NextRequest): Promise<Response> {
         organization_id: activeOrg.orgId,
         actor: { type: "user", id: authUser.id },
         requestId,
+        idioma: authUser.idioma,
       },
       input as CreateLeadInput,
     );

--- a/app/api/v1/lgpd/anonymize/route.ts
+++ b/app/api/v1/lgpd/anonymize/route.ts
@@ -45,7 +45,6 @@ export async function POST(req: NextRequest): Promise<Response> {
   if (authErr || !user) {
     return fail("unauthenticated", "Auth required.", 401, { requestId });
   }
-
   let input;
   try {
     input = await validateRequest(lgpdAnonymizeSchema, req);
@@ -69,6 +68,11 @@ export async function POST(req: NextRequest): Promise<Response> {
     return fail("internal_error", selErr.message, 500, { requestId });
   }
   if (!existing) {
+    // Sem `t()` de propósito: o único consumidor (`useAnonymizeContact`) usa
+    // `showApiError`, que já traduz `err.message` no FRONTEND — traduzir aqui
+    // também exigiria um `loadAuthUser()` extra, redundante com o que
+    // `requireRole` já faz logo abaixo, e chegou a quebrar teste que não
+    // esperava essa chamada a mais.
     return fail("not_found", "Contato não encontrado.", 404, { requestId });
   }
 

--- a/app/api/v1/lgpd/requests/[id]/approve/route.ts
+++ b/app/api/v1/lgpd/requests/[id]/approve/route.ts
@@ -16,6 +16,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -35,6 +36,7 @@ export async function POST(
     allowPlatformAdmin: true,
   });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   // Idempotency-Key is required
@@ -43,7 +45,7 @@ export async function POST(
   if (!idempotencyKey) {
     return fail(
       "missing_idempotency_key",
-      "Header Idempotency-Key é obrigatório.",
+      t("Header Idempotency-Key é obrigatório."),
       422,
       { requestId },
     );
@@ -58,12 +60,12 @@ export async function POST(
   try {
     rawBody = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
 
   const parsed = bodySchema.safeParse(rawBody);
   if (!parsed.success) {
-    return fail("validation_failed", "Parâmetros inválidos.", 422, {
+    return fail("validation_failed", t("Parâmetros inválidos."), 422, {
       details: parsed.error.flatten(),
       requestId,
     });
@@ -110,7 +112,7 @@ export async function POST(
     return fail("internal_error", reqErr.message, 500, { requestId });
   }
   if (!request) {
-    return fail("not_found", "Solicitação não encontrada.", 404, { requestId });
+    return fail("not_found", t("Solicitação não encontrada."), 404, { requestId });
   }
 
   // Only 'received' can be approved

--- a/app/api/v1/lgpd/requests/[id]/preview/route.ts
+++ b/app/api/v1/lgpd/requests/[id]/preview/route.ts
@@ -17,6 +17,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { collectExportData } from "@/lib/lgpd/export-collector";
 import { maskEmail, maskPhone } from "@/lib/lgpd/mask";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -34,6 +35,7 @@ export async function GET(
     allowPlatformAdmin: true,
   });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const { id } = await params;
@@ -52,7 +54,7 @@ export async function GET(
     return fail("internal_error", reqErr.message, 500, { requestId });
   }
   if (!request) {
-    return fail("not_found", "Solicitação não encontrada.", 404, { requestId });
+    return fail("not_found", t("Solicitação não encontrada."), 404, { requestId });
   }
 
   // collectExportData — read-only, never writes

--- a/app/api/v1/lgpd/requests/[id]/route.ts
+++ b/app/api/v1/lgpd/requests/[id]/route.ts
@@ -13,6 +13,7 @@ import type { NextRequest } from "next/server";
 import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -28,6 +29,7 @@ export async function GET(
     allowPlatformAdmin: true,
   });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const { id } = await params;
@@ -48,7 +50,7 @@ export async function GET(
     return fail("internal_error", reqErr.message, 500, { requestId });
   }
   if (!request) {
-    return fail("not_found", "Solicitação não encontrada.", 404, { requestId });
+    return fail("not_found", t("Solicitação não encontrada."), 404, { requestId });
   }
 
   // Fetch audit trail entries for this request

--- a/app/api/v1/lgpd/requests/route.ts
+++ b/app/api/v1/lgpd/requests/route.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -52,6 +53,7 @@ export async function GET(req: NextRequest): Promise<Response> {
     allowPlatformAdmin: true,
   });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const supabase = await createClient();
@@ -63,7 +65,7 @@ export async function GET(req: NextRequest): Promise<Response> {
   });
   const parsed = querySchema.safeParse(rawParams);
   if (!parsed.success) {
-    return fail("validation_failed", "Parâmetros inválidos.", 422, {
+    return fail("validation_failed", t("Parâmetros inválidos."), 422, {
       details: parsed.error.flatten(),
       requestId,
     });

--- a/app/api/v1/message-templates/[id]/route.ts
+++ b/app/api/v1/message-templates/[id]/route.ts
@@ -14,6 +14,7 @@ import { fail, ok, noContent } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { updateTemplateSchema } from "@/lib/schemas/templates";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 const COLS = "id, organization_id, owner_user_id, title, body, shortcut, created_by_user_id, created_at, updated_at";
@@ -26,13 +27,14 @@ export async function PATCH(req: NextRequest, { params }: RouteParams): Promise<
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "message_templates" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org } = authz;
   const { id } = await params;
 
   const raw = await req.json().catch(() => null);
   const parsed = updateTemplateSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("validation_failed", "Dados inválidos.", 422, {
+    return fail("validation_failed", t("Dados inválidos."), 422, {
       requestId,
       details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
     });
@@ -46,7 +48,7 @@ export async function PATCH(req: NextRequest, { params }: RouteParams): Promise<
     .eq("organization_id", org.orgId)
     .select(COLS)
     .single();
-  if (error || !data) return fail("not_found", "Template não encontrado.", 404, { requestId });
+  if (error || !data) return fail("not_found", t("Template não encontrado."), 404, { requestId });
 
   void audit({
     action: "template.updated",
@@ -64,6 +66,7 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams): Promis
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "message_templates" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org } = authz;
   const { id } = await params;
 
@@ -79,7 +82,7 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams): Promis
     .select("id")
     .maybeSingle();
   if (error) return fail("internal_error", "Erro ao excluir template.", 500, { requestId });
-  if (!deleted) return fail("not_found", "Template não encontrado.", 404, { requestId });
+  if (!deleted) return fail("not_found", t("Template não encontrado."), 404, { requestId });
 
   void audit({
     action: "template.deleted",

--- a/app/api/v1/message-templates/route.ts
+++ b/app/api/v1/message-templates/route.ts
@@ -14,6 +14,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { roleAtLeast } from "@/lib/auth/types";
 import { createTemplateSchema } from "@/lib/schemas/templates";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 const COLS = "id, organization_id, owner_user_id, title, body, shortcut, created_by_user_id, created_at, updated_at";
@@ -39,12 +40,13 @@ export async function POST(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "message_templates" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org } = authz;
 
   const raw = await req.json().catch(() => null);
   const parsed = createTemplateSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("validation_failed", "Dados inválidos.", 422, {
+    return fail("validation_failed", t("Dados inválidos."), 422, {
       requestId,
       details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
     });
@@ -54,7 +56,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   // banco em org.role — reusar em vez de uma 2ª chamada/RPC. A RLS with_check
   // barra de qualquer forma; isto só dá um erro claro antes do insert.
   if (shared && !roleAtLeast(org.role, "manager")) {
-    return fail("forbidden", "Só manager+ cria template compartilhado.", 403, { requestId });
+    return fail("forbidden", t("Só manager+ cria template compartilhado."), 403, { requestId });
   }
   const supabase = await createClient();
   const { data, error } = await supabase

--- a/app/api/v1/messages/[id]/media/route.ts
+++ b/app/api/v1/messages/[id]/media/route.ts
@@ -11,6 +11,7 @@ import { NextResponse, type NextRequest } from "next/server";
 
 import { fail } from "@/lib/api/wrappers";
 import { loadAuthUser, resolveActiveOrg } from "@/lib/auth/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 import {
   CHANNEL_SESSION_REF_COLUMNS,
   DEFAULT_CHANNEL_PROVIDER,
@@ -43,9 +44,10 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
     return fail("unauthenticated", "Auth required.", 401, { requestId });
   }
   const authUser = await loadAuthUser();
+  const t = (texto: string) => traduzir(texto, authUser?.idioma ?? "pt-BR");
   const activeOrg = authUser ? await resolveActiveOrg(authUser) : null;
   if (!activeOrg) {
-    return fail("no_active_org", "No active organization.", 403, { requestId });
+    return fail("no_active_org", t("No active organization."), 403, { requestId });
   }
 
   // Client de sessão: RLS garante que a mensagem pertence a uma org do usuário.
@@ -57,10 +59,10 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
   if (error) {
-    return fail("internal_error", "Erro ao buscar mensagem.", 500, { requestId });
+    return fail("internal_error", t("Erro ao buscar mensagem."), 500, { requestId });
   }
   if (!msg || (!msg.media_storage_path && !msg.media_url)) {
-    return fail("not_found", "Mensagem sem mídia.", 404, { requestId });
+    return fail("not_found", t("Mensagem sem mídia."), 404, { requestId });
   }
 
   if (msg.media_storage_path) {
@@ -105,7 +107,7 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
       if (!adapter.fetchInboundMedia || !sessionRef) {
         // Canal sem mídia de entrada não é defeito: é estado normal. 404 diz a
         // verdade ("não há o que servir"); 502 acusaria uma falha inexistente.
-        return fail("not_found", "Mensagem sem mídia.", 404, { requestId });
+        return fail("not_found", t("Mensagem sem mídia."), 404, { requestId });
       }
 
       const media = await adapter.fetchInboundMedia({
@@ -123,9 +125,9 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
         },
       });
     } catch {
-      return fail("bad_gateway", "Mídia indisponível no momento.", 502, { requestId });
+      return fail("bad_gateway", t("Mídia indisponível no momento."), 502, { requestId });
     }
   }
 
-  return fail("not_found", "Mensagem sem mídia.", 404, { requestId });
+  return fail("not_found", t("Mensagem sem mídia."), 404, { requestId });
 }

--- a/app/api/v1/messages/_handler.ts
+++ b/app/api/v1/messages/_handler.ts
@@ -11,6 +11,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { ApiError } from "@/lib/api/types";
 import type { Actor, HandlerCtx } from "@/lib/api/handlers/types";
 import { audit } from "@/lib/audit";
+import { traduzir } from "@/lib/i18n/dicionario";
 import {
   CHANNEL_SESSION_REF_COLUMNS,
   DEFAULT_CHANNEL_PROVIDER,
@@ -195,7 +196,13 @@ export async function listMessagesHandler(
   if (q.cursor) {
     const c = decodeMsgCursor(q.cursor);
     if (!c) {
-      throw new ApiError(400, "invalid_cursor", undefined, ctx.requestId, "Cursor inválido.");
+      throw new ApiError(
+        400,
+        "invalid_cursor",
+        undefined,
+        ctx.requestId,
+        traduzir("Cursor inválido.", ctx.idioma ?? "pt-BR"),
+      );
     }
     query = query.or(`sent_at.lt.${c.sent_at},and(sent_at.eq.${c.sent_at},id.lt.${c.id})`);
   }
@@ -279,7 +286,13 @@ export async function sendMessageHandler(
     throw new ApiError(500, "internal_error", undefined, ctx.requestId, convErr.message);
   }
   if (!conv) {
-    throw new ApiError(404, "not_found", undefined, ctx.requestId, "Conversa não encontrada.");
+    throw new ApiError(
+      404,
+      "not_found",
+      undefined,
+      ctx.requestId,
+      traduzir("Conversa não encontrada.", ctx.idioma ?? "pt-BR"),
+    );
   }
 
   type Joined = {
@@ -308,7 +321,7 @@ export async function sendMessageHandler(
       "forbidden",
       undefined,
       ctx.requestId,
-      "Contato bloqueou o atendimento.",
+      traduzir("Contato bloqueou o atendimento.", ctx.idioma ?? "pt-BR"),
     );
   }
 
@@ -340,7 +353,13 @@ export async function sendMessageHandler(
         throw new ApiError(500, "internal_error", undefined, ctx.requestId, sharedErr.message);
       }
       if (!shared) {
-        throw new ApiError(404, "not_found", undefined, ctx.requestId, "Contato não encontrado.");
+        throw new ApiError(
+          404,
+          "not_found",
+          undefined,
+          ctx.requestId,
+          traduzir("Contato não encontrado.", ctx.idioma ?? "pt-BR"),
+        );
       }
       const row = shared as {
         id: string;
@@ -356,7 +375,7 @@ export async function sendMessageHandler(
           "contact_anonymized",
           undefined,
           ctx.requestId,
-          "Contato anonimizado não pode ser compartilhado.",
+          traduzir("Contato anonimizado não pode ser compartilhado.", ctx.idioma ?? "pt-BR"),
         );
       }
       if (!row.phone_number) {
@@ -365,7 +384,7 @@ export async function sendMessageHandler(
           "missing_phone_number",
           undefined,
           ctx.requestId,
-          "Contato sem telefone para envio como cartão.",
+          traduzir("Contato sem telefone para envio como cartão.", ctx.idioma ?? "pt-BR"),
         );
       }
       const displayName = row.display_name ?? row.name ?? row.phone_number;
@@ -388,7 +407,7 @@ export async function sendMessageHandler(
           "invalid_payload",
           undefined,
           ctx.requestId,
-          "Telefone inválido para envio como cartão.",
+          traduzir("Telefone inválido para envio como cartão.", ctx.idioma ?? "pt-BR"),
         );
       }
       const nameRaw = typeof o.name === "string" ? o.name.trim() : "";
@@ -404,7 +423,10 @@ export async function sendMessageHandler(
         "invalid_payload",
         undefined,
         ctx.requestId,
-        "Informe metadata.shared_contact_id ou metadata.shared_contact com telefone.",
+        traduzir(
+          "Informe metadata.shared_contact_id ou metadata.shared_contact com telefone.",
+          ctx.idioma ?? "pt-BR",
+        ),
       );
     }
   }
@@ -436,7 +458,7 @@ export async function sendMessageHandler(
         "validation_error",
         undefined,
         ctx.requestId,
-        "A mensagem citada não é desta conversa.",
+        traduzir("A mensagem citada não é desta conversa.", ctx.idioma ?? "pt-BR"),
       );
     }
     citada = alvo as { id: string; external_id: string | null };

--- a/app/api/v1/messages/route.ts
+++ b/app/api/v1/messages/route.ts
@@ -44,6 +44,7 @@ export async function POST(req: NextRequest): Promise<Response> {
         organization_id: activeOrg.orgId,
         actor: { type: "user", id: user.id },
         requestId,
+        idioma: user.idioma,
       },
       input as SendMessageInput,
     );

--- a/app/api/v1/metrics/atrito/route.ts
+++ b/app/api/v1/metrics/atrito/route.ts
@@ -100,7 +100,7 @@ export async function GET(req: NextRequest): Promise<Response> {
     to: url.searchParams.get("to") ?? undefined,
   });
   if (!parsed.success) {
-    return fail("validation_failed", "Query inválida.", 422, {
+    return fail("validation_failed", t("Query inválida."), 422, {
       details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
       requestId,
     });
@@ -111,7 +111,7 @@ export async function GET(req: NextRequest): Promise<Response> {
     ? new Date(parsed.data.from)
     : new Date(to.getTime() - THIRTY_DAYS_MS);
   if (from.getTime() >= to.getTime()) {
-    return fail("validation_failed", "Janela inválida: 'from' deve ser anterior a 'to'.", 422, {
+    return fail("validation_failed", t("Janela inválida: 'from' deve ser anterior a 'to'."), 422, {
       requestId,
     });
   }
@@ -191,19 +191,20 @@ export async function PATCH(req: NextRequest): Promise<Response> {
 
   const authz = await requireRole("manager", { requestId, resource: "metrics" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg, user } = authz;
 
   let corpo: unknown;
   try {
     corpo = await req.json();
   } catch {
-    return fail("validation_failed", "Corpo inválido.", 422, { requestId });
+    return fail("validation_failed", t("Corpo inválido."), 422, { requestId });
   }
   const parsed = patchSchema.safeParse(corpo);
   if (!parsed.success) {
     return fail(
       "validation_failed",
-      "A régua do abandono precisa ser um número inteiro de horas entre 1 e 2160.",
+      t("A régua do abandono precisa ser um número inteiro de horas entre 1 e 2160."),
       422,
       { details: parsed.error.flatten().fieldErrors as Record<string, unknown>, requestId },
     );

--- a/app/api/v1/metrics/attendants/route.ts
+++ b/app/api/v1/metrics/attendants/route.ts
@@ -17,6 +17,7 @@ import { isServiceRoleConfigured } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -47,6 +48,7 @@ export async function GET(req: NextRequest): Promise<Response> {
   // spec 13 §6.1: piso agent (vê as próprias); RLS gate a comparação manager+.
   const authz = await requireRole("agent", { requestId, resource: "metrics" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const url = new URL(req.url);
@@ -56,7 +58,7 @@ export async function GET(req: NextRequest): Promise<Response> {
     owner_user_id: url.searchParams.get("owner_user_id") ?? undefined,
   });
   if (!parsed.success) {
-    return fail("validation_failed", "Query inválida.", 422, {
+    return fail("validation_failed", t("Query inválida."), 422, {
       details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
       requestId,
     });
@@ -67,7 +69,7 @@ export async function GET(req: NextRequest): Promise<Response> {
     ? new Date(parsed.data.from)
     : new Date(to.getTime() - THIRTY_DAYS_MS);
   if (from.getTime() >= to.getTime()) {
-    return fail("validation_failed", "Janela inválida: 'from' deve ser anterior a 'to'.", 422, {
+    return fail("validation_failed", t("Janela inválida: 'from' deve ser anterior a 'to'."), 422, {
       requestId,
     });
   }

--- a/app/api/v1/notifications/push/route.ts
+++ b/app/api/v1/notifications/push/route.ts
@@ -12,6 +12,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 import { vapidPronto, vapidPublica } from "@/lib/notifications/vapid";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -37,19 +38,20 @@ export async function PUT(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("viewer", { requestId, resource: "push_subscriptions" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   if (!vapidPronto()) {
-    return fail("unavailable", "Web Push não configurado nesta instalação.", 503, { requestId });
+    return fail("unavailable", t("Web Push não configurado nesta instalação."), 503, { requestId });
   }
 
   let raw: unknown;
   try {
     raw = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
   const parsed = subSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, {
+    return fail("validation_failed", t("Campos inválidos."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -71,7 +73,7 @@ export async function PUT(req: NextRequest): Promise<Response> {
 
   if (error) {
     if (error.code === "PGRST205") {
-      return fail("unavailable", "Web Push ainda não está no banco desta instalação.", 503, { requestId });
+      return fail("unavailable", t("Web Push ainda não está no banco desta instalação."), 503, { requestId });
     }
     return fail("internal_error", error.message, 500, { requestId });
   }
@@ -92,16 +94,17 @@ export async function DELETE(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("viewer", { requestId, resource: "push_subscriptions" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   let raw: unknown;
   try {
     raw = await req.json();
   } catch {
-    return fail("invalid_request", "Body JSON inválido.", 400, { requestId });
+    return fail("invalid_request", t("Body JSON inválido."), 400, { requestId });
   }
   const parsed = z.object({ endpoint: z.string().url() }).safeParse(raw);
   if (!parsed.success) {
-    return fail("validation_failed", "Campos inválidos.", 422, { requestId });
+    return fail("validation_failed", t("Campos inválidos."), 422, { requestId });
   }
 
   const supabase = await createClient();

--- a/app/api/v1/pipelines/[id]/agent-mapping/route.ts
+++ b/app/api/v1/pipelines/[id]/agent-mapping/route.ts
@@ -31,6 +31,7 @@ import {
   type EtapaDoMapa,
 } from "@/lib/leads/agent-mapping";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -154,13 +155,14 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "pipeline_agent_mapping" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   const { id: pipelineId } = await ctx.params;
   const supabase = await createClient();
 
   try {
     const funil = await lerFunil(supabase, authz.org.orgId, pipelineId);
-    if (!funil) return fail("not_found", "Funil não encontrado.", 404, { requestId });
+    if (!funil) return fail("not_found", t("Funil não encontrado."), 404, { requestId });
     return ok(corpo(funil.etapas), { requestId });
   } catch (err) {
     return fail("internal_error", (err as Error).message, 500, { requestId });
@@ -171,6 +173,7 @@ export async function PUT(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "pipeline_agent_mapping" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const orgId = authz.org.orgId;
 
   const { id: pipelineId } = await ctx.params;
@@ -179,14 +182,14 @@ export async function PUT(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   try {
     json = await req.json();
   } catch {
-    return fail("invalid_request", "Corpo não é JSON válido.", 400, { requestId });
+    return fail("invalid_request", t("Corpo não é JSON válido."), 400, { requestId });
   }
 
   const parsed = bodySchema.safeParse(json);
   if (!parsed.success) {
     return fail(
       "validation_failed",
-      "Envie o mapeamento completo dos sete passos do atendimento.",
+      t("Envie o mapeamento completo dos sete passos do atendimento."),
       422,
       { requestId, details: parsed.error.flatten() },
     );
@@ -202,7 +205,7 @@ export async function PUT(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   }
   // Pipeline de outra org morre AQUI, antes de qualquer escrita: responder 404
   // depois de gravar seria pior que responder 200.
-  if (!funil) return fail("not_found", "Funil não encontrado.", 404, { requestId });
+  if (!funil) return fail("not_found", t("Funil não encontrado."), 404, { requestId });
 
   const { mapeamento } = parsed.data;
 
@@ -273,7 +276,7 @@ export async function PUT(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   // inclusive se um update parcial deixou o funil diferente do mapa enviado.
   try {
     const depois = await lerFunil(supabase, orgId, pipelineId);
-    if (!depois) return fail("not_found", "Funil não encontrado.", 404, { requestId });
+    if (!depois) return fail("not_found", t("Funil não encontrado."), 404, { requestId });
     return ok(corpo(depois.etapas), { requestId });
   } catch (err) {
     return fail("internal_error", (err as Error).message, 500, { requestId });

--- a/app/api/v1/pipelines/[id]/board/route.ts
+++ b/app/api/v1/pipelines/[id]/board/route.ts
@@ -16,6 +16,8 @@ import { randomUUID } from "node:crypto";
 import { type NextRequest } from "next/server";
 
 import { fail, ok } from "@/lib/api/wrappers";
+import { loadAuthUser } from "@/lib/auth/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 import {
   roteiaProximasAcoes,
   type EstadoDoContato,
@@ -355,6 +357,8 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
   if (authErr || !user) {
     return fail("unauthenticated", "Auth required.", 401, { requestId });
   }
+  const authUser = await loadAuthUser();
+  const t = (texto: string) => traduzir(texto, authUser?.idioma ?? "pt-BR");
 
   const [
     { data: pipeline, error: pipelineErr },
@@ -379,7 +383,7 @@ export async function GET(_req: NextRequest, ctx: RouteCtx): Promise<Response> {
   if (pipelineErr) return fail("internal_error", pipelineErr.message, 500, { requestId });
   if (stagesErr) return fail("internal_error", stagesErr.message, 500, { requestId });
   if (leadsErr) return fail("internal_error", leadsErr.message, 500, { requestId });
-  if (!pipeline) return fail("resource_not_found", "Pipeline não encontrado.", 404, { requestId });
+  if (!pipeline) return fail("resource_not_found", t("Pipeline não encontrado."), 404, { requestId });
 
   const leadsWithOwner = await withOwnerAgents(
     supabase,

--- a/app/api/v1/pipelines/[id]/route.ts
+++ b/app/api/v1/pipelines/[id]/route.ts
@@ -33,6 +33,7 @@ import {
 import { createClient } from "@/lib/supabase/server";
 
 import { conflitoDoBanco, corpo, lerDependencias, lerFunis } from "../_funis";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -62,6 +63,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "crm_pipelines" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const orgId = authz.org.orgId;
 
   const { id: pipelineId } = await ctx.params;
@@ -70,12 +72,12 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
   try {
     json = await req.json();
   } catch {
-    return fail("invalid_request", "Corpo não é JSON válido.", 400, { requestId });
+    return fail("invalid_request", t("Corpo não é JSON válido."), 400, { requestId });
   }
 
   const parsed = bodySchema.safeParse(json);
   if (!parsed.success) {
-    return fail("unprocessable_entity", "Não entendi o que mudar neste funil.", 422, {
+    return fail("unprocessable_entity", t("Não entendi o que mudar neste funil."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -96,7 +98,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
   // resposta é a mesma de um funil inexistente (dizer "existe, mas não é seu" já
   // vaza a existência).
   const alvo = funis.find((f) => f.id === pipelineId);
-  if (!alvo) return fail("not_found", "Funil não encontrado.", 404, { requestId });
+  if (!alvo) return fail("not_found", t("Funil não encontrado."), 404, { requestId });
 
   // ⚠️ ARQUIVADO NÃO SE EDITA. `uniq_crm_pipelines_org_default` é PARCIAL
   // (`where is_archived = false`): marcar um funil arquivado como padrão passa
@@ -143,7 +145,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
     if (pedido.depois_de !== null && i < 0) {
       return fail(
         "unprocessable_entity",
-        "O funil que você escolheu como vizinho não está mais na lista. Recarregue a página.",
+        t("O funil que você escolheu como vizinho não está mais na lista. Recarregue a página."),
         422,
         { requestId },
       );
@@ -156,7 +158,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
     if (!Number.isFinite(posicao)) {
       return fail(
         "state_conflict",
-        "Os funis desta lista estão empatados na ordenação. Recarregue a página e mova o funil para outro lugar.",
+        t("Os funis desta lista estão empatados na ordenação. Recarregue a página e mova o funil para outro lugar."),
         409,
         { requestId },
       );
@@ -218,6 +220,7 @@ export async function DELETE(req: NextRequest, ctx: RouteCtx): Promise<Response>
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "crm_pipelines" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const orgId = authz.org.orgId;
 
   const { id: pipelineId } = await ctx.params;
@@ -232,7 +235,7 @@ export async function DELETE(req: NextRequest, ctx: RouteCtx): Promise<Response>
     return fail("internal_error", (err as Error).message, 500, { requestId });
   }
   const alvo = funis.find((f) => f.id === pipelineId);
-  if (!alvo) return fail("not_found", "Funil não encontrado.", 404, { requestId });
+  if (!alvo) return fail("not_found", t("Funil não encontrado."), 404, { requestId });
 
   let deps;
   try {

--- a/app/api/v1/pipelines/[id]/stages/[stageId]/route.ts
+++ b/app/api/v1/pipelines/[id]/stages/[stageId]/route.ts
@@ -23,6 +23,7 @@ import { fail, ok } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { arquivarEtapa, atualizarEtapa } from "@/lib/leads/stage-operations";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -50,6 +51,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "crm_stages" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   const { id: pipelineId, stageId } = await ctx.params;
 
@@ -57,12 +59,12 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
   try {
     json = await req.json();
   } catch {
-    return fail("invalid_request", "Corpo não é JSON válido.", 400, { requestId });
+    return fail("invalid_request", t("Corpo não é JSON válido."), 400, { requestId });
   }
 
   const parsed = bodySchema.safeParse(json);
   if (!parsed.success) {
-    return fail("unprocessable_entity", "Não entendi o que mudar nesta etapa.", 422, {
+    return fail("unprocessable_entity", t("Não entendi o que mudar nesta etapa."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });

--- a/app/api/v1/pipelines/[id]/stages/route.ts
+++ b/app/api/v1/pipelines/[id]/stages/route.ts
@@ -25,6 +25,7 @@ import { fail, ok } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { criarEtapa } from "@/lib/leads/stage-operations";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -40,6 +41,7 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "crm_stages" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   const { id: pipelineId } = await ctx.params;
 
@@ -47,12 +49,12 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<Response> {
   try {
     json = await req.json();
   } catch {
-    return fail("invalid_request", "Corpo não é JSON válido.", 400, { requestId });
+    return fail("invalid_request", t("Corpo não é JSON válido."), 400, { requestId });
   }
 
   const parsed = bodySchema.safeParse(json);
   if (!parsed.success) {
-    return fail("unprocessable_entity", "Dê um nome à etapa — é o que aparece no topo da coluna.", 422, {
+    return fail("unprocessable_entity", t("Dê um nome à etapa — é o que aparece no topo da coluna."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });

--- a/app/api/v1/pipelines/default/route.ts
+++ b/app/api/v1/pipelines/default/route.ts
@@ -12,6 +12,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
 import type { Pipeline, Stage } from "@/lib/kanban/types";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -19,6 +20,7 @@ export async function GET(): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("agent", { requestId, resource: "pipelines" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org } = authz;
 
   const supabase = await createClient();
@@ -34,7 +36,7 @@ export async function GET(): Promise<Response> {
     .maybeSingle();
   if (pipelineErr) return fail("internal_error", pipelineErr.message, 500, { requestId });
   if (!pipeline) {
-    return fail("resource_not_found", "Nenhum funil configurado nesta organização.", 404, {
+    return fail("resource_not_found", t("Nenhum funil configurado nesta organização."), 404, {
       requestId,
     });
   }

--- a/app/api/v1/pipelines/route.ts
+++ b/app/api/v1/pipelines/route.ts
@@ -22,6 +22,7 @@ import {
 import { createClient } from "@/lib/supabase/server";
 import { conflitoDoBanco, corpo, lerFunis } from "./_funis";
 import { listPipelinesHandler } from "./_handler";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -29,6 +30,7 @@ export async function GET(): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "pipelines" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   const supabase = await createClient();
   try {
@@ -39,7 +41,7 @@ export async function GET(): Promise<Response> {
     });
     return ok(pipelines, { requestId });
   } catch {
-    return fail("internal_error", "Falha ao listar funis.", 500, { requestId });
+    return fail("internal_error", t("Falha ao listar funis."), 500, { requestId });
   }
 }
 
@@ -69,18 +71,19 @@ export async function POST(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "crm_pipelines" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const orgId = authz.org.orgId;
 
   let json: unknown;
   try {
     json = await req.json();
   } catch {
-    return fail("invalid_request", "Corpo não é JSON válido.", 400, { requestId });
+    return fail("invalid_request", t("Corpo não é JSON válido."), 400, { requestId });
   }
 
   const parsed = bodySchema.safeParse(json);
   if (!parsed.success) {
-    return fail("unprocessable_entity", "Dê um nome ao funil — é o que aparece na lista.", 422, {
+    return fail("unprocessable_entity", t("Dê um nome ao funil — é o que aparece na lista."), 422, {
       requestId,
       details: parsed.error.flatten(),
     });

--- a/app/api/v1/products/[id]/route.ts
+++ b/app/api/v1/products/[id]/route.ts
@@ -14,6 +14,7 @@ import { fail, ok } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { COLUNAS_DO_PRODUTO, produtoPatchSchema } from "@/lib/schemas/produtos";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -24,17 +25,18 @@ export async function PATCH(
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "catalog_products" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { id } = await params;
 
   const parsed = produtoPatchSchema.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
-    return fail("validation_failed", "Dados inválidos.", 422, {
+    return fail("validation_failed", t("Dados inválidos."), 422, {
       requestId,
       details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
     });
   }
   if (Object.keys(parsed.data).length === 0) {
-    return fail("validation_failed", "Nada para alterar.", 422, { requestId });
+    return fail("validation_failed", t("Nada para alterar."), 422, { requestId });
   }
 
   const supabase = await createClient();
@@ -48,13 +50,13 @@ export async function PATCH(
 
   if (error) {
     if (error.code === "23505") {
-      return fail("conflict", "Já existe um produto com esse código.", 409, { requestId });
+      return fail("conflict", t("Já existe um produto com esse código."), 409, { requestId });
     }
     return fail("internal_error", "Erro ao salvar o produto.", 500, { requestId });
   }
   // `maybeSingle` devolve null quando a RLS barrou ou o id não é desta org — os
   // dois são "não existe para você", e 404 é a resposta honesta.
-  if (!data) return fail("not_found", "Produto não encontrado.", 404, { requestId });
+  if (!data) return fail("not_found", t("Produto não encontrado."), 404, { requestId });
 
   await audit({
     organizationId: authz.org.orgId,
@@ -75,6 +77,7 @@ export async function DELETE(
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "catalog_products" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { id } = await params;
 
   const supabase = await createClient();
@@ -87,7 +90,7 @@ export async function DELETE(
     .maybeSingle();
 
   if (error) return fail("internal_error", "Erro ao remover o produto.", 500, { requestId });
-  if (!data) return fail("not_found", "Produto não encontrado.", 404, { requestId });
+  if (!data) return fail("not_found", t("Produto não encontrado."), 404, { requestId });
 
   await audit({
     organizationId: authz.org.orgId,

--- a/app/api/v1/products/import/route.ts
+++ b/app/api/v1/products/import/route.ts
@@ -24,6 +24,7 @@ import { fail, ok } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { moedaDaOrganizacao } from "@/lib/catalogo/moeda-da-org";
 import { lerPlanilha, type ErroDaLinha } from "@/lib/catalogo/planilha";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { CSV_MAX_BYTES, CSV_MAX_DATA_ROWS, decodificarCsv } from "@/lib/contacts/csv";
 import { COLUNAS_DO_PRODUTO } from "@/lib/schemas/produtos";
 import { createClient } from "@/lib/supabase/server";
@@ -55,6 +56,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   const authz = await requireRole("manager", { requestId, resource: "catalog_products" });
   if (!authz.ok) return authz.response;
   const orgId = authz.org.orgId;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   let arquivo: File;
   try {
@@ -63,7 +65,7 @@ export async function POST(req: NextRequest): Promise<Response> {
     if (!(f instanceof File)) throw new Error("sem arquivo");
     arquivo = f;
   } catch {
-    return fail("validation_failed", "Envie o arquivo no campo 'file'.", 422, { requestId });
+    return fail("validation_failed", t("Envie o arquivo no campo 'file'."), 422, { requestId });
   }
 
   const nome = arquivo.name ?? "";
@@ -74,7 +76,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   if (!tipoOk) {
     return fail(
       "validation_failed",
-      "Formato não suportado — envie um arquivo .csv. No Excel use 'Salvar como' → 'CSV UTF-8'.",
+      t("Formato não suportado — envie um arquivo .csv. No Excel use 'Salvar como' → 'CSV UTF-8'."),
       422,
       { requestId },
     );
@@ -82,7 +84,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   if (arquivo.size > CSV_MAX_BYTES) {
     return fail(
       "validation_failed",
-      `Arquivo maior que ${Math.floor(CSV_MAX_BYTES / 1024 / 1024)}MB.`,
+      t("Arquivo maior que ") + `${Math.floor(CSV_MAX_BYTES / 1024 / 1024)}MB.`,
       413,
       { requestId },
     );
@@ -93,9 +95,9 @@ export async function POST(req: NextRequest): Promise<Response> {
   // catálogo sem um erro sequer, e é ele que o agente lê para o cliente (#483).
   const decodificado = decodificarCsv(await arquivo.arrayBuffer());
   if ("erro" in decodificado) {
-    return fail("validation_failed", decodificado.erro, 422, { requestId });
+    return fail("validation_failed", t(decodificado.erro), 422, { requestId });
   }
-  const lido = lerPlanilha(decodificado.texto);
+  const lido = lerPlanilha(decodificado.texto, t);
   // Problema do ARQUIVO (falta a coluna de preço) é 422 com a frase inteira —
   // e não um relatório com 300 erros idênticos.
   if ("erro" in lido) return fail("validation_failed", lido.erro, 422, { requestId });
@@ -104,7 +106,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   if (totalLinhas > CSV_MAX_DATA_ROWS) {
     return fail(
       "validation_failed",
-      `Máximo de ${CSV_MAX_DATA_ROWS} produtos por importação — divida a planilha.`,
+      `${t("Máximo de")} ${CSV_MAX_DATA_ROWS} ${t("produtos por importação — divida a planilha.")}`,
       422,
       { requestId },
     );
@@ -240,6 +242,7 @@ export async function GET(): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "catalog_products" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   const modelo = [
     "codigo,nome,marca,categoria,preco,custo,estoque",

--- a/app/api/v1/products/route.ts
+++ b/app/api/v1/products/route.ts
@@ -15,6 +15,7 @@ import { requireRole } from "@/lib/auth/require-role";
 import { moedaDaOrganizacao } from "@/lib/catalogo/moeda-da-org";
 import { COLUNAS_DO_PRODUTO, produtoCreateSchema } from "@/lib/schemas/produtos";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -49,10 +50,11 @@ export async function POST(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "catalog_products" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   const parsed = produtoCreateSchema.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
-    return fail("validation_failed", "Dados inválidos.", 422, {
+    return fail("validation_failed", t("Dados inválidos."), 422, {
       requestId,
       details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
     });
@@ -71,7 +73,7 @@ export async function POST(req: NextRequest): Promise<Response> {
     // 23505 = já existe produto com este código nesta organização. A recusa
     // nomeia o campo porque quem lê é quem digitou.
     if (error.code === "23505") {
-      return fail("conflict", "Já existe um produto com esse código.", 409, { requestId });
+      return fail("conflict", t("Já existe um produto com esse código."), 409, { requestId });
     }
     return fail("internal_error", "Erro ao salvar o produto.", 500, { requestId });
   }

--- a/app/api/v1/settings/api-tokens/[id]/revoke/route.ts
+++ b/app/api/v1/settings/api-tokens/[id]/revoke/route.ts
@@ -9,6 +9,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -21,6 +22,7 @@ export async function POST(
 
   const authz = await requireRole("admin", { requestId, resource: "api_tokens" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   const supabase = await createClient();
@@ -31,7 +33,7 @@ export async function POST(
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
   if (fetchErr) return fail("internal_error", fetchErr.message, 500, { requestId });
-  if (!token) return fail("not_found", "Token não encontrado.", 404, { requestId });
+  if (!token) return fail("not_found", t("Token não encontrado."), 404, { requestId });
   if (token.revoked_at) {
     return ok({ id, already_revoked: true }, { requestId });
   }

--- a/app/api/v1/settings/api-tokens/route.ts
+++ b/app/api/v1/settings/api-tokens/route.ts
@@ -14,6 +14,7 @@ import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createApiTokenSchema, validateRequest } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -40,6 +41,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("admin", { requestId, resource: "api_tokens" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
 
   let input;
@@ -96,7 +98,7 @@ export async function POST(req: NextRequest): Promise<Response> {
     {
       ...created,
       plaintext,
-      _warning: "Salve este token agora — ele não será mostrado novamente.",
+      _warning: t("Salve este token agora — ele não será mostrado novamente."),
     },
     { status: 201, requestId },
   );

--- a/app/api/v1/tasks/[id]/route.ts
+++ b/app/api/v1/tasks/[id]/route.ts
@@ -18,6 +18,7 @@ import { z } from "zod";
 import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { createClient } from "@/lib/supabase/server";
 import { registraAtividadeDaTarefa } from "@/lib/tarefas/atividade";
 import { PRIORIDADES_DA_TAREFA, SITUACOES_DA_TAREFA, type Tarefa } from "@/lib/tarefas/tipos";
@@ -52,10 +53,11 @@ export async function PATCH(req: NextRequest, ctx: Contexto): Promise<Response> 
 
   const authz = await requireRole("agent", { requestId, resource: "crm_tasks" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   const parsed = edicaoSchema.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
-    return fail("validation_failed", "Dados inválidos.", 422, {
+    return fail("validation_failed", t("Dados inválidos."), 422, {
       requestId,
       details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
     });
@@ -83,14 +85,14 @@ export async function PATCH(req: NextRequest, ctx: Contexto): Promise<Response> 
 
   if (error) {
     if (error.code === "PGRST116") {
-      return fail("not_found", "Tarefa não encontrada.", 404, { requestId });
+      return fail("not_found", t("Tarefa não encontrada."), 404, { requestId });
     }
     if (error.code === "23503") {
-      return fail("validation_failed", "O negócio ou contato vinculado não existe.", 422, {
+      return fail("validation_failed", t("O negócio ou contato vinculado não existe."), 422, {
         requestId,
       });
     }
-    return fail("internal_error", "Erro ao salvar a tarefa.", 500, { requestId });
+    return fail("internal_error", t("Erro ao salvar a tarefa."), 500, { requestId });
   }
 
   const tarefa = data as unknown as Tarefa;
@@ -125,6 +127,7 @@ export async function DELETE(_req: NextRequest, ctx: Contexto): Promise<Response
 
   const authz = await requireRole("agent", { requestId, resource: "crm_tasks" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   const supabase = await createClient();
   // `.select()` no delete para saber se ALGUMA linha saiu. Sem isso, apagar uma
@@ -138,10 +141,10 @@ export async function DELETE(_req: NextRequest, ctx: Contexto): Promise<Response
     .select("id");
 
   if (error) {
-    return fail("internal_error", "Erro ao apagar a tarefa.", 500, { requestId });
+    return fail("internal_error", t("Erro ao apagar a tarefa."), 500, { requestId });
   }
   if (!data || data.length === 0) {
-    return fail("not_found", "Tarefa não encontrada.", 404, { requestId });
+    return fail("not_found", t("Tarefa não encontrada."), 404, { requestId });
   }
 
   await audit({

--- a/app/api/v1/tasks/route.ts
+++ b/app/api/v1/tasks/route.ts
@@ -29,6 +29,7 @@ import { z } from "zod";
 import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { createClient } from "@/lib/supabase/server";
 import { registraAtividadeDaTarefa } from "@/lib/tarefas/atividade";
 import { PRIORIDADES_DA_TAREFA, SITUACOES_DA_TAREFA, type Tarefa } from "@/lib/tarefas/tipos";
@@ -66,10 +67,11 @@ export async function GET(req: NextRequest): Promise<Response> {
 
   const authz = await requireRole("viewer", { requestId, resource: "crm_tasks" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   const parsed = listaSchema.safeParse(Object.fromEntries(new URL(req.url).searchParams));
   if (!parsed.success) {
-    return fail("validation_failed", "Parâmetros inválidos.", 422, {
+    return fail("validation_failed", t("Parâmetros inválidos."), 422, {
       requestId,
       details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
     });
@@ -98,7 +100,7 @@ export async function GET(req: NextRequest): Promise<Response> {
 
   const { data, error } = await query;
   if (error) {
-    return fail("internal_error", "Erro ao listar as tarefas.", 500, { requestId });
+    return fail("internal_error", t("Erro ao listar as tarefas."), 500, { requestId });
   }
 
   return ok({ tasks: (data ?? []) as unknown as Tarefa[] }, { requestId });
@@ -110,10 +112,11 @@ export async function POST(req: NextRequest): Promise<Response> {
   // `agent` e não `manager`: criar tarefa é o gesto de quem ATENDE, todo dia.
   const authz = await requireRole("agent", { requestId, resource: "crm_tasks" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   const parsed = criacaoSchema.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
-    return fail("validation_failed", "Dados inválidos.", 422, {
+    return fail("validation_failed", t("Dados inválidos."), 422, {
       requestId,
       details: parsed.error.flatten().fieldErrors as Record<string, unknown>,
     });
@@ -134,11 +137,11 @@ export async function POST(req: NextRequest): Promise<Response> {
     // 23503 = lead ou contato de outra organização (ou apagado no meio). A
     // recusa nomeia o campo porque quem lê é quem escolheu na tela.
     if (error.code === "23503") {
-      return fail("validation_failed", "O negócio ou contato vinculado não existe.", 422, {
+      return fail("validation_failed", t("O negócio ou contato vinculado não existe."), 422, {
         requestId,
       });
     }
-    return fail("internal_error", "Erro ao salvar a tarefa.", 500, { requestId });
+    return fail("internal_error", t("Erro ao salvar a tarefa."), 500, { requestId });
   }
 
   const tarefa = data as unknown as Tarefa;

--- a/app/api/v1/team/[user_id]/_shared.ts
+++ b/app/api/v1/team/[user_id]/_shared.ts
@@ -16,6 +16,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { ApiError } from "@/lib/api/types";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { changeRoleSchema, validateRequest } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
 
@@ -29,6 +30,7 @@ export async function changeMemberRole(
   const authz = await requireRole("admin", { requestId, resource: "team" });
   if (!authz.ok) return authz.response;
   const { user: authUser, org: activeOrg } = authz;
+  const t = (texto: string) => traduzir(texto, authUser.idioma);
 
   let input;
   try {
@@ -52,9 +54,9 @@ export async function changeMemberRole(
     .eq("user_id", targetUserId)
     .maybeSingle();
   if (fetchErr) return fail("internal_error", fetchErr.message, 500, { requestId });
-  if (!target) return fail("not_found", "Membro não encontrado.", 404, { requestId });
+  if (!target) return fail("not_found", t("Membro não encontrado."), 404, { requestId });
   if (target.revoked_at) {
-    return fail("state_conflict", "Membro está revogado.", 409, { requestId });
+    return fail("state_conflict", t("Membro está revogado."), 409, { requestId });
   }
 
   if (target.role === "admin" && input.role !== "admin") {
@@ -68,7 +70,7 @@ export async function changeMemberRole(
     if ((count ?? 0) <= 1) {
       return fail(
         "state_conflict",
-        "Não é possível rebaixar o último admin do tenant.",
+        t("Não é possível rebaixar o último admin do tenant."),
         409,
         { requestId },
       );

--- a/app/api/v1/team/[user_id]/revoke/route.ts
+++ b/app/api/v1/team/[user_id]/revoke/route.ts
@@ -13,6 +13,7 @@ import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -25,9 +26,10 @@ export async function POST(
 
   const authz = await requireRole("admin", { requestId, resource: "team" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user: authUser, org: activeOrg } = authz;
   if (targetUserId === authUser.id) {
-    return fail("state_conflict", "Não é possível revogar o próprio acesso.", 409, { requestId });
+    return fail("state_conflict", t("Não é possível revogar o próprio acesso."), 409, { requestId });
   }
 
   const supabase = await createClient();
@@ -39,7 +41,7 @@ export async function POST(
     .eq("user_id", targetUserId)
     .maybeSingle();
   if (fetchErr) return fail("internal_error", fetchErr.message, 500, { requestId });
-  if (!target) return fail("not_found", "Membro não encontrado.", 404, { requestId });
+  if (!target) return fail("not_found", t("Membro não encontrado."), 404, { requestId });
   if (target.revoked_at) {
     return ok({ user_id: targetUserId, already_revoked: true }, { requestId });
   }
@@ -55,7 +57,7 @@ export async function POST(
     if ((count ?? 0) <= 1) {
       return fail(
         "state_conflict",
-        "Não é possível revogar o último admin do tenant.",
+        t("Não é possível revogar o último admin do tenant."),
         409,
         { requestId },
       );

--- a/app/api/v1/webhook-sources/[id]/events/route.ts
+++ b/app/api/v1/webhook-sources/[id]/events/route.ts
@@ -8,6 +8,7 @@ import { randomUUID } from "node:crypto";
 import { ok, fail } from "@/lib/api/wrappers";
 import { requireRole } from "@/lib/auth/require-role";
 import { createClient } from "@/lib/supabase/server";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -20,6 +21,7 @@ export async function GET(_req: Request, ctx: RouteCtx): Promise<Response> {
   const { id } = await ctx.params;
   const authz = await requireRole("manager", { requestId, resource: "webhook_sources" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { org: activeOrg } = authz;
 
   const supabase = await createClient();
@@ -30,7 +32,7 @@ export async function GET(_req: Request, ctx: RouteCtx): Promise<Response> {
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
   if (sourceErr) return fail("internal_error", sourceErr.message, 500, { requestId });
-  if (!source) return fail("not_found", "Fonte não encontrada.", 404, { requestId });
+  if (!source) return fail("not_found", t("Fonte não encontrada."), 404, { requestId });
 
   const { data, error } = await supabase
     .from("webhook_events_log")

--- a/app/api/v1/webhook-sources/[id]/route.ts
+++ b/app/api/v1/webhook-sources/[id]/route.ts
@@ -13,6 +13,7 @@ import { updateWebhookSourceSchema } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { encryptWebhookSecret } from "@/lib/webhooks/secrets";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -25,6 +26,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
   const { id } = await ctx.params;
   const authz = await requireRole("manager", { requestId, resource: "webhook_sources" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org: activeOrg } = authz;
 
   let raw: unknown = {};
@@ -35,7 +37,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
   }
   const parsed = updateWebhookSourceSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("invalid_request", "Dados inválidos.", 400, {
+    return fail("invalid_request", t("Dados inválidos."), 400, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -49,7 +51,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
   if (fetchErr) return fail("internal_error", fetchErr.message, 500, { requestId });
-  if (!existing) return fail("not_found", "Fonte não encontrada.", 404, { requestId });
+  if (!existing) return fail("not_found", t("Fonte não encontrada."), 404, { requestId });
 
   // secret plaintext do input vira secret_encrypted (migration 0041); a coluna
   // em claro não existe mais. `secret: null` remove o segredo da fonte.
@@ -70,7 +72,7 @@ export async function PATCH(req: NextRequest, ctx: RouteCtx): Promise<Response> 
       if (enc === null) {
         return fail(
           "encryption_unavailable",
-          "Não foi possível guardar o segredo com segurança: a chave de cifra desta instalação não está ativa. Quem administra o servidor resolve rodando o update.sh, que gera e ativa a chave.",
+          t("Não foi possível guardar o segredo com segurança: a chave de cifra desta instalação não está ativa. Quem administra o servidor resolve rodando o update.sh, que gera e ativa a chave."),
           422,
           { requestId },
         );
@@ -107,6 +109,7 @@ export async function DELETE(_req: NextRequest, ctx: RouteCtx): Promise<Response
   const { id } = await ctx.params;
   const authz = await requireRole("manager", { requestId, resource: "webhook_sources" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
   const { user, org: activeOrg } = authz;
 
   const supabase = await createClient();
@@ -117,7 +120,7 @@ export async function DELETE(_req: NextRequest, ctx: RouteCtx): Promise<Response
     .eq("organization_id", activeOrg.orgId)
     .maybeSingle();
   if (fetchErr) return fail("internal_error", fetchErr.message, 500, { requestId });
-  if (!existing) return fail("not_found", "Fonte não encontrada.", 404, { requestId });
+  if (!existing) return fail("not_found", t("Fonte não encontrada."), 404, { requestId });
 
   const { error: delErr } = await supabase.from("webhook_sources").delete().eq("id", id);
   if (delErr) return fail("internal_error", delErr.message, 500, { requestId });

--- a/app/api/v1/webhook-sources/route.ts
+++ b/app/api/v1/webhook-sources/route.ts
@@ -29,6 +29,7 @@ import { createWebhookSourceSchema } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { encryptWebhookSecret } from "@/lib/webhooks/secrets";
+import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
 
@@ -55,6 +56,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
   const authz = await requireRole("manager", { requestId, resource: "webhook_sources" });
   if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
 
   let raw: unknown = {};
   try {
@@ -64,7 +66,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   }
   const parsed = createWebhookSourceSchema.safeParse(raw);
   if (!parsed.success) {
-    return fail("invalid_request", "Dados inválidos.", 400, {
+    return fail("invalid_request", t("Dados inválidos."), 400, {
       requestId,
       details: parsed.error.flatten(),
     });
@@ -79,7 +81,7 @@ export async function POST(req: NextRequest): Promise<Response> {
     if (secretEncrypted === null) {
       return fail(
         "encryption_unavailable",
-        "Não foi possível guardar o segredo com segurança: a chave de cifra desta instalação não está ativa. Quem administra o servidor resolve rodando o update.sh, que gera e ativa a chave. Enquanto isso, você pode criar a fonte sem segredo.",
+        t("Não foi possível guardar o segredo com segurança: a chave de cifra desta instalação não está ativa. Quem administra o servidor resolve rodando o update.sh, que gera e ativa a chave. Enquanto isso, você pode criar a fonte sem segredo."),
         422,
         { requestId },
       );

--- a/app/app/agenda/_client.tsx
+++ b/app/app/agenda/_client.tsx
@@ -676,7 +676,7 @@ export function AgendaClient({
                 const alvo = todos.find((a) => a.id === cancelandoId);
                 if (!alvo) return t("Este agendamento não está mais na lista.");
                 const quem = alvo.quemSeraAtendido ? ` ${t("de")} ${alvo.quemSeraAtendido}` : "";
-                return `${t(alvo.titulo)}${quem}, ${format(new Date(alvo.comeca), t("d 'de' MMMM 'às' HH:mm"), { locale: localeDaData })}.`;
+                return `${alvo.titulo}${quem}, ${format(new Date(alvo.comeca), t("d 'de' MMMM 'às' HH:mm"), { locale: localeDaData })}.`;
               })()}
             </p>
             <label className="block text-xs font-medium text-text-muted" htmlFor="motivo-do-cancelamento">

--- a/app/app/ai/agents/[id]/_components/PainelDeSeguranca.tsx
+++ b/app/app/ai/agents/[id]/_components/PainelDeSeguranca.tsx
@@ -81,12 +81,12 @@ function Conferencia({
         {ordem ?? "•"}
       </span>
       <div className="space-y-1">
-        <p className="text-sm font-medium">{c.rotulo}</p>
-        <p className="text-xs text-muted-foreground">{c.oQueProtege}</p>
+        <p className="text-sm font-medium">{t(c.rotulo)}</p>
+        <p className="text-xs text-muted-foreground">{t(c.oQueProtege)}</p>
         {c.escolha === null ? (
           <p data-testid={`conferencia-${c.nome}-fixa`} className="text-xs text-muted-foreground">
             <span className="font-medium text-foreground">{t("Isto não se desliga.")}</span>{" "}
-            {c.porQueNaoSeDesliga}
+            {t(c.porQueNaoSeDesliga)}
           </p>
         ) : (
           <div data-testid={`conferencia-${c.nome}-escolha`} className="space-y-1">
@@ -96,7 +96,7 @@ function Conferencia({
                 checked={estado?.efetivo ?? false}
                 disabled={!podeEditar || salvando}
                 onCheckedChange={(v) => onToggle(c.nome, v)}
-                aria-label={c.rotulo}
+                aria-label={t(c.rotulo)}
               />
               <span className="text-xs text-muted-foreground">
                 {estado === undefined
@@ -109,7 +109,7 @@ function Conferencia({
               </span>
             </div>
             <p className="text-xs text-muted-foreground">
-              {t("Custa")} {c.escolha.custo}
+              {t("Custa")} {t(c.escolha.custo)}
               {t(". O modelo usado se escolhe em")}{" "}
               <a className="underline underline-offset-2" href="/app/ai/providers">
                 {t("Provedores de IA")}

--- a/app/app/ai/agents/[id]/_components/ToolPicker.tsx
+++ b/app/app/ai/agents/[id]/_components/ToolPicker.tsx
@@ -74,10 +74,11 @@ const CLASSE_RISCO: Record<ToolRisk, string> = {
 };
 
 function BadgeRisco({ risco }: { risco: ToolRisk }) {
+  const t = useT();
   const meta = riscoMeta(risco);
   return (
-    <Badge variant="outline" className={`text-[11px] ${CLASSE_RISCO[risco]}`} title={meta.explicacao}>
-      {meta.rotulo}
+    <Badge variant="outline" className={`text-[11px] ${CLASSE_RISCO[risco]}`} title={t(meta.explicacao)}>
+      {t(meta.rotulo)}
     </Badge>
   );
 }
@@ -98,6 +99,7 @@ function FichaCapacidade({
   disabled?: boolean;
   mostrarNomeTecnico?: boolean;
 }) {
+  const t = useT();
   return (
     <label
       data-testid={`capacidade-${capacidade.name}`}
@@ -113,15 +115,15 @@ function FichaCapacidade({
         checked={marcada}
         onChange={onToggle}
         disabled={disabled || bloqueada}
-        aria-label={capacidade.rotulo}
+        aria-label={t(capacidade.rotulo)}
       />
       <span className="flex-1 space-y-1">
         <span className="flex flex-wrap items-center gap-2">
-          <span className="text-sm font-medium">{capacidade.rotulo}</span>
+          <span className="text-sm font-medium">{t(capacidade.rotulo)}</span>
           <BadgeRisco risco={capacidade.risco} />
-          <span className="text-xs text-muted-foreground">· {capacidade.o_que_toca}</span>
+          <span className="text-xs text-muted-foreground">· {t(capacidade.o_que_toca)}</span>
         </span>
-        <span className="block text-xs text-muted-foreground">{capacidade.explicacao}</span>
+        <span className="block text-xs text-muted-foreground">{t(capacidade.explicacao)}</span>
         {mostrarNomeTecnico ? (
           <code className="block font-mono text-[11px] text-muted-foreground">
             {capacidade.name}

--- a/app/app/ai/agents/[id]/_components/UsoDasCapacidades.tsx
+++ b/app/app/ai/agents/[id]/_components/UsoDasCapacidades.tsx
@@ -172,7 +172,7 @@ export function UsoDasCapacidades({ agentId, active }: Props) {
               className="rounded-md border border-border/60 p-3"
             >
               <div className="flex flex-wrap items-center gap-2">
-                <span className="text-sm font-medium">{c.rotulo}</span>
+                <span className="text-sm font-medium">{t(c.rotulo)}</span>
                 <Badge variant="outline" className={`text-[11px] ${SINAL[c.sinal].classe}`}>
                   {t(SINAL[c.sinal].rotulo)}
                 </Badge>
@@ -181,10 +181,10 @@ export function UsoDasCapacidades({ agentId, active }: Props) {
                     {t("desligada")}
                   </Badge>
                 ) : null}
-                <span className="text-xs text-muted-foreground">· {c.o_que_toca}</span>
+                <span className="text-xs text-muted-foreground">· {t(c.o_que_toca)}</span>
               </div>
 
-              <p className="pt-1 text-xs text-muted-foreground">{c.recomendacao}</p>
+              <p className="pt-1 text-xs text-muted-foreground">{t(c.recomendacao)}</p>
 
               <div className="flex flex-wrap gap-x-4 pt-2 font-mono text-[11px] text-muted-foreground">
                 <span>

--- a/app/app/ai/agents/_components/AgentStatusBadge.tsx
+++ b/app/app/ai/agents/_components/AgentStatusBadge.tsx
@@ -2,6 +2,7 @@
 import { Badge } from "@/components/ui/badge";
 import { estadoDoAgente } from "@/lib/ai/agents/no-ar";
 import type { AgentRow } from "@/hooks/ai/useAgent";
+import { useT } from "@/hooks/i18n/useT";
 
 export type AgentStatus = "published" | "draft" | "paused" | "archived" | "invalid";
 
@@ -59,9 +60,10 @@ const VARIANT: Record<AgentStatus, "default" | "secondary" | "outline" | "destru
 };
 
 export function AgentStatusBadge({ status }: { status: AgentStatus }) {
+  const t = useT();
   return (
-    <Badge variant={VARIANT[status]} aria-label={`status: ${LABEL[status]}`}>
-      {LABEL[status]}
+    <Badge variant={VARIANT[status]} aria-label={`status: ${t(LABEL[status])}`}>
+      {t(LABEL[status])}
     </Badge>
   );
 }

--- a/app/app/ai/followups/[id]/_components/TriggerConfigControl.tsx
+++ b/app/app/ai/followups/[id]/_components/TriggerConfigControl.tsx
@@ -245,7 +245,7 @@ export function TriggerConfigControl({ flowId, triggerConfig }: Props) {
 
           {form.kind === "stage_change" && (
             <div className="space-y-2">
-              <Label htmlFor="trigger-stage">Etapa que dispara o fluxo</Label>
+              <Label htmlFor="trigger-stage">{t("Etapa que dispara o fluxo")}</Label>
               <Select
                 value={form.stageId}
                 onValueChange={(v) => setForm((f) => ({ ...f, stageId: v }))}
@@ -338,7 +338,7 @@ export function TriggerConfigControl({ flowId, triggerConfig }: Props) {
           )}
 
           <div className="flex items-center justify-between gap-2">
-            <Label htmlFor="trigger-cancel-on-reply">Cancelar se o lead responder</Label>
+            <Label htmlFor="trigger-cancel-on-reply">{t("Cancelar se o lead responder")}</Label>
             <Switch
               id="trigger-cancel-on-reply"
               checked={form.cancelOnReply}

--- a/app/app/ai/followups/[id]/_components/forms/ActionForm.tsx
+++ b/app/app/ai/followups/[id]/_components/forms/ActionForm.tsx
@@ -147,7 +147,7 @@ export function ActionForm({
 
       {mode === "text" ? (
         <div className="space-y-2">
-          <Label htmlFor="action-body">Texto enviado ao contato</Label>
+          <Label htmlFor="action-body">{t("Texto enviado ao contato")}</Label>
           <Textarea
             id="action-body"
             maxLength={4000}

--- a/app/app/ai/followups/[id]/_components/forms/MatchReplyForm.tsx
+++ b/app/app/ai/followups/[id]/_components/forms/MatchReplyForm.tsx
@@ -75,7 +75,7 @@ export function MatchReplyForm({
   return (
     <div className="space-y-3">
       <div className="space-y-2">
-        <Label>Regras de texto</Label>
+        <Label>{t("Regras de texto")}</Label>
         {branches.map((branch, index) => (
           <div key={branch.id} className="space-y-2 rounded-md border border-border p-2">
             <Input
@@ -155,7 +155,7 @@ export function MatchReplyForm({
         <p className="text-xs text-text-muted">{ESPERA_PELA_RESPOSTA.ajuda}</p>
       </div>
       <div className="space-y-2">
-        <Label htmlFor="match-reply-save">Gravar a resposta em</Label>
+        <Label htmlFor="match-reply-save">{t("Gravar a resposta em")}</Label>
         <Select
           value={
             saveTo?.kind === "contact_name"
@@ -181,7 +181,7 @@ export function MatchReplyForm({
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="__none__">{t("Não gravar")}</SelectItem>
-            <SelectItem value="__contact_name__">Nome do contato</SelectItem>
+            <SelectItem value="__contact_name__">{t("Nome do contato")}</SelectItem>
             {camposUnicos.map((c) => (
               <SelectItem key={c.key} value={c.key}>
                 {c.label} ({c.key})
@@ -192,7 +192,7 @@ export function MatchReplyForm({
         </Select>
         {saveTo?.kind === "lead_custom" && !camposUnicos.some((c) => c.key === saveTo.key) && (
           <Input
-            aria-label="Chave do campo personalizado"
+            aria-label={t("Chave do campo personalizado")}
             value={saveTo.key}
             onChange={(e) => {
               const next: ReplySaveTo = { kind: "lead_custom", key: e.target.value };

--- a/app/app/ai/followups/_components/DeleteFollowupFlowButton.tsx
+++ b/app/app/ai/followups/_components/DeleteFollowupFlowButton.tsx
@@ -56,18 +56,20 @@ export function DeleteFollowupFlowButton({
         }}
       >
         <Trash size={14} aria-hidden className="mr-1" />
-        Excluir
+        {t("Excluir")}
       </Button>
       <AlertDialog open={open} onOpenChange={setOpen}>
         <AlertDialogContent onClick={(e) => e.stopPropagation()}>
           <AlertDialogHeader>
-            <AlertDialogTitle>Excluir &ldquo;{flowName}&rdquo;?</AlertDialogTitle>
+            <AlertDialogTitle>
+              {t("Excluir")} &ldquo;{flowName}&rdquo;?
+            </AlertDialogTitle>
             <AlertDialogDescription>
               {t("Inscrições e versões deste fluxo são apagadas junto. Não é possível desfazer.")}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogCancel>{t("Cancelar")}</AlertDialogCancel>
             <AlertDialogAction
               disabled={del.isPending}
               onClick={(e) => {

--- a/app/app/ai/followups/enrollments/[id]/_components/DossieDoFollowup.tsx
+++ b/app/app/ai/followups/enrollments/[id]/_components/DossieDoFollowup.tsx
@@ -140,8 +140,8 @@ function LinhaDoTempo({
                 )}
               />
               <div className="min-w-0 flex-1">
-                <p className="text-sm text-text">{lido.titulo}</p>
-                {lido.detalhe && <p className="mt-0.5 text-xs text-text-muted">{lido.detalhe}</p>}
+                <p className="text-sm text-text">{t(lido.titulo)}</p>
+                {lido.detalhe && <p className="mt-0.5 text-xs text-text-muted">{t(lido.detalhe)}</p>}
                 <p className="mt-0.5 text-[11px] text-text-muted">
                   {lido.onde}
                   {nome ? ` · ${nome}` : ""} · {absoluta(evento.created_at, localeDaData)}
@@ -229,7 +229,7 @@ export function DossieDoFollowup({ id, canWrite }: Props) {
               <>
                 <span className="font-medium">{data.no_atual.rotulo}</span>{" "}
                 <span className="text-text-muted">
-                  ({tipoDoNo(data.no_atual.tipo)} — {data.no_atual.resumo})
+                  ({t(tipoDoNo(data.no_atual.tipo))} — {t(data.no_atual.resumo)})
                 </span>
               </>
             ) : (

--- a/app/app/ai/followups/page.tsx
+++ b/app/app/ai/followups/page.tsx
@@ -46,7 +46,7 @@ export default async function FollowupFlowsPage() {
       </header>
       <Tabs defaultValue="fluxos" className="flex flex-1 flex-col">
         <TabsList>
-          <TabsTrigger value="fluxos">Fluxos</TabsTrigger>
+          <TabsTrigger value="fluxos">{t("Fluxos")}</TabsTrigger>
           <TabsTrigger value="fila">Fila</TabsTrigger>
         </TabsList>
         <TabsContent value="fluxos">

--- a/app/app/ai/inbox/_components/AgentInboxList.tsx
+++ b/app/app/ai/inbox/_components/AgentInboxList.tsx
@@ -93,11 +93,11 @@ function InboxRow({
         {t(SEVERITY_LABEL[item.severity])}
       </Badge>
       <div className="min-w-0 flex-1">
-        <p className="text-sm font-medium">{item.title}</p>
+        <p className="text-sm font-medium">{t(item.title)}</p>
         <p className="text-xs text-muted-foreground">
           {kindLabel(item.kind, t)} · {when}
         </p>
-        {item.body ? <p className="mt-1 text-xs text-muted-foreground">{item.body}</p> : null}
+        {item.body ? <p className="mt-1 text-xs text-muted-foreground">{t(item.body)}</p> : null}
       </div>
       {canResolve ? (
         item.status === "resolved" ? (

--- a/app/app/ai/providers/_components/PainelDeProvedores.tsx
+++ b/app/app/ai/providers/_components/PainelDeProvedores.tsx
@@ -319,7 +319,7 @@ function CartaoDoPonto({
         return;
       }
       const avisos: string[] = json?.data?.avisos ?? [];
-      if (avisos.length > 0) avisos.forEach((a) => toast.warning(a));
+      if (avisos.length > 0) avisos.forEach((a) => toast.warning(t(a)));
       else toast.success(`"${t(ponto.rotulo)}" ${t("agora usa")} ${modelId}`);
       await aoSalvar();
     } finally {
@@ -363,7 +363,7 @@ function CartaoDoPonto({
           className="mt-2 rounded-md bg-amber-500/10 p-2 text-xs text-amber-700 dark:text-amber-500"
           data-testid={`aviso-${ponto.id}`}
         >
-          {a}
+          {t(a)}
         </p>
       ))}
 

--- a/app/app/contacts/[id]/_client.tsx
+++ b/app/app/contacts/[id]/_client.tsx
@@ -51,7 +51,7 @@ export function ContactDetailClient({ contactId }: Props) {
   if (q.isError || !q.data) {
     return (
       <div className="p-6">
-        <Card className="p-6 text-center text-sm text-error-fg">Erro ao carregar contato.</Card>
+        <Card className="p-6 text-center text-sm text-error-fg">{t("Erro ao carregar contato.")}</Card>
       </div>
     );
   }
@@ -63,7 +63,7 @@ export function ContactDetailClient({ contactId }: Props) {
   // Uma decisão, um lugar (lib/contacts/rotulo-do-contato.ts). Esta tela era
   // uma das DUAS que ignoravam o telefone: contato com número e sem nome
   // aparecia como "Sem nome" aqui e com o número no inbox.
-  const displayName = rotuloDoContato(contact);
+  const displayName = rotuloDoContato(contact, t);
 
   return (
     <div className="space-y-4 p-6">
@@ -74,7 +74,7 @@ export function ContactDetailClient({ contactId }: Props) {
         >
           <ShieldCheck size={18} weight="duotone" aria-hidden />
           <span>
-            Contato anonimizado (LGPD)
+            {t("Contato anonimizado (LGPD)")}
             {contact.anonymized_at &&
               ` em ${format(new Date(contact.anonymized_at), "dd/MM/yyyy", { locale: localeDaData })}`}
             {t(" — edição bloqueada.")}
@@ -99,14 +99,14 @@ export function ContactDetailClient({ contactId }: Props) {
                 {t}
               </Badge>
             ))}
-            {contact.is_blocked && <Badge variant="warning">Bloqueado</Badge>}
-            {contact.is_anonymized && <Badge variant="destructive">Anonimizado</Badge>}
+            {contact.is_blocked && <Badge variant="warning">{t("Bloqueado")}</Badge>}
+            {contact.is_anonymized && <Badge variant="destructive">{t("Anonimizado")}</Badge>}
           </div>
         </div>
         {!contact.is_anonymized && (
           <Button variant="outline" onClick={() => setEditOpen(true)} className="shrink-0">
             <PencilSimple size={16} weight="bold" aria-hidden />
-            <span>Editar</span>
+            <span>{t("Editar")}</span>
           </Button>
         )}
       </header>
@@ -136,7 +136,7 @@ export function ContactDetailClient({ contactId }: Props) {
           <Card className="p-4">
             <dl className="grid grid-cols-1 gap-4 text-sm md:grid-cols-2">
               <div>
-                <dt className="text-xs uppercase text-muted-foreground">Nome</dt>
+                <dt className="text-xs uppercase text-muted-foreground">{t("Nome")}</dt>
                 <dd className="mt-1">{contact.name ?? "—"}</dd>
               </div>
               <div>
@@ -154,7 +154,7 @@ export function ContactDetailClient({ contactId }: Props) {
                 </dd>
               </div>
               <div>
-                <dt className="text-xs uppercase text-muted-foreground">Origem</dt>
+                <dt className="text-xs uppercase text-muted-foreground">{t("Origem")}</dt>
                 <dd className="mt-1">{contact.source}</dd>
               </div>
               <div>
@@ -168,7 +168,7 @@ export function ContactDetailClient({ contactId }: Props) {
                 </dd>
               </div>
               <div>
-                <dt className="text-xs uppercase text-muted-foreground">Criado em</dt>
+                <dt className="text-xs uppercase text-muted-foreground">{t("Criado em")}</dt>
                 <dd className="mt-1">
                   {format(new Date(contact.created_at), "dd/MM/yyyy", { locale: localeDaData })}
                 </dd>
@@ -197,7 +197,7 @@ export function ContactDetailClient({ contactId }: Props) {
           <TabsContent value="lgpd" className="mt-4">
             <Card className="space-y-4 p-4">
               <div>
-                <h2 className="text-lg font-semibold">Direito ao esquecimento (LGPD)</h2>
+                <h2 className="text-lg font-semibold">{t("Direito ao esquecimento (LGPD)")}</h2>
                 <p className="mt-1 text-sm text-muted-foreground">
                   {t(
                     "A anonimização é irreversível. Use somente após confirmação formal do titular ou ordem judicial.",
@@ -213,7 +213,7 @@ export function ContactDetailClient({ contactId }: Props) {
                 </p>
               ) : (
                 <Button variant="destructive" onClick={() => setAnonOpen(true)}>
-                  Anonimizar contato
+                  {t("Anonimizar contato")}
                 </Button>
               )}
             </Card>

--- a/app/app/kanban/_client.tsx
+++ b/app/app/kanban/_client.tsx
@@ -49,7 +49,7 @@ export function vizinhoAoMover(
  * uma instrução acionável em um beco sem saída.
  */
 function textoDoErro(e: unknown, t: (texto: string) => string): string {
-  if (e instanceof ApiError) return e.message;
+  if (e instanceof ApiError) return t(e.message);
   if (e instanceof Error && e.message) return e.message;
   return t("Não consegui completar essa ação. Tente de novo.");
 }

--- a/app/app/settings/tenant/agenda/_client.tsx
+++ b/app/app/settings/tenant/agenda/_client.tsx
@@ -205,7 +205,7 @@ export function TiposDeAgendamentoClient({
                 >
                   {LOCAIS.map((l) => (
                     <option key={l.valor} value={l.valor}>
-                      {l.rotulo}
+                      {t(l.rotulo)}
                     </option>
                   ))}
                 </select>
@@ -234,7 +234,7 @@ export function TiposDeAgendamentoClient({
               </label>
               <div className="flex justify-end gap-2 sm:col-span-2">
                 <Button type="button" variant="ghost" size="sm" onClick={() => setCriando(false)}>
-                  Cancelar
+                  {t("Cancelar")}
                 </Button>
                 <Button type="submit" size="sm" data-testid="salvar-novo-tipo" disabled={salvando}>
                   {salvando ? t("Criando…") : t("Criar tipo")}
@@ -243,7 +243,7 @@ export function TiposDeAgendamentoClient({
             </form>
           ) : (
             <Button size="sm" data-testid="abrir-novo-tipo" onClick={() => setCriando(true)}>
-              Novo tipo de agendamento
+              {t("Novo tipo de agendamento")}
             </Button>
           )}
         </div>
@@ -262,12 +262,15 @@ export function TiposDeAgendamentoClient({
             className={`rounded-lg border border-border bg-surface p-3 ${tipo.is_active ? "" : "opacity-60"}`}
           >
             <div className="flex flex-wrap items-center gap-2">
-              <span className="text-sm font-medium text-text">{t(tipo.name)}</span>
+              {/* Sem t(): é o nome que quem opera digitou no campo acima, não
+                  rótulo do sistema — traduzir trocaria "Retorno" por
+                  "Seguimiento" (chave existente, de outro contexto). */}
+              <span className="text-sm font-medium text-text">{tipo.name}</span>
               <span className="rounded-full border border-border px-2 py-0.5 text-[11px] text-text-muted">
-                {rotuloDe(CATEGORIAS, tipo.category)}
+                {t(rotuloDe(CATEGORIAS, tipo.category))}
               </span>
               <span className="text-xs tabular-nums text-text-muted">{tipo.duration_minutes} min</span>
-              <span className="text-xs text-text-muted">{rotuloDe(LOCAIS, tipo.location_kind)}</span>
+              <span className="text-xs text-text-muted">{t(rotuloDe(LOCAIS, tipo.location_kind))}</span>
               {!tipo.default_owner_user_id ? (
                 // O aviso existe porque o sintoma é MUDO: sem dono, a tela de
                 // marcar simplesmente não mostra horário, sem dizer por quê.

--- a/app/app/settings/tenant/agenda/page.tsx
+++ b/app/app/settings/tenant/agenda/page.tsx
@@ -76,7 +76,7 @@ export default async function TiposDeAgendamentoPage() {
   return (
     <div className="flex h-full flex-col gap-6 p-6">
       <header>
-        <h1 className="text-2xl font-semibold tracking-tight">Tipos de agendamento</h1>
+        <h1 className="text-2xl font-semibold tracking-tight">{t("Tipos de agendamento")}</h1>
         <p className="mt-1 text-sm text-text-muted">
           {t("O que se pode marcar, quanto dura e quem atende. É isto que a tela de marcar e o agente de IA oferecem ao cliente.")}
         </p>

--- a/app/app/settings/tenant/pipelines/_client.tsx
+++ b/app/app/settings/tenant/pipelines/_client.tsx
@@ -116,8 +116,8 @@ function PipelineEditor({ pipeline }: { pipeline: PipelineRow }) {
     };
     startTransition(async () => {
       const r = await updatePipelineConfig(pipeline.id, patch);
-      if (r.ok) toast.success(`${pipeline.name} atualizado.`);
-      else toast.error(`Erro: ${r.error}`);
+      if (r.ok) toast.success(`${pipeline.name} ${t("atualizado.")}`);
+      else toast.error(`${t("Erro:")} ${r.error}`);
     });
   }
 

--- a/app/app/team/_components/AttendantsClient.tsx
+++ b/app/app/team/_components/AttendantsClient.tsx
@@ -279,7 +279,7 @@ function RoutingCard({ canManage }: { canManage: boolean }) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Modo de roteamento</CardTitle>
+        <CardTitle>{t("Modo de roteamento")}</CardTitle>
         <CardDescription>
           {t("Como as conversas novas são distribuídas entre os atendentes da organização.")}
         </CardDescription>
@@ -413,10 +413,10 @@ export function AttendantsClient({ canManage }: Props) {
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Atendente</TableHead>
+                <TableHead>{t("Atendente")}</TableHead>
                 <TableHead>Status</TableHead>
-                <TableHead>Carga</TableHead>
-                <TableHead>Capacidade</TableHead>
+                <TableHead>{t("Carga")}</TableHead>
+                <TableHead>{t("Capacidade")}</TableHead>
                 <TableHead>{t("Horário")}</TableHead>
                 {canManage ? <TableHead className="w-[120px]">{t("Disponível")}</TableHead> : null}
               </TableRow>

--- a/app/app/team/invite/_components/InviteForm.tsx
+++ b/app/app/team/invite/_components/InviteForm.tsx
@@ -15,6 +15,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ROLES, type Role } from "@/lib/schemas/team";
+import { descreverMotivoDaFalha } from "./motivo-da-falha";
 
 interface ResultState {
   sent: Array<{ email: string; accept_url: string; email_dispatched: boolean; expires_at: string }>;
@@ -126,7 +127,7 @@ export function InviteForm() {
                   {result.failed.map((f) => (
                     <li key={f.email}>
                       <span className="font-medium">{f.email}</span>{" "}
-                      <span className="text-muted-foreground">— {f.reason}</span>
+                      <span className="text-muted-foreground">— {t(descreverMotivoDaFalha(f.reason))}</span>
                     </li>
                   ))}
                 </ul>

--- a/app/app/team/invite/_components/motivo-da-falha.test.ts
+++ b/app/app/team/invite/_components/motivo-da-falha.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { descreverMotivoDaFalha } from "./motivo-da-falha";
+
+describe("descreverMotivoDaFalha", () => {
+  it("already_member vira frase, não código cru", () => {
+    expect(descreverMotivoDaFalha("already_member")).toBe("Já é membro desta organização.");
+  });
+
+  it("código desconhecido não some: devolve o próprio código", () => {
+    expect(descreverMotivoDaFalha("um_codigo_futuro")).toBe("um_codigo_futuro");
+  });
+});

--- a/app/app/team/invite/_components/motivo-da-falha.ts
+++ b/app/app/team/invite/_components/motivo-da-falha.ts
@@ -1,0 +1,16 @@
+/**
+ * O `reason` de `failed` em POST /api/v1/team/invite (`app/api/v1/team/invite/route.ts`)
+ * é código estável de contrato de API — `tests/e2e/invite-lifecycle.spec.ts` faz
+ * `reason === "already_member"` — não frase para tela. Esta é a única tradução
+ * de código para frase; o card não conhece os códigos.
+ *
+ * A frase é chave de `t()`: pt-BR aqui, espanhol em `lib/i18n/dicionario.ts`.
+ */
+const MOTIVOS_DE_FALHA: Record<string, string> = {
+  already_member: "Já é membro desta organização.",
+};
+
+/** Código sem tradução conhecida: devolve o próprio código, nunca some da tela. */
+export function descreverMotivoDaFalha(reason: string): string {
+  return MOTIVOS_DE_FALHA[reason] ?? reason;
+}

--- a/app/app/team/page.tsx
+++ b/app/app/team/page.tsx
@@ -46,22 +46,22 @@ export default async function TeamPage({
     <div className="flex h-full flex-col gap-6 p-6">
       <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="min-w-0">
-          <h1 className="text-2xl font-semibold tracking-tight">Equipe</h1>
+          <h1 className="text-2xl font-semibold tracking-tight">{t("Equipe")}</h1>
           <p className="text-sm text-muted-foreground">
             {t("Gestão de membros, roles e atendimento do tenant.")}
           </p>
         </div>
         {isAdmin ? (
           <Button asChild className="shrink-0">
-            <Link href="/app/team/invite">Convidar membros</Link>
+            <Link href="/app/team/invite">{t("Convidar membros")}</Link>
           </Button>
         ) : null}
       </header>
 
       <Tabs defaultValue={abaInicial} className="flex flex-1 flex-col">
         <TabsList>
-          <TabsTrigger value="members">Membros</TabsTrigger>
-          <TabsTrigger value="attendants">Atendimento</TabsTrigger>
+          <TabsTrigger value="members">{t("Membros")}</TabsTrigger>
+          <TabsTrigger value="attendants">{t("Atendimento")}</TabsTrigger>
         </TabsList>
         <TabsContent value="members" className="mt-4">
           <TeamMembersClient currentUserId={user.id} canManage={isAdmin} />

--- a/app/app/webhooks/_components/ActionConfigForm.tsx
+++ b/app/app/webhooks/_components/ActionConfigForm.tsx
@@ -73,7 +73,7 @@ function CreateOrMoveLeadForm({
   return (
     <div className="grid gap-2 sm:grid-cols-2">
       <div className="space-y-1">
-        <Label>Funil</Label>
+        <Label>{t("Funil")}</Label>
         <Select
           value={config.pipeline_id}
           onValueChange={(v) => onChange({ pipeline_id: v, stage_id: "" })}
@@ -92,7 +92,7 @@ function CreateOrMoveLeadForm({
         </Select>
       </div>
       <div className="space-y-1">
-        <Label>Etapa</Label>
+        <Label>{t("Etapa")}</Label>
         <Select
           value={config.stage_id}
           onValueChange={(v) => onChange({ ...config, stage_id: v })}
@@ -169,7 +169,7 @@ function SendWhatsappForm({
         ) : null}
       </div>
       <div className="space-y-1">
-        <Label>Mensagem</Label>
+        <Label>{t("Mensagem")}</Label>
         <div className="flex flex-wrap gap-1">
           {TEMPLATE_VARS.map((v) => (
             <Button
@@ -227,7 +227,7 @@ function SendAiMessageForm({
   return (
     <div className="space-y-3">
       <div className="space-y-1">
-        <Label>Qual agente escreve</Label>
+        <Label>{t("Qual agente escreve")}</Label>
         <Select
           value={config.agent_id}
           onValueChange={(v) => onChange({ ...config, agent_id: v })}
@@ -317,7 +317,7 @@ function AssignOwnerForm({ config, onChange }: FormProps<{ user_id: string }>) {
   const { data: members } = useAssignableMembers(true);
   return (
     <div className="space-y-1">
-      <Label>Atendente</Label>
+      <Label>{t("Atendente")}</Label>
       <Select value={config.user_id} onValueChange={(v) => onChange({ user_id: v })}>
         <SelectTrigger>
           <SelectValue placeholder={t("Escolha o atendente")} />

--- a/components/agenda/GradeDaAgenda.tsx
+++ b/components/agenda/GradeDaAgenda.tsx
@@ -359,7 +359,10 @@ function BlocoDeAgendamento({
       // rótulo dizia `, com ${pessoa.nome}`, que é o ATENDENTE: quem usa leitor
       // de tela ouvia os dois papéis trocados, e o card visual não desmente
       // porque em compromisso de 30min ele nem mostra o contato.
-      aria-label={`${t(agendamento.titulo)}, ${format(comeca, "HH:mm")} ${t("às")} ${format(termina, "HH:mm")}${
+      // `titulo` é DADO DO OPERADOR — a rota grava `title ?? tipo.name`, e
+      // `tipo.name` é o nome que ele cadastrou em Tipos de agendamento. Passá-lo
+      // por `t()` fazia "Retorno" virar "Seguimiento" na leitura de tela.
+      aria-label={`${agendamento.titulo}, ${format(comeca, "HH:mm")} ${t("às")} ${format(termina, "HH:mm")}${
         agendamento.quemSeraAtendido ? `, ${t("com")} ${agendamento.quemSeraAtendido}` : ""
       }${pessoa ? `, ${t("atendido por")} ${pessoa.nome}` : ""}${
         doGoogle ? `, ${t("ocupado na agenda do Google")}` : ""
@@ -704,7 +707,7 @@ function VisaoDeMes({
                         style={{ backgroundColor: corDaTrilha(trilha) }}
                       />
                       <span className="truncate text-[10px] leading-4 text-text">
-                        {format(new Date(c.comeca), "HH:mm")} {t(c.titulo)}
+                        {format(new Date(c.comeca), "HH:mm")} {c.titulo}
                       </span>
                     </div>
                   );

--- a/components/agenda/HistoricoDaAgenda.tsx
+++ b/components/agenda/HistoricoDaAgenda.tsx
@@ -192,9 +192,13 @@ export function HistoricoDaAgenda({
                     </div>
                   </div>
                   <div className="min-w-0 flex-1">
-                    <div className="truncate text-sm">{a.quemSeraAtendido ?? t(a.titulo)}</div>
+                    {/* `titulo` e `tipo` são DADO DO OPERADOR (o nome que ele
+                        cadastrou em Tipos de agendamento) e saem como ele
+                        escreveu. Só o fallback "Agendamento" é rótulo nosso, e
+                        esse traduz. */}
+                    <div className="truncate text-sm">{a.quemSeraAtendido ?? a.titulo}</div>
                     <div className="truncate text-[11px] text-text-muted">
-                      {a.tipo ? t(a.tipo) : t("Agendamento")}
+                      {a.tipo || t("Agendamento")}
                       {pessoa ? ` · ${t("com")} ${pessoa.nome}` : ""}
                     </div>
                   </div>

--- a/components/auth/RecoveryForm.tsx
+++ b/components/auth/RecoveryForm.tsx
@@ -80,7 +80,7 @@ export function RecoveryForm({ next }: RecoveryFormProps) {
       )}
 
       <Button type="submit" className="w-full" disabled={isPending}>
-        {isPending ? t("Validando...") : t("Recuperar acesso")}
+        {isPending ? t("Validando…") : t("Recuperar acesso")}
       </Button>
     </form>
   );

--- a/components/connections/AntiBanSheet.tsx
+++ b/components/connections/AntiBanSheet.tsx
@@ -84,8 +84,8 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
     // Mesma cadeia que vazava `org_xxxx` no seletor do editor de agente: o
     // identificador do transporte era o penúltimo degrau, então uma conexão sem
     // apelido e sem número aparecia com ele no título do painel.
-    return nomeDoCanal(item.channel_session);
-  }, [item]);
+    return nomeDoCanal(item.channel_session, t);
+  }, [item, t]);
 
   if (!item || !form) return null;
   const eff = item.effective;

--- a/components/contacts/CustomFieldsEditor.tsx
+++ b/components/contacts/CustomFieldsEditor.tsx
@@ -117,7 +117,7 @@ export function CustomFieldsEditor({ fields, value, onChange, disabled, classNam
                   disabled={disabled}
                 >
                   <SelectTrigger id={id}>
-                    <SelectValue placeholder="Selecione…" />
+                    <SelectValue placeholder={t("Selecione…")} />
                   </SelectTrigger>
                   <SelectContent>
                     {f.options?.map((o) => (
@@ -195,7 +195,7 @@ export function CustomFieldsEditor({ fields, value, onChange, disabled, classNam
                   onChange={(e) => set(f.key, e.target.value)}
                   disabled={disabled}
                 />
-                <p className="text-xs text-muted-foreground">Formato E.164</p>
+                <p className="text-xs text-muted-foreground">{t("Formato E.164")}</p>
               </div>
             );
           case "url":

--- a/components/contacts/MergeDialog.tsx
+++ b/components/contacts/MergeDialog.tsx
@@ -145,7 +145,7 @@ function GrupoDeDuplicados({
               aria-label={t("Manter este cadastro")}
             />
             <span className="min-w-0">
-              <span className="block truncate font-medium">{rotuloDoContato(c)}</span>
+              <span className="block truncate font-medium">{rotuloDoContato(c, t)}</span>
               <span className="block truncate text-muted-foreground">{c.email ?? "—"}</span>
               <span className="block truncate text-muted-foreground">
                 {c.phone_number ? phoneForDisplay(c.phone_number) : "—"}

--- a/components/contacts/TimelineView.tsx
+++ b/components/contacts/TimelineView.tsx
@@ -111,7 +111,8 @@ export function TimelineView({ contactId, types }: Props) {
               {items.map((it) => {
                 const Icon = ICON_MAP[it.source_module] ?? Gear;
                 const label = t(activityLabel(it.type));
-                const corpo = (it.reason ?? "").trim() || summarizePayload(it.payload);
+                const reasonTrim = (it.reason ?? "").trim();
+                const corpo = reasonTrim ? t(reasonTrim) : summarizePayload(it.payload);
                 const forma = actorShape(it.actor_kind ?? null);
                 const quem = actorName(
                   it.actor_kind ?? null,

--- a/components/inbox/CRMSidePanel.tsx
+++ b/components/inbox/CRMSidePanel.tsx
@@ -327,7 +327,7 @@ function CamposDoFunil({
   async function salvar() {
     try {
       await edit.mutateAsync({ leadId, patch: { custom_fields: customFields } });
-      toast.success("Campos atualizados");
+      toast.success(t("Campos atualizados"));
       onSalvo();
     } catch {
       // toast already shown
@@ -462,7 +462,7 @@ export function CRMSidePanel({ conversation }: Props) {
   const recarregar = useCallback(() => setTentativa((n) => n + 1), []);
 
   const tags = contact?.tags ?? [];
-  const displayName = rotuloDoContato(contact);
+  const displayName = rotuloDoContato(contact, t);
 
   // `erro` PRIMEIRO, e não é detalhe: as três listas voltam a `null` quando a
   // leitura falha, e este derivado lê `null` como "ainda não chegou". Sem esta
@@ -697,7 +697,7 @@ export function CRMSidePanel({ conversation }: Props) {
                   />
                   {t(activityLabel(a.type))}
                 </div>
-                {a.reason && <div className="mt-0.5 truncate text-muted-foreground">{a.reason}</div>}
+                {a.reason && <div className="mt-0.5 truncate text-muted-foreground">{t(a.reason)}</div>}
                 <div className="text-muted-foreground">
                   {a.performed_by_name ?? t(actorLabel(a.actor_kind))} · {shortDate(a.performed_at, localeDaData)}
                 </div>

--- a/components/inbox/ConversationHeader.tsx
+++ b/components/inbox/ConversationHeader.tsx
@@ -65,7 +65,7 @@ export function ConversationHeader({ conversation }: Props) {
   const [reassignOpen, setReassignOpen] = useState(false);
 
   const c = conversation.contacts ?? null;
-  const displayName = rotuloDoContato(c);
+  const displayName = rotuloDoContato(c, t);
   const phone = c?.phone_number ? phoneForDisplay(c.phone_number) : null;
   const status = conversation.status;
   const isMineAssigned = conversation.assigned_to_user_id === user.id;

--- a/components/inbox/ConversationList.tsx
+++ b/components/inbox/ConversationList.tsx
@@ -121,7 +121,7 @@ export function ConversationList({
   if (q.isError) {
     return (
       <div className="p-4 text-center text-sm text-muted-foreground">
-        <p>Erro ao carregar conversas.</p>
+        <p>{t("Erro ao carregar conversas.")}</p>
         <Button
           size="sm"
           variant="outline"

--- a/components/inbox/ConversationListItem.tsx
+++ b/components/inbox/ConversationListItem.tsx
@@ -123,7 +123,7 @@ export function ConversationListItem({
   const localeDaData = useLocaleDeData();
   const t = useT();
   const c = conversation.contacts ?? null;
-  const displayName = rotuloDoContato(c);
+  const displayName = rotuloDoContato(c, t);
   const phoneFallback = c?.phone_number ? phoneForDisplay(c.phone_number) : "??";
   const tags = c?.tags ?? [];
   const visibleTags = tags.slice(0, 2);

--- a/components/inbox/MessageBubble.tsx
+++ b/components/inbox/MessageBubble.tsx
@@ -220,7 +220,7 @@ export function MessageBubble({ message, debugCitations, onResponder, citada }: 
                   </span>
                 </TooltipTrigger>
                 <TooltipContent>
-                  {message.error_message ?? message.error_code ?? t("Erro desconhecido")}
+                  {message.error_message ? t(message.error_message) : (message.error_code ?? t("Erro desconhecido"))}
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>

--- a/components/inbox/composer/ContactPickerDialog.tsx
+++ b/components/inbox/composer/ContactPickerDialog.tsx
@@ -123,7 +123,7 @@ export function ContactPickerDialog({
     <Dialog open={open} onOpenChange={close}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Enviar contato</DialogTitle>
+          <DialogTitle>{t("Enviar contato")}</DialogTitle>
           <DialogDescription>
             {t("Escolha alguém da base ou informe nome e telefone — como no WhatsApp.")}
           </DialogDescription>
@@ -232,7 +232,7 @@ export function ContactPickerDialog({
               />
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="manual-contact-phone">Telefone</Label>
+              <Label htmlFor="manual-contact-phone">{t("Telefone")}</Label>
               <Input
                 id="manual-contact-phone"
                 value={manualPhone}

--- a/components/kanban/LeadFieldsForm.tsx
+++ b/components/kanban/LeadFieldsForm.tsx
@@ -86,7 +86,7 @@ export function LeadFieldsForm({ lead, pipelineId, fieldDefs = [], onSaved, onCa
     if (reais.length > 0) {
       valueCents = parseReaisToCents(reais);
       if (valueCents === null) {
-        form.setError("valueReais", { message: "Valor inválido" });
+        form.setError("valueReais", { message: t("Valor inválido") });
         return;
       }
     }
@@ -103,7 +103,7 @@ export function LeadFieldsForm({ lead, pipelineId, fieldDefs = [], onSaved, onCa
     const parsed = updateLeadSchema.safeParse(patch);
     if (!parsed.success) {
       const first = parsed.error.issues[0];
-      toast.error(first?.message ?? "Dados inválidos");
+      toast.error(first?.message ?? t("Dados inválidos"));
       return;
     }
 
@@ -112,7 +112,7 @@ export function LeadFieldsForm({ lead, pipelineId, fieldDefs = [], onSaved, onCa
         leadId: lead.id,
         patch: parsed.data as UpdateLeadInput,
       });
-      toast.success("Lead atualizado");
+      toast.success(t("Lead atualizado"));
       onSaved?.();
     } catch {
       // toast already shown
@@ -137,7 +137,7 @@ export function LeadFieldsForm({ lead, pipelineId, fieldDefs = [], onSaved, onCa
 
         <div className="grid grid-cols-2 gap-3">
           <div className="space-y-2">
-            <Label htmlFor="valueReais">Valor (R$)</Label>
+            <Label htmlFor="valueReais">{t("Valor (R$)")}</Label>
             <Input
               id="valueReais"
               inputMode="decimal"
@@ -147,12 +147,12 @@ export function LeadFieldsForm({ lead, pipelineId, fieldDefs = [], onSaved, onCa
             <EcoDoValor control={form.control} />
             {form.formState.errors.valueReais && (
               <p className="text-xs text-error-fg">
-                {form.formState.errors.valueReais.message}
+                {t(form.formState.errors.valueReais.message ?? "")}
               </p>
             )}
           </div>
           <div className="space-y-2">
-            <Label htmlFor="expected_close_date">Fechamento previsto</Label>
+            <Label htmlFor="expected_close_date">{t("Fechamento previsto")}</Label>
             <Input
               id="expected_close_date"
               type="date"
@@ -181,11 +181,11 @@ export function LeadFieldsForm({ lead, pipelineId, fieldDefs = [], onSaved, onCa
       <div className="flex justify-end gap-2">
         {onCancel && (
           <Button type="button" variant="ghost" onClick={onCancel} disabled={edit.isPending}>
-            Cancelar
+            {t("Cancelar")}
           </Button>
         )}
         <Button type="submit" disabled={edit.isPending}>
-          {edit.isPending ? "Salvando…" : "Salvar"}
+          {edit.isPending ? t("Salvando…") : t("Salvar")}
         </Button>
       </div>
     </form>

--- a/components/kanban/LeadTimeline.tsx
+++ b/components/kanban/LeadTimeline.tsx
@@ -76,7 +76,7 @@ function Linha({ item, aoVivo }: { item: TimelineItemView; aoVivo?: boolean }) {
             </span>
           )}
         </p>
-        {item.reason && <p className="mt-0.5 text-xs text-text-muted">{item.reason}</p>}
+        {item.reason && <p className="mt-0.5 text-xs text-text-muted">{t(item.reason)}</p>}
         <p className="mt-0.5 text-[11px] text-text-muted">
           {nome} · {quando(item.performed_at, tagDoIdioma)}
         </p>

--- a/components/kanban/NewLeadDialog.tsx
+++ b/components/kanban/NewLeadDialog.tsx
@@ -170,13 +170,13 @@ export function NewLeadDialog({
           </div>
 
           <div className="space-y-2">
-            <Label>Etapa</Label>
+            <Label>{t("Etapa")}</Label>
             <Select
               value={stageId}
               onValueChange={(v) => form.setValue("stage_id", v)}
             >
               <SelectTrigger>
-                <SelectValue placeholder="Selecione a etapa" />
+                <SelectValue placeholder={t("Selecione a etapa")} />
               </SelectTrigger>
               <SelectContent>
                 {stages
@@ -207,7 +207,7 @@ export function NewLeadDialog({
               )}
             </div>
             <div className="space-y-2">
-              <Label htmlFor="expected_close_date">Fechamento previsto</Label>
+              <Label htmlFor="expected_close_date">{t("Fechamento previsto")}</Label>
               <Input
                 id="expected_close_date"
                 type="date"

--- a/lib/api/handlers/types.ts
+++ b/lib/api/handlers/types.ts
@@ -5,6 +5,7 @@
  * (S-13.03). O `Actor` discriminado permite que o mesmo handler atenda usuário
  * humano (cookie session) ou agente de IA (Bearer token com actor_type='ai_agent').
  */
+import type { Idioma } from "@/lib/i18n/idiomas";
 
 export type Actor =
   | { type: "user"; id: string; role?: string }
@@ -30,4 +31,12 @@ export interface HandlerCtx {
   organization_id: string;
   actor: Actor;
   requestId: string;
+  /**
+   * Idioma de quem chamou, só quando é um usuário humano de verdade — as
+   * rotas REST passam `authz.user.idioma`. MCP e webhook não têm preferência
+   * de idioma humana, então ficam `undefined` de propósito: mensagem de erro
+   * que atravessa o handler degrada para português (o fallback de
+   * `traduzir()`), que é o comportamento de sempre para esses dois canais.
+   */
+  idioma?: Idioma;
 }

--- a/lib/auth/require-role.ts
+++ b/lib/auth/require-role.ts
@@ -22,6 +22,7 @@ import { fail, type ApiError } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { loadAuthUser, mfaEmDivida, resolveActiveOrg } from "@/lib/auth/server";
 import { ROLE_RANK, type ActiveOrg, type AuthUser, type Role } from "@/lib/auth/types";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { createClient } from "@/lib/supabase/server";
 
 export type RoleCheck =
@@ -55,6 +56,7 @@ export async function requireRole(min: Role, opts: RequireRoleOpts = {}): Promis
   if (!user) {
     return { ok: false, response: fail("unauthenticated", "Auth required.", 401, { requestId }) };
   }
+  const t = (texto: string) => traduzir(texto, user.idioma);
 
   let org: ActiveOrg | null;
   if (organizationId) {
@@ -74,7 +76,7 @@ export async function requireRole(min: Role, opts: RequireRoleOpts = {}): Promis
   if (!org) {
     return {
       ok: false,
-      response: fail("forbidden_tenant", "Sem organização ativa.", 403, { requestId }),
+      response: fail("forbidden_tenant", t("Sem organização ativa."), 403, { requestId }),
     };
   }
 
@@ -118,7 +120,9 @@ export async function requireRole(min: Role, opts: RequireRoleOpts = {}): Promis
       ok: false,
       response: fail(
         "mfa_required",
-        "Esta sessão precisa da verificação em duas etapas. Entre novamente com o código do aplicativo.",
+        t(
+          "Esta sessão precisa da verificação em duas etapas. Entre novamente com o código do aplicativo.",
+        ),
         403,
         { requestId },
       ),

--- a/lib/catalogo/planilha.test.ts
+++ b/lib/catalogo/planilha.test.ts
@@ -54,3 +54,70 @@ describe("lerPlanilha — mensagens de erro passam por t()", () => {
     expect(resultado.erros[0]!.motivo).toBe('preço não reconhecido ("abc") — escreva assim: 5.499,00');
   });
 });
+
+/**
+ * A RECUSA DIZ QUAL COLUNA FALTA — e isso vale nos DOIS idiomas.
+ *
+ * ─── O defeito que este bloco guarda ────────────────────────────────────────
+ *
+ * A mensagem era montada com o que de fato faltava
+ * (`faltando.map(...).join(" e de ")`). Ao virar chave de tradução ela virou
+ * uma frase FIXA: "precisa de uma coluna de nome e de preço", dita também para
+ * quem já tinha a coluna `nome` e só não tinha a de preço.
+ *
+ * Quem recebe esse texto vai conferir a coluna `nome` — que está lá —, não
+ * encontra o erro que a mensagem descreve, e desiste do arquivo. É a primeira
+ * tela do catálogo, e o idioma majoritário do produto é o português: a
+ * tradução não pode custar informação a quem já usava o sistema.
+ *
+ * ─── Por que o caso "faltam as duas" está aqui mesmo não discriminando ──────
+ *
+ * Ele passa nas duas versões, de propósito: é o par do «não faça X». Sem ele,
+ * "sempre diga só uma coluna" satisfaria os outros dois casos e quebraria a
+ * frase de quem manda uma planilha sem cabeçalho nenhum.
+ */
+const ES: Record<string, string> = {
+  "A planilha precisa de uma coluna de nome. Encontrei: ":
+    "La planilla necesita una columna de nombre. Encontré: ",
+  "A planilha precisa de uma coluna de preço. Encontrei: ":
+    "La planilla necesita una columna de precio. Encontré: ",
+  "A planilha precisa de uma coluna de nome e de preço. Encontrei: ":
+    "La planilla necesita una columna de nombre y de precio. Encontré: ",
+};
+const espanhol = (texto: string): string => ES[texto] ?? texto;
+
+function recusa(csv: string, t?: (s: string) => string): string {
+  const r = lerPlanilha(csv, t);
+  if (!("erro" in r)) throw new Error("a planilha deveria ter sido recusada inteira");
+  return r.erro;
+}
+
+describe("lerPlanilha — a recusa nomeia a coluna que falta", () => {
+  it("tem nome, falta preço: pede PREÇO e não menciona a coluna que já existe", () => {
+    const erro = recusa("nome,marca\nCafé,Melitta\n");
+    expect(erro).toBe("A planilha precisa de uma coluna de preço. Encontrei: nome, marca.");
+    // A asserção que reprova a frase fixa: ela pediria "nome e de preço".
+    expect(erro).not.toContain("coluna de nome");
+  });
+
+  it("tem preço, falta nome: pede NOME", () => {
+    const erro = recusa("preco,marca\n9.90,Melitta\n");
+    expect(erro).toBe("A planilha precisa de uma coluna de nome. Encontrei: preco, marca.");
+    expect(erro).not.toContain("de preço");
+  });
+
+  it("faltam as duas: pede as duas", () => {
+    const erro = recusa("marca,categoria\nMelitta,Café\n");
+    expect(erro).toBe(
+      "A planilha precisa de uma coluna de nome e de preço. Encontrei: marca, categoria.",
+    );
+  });
+
+  it("em espanhol, a coluna que falta continua sendo a nomeada", () => {
+    // A intenção do PR #600 — quem usa espanhol lê espanhol — sobrevive ao
+    // conserto: o que não podia sobreviver era perder QUAL coluna falta.
+    const erro = recusa("nome,marca\nCafé,Melitta\n", espanhol);
+    expect(erro).toBe("La planilla necesita una columna de precio. Encontré: nome, marca.");
+    expect(erro).not.toContain("de nombre");
+  });
+});

--- a/lib/catalogo/planilha.test.ts
+++ b/lib/catalogo/planilha.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { lerPlanilha } from "./planilha";
+
+/**
+ * `traduzir()` real só troca a CHAVE que bate byte a byte com uma entrada do
+ * dicionário; o resto degrada para o próprio texto (`lib/i18n/dicionario.ts`).
+ * Um mock que maiusculiza QUALQUER string escondia o bug real: a chave que o
+ * código montava (`") — escreva assim…"`, com o parêntese dentro de `t()`)
+ * nunca bateu com a entrada do dicionário (sem o parêntese) — e um mock
+ * "universal" não reproduz esse descasamento, porque ele nunca falha em
+ * traduzir nada. Este fake replica o comportamento de fallback: só a chave
+ * que está no mapa mock é transformada; o resto sai como entrou.
+ */
+const DICIONARIO_FAKE: Record<string, string> = {
+  "preço não reconhecido (": "PRECIO NO RECONOCIDO (",
+  " — escreva assim: 5.499,00": " — ESCRÍBALO ASÍ: 5.499,00",
+  "custo não reconhecido (": "COSTO NO RECONOCIDO (",
+  "código repetido na planilha (": "CÓDIGO REPETIDO EN LA PLANILLA (",
+};
+const gritar = (texto: string): string => DICIONARIO_FAKE[texto] ?? texto;
+
+describe("lerPlanilha — mensagens de erro passam por t()", () => {
+  it("traduz a mensagem de preço não reconhecido por completo, incluindo o texto após o valor cru", () => {
+    const csv = "codigo,nome,preco\nX1,Produto,abc\n";
+    const resultado = lerPlanilha(csv, gritar);
+    if ("erro" in resultado) throw new Error("não deveria ser erro de planilha inteira");
+    expect(resultado.erros).toHaveLength(1);
+    // O valor cru ("abc") não passa por t() — só o texto fixo ao redor, e
+    // TODO ele: um pedaço que ficasse fora de `_t()` bateria com uma chave
+    // ausente do DICIONARIO_FAKE e sairia em português, reprovando o teste.
+    const motivo = resultado.erros[0]!.motivo;
+    expect(motivo).toBe('PRECIO NO RECONOCIDO ("abc") — ESCRÍBALO ASÍ: 5.499,00');
+  });
+
+  it("traduz custo não reconhecido por completo", () => {
+    const csv = "codigo,nome,preco,custo\nX1,Produto,10.00,xyz\n";
+    const resultado = lerPlanilha(csv, gritar);
+    if ("erro" in resultado) throw new Error("não deveria ser erro de planilha inteira");
+    expect(resultado.erros[0]!.motivo).toBe('COSTO NO RECONOCIDO ("xyz")');
+  });
+
+  it("traduz código repetido por completo", () => {
+    const csv = "codigo,nome,preco\nDUP,Um,10.00\nDUP,Dois,20.00\n";
+    const resultado = lerPlanilha(csv, gritar);
+    if ("erro" in resultado) throw new Error("não deveria ser erro de planilha inteira");
+    expect(resultado.erros[0]!.motivo).toBe('CÓDIGO REPETIDO EN LA PLANILLA ("DUP")');
+  });
+
+  it("sem função t: comportamento idêntico ao de antes (degrada para o texto original)", () => {
+    const csv = "codigo,nome,preco\nX1,Produto,abc\n";
+    const resultado = lerPlanilha(csv);
+    if ("erro" in resultado) throw new Error("não deveria ser erro de planilha inteira");
+    expect(resultado.erros[0]!.motivo).toBe('preço não reconhecido ("abc") — escreva assim: 5.499,00');
+  });
+});

--- a/lib/catalogo/planilha.ts
+++ b/lib/catalogo/planilha.ts
@@ -75,9 +75,13 @@ export interface ResultadoDaLeitura {
   colunasIgnoradas: string[];
 }
 
-export function lerPlanilha(conteudo: string): ResultadoDaLeitura | { erro: string } {
+export function lerPlanilha(
+  conteudo: string,
+  t?: (text: string) => string,
+): ResultadoDaLeitura | { erro: string } {
+  const _t = t || ((x) => x);
   const linhas = parseCsv(conteudo).filter((l) => l.some((c) => c.trim() !== ""));
-  if (linhas.length === 0) return { erro: "A planilha está vazia." };
+  if (linhas.length === 0) return { erro: _t("A planilha está vazia.") };
 
   const cabecalho = linhas[0]!;
   const mapa = new Map<number, string>();
@@ -95,8 +99,9 @@ export function lerPlanilha(conteudo: string): ResultadoDaLeitura | { erro: stri
   if (faltando.length > 0) {
     return {
       erro:
-        `A planilha precisa de uma coluna de ${faltando.map((f) => (f === "preco" ? "preço" : f)).join(" e de ")}. ` +
-        `Encontrei: ${cabecalho.filter((c) => c.trim()).join(", ") || "nenhuma coluna"}.`,
+        _t("A planilha precisa de uma coluna de nome e de preço. Encontrei: ") +
+        (cabecalho.filter((c) => c.trim()).join(", ") || _t("nenhuma coluna")) +
+        ".",
     };
   }
 
@@ -114,7 +119,7 @@ export function lerPlanilha(conteudo: string): ResultadoDaLeitura | { erro: stri
 
     const nome = valor("nome").replace(/\s+/g, " ");
     if (nome === "") {
-      erros.push({ linha: numeroNaPlanilha, motivo: "sem nome do produto" });
+      erros.push({ linha: numeroNaPlanilha, motivo: _t("sem nome do produto") });
       continue;
     }
 
@@ -123,7 +128,8 @@ export function lerPlanilha(conteudo: string): ResultadoDaLeitura | { erro: stri
       // O valor cru entra na mensagem: quem vai corrigir precisa achar a célula.
       erros.push({
         linha: numeroNaPlanilha,
-        motivo: `preço não reconhecido ("${valor("preco")}") — escreva assim: 5.499,00`,
+        motivo:
+          _t("preço não reconhecido (") + `"${valor("preco")}"` + ")" + _t(" — escreva assim: 5.499,00"),
       });
       continue;
     }
@@ -131,7 +137,10 @@ export function lerPlanilha(conteudo: string): ResultadoDaLeitura | { erro: stri
     const custoTexto = valor("custo");
     const custo_cents = custoTexto === "" ? null : precoParaCentavos(custoTexto);
     if (custoTexto !== "" && custo_cents === null) {
-      erros.push({ linha: numeroNaPlanilha, motivo: `custo não reconhecido ("${custoTexto}")` });
+      erros.push({
+        linha: numeroNaPlanilha,
+        motivo: _t("custo não reconhecido (") + `"${custoTexto}"` + ")",
+      });
       continue;
     }
 
@@ -140,7 +149,10 @@ export function lerPlanilha(conteudo: string): ResultadoDaLeitura | { erro: stri
     // loja quando o preço muda.
     const codigo = (valor("codigo") || nome).slice(0, 60).replace(/\s+/g, " ");
     if (codigosVistos.has(codigo.toLowerCase())) {
-      erros.push({ linha: numeroNaPlanilha, motivo: `código repetido na planilha ("${codigo}")` });
+      erros.push({
+        linha: numeroNaPlanilha,
+        motivo: _t("código repetido na planilha (") + `"${codigo}"` + ")",
+      });
       continue;
     }
     codigosVistos.add(codigo.toLowerCase());

--- a/lib/catalogo/planilha.ts
+++ b/lib/catalogo/planilha.ts
@@ -97,11 +97,21 @@ export function lerPlanilha(
   // linhas é o que evita um relatório com 300 erros iguais.
   const faltando = ["nome", "preco"].filter((c) => !campos.has(c));
   if (faltando.length > 0) {
+    // A recusa NOMEIA a coluna que falta, uma frase por combinação. Quem tem
+    // `nome` e não tem preço, se ler "precisa de uma coluna de nome e de
+    // preço", vai procurar a coluna que já tem — e o arquivo dele fica parado
+    // na primeira tela do catálogo. A frase inteira é a chave de tradução: em
+    // espanhol a ordem das palavras não é a mesma, e montar por pedaços
+    // entregaria frase torta.
+    const pedido =
+      faltando.length === 2
+        ? _t("A planilha precisa de uma coluna de nome e de preço. Encontrei: ")
+        : faltando[0] === "nome"
+          ? _t("A planilha precisa de uma coluna de nome. Encontrei: ")
+          : _t("A planilha precisa de uma coluna de preço. Encontrei: ");
     return {
       erro:
-        _t("A planilha precisa de uma coluna de nome e de preço. Encontrei: ") +
-        (cabecalho.filter((c) => c.trim()).join(", ") || _t("nenhuma coluna")) +
-        ".",
+        pedido + (cabecalho.filter((c) => c.trim()).join(", ") || _t("nenhuma coluna")) + ".",
     };
   }
 

--- a/lib/channels/estado.ts
+++ b/lib/channels/estado.ts
@@ -99,13 +99,16 @@ export function rotuloDoEstadoDoCanal(
  * como se fosse o nome do número da pessoa. Um canal sem apelido e sem telefone
  * é um canal sem nome, e dizer isso é melhor do que inventar um.
  */
-export function nomeDoCanal(c: {
-  display_name?: string | null;
-  phone_number?: string | null;
-}): string {
+export function nomeDoCanal(
+  c: {
+    display_name?: string | null;
+    phone_number?: string | null;
+  },
+  t: (texto: string) => string = (texto) => texto,
+): string {
   const apelido = (c.display_name ?? "").trim();
   if (apelido) return apelido;
   const telefone = (c.phone_number ?? "").trim();
   if (telefone) return telefone;
-  return "Número sem nome";
+  return t("Número sem nome");
 }

--- a/lib/contacts/csv.test.ts
+++ b/lib/contacts/csv.test.ts
@@ -156,6 +156,58 @@ describe("mapLinha", () => {
   });
 });
 
+/**
+ * `traduzir()` real só troca a CHAVE que bate byte a byte com uma entrada do
+ * dicionário; o resto degrada para o próprio texto. Um mock que traduz
+ * QUALQUER string esconderia um pedaço colado FORA de `t()` que deveria estar
+ * dentro (ou vice-versa) — ver o bug real corrigido em
+ * `lib/catalogo/planilha.test.ts` e `lib/leads/planilha.test.ts`.
+ */
+describe("mapHeader / mapLinha — mensagens de erro passam por t()", () => {
+  const indices = mapHeader(["Nome", "Telefone", "Email", "Tags"]).indices;
+  const DICIONARIO_FAKE: Record<string, string> = {
+    "cabeçalho sem coluna de telefone nem e-mail": "CABECERA SIN COLUMNA DE TELÉFONO NI E-MAIL",
+    "e-mail inválido: ": "E-MAIL INVÁLIDO: ",
+    "telefone inválido: ": "TELÉFONO INVÁLIDO: ",
+    " (use DDI+DDD+número, ex.: +5511999998888)":
+      " (USA CÓDIGO DE PAÍS+CÓDIGO DE ÁREA+NÚMERO, EJ.: +5511999998888)",
+    "linha sem telefone nem e-mail": "LÍNEA SIN TELÉFONO NI E-MAIL",
+  };
+  const gritar = (texto: string): string => DICIONARIO_FAKE[texto] ?? texto;
+
+  it("mapHeader: sem identificador traduz por completo", () => {
+    const { motivo } = mapHeader(["Nome", "Idade"], gritar);
+    expect(motivo).toBe("CABECERA SIN COLUMNA DE TELÉFONO NI E-MAIL");
+  });
+
+  it("mapHeader: sem t, comportamento idêntico ao de antes", () => {
+    const { motivo } = mapHeader(["Nome", "Idade"]);
+    expect(motivo).toBe("cabeçalho sem coluna de telefone nem e-mail");
+  });
+
+  it("mapLinha: sem telefone/e-mail traduz por completo", () => {
+    const { motivo } = mapLinha(["Só Nome", "", "", ""], indices, gritar);
+    expect(motivo).toBe("LÍNEA SIN TELÉFONO NI E-MAIL");
+  });
+
+  it("mapLinha: telefone inválido traduz por completo, incluindo o texto após o valor cru", () => {
+    const { motivo } = mapLinha(["Ana", "123", "", ""], indices, gritar);
+    expect(motivo).toBe(
+      'TELÉFONO INVÁLIDO: "123" (USA CÓDIGO DE PAÍS+CÓDIGO DE ÁREA+NÚMERO, EJ.: +5511999998888)',
+    );
+  });
+
+  it("mapLinha: e-mail inválido traduz por completo", () => {
+    const { motivo } = mapLinha(["Ana", "", "nao-e-email", ""], indices, gritar);
+    expect(motivo).toBe('E-MAIL INVÁLIDO: "nao-e-email"');
+  });
+
+  it("mapLinha: sem t, comportamento idêntico ao de antes (degrada para o texto original)", () => {
+    const { motivo } = mapLinha(["Ana", "123", "", ""], indices);
+    expect(motivo).toBe('telefone inválido: "123" (use DDI+DDD+número, ex.: +5511999998888)');
+  });
+});
+
 describe("limites declarados", () => {
   it("teto de linhas e tamanho são os mesmos que a rota cobra", () => {
     // Guarda barata: a rota lê estas constantes; o teste existe para o dia em

--- a/lib/contacts/csv.ts
+++ b/lib/contacts/csv.ts
@@ -229,7 +229,11 @@ function normalizaHeader(h: string): string {
  * (telefone/e-mail) — sem isso nada importável existe, e falhar aberto é
  * melhor que criar 300 contatos vazios.
  */
-export function mapHeader(header: string[]): { indices: Record<string, number>; motivo: string | null } {
+export function mapHeader(
+  header: string[],
+  t?: (text: string) => string,
+): { indices: Record<string, number>; motivo: string | null } {
+  const _t = t || ((x) => x);
   const indices: Record<string, number> = {};
   header.forEach((rawCell, idx) => {
     const cell = normalizaHeader(rawCell);
@@ -243,7 +247,7 @@ export function mapHeader(header: string[]): { indices: Record<string, number>; 
   const temIdentificador = indices.phone_number !== undefined || indices.email !== undefined;
   return {
     indices,
-    motivo: temIdentificador ? null : "cabeçalho sem coluna de telefone nem e-mail",
+    motivo: temIdentificador ? null : _t("cabeçalho sem coluna de telefone nem e-mail"),
   };
 }
 
@@ -317,7 +321,9 @@ export function normalizaData(raw: string): string | null {
 export function mapLinha(
   cells: string[],
   indices: Record<string, number>,
+  t?: (text: string) => string,
 ): { contato: LinhaNormalizada; motivo: string | null } {
+  const _t = t || ((x) => x);
   const get = (campo: string): string => {
     const idx = indices[campo];
     return idx === undefined ? "" : (cells[idx] ?? "").trim();
@@ -333,7 +339,7 @@ export function mapLinha(
   const email = get("email");
   if (email !== "") {
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-      return { contato: {}, motivo: `e-mail inválido: "${email}"` };
+      return { contato: {}, motivo: _t("e-mail inválido: ") + `"${email}"` };
     }
     contato.email = email;
   }
@@ -344,14 +350,17 @@ export function mapLinha(
     if (phone === null) {
       return {
         contato: {},
-        motivo: `telefone inválido: "${phoneRaw}" (use DDI+DDD+número, ex.: +5511999998888)`,
+        motivo:
+          _t("telefone inválido: ") +
+          `"${phoneRaw}"` +
+          _t(" (use DDI+DDD+número, ex.: +5511999998888)"),
       };
     }
     contato.phone_number = phone;
   }
 
   if (contato.phone_number === undefined && contato.email === undefined) {
-    return { contato: {}, motivo: "linha sem telefone nem e-mail" };
+    return { contato: {}, motivo: _t("linha sem telefone nem e-mail") };
   }
 
   const cpf = get("cpf").replace(/\D/g, "");

--- a/lib/followup/intervencao-resposta.ts
+++ b/lib/followup/intervencao-resposta.ts
@@ -8,31 +8,36 @@
 import { fail } from "@/lib/api/wrappers";
 import type { FalhaDaIntervencao } from "./intervencao";
 
-export function respostaDaFalha(falha: FalhaDaIntervencao, requestId: string) {
+export function respostaDaFalha(
+  falha: FalhaDaIntervencao,
+  requestId: string,
+  t: (texto: string) => string,
+) {
   switch (falha.codigo) {
     case "nao_encontrado":
-      return fail("not_found", falha.mensagem, 404, { requestId });
+      return fail("not_found", t(falha.mensagem), 404, { requestId });
     case "estado_incompativel":
     case "motor_ocupado":
       // 409, e a MENSAGEM carrega a diferença: "mudou de estado" e "o automático
       // está executando agora" pedem coisas diferentes de quem clicou (recarregar
       // vs. tentar de novo em instantes). O `details.motivo` deixa isso legível
       // por máquina sem inventar um código de erro por caso.
-      return fail("state_conflict", falha.mensagem, 409, {
+      return fail("state_conflict", t(falha.mensagem), 409, {
         requestId,
         details: { motivo: falha.codigo },
       });
     case "caminho_invalido":
-      return fail("invalid_request", falha.mensagem, 400, { requestId, details: falha.detalhes });
+      return fail("invalid_request", t(falha.mensagem), 400, { requestId, details: falha.detalhes });
     case "sem_caminho":
     case "escolha_necessaria":
-      return fail("unprocessable_entity", falha.mensagem, 422, {
+      return fail("unprocessable_entity", t(falha.mensagem), 422, {
         requestId,
         details: { motivo: falha.codigo, ...(falha.detalhes as Record<string, unknown> | undefined) },
       });
     case "adiamento_invalido":
-      return fail("validation_failed", falha.mensagem, 422, { requestId, details: falha.detalhes });
+      return fail("validation_failed", t(falha.mensagem), 422, { requestId, details: falha.detalhes });
     case "erro_interno":
+      // Texto de driver/Postgres — nunca traduzir (doutrina do repo).
       return fail("internal_error", falha.mensagem, 500, { requestId });
   }
 }

--- a/lib/i18n/dicionario.ts
+++ b/lib/i18n/dicionario.ts
@@ -120,6 +120,7 @@ export const DICIONARIO: Traducoes = {
     es: "Automático pausado para este cliente",
   },
   "Automático volta em instantes": { es: "El automático vuelve en instantes" },
+  "Cliente pediu para não receber mensagens": { es: "El cliente pidió no recibir mensajes" },
   "Pausar o automático": { es: "Pausar el automático" },
   "Ver contato": { es: "Ver contacto" },
 
@@ -1134,6 +1135,35 @@ export const DICIONARIO: Traducoes = {
   "Este passo tem mais de um caminho no fluxo. Escolher por você seria decidir o rumo do atendimento sem perguntar.": {
     es: "Este paso tiene más de un camino en el flujo. Elegir por ti sería decidir el rumbo de la atención sin preguntar.",
   },
+  // ─── lib/followup/intervencao.ts (respostaDaFalha) ───
+  "O automático está executando este follow-up agora. Nada foi alterado — tente de novo em alguns instantes.": {
+    es: "El automático está ejecutando este seguimiento ahora. Nada fue alterado — intenta de nuevo en unos instantes.",
+  },
+  "Este follow-up mudou de estado enquanto você decidia. Nada foi alterado — recarregue e confira.": {
+    es: "Este seguimiento cambió de estado mientras decidías. Nada fue alterado — recarga y confirma.",
+  },
+  "Só dá para pausar um follow-up que está andando (ativo ou aguardando resposta).": {
+    es: "Solo se puede pausar un seguimiento que está en curso (activo o esperando respuesta).",
+  },
+  "Este follow-up não está pausado por uma pessoa.": {
+    es: "Este seguimiento no está pausado por una persona.",
+  },
+  "Data inválida.": { es: "Fecha inválida." },
+  "Escolha um horário no futuro.": { es: "Elige un horario en el futuro." },
+  "O adiamento máximo é de 90 dias.": { es: "El aplazamiento máximo es de 90 días." },
+  "Só dá para adiar um follow-up que está andando (ativo ou aguardando resposta).": {
+    es: "Solo se puede aplazar un seguimiento que está en curso (activo o esperando respuesta).",
+  },
+  "Só dá para pular o passo de um follow-up que está andando (ativo ou aguardando resposta).": {
+    es: "Solo se puede saltar el paso de un seguimiento que está en curso (activo o esperando respuesta).",
+  },
+  "Este passo não tem saída no fluxo — não há para onde pular.": {
+    es: "Este paso no tiene salida en el flujo — no hay adónde saltar.",
+  },
+  "O caminho escolhido não sai deste passo.": { es: "El camino elegido no sale de este paso." },
+  "Este passo tem mais de um caminho. Escolha por onde seguir.": {
+    es: "Este paso tiene más de un camino. Elige por dónde seguir.",
+  },
   "O tempo que o agente escolheu": { es: "El tiempo que eligió el agente" },
   Decidido: { es: "Decidido" },
   "no início do follow-up": { es: "al inicio del seguimiento" },
@@ -1359,6 +1389,37 @@ export const DICIONARIO: Traducoes = {
   "Escreva sua resposta para a IA...": { es: "Escribe tu respuesta para la IA..." },
   "Escolha uma das opções acima para enviar.": { es: "Elige una de las opciones de arriba para enviar." },
   "Enviando...": { es: "Enviando..." },
+  // ─── lib/ai/case-copy.ts (status, ações e timeline dos casos humanos) ───
+  "Aguardando você": { es: "Esperándote" },
+  "Virou atendimento humano": { es: "Se convirtió en atención humana" },
+  "Aguardando o cliente responder — a IA avisa você quando tiver a informação.": {
+    es: "Esperando que el cliente responda — la IA te avisa cuando tenga la información.",
+  },
+  "Este caso já foi concluído.": { es: "Este caso ya fue concluido." },
+  "Este caso virou atendimento humano — não precisa mais de resposta aqui.": {
+    es: "Este caso se convirtió en atención humana — ya no necesita respuesta aquí.",
+  },
+  "Este caso foi cancelado.": { es: "Este caso fue cancelado." },
+  "Concluí": { es: "Concluí" },
+  "A IA avisa o cliente e encerra o assunto.": { es: "La IA avisa al cliente y cierra el asunto." },
+  "Preciso de info do cliente": { es: "Necesito info del cliente" },
+  "A IA pergunta ao cliente e o caso volta pra você quando ele responder.": {
+    es: "La IA le pregunta al cliente y el caso vuelve a ti cuando responda.",
+  },
+  "Não consigo — passar pra humano": { es: "No puedo — pasar a humano" },
+  "Sai da IA: a conversa vira um atendimento humano de verdade.": {
+    es: "Sale de la IA: la conversación se convierte en una atención humana de verdad.",
+  },
+  "A IA abriu o caso": { es: "La IA abrió el caso" },
+  "Você respondeu": { es: "Tú respondiste" },
+  "A IA perguntou ao cliente": { es: "La IA le preguntó al cliente" },
+  "O cliente respondeu": { es: "El cliente respondió" },
+  "O cliente não respondeu a tempo": { es: "El cliente no respondió a tiempo" },
+  "Você concluiu o caso": { es: "Tú concluiste el caso" },
+  "Você pediu uma informação ao cliente": { es: "Tú le pediste una información al cliente" },
+  "Você decidiu passar para atendimento humano": { es: "Tú decidiste pasar a atención humana" },
+  "O sistema abriu o caso automaticamente": { es: "El sistema abrió el caso automáticamente" },
+  "Atualização do caso": { es: "Actualización del caso" },
   "Um roteador entende o que o cliente quer e entrega a conversa para o agente certo — plugado em um número de WhatsApp.":
     {
       es: "Un enrutador entiende lo que el cliente quiere y entrega la conversación al agente correcto — conectado a un número de WhatsApp.",
@@ -2643,6 +2704,23 @@ export const DICIONARIO: Traducoes = {
   "Confirme o segundo fator nesta sessão e tente de novo.": {
     es: "Confirma el segundo factor en esta sesión e intenta de nuevo.",
   },
+  // ─── app/api/v1/marca/logo/route.ts (frontend-traduz via CampoDeLogo.tsx) ───
+  "Campo 'escopo' inválido.": { es: "Campo 'escopo' inválido." },
+  "O logo precisa ter até 512 KB. Arquivo maior vai inteiro para o navegador em toda página.": {
+    es: "El logo debe tener hasta 512 KB. Un archivo más grande va entero al navegador en cada página.",
+  },
+  "SVG não é aceito como logo: ele pode executar código quando aberto direto do endereço da imagem. Exporte o mesmo arquivo em PNG (fundo transparente) ou JPG.": {
+    es: "SVG no se acepta como logo: puede ejecutar código cuando se abre directo desde la dirección de la imagen. Exporta el mismo archivo en PNG (fondo transparente) o JPG.",
+  },
+  "Erro ao gravar o logo.": { es: "Error al guardar el logo." },
+  "O caminho do logo não pertence a esta empresa.": {
+    es: "La ruta del logo no pertenece a esta empresa.",
+  },
+  "O logo não foi gravado.": { es: "El logo no fue guardado." },
+  // ─── lib/auth/require-role.ts (gate ÚNICO de autorização — toda rota /api/v1) ───
+  "Esta sessão precisa da verificação em duas etapas. Entre novamente com o código do aplicativo.": {
+    es: "Esta sesión necesita la verificación en dos pasos. Entra de nuevo con el código de la aplicación.",
+  },
   "Muitas trocas seguidas. Tente de novo em alguns minutos.": {
     es: "Demasiados cambios seguidos. Intenta de nuevo en unos minutos.",
   },
@@ -2889,6 +2967,31 @@ export const DICIONARIO: Traducoes = {
   },
   "A mensagem está na fila e sai assim que o canal aceitar.": {
     es: "El mensaje está en la cola y sale en cuanto el canal lo acepte.",
+  },
+  // ─── lib/channels/frases-de-falha.ts (texto de tela por código do adapter) ───
+  "O número escolhido não está conectado no momento. Reconecte em Conexões — a mensagem sai sozinha quando ele voltar.": {
+    es: "El número elegido no está conectado en este momento. Reconéctalo en Conexiones — el mensaje sale solo cuando vuelva.",
+  },
+  "A conexão de WhatsApp ainda não foi configurada nesta instalação.": {
+    es: "La conexión de WhatsApp todavía no fue configurada en esta instalación.",
+  },
+  "Esse número foi excluído da Central de Conexões. Escolha outro número nesta automação.": {
+    es: "Ese número fue eliminado de la Central de Conexiones. Elige otro número en esta automatización.",
+  },
+  "O contato não tem telefone para receber a mensagem.": {
+    es: "El contacto no tiene teléfono para recibir el mensaje.",
+  },
+  "Não conseguimos falar com o serviço de WhatsApp. Confira se ele está no ar.": {
+    es: "No pudimos comunicarnos con el servicio de WhatsApp. Verifica que esté funcionando.",
+  },
+  "O WhatsApp Oficial recusou o envio. Confira a conexão em Conexões.": {
+    es: "El WhatsApp Oficial rechazó el envío. Verifica la conexión en Conexiones.",
+  },
+  "O canal recusou o envio. Confira a conexão em Conexões.": {
+    es: "El canal rechazó el envío. Verifica la conexión en Conexiones.",
+  },
+  "Não conseguimos preparar o arquivo para envio.": {
+    es: "No pudimos preparar el archivo para el envío.",
   },
   "O agente escolhido não tem versão publicada. Publique-o em Agentes de IA para a automação poder usá-lo.": {
     es: "El agente elegido no tiene versión publicada. Publícalo en Agentes de IA para que la automatización pueda usarlo.",
@@ -3141,6 +3244,43 @@ export const DICIONARIO: Traducoes = {
   "Este número não tem conversa, mensagem nem configuração ligada a ele.": {
     es: "Este número no tiene conversación, mensaje ni configuración ligada a él.",
   },
+  "conversa": { es: "conversación" },
+  "mensagem": { es: "mensaje" },
+  "versão de agente": { es: "versión de agente" },
+  "versões de agente": { es: "versiones de agente" },
+  "roteador de IA": { es: "enrutador de IA" },
+  "roteadores de IA": { es: "enrutadores de IA" },
+  "ajuste de proteção de envio": { es: "ajuste de protección de envío" },
+  "ajustes de proteção de envio": { es: "ajustes de protección de envío" },
+  "conversa continua": { es: "conversación continúa" },
+  "conversas continuam": { es: "conversaciones continúan" },
+
+  // ─── lib/channels/meta/template-contract.ts (preview de template do WhatsApp) ───
+  "cabeçalho": { es: "encabezado" },
+  "corpo": { es: "cuerpo" },
+
+  // ─── lib/channels/zernio/avisos.ts (avisos de número/conta na Central) ───
+  "Número ativado.": { es: "Número activado." },
+  "Número reativado.": { es: "Número reactivado." },
+  "Documentação enviada para verificação.": { es: "Documentación enviada para verificación." },
+  "A plataforma pede verificação deste número.": {
+    es: "La plataforma pide verificación de este número.",
+  },
+  "A plataforma pede uma ação neste número.": {
+    es: "La plataforma pide una acción en este número.",
+  },
+  "Número recusado pela plataforma.": { es: "Número rechazado por la plataforma." },
+  "Número SUSPENSO — não é possível enviar.": {
+    es: "Número SUSPENDIDO — no se puede enviar.",
+  },
+  "Número liberado e não utilizável (terminal).": {
+    es: "Número liberado y no utilizable (terminal).",
+  },
+  "A conta do canal foi desconectada.": { es: "La cuenta del canal fue desconectada." },
+  "Conta do canal conectada.": { es: "Cuenta del canal conectada." },
+  "Verificação recusada.": { es: "Verificación rechazada." },
+  "Verificação aprovada.": { es: "Verificación aprobada." },
+
   "Continua no inbox:": { es: "Sigue en el inbox:" },
   "Fica salvo, mas sem número — para de atender:": {
     es: "Queda guardado, pero sin número — deja de atender:",
@@ -3477,6 +3617,12 @@ export const DICIONARIO: Traducoes = {
     es: "Detalles técnicos (útil si vas a pedir ayuda)",
   },
   "Atualização do sistema": { es: "Actualización del sistema" },
+  "Guardando uma cópia de segurança dos seus dados": {
+    es: "Guardando una copia de seguridad de tus datos",
+  },
+  "Baixando a versão nova": { es: "Descargando la versión nueva" },
+  "Atualizando o banco de dados": { es: "Actualizando la base de datos" },
+  "Reiniciando o sistema": { es: "Reiniciando el sistema" },
   "Reiniciando…": { es: "Reiniciando…" },
   "O sistema está voltando. Esta página se atualiza sozinha em alguns instantes.": {
     es: "El sistema está volviendo. Esta página se actualiza sola en unos instantes.",
@@ -3533,6 +3679,7 @@ export const DICIONARIO: Traducoes = {
   "Preferências de notificação em breve. Por enquanto, alertas críticos são enviados por email.": {
     es: "Preferencias de notificación próximamente. Por ahora, las alertas críticas se envían por correo.",
   },
+  "Nova mensagem": { es: "Mensaje nuevo" },
   "Lead atribuído a você": { es: "Lead asignado a ti" },
   "Lead ganho": { es: "Lead ganado" },
   "Lead perdido": { es: "Lead perdido" },
@@ -3563,6 +3710,23 @@ export const DICIONARIO: Traducoes = {
   },
   "Verificação desligada.": { es: "Verificación desactivada." },
   "Desligando…": { es: "Desactivando…" },
+
+  // ─── app/actions/auth/politicaDeMfa.ts (erros do painel de Segurança/MFA) ───
+  "Sua sessão expirou. Entre de novo.": { es: "Tu sesión expiró. Entra de nuevo." },
+  "Nenhuma empresa ativa.": { es: "Ninguna empresa activa." },
+  "Só um administrador pode mudar essa regra.": {
+    es: "Solo un administrador puede cambiar esta regla.",
+  },
+  "Não consegui ler a configuração agora.": { es: "No pude leer la configuración ahora." },
+  "Não consegui salvar essa mudança agora.": { es: "No pude guardar ese cambio ahora." },
+  "A verificação em duas etapas é obrigatória para administradores desta empresa. Desligue a regra antes.":
+    {
+      es: "La verificación en dos pasos es obligatoria para administradores de esta empresa. Desactiva la regla antes.",
+    },
+  "Entre de novo e informe o código de 6 dígitos antes de desligar a verificação.": {
+    es: "Entra de nuevo e ingresa el código de 6 dígitos antes de desactivar la verificación.",
+  },
+  "Não consegui remover a verificação agora.": { es: "No pude quitar la verificación ahora." },
   Ativar: { es: "Activar" },
   "Exigir de quem administra": { es: "Exigir a quien administra" },
   "Agora os administradores precisam da verificação.": {
@@ -4665,10 +4829,81 @@ export const DICIONARIO: Traducoes = {
   "Sugestão de retomada venceu sem decisão": { es: "La sugerencia de retomada venció sin decisión" },
   "Retorno agendado": { es: "Retorno agendado" },
   "Retorno cancelado": { es: "Retorno cancelado" },
+  "Desmarcado por uma pessoa da equipe": { es: "Desmarcado por una persona del equipo" },
+  "Sem motivo informado": { es: "Sin motivo informado" },
   "Follow-up pausado": { es: "Follow-up pausado" },
   "Follow-up retomado": { es: "Follow-up retomado" },
   "Follow-up adiado": { es: "Follow-up pospuesto" },
   "Passo do follow-up pulado": { es: "Paso del follow-up saltado" },
+  // ─── lib/followup/eventos-legiveis.ts (dossiê do follow-up) ───
+  // STATUS (rotuloDoStatus)
+  "concluída": { es: "concluida" },
+  "cancelada": { es: "cancelada" },
+  // TIPO_DO_NO (tipoDoNo)
+  "Espera": { es: "Espera" },
+  "Interpretação da resposta": { es: "Interpretación de la respuesta" },
+  "Resposta (texto)": { es: "Respuesta (texto)" },
+  "Repetição": { es: "Repetición" },
+  "Passo": { es: "Paso" },
+  // DESFECHO (standalone, quando `detalhe` do evento `flow_completed` é só o desfecho)
+  "converteu": { es: "convirtió" },
+  "esgotou as tentativas": { es: "agotó los intentos" },
+  "pediu para parar": { es: "pidió parar" },
+  "passou para uma pessoa": { es: "pasó a una persona" },
+  "desfecho próprio": { es: "desenlace propio" },
+  // descreveEvento — títulos e detalhes fixos (sem interpolação)
+  "Seguiu em frente": { es: "Siguió adelante" },
+  "Começou a esperar": { es: "Empezó a esperar" },
+  "Pediu ao agente para planejar os tempos de espera": {
+    es: "Le pidió al agente que planeara los tiempos de espera",
+  },
+  "Pediu ao agente para escrever a mensagem": { es: "Le pidió al agente que escribiera el mensaje" },
+  "Pediu ao agente para interpretar a resposta": { es: "Le pidió al agente que interpretara la respuesta" },
+  "Conferiu se a mensagem já tinha saído": { es: "Verificó si el mensaje ya había salido" },
+  "Mensagem enviada": { es: "Mensaje enviado" },
+  "O agente interpretou a resposta": { es: "El agente interpretó la respuesta" },
+  "Fluxo concluído": { es: "Flujo concluido" },
+  "O fluxo parou de tentar": { es: "El flujo dejó de intentar" },
+  "Falhou neste passo": { es: "Falló en este paso" },
+  "O cliente respondeu — o fluxo acordou na hora": { es: "El cliente respondió — el flujo despertó a tiempo" },
+  "Encerrado porque o cliente respondeu": { es: "Finalizado porque el cliente respondió" },
+  "Encerrado porque o cliente pediu para parar": { es: "Finalizado porque el cliente pidió parar" },
+  "Encerrado porque uma pessoa assumiu a conversa": {
+    es: "Finalizado porque una persona asumió la conversación",
+  },
+  "Pausado porque uma pessoa assumiu a conversa": { es: "Pausado porque una persona asumió la conversación" },
+  "Retomado: o atendimento voltou para o agente": { es: "Reanudado: la atención volvió al agente" },
+  "O agente decidiu quanto esperar em cada passo": { es: "El agente decidió cuánto esperar en cada paso" },
+  "Seguiu sem o plano de tempo": { es: "Siguió sin el plan de tiempo" },
+  "Cancelado por uma pessoa da equipe": { es: "Cancelado por una persona del equipo" },
+  "Pausado por uma pessoa da equipe": { es: "Pausado por una persona del equipo" },
+  "Retomado por uma pessoa da equipe": { es: "Reanudado por una persona del equipo" },
+  "Adiado por uma pessoa da equipe": { es: "Pospuesto por una persona del equipo" },
+  "Passo pulado por uma pessoa da equipe": { es: "Paso saltado por una persona del equipo" },
+  "Começou porque o negócio entrou numa etapa": { es: "Empezó porque el negocio entró en una etapa" },
+  "Começou porque o agente pediu ajuda de um humano": {
+    es: "Empezó porque el agente pidió ayuda a un humano",
+  },
+  "Cancelado porque o caso foi resolvido": { es: "Cancelado porque el caso fue resuelto" },
+  "Passo registrado pelo motor": { es: "Paso registrado por el motor" },
+  "a etapa escolhida no gatilho deste fluxo": { es: "la etapa elegida en el gatillo de este flujo" },
+  "o caso foi aberto por uma trava de segurança, não por decisão do agente": {
+    es: "el caso fue abierto por un bloqueo de seguridad, no por decisión del agente",
+  },
+  "o agente abriu um caso de atendimento": { es: "el agente abrió un caso de atención" },
+  "o follow-up existia para esse caso e parou junto com ele": {
+    es: "el follow-up existía para ese caso y se detuvo junto con él",
+  },
+  "o agente não respondeu a tempo; cada espera usa o máximo configurado": {
+    es: "el agente no respondió a tiempo; cada espera usa el máximo configurado",
+  },
+  // resumoDoNo — trechos fixos (sem interpolação)
+  "onde o follow-up começa": { es: "donde empieza el follow-up" },
+  "o agente escreve e envia a mensagem": { es: "el agente escribe y envía el mensaje" },
+  "envia um texto fixo": { es: "envía un texto fijo" },
+  "envia uma mensagem de modelo pronto": { es: "envía un mensaje de plantilla lista" },
+  // refDoNo
+  "sem passo associado": { es: "sin paso asociado" },
   "Promessa sem responsável": { es: "Promesa sin responsable" },
   "Demanda encerrada": { es: "Demanda cerrada" },
   "Consentimento de contato recusado no formulário": { es: "Consentimiento de contacto rechazado en el formulario" },
@@ -4730,6 +4965,23 @@ export const DICIONARIO: Traducoes = {
   "Contatos juntados. {n} registro(s) continuaram no cadastro antigo — veja a auditoria.": {
     es: "Contactos juntados. {n} registro(s) siguieron en la ficha antigua — revisa la auditoría.",
   },
+
+  // ─── app/api/v1/contacts/merge/route.ts (DESFECHOS que chegam à tela via showApiError) ───
+  "Seleção inválida: escolha um contato principal e ao menos um a ser absorvido.": {
+    es: "Selección inválida: elige un contacto principal y al menos uno para absorber.",
+  },
+  "O mesmo contato aparece duas vezes na seleção.": {
+    es: "El mismo contacto aparece dos veces en la selección.",
+  },
+  "O contato principal não está disponível — ele pode ter sido anonimizado ou já mesclado em outro.":
+    {
+      es: "El contacto principal no está disponible — puede haber sido anonimizado o ya fusionado en otro.",
+    },
+  "Um dos contatos selecionados não está disponível — ele pode ter sido anonimizado ou já mesclado em outro.":
+    {
+      es: "Uno de los contactos seleccionados no está disponible — puede haber sido anonimizado o ya fusionado en otro.",
+    },
+  "Organização ativa não resolvida.": { es: "No se resolvió la organización activa." },
   "Mostrando os duplicados entre os contatos mais antigos. Junte estes e reabra para ver os próximos.": {
     es: "Mostrando los duplicados entre los contactos más antiguos. Junta estos y vuelve a abrir para ver los siguientes.",
   },
@@ -4780,6 +5032,9 @@ export const DICIONARIO: Traducoes = {
   "Importar contatos de planilha": { es: "Importar contactos desde hoja de cálculo" },
   "Envie um arquivo .csv com cabeçalho — colunas reconhecidas: nome, telefone, email, cpf, nascimento, tags. Excel: use “Salvar como” → “CSV UTF-8”. Máximo de 500 linhas por arquivo.": {
     es: "Envía un archivo .csv con encabezado — columnas reconocidas: nombre, teléfono, email, cpf, nacimiento, tags. Excel: usa “Guardar como” → “CSV UTF-8”. Máximo 500 líneas por archivo.",
+  },
+  "Este arquivo não parece ser um CSV de texto. No Excel use “Salvar como” → “CSV UTF-8 (delimitado por vírgulas)”.": {
+    es: "Este archivo no parece ser un CSV de texto. En Excel usa “Guardar como” → “CSV UTF-8 (delimitado por comas)”.",
   },
   "Arquivo CSV": { es: "Archivo CSV" },
   "Importando…": { es: "Importando…" },
@@ -5400,7 +5655,7 @@ export const DICIONARIO: Traducoes = {
   "Use um dos 10 códigos que você salvou ao configurar a verificação em duas etapas.": {
     es: "Usa uno de los 10 códigos que guardaste al configurar la verificación en dos pasos.",
   },
-  "Validando...": { es: "Validando..." },
+  "Validando…": { es: "Validando…" },
   "Sua conta tem verificação em duas etapas. Digite o código de 6 dígitos do seu app autenticador para concluir.": {
     es: "Tu cuenta tiene verificación en dos pasos. Escribe el código de 6 dígitos de tu app autenticadora para concluir.",
   },
@@ -5615,6 +5870,10 @@ export const DICIONARIO: Traducoes = {
   "Ao trocar uma credencial já em uso:": { es: "Al cambiar una credencial ya en uso:" },
   "quem já conectou a agenda vai precisar conectar de novo. O Google invalida as autorizações antigas quando o aplicativo muda — não há como evitar, e ninguém perde compromisso por isso.": { es: "quien ya conectó su agenda tendrá que conectarla otra vez. Google invalida las autorizaciones anteriores cuando la aplicación cambia — no hay forma de evitarlo, y nadie pierde ninguna cita por eso." },
   "Nunca configurado por aqui.": { es: "Nunca configurado por aquí." },
+  "Credenciais do Google salvas.": { es: "Credenciales de Google guardadas." },
+  "cifra indisponível nesta instalação (GUC app.nuvemshop_oauth_key ausente) — o segredo não foi gravado": {
+    es: "cifrado no disponible en esta instalación (GUC app.nuvemshop_oauth_key ausente) — el secreto no fue guardado",
+  },
   "Falta cadastrar o aplicativo do Google desta instalação. Leva um minuto e você faz por aqui mesmo.": { es: "Falta registrar la aplicación de Google de esta instalación. Toma un minuto y lo haces aquí mismo." },
   "O que ele consulta antes de responder": { es: "Qué consulta antes de responder" },
   "Marque o material do seu negócio que este assistente pode ler. Ele procura ali antes de responder, em vez de improvisar — e cita de onde tirou.": { es: "Marca el material de tu negocio que este asistente puede leer. Busca ahí antes de responder, en vez de improvisar — y cita de dónde lo sacó." },
@@ -5635,6 +5894,12 @@ export const DICIONARIO: Traducoes = {
   "Contém": { es: "Contiene" },
   "É igual a": { es: "Es igual a" },
   "Não gravar": { es: "No guardar" },
+  "Regras de texto": { es: "Reglas de texto" },
+  "Gravar a resposta em": { es: "Guardar la respuesta en" },
+  "Nome do contato": { es: "Nombre del contacto" },
+  "Chave do campo personalizado": { es: "Clave del campo personalizado" },
+  "Texto enviado ao contato": { es: "Texto enviado al contacto" },
+  "Chave secreta do cliente": { es: "Clave secreta del cliente" },
   "Chave livre (use": { es: "Clave libre (usa" },
   "no laço)": { es: "en el bucle)" },
   "Crie os campos em Configurações → Funis. A resposta só grava quando o contato responde (não no timeout).": { es: "Crea los campos en Configuración → Embudos. La respuesta solo se guarda cuando el contacto responde (no en el timeout)." },
@@ -5710,6 +5975,7 @@ export const DICIONARIO: Traducoes = {
   "Mostrando os primeiros trechos de": { es: "Mostrando los primeros fragmentos de" },
   ". Uma tela não folheia mil pedaços — o restante está no acervo e o agente alcança todos.": { es: ". Una pantalla no hojea mil pedazos — el resto está en el acervo y el agente los alcanza todos." },
   "Este funil não tem campos extras.": { es: "Este embudo no tiene campos extra." },
+  "Campos atualizados": { es: "Campos actualizados" },
 
   // ─── Tabela de Contatos ───
   //
@@ -5922,6 +6188,9 @@ export const DICIONARIO: Traducoes = {
   "Dê um nome à etapa — é o que aparece no topo da coluna.": {
     es: "Ponle un nombre a la etapa — es lo que aparece arriba de la columna.",
   },
+  "Dê um nome ao funil — é o que aparece na lista e no topo do quadro.": {
+    es: "Ponle un nombre al embudo — es lo que aparece en la lista y arriba del tablero.",
+  },
   "Dê um nome ao funil — é o que aparece na lista.": { es: "Ponle un nombre al embudo — es lo que aparece en la lista." },
   "Duas intenções não podem ter o mesmo nome no router.": {
     es: "Dos intenciones no pueden tener el mismo nombre en el router.",
@@ -5929,6 +6198,9 @@ export const DICIONARIO: Traducoes = {
   "Enrollment já está encerrado.": { es: "El enrollment ya está cerrado." },
   "Enrollment não encontrado.": { es: "Enrollment no encontrado." },
   "Entrada de memória não encontrada nesta organização.": { es: "Entrada de memoria no encontrada en esta organización." },
+  "Envie o mapeamento completo dos sete passos do atendimento.": {
+    es: "Envía el mapeo completo de los siete pasos de la atención.",
+  },
   "Envie o arquivo como multipart/form-data no campo 'file'.": {
     es: "Envía el archivo como multipart/form-data en el campo 'file'.",
   },
@@ -6100,6 +6372,9 @@ export const DICIONARIO: Traducoes = {
   "Sessão expirada": { es: "Sesión expirada" },
   "Sessão sem token.": { es: "Sesión sin token." },
   "Skill não encontrada no catálogo de plataforma.": { es: "Skill no encontrada en el catálogo de la plataforma." },
+  "Suba o Docker (docker compose up -d waha) e tente novamente.": {
+    es: "Levanta el Docker (docker compose up -d waha) e intenta de nuevo.",
+  },
   "Skill não está instalada nesta organização.": { es: "La skill no está instalada en esta organización." },
   "Solicitação não encontrada.": { es: "Solicitud no encontrada." },
   "Só manager+ cria template compartilhado.": { es: "Solo manager+ puede crear una plantilla compartida." },
@@ -6125,6 +6400,25 @@ export const DICIONARIO: Traducoes = {
   "Telefone inválido.": { es: "Teléfono inválido." },
   "Template não encontrado.": { es: "Plantilla no encontrada." },
   "Tipo de agendamento não encontrado.": { es: "Tipo de agendamiento no encontrado." },
+  // ─── app/api/v1/agenda/agendamentos/_handler.ts + lib/agenda/consulta.ts ───
+  "O tipo deste agendamento não existe mais.": { es: "El tipo de este agendamiento ya no existe." },
+  "Agendamento não encontrado.": { es: "Agendamiento no encontrado." },
+  "Este agendamento foi cancelado. Marque um novo em vez de reabrir este.": {
+    es: "Este agendamiento fue cancelado. Agenda uno nuevo en vez de reabrir este.",
+  },
+  "Este compromisso ainda não começou — não dá para registrar se a pessoa veio ou faltou. Se ela avisou que não vem, desmarque em vez de registrar falta.": {
+    es: "Este compromiso todavía no empezó — no se puede registrar si la persona vino o faltó. Si avisó que no viene, cancela en vez de registrar falta.",
+  },
+  "Este responsável ainda não publicou horários de atendimento.": {
+    es: "Este responsable todavía no publicó horarios de atención.",
+  },
+  "Este horário não está disponível. Consulte os horários livres e escolha outro.": {
+    es: "Este horario no está disponible. Consulta los horarios libres y elige otro.",
+  },
+  "listagem sem recorte: informe contato, lead, dia, período (de+ate) ou responsável.": {
+    es: "listado sin recorte: indica contacto, lead, día, período (de+ate) o responsable.",
+  },
+  "O período não pode passar de 62 dias.": { es: "El período no puede pasar de 62 días." },
   "title e body são obrigatórios.": { es: "title y body son obligatorios." },
   "Token não encontrado.": { es: "Token no encontrado." },
   "tool_ids contém ids inexistentes no catálogo MCP.": { es: "tool_ids contiene ids inexistentes en el catálogo MCP." },
@@ -6161,6 +6455,9 @@ export const DICIONARIO: Traducoes = {
   "O resultado vai no arquivo": { es: "El resultado va en el archivo" },
   "Email ainda não está disponível.": { es: "El email todavía no está disponible." },
   "Trechos que o agente encontra": { es: "Fragmentos que el agente encuentra" },
+  "Regra que você ensinou": { es: "Regla que enseñaste" },
+  "Melhoria que você aprovou": { es: "Mejora que aprobaste" },
+  "Habilidade instalada": { es: "Habilidad instalada" },
   "Preparar de novo": { es: "Preparar de nuevo" },
   "Ver o que ele aprendeu": { es: "Ver lo que aprendió" },
   "O que o agente sabe": { es: "Lo que el agente sabe" },
@@ -6223,6 +6520,19 @@ export const DICIONARIO: Traducoes = {
   "Aviso do assistente": { es: "Aviso del asistente" },
   // `informativo` e `crítico` saem iguais nos dois idiomas — sem linha, por isso.
   "atenção": { es: "atención" },
+  // ─── lib/ai/agent-inbox-copy.ts (copyDaPromessaSemDono) ───
+  "O assistente prometeu algo ao cliente e ninguém ficou responsável": {
+    es: "El asistente prometió algo al cliente y nadie se hizo responsable",
+  },
+  "Nesta conversa o assistente combinou algo com o cliente. Ele ainda não tem nenhuma capacidade marcada para registrar isso no sistema, então nada foi agendado nem anotado. Abra a conversa para ver o que foi combinado — e, na tela do assistente, marque o que ele pode fazer.": {
+    es: "En esta conversación el asistente acordó algo con el cliente. Todavía no tiene ninguna capacidad marcada para registrar esto en el sistema, así que nada fue agendado ni anotado. Abre la conversación para ver qué se acordó — y, en la pantalla del asistente, marca lo que puede hacer.",
+  },
+  "Nesta conversa o assistente combinou algo com o cliente e não registrou nenhum próximo passo para isso — não há retorno agendado. Abra a conversa, veja o que foi combinado e decida quem faz.": {
+    es: "En esta conversación el asistente acordó algo con el cliente y no registró ningún próximo paso para esto — no hay retorno agendado. Abre la conversación, mira qué se acordó y decide quién lo hace.",
+  },
+  "Nesta conversa o assistente combinou algo com o cliente, e a parte que organiza o sistema não rodou neste atendimento. Nada foi agendado. Abra a conversa para ver o que foi combinado e decida quem faz.": {
+    es: "En esta conversación el asistente acordó algo con el cliente, y la parte que organiza el sistema no corrió en esta atención. Nada fue agendado. Abre la conversación para ver qué se acordó y decide quién lo hace.",
+  },
 
   // ─── Estado do material do acervo (components/ai/SourceStatusBadge.tsx) ───
   //
@@ -6399,6 +6709,11 @@ export const DICIONARIO: Traducoes = {
   "Reunião": { es: "Reunión" },
   "Demonstração": { es: "Demostración" },
   "Outro": { es: "Otro" },
+  "Consulta": { es: "Consulta" },
+  "Visita": { es: "Visita" },
+  "Call": { es: "Call" },
+  "Presencial": { es: "Presencial" },
+  "Link de vídeo": { es: "Enlace de video" },
   "Mostrar todos (agora só": { es: "Mostrar todos (ahora solo" },
   "Ver só a agenda de": { es: "Ver solo la agenda de" },
   "com": { es: "con" },
@@ -6481,6 +6796,18 @@ export const DICIONARIO: Traducoes = {
   "Salvar produto": { es: "Guardar producto" },
   "em estoque": { es: "en stock" },
   "sem controle de estoque": { es: "sin control de stock" },
+  // Mensajes de error de importación de planilha (lib/catalogo/planilha.ts)
+  "A planilha está vazia.": { es: "La planilla está vacía." },
+  "A planilha precisa de uma coluna de nome e de preço. Encontrei: ": {
+    es: "La planilla necesita una columna de nombre y de precio. Encontré: ",
+  },
+  "sem nome do produto": { es: "sin nombre del producto" },
+  "preço não reconhecido (": { es: "precio no reconocido (" },
+  " — escreva assim: 5.499,00": { es: " — escríbalo así: 5.499,00" },
+  "custo não reconhecido (": { es: "costo no reconocido (" },
+  "código repetido na planilha (": { es: "código repetido en la planilla (" },
+  "nenhuma coluna": { es: "ninguna columna" },
+
   // ─── Análise → Meta Ads e Configurações → Meta Ads (0214) ───
   //
   // ⚠️ Boa parte deste bloco o teste `i18n-espanhol-cobre-a-tela` NÃO cobre, e
@@ -6601,6 +6928,24 @@ export const DICIONARIO: Traducoes = {
     { es: "Desconectar borra el token guardado. La pantalla de Meta Ads vuelve a pedir una conexión, y no se pierde ningún dato histórico — aquí no se almacena nada." },
   "Não consegui desconectar agora.": { es: "No pude desconectar ahora." },
 
+  // ─── ERRO_EM_PORTUGUES compartida por meta-ads/_form.tsx e conversoes/_form.tsx ───
+  "Você não está em nenhuma organização ativa.": {
+    es: "No estás en ninguna organización activa.",
+  },
+  "Só um administrador da organização pode mudar esta conexão.": {
+    es: "Solo un administrador de la organización puede cambiar esta conexión.",
+  },
+  "Confirme o segundo fator para salvar esta mudança.": {
+    es: "Confirma el segundo factor para guardar este cambio.",
+  },
+  "Esta instalação está sem a chave mestra de criptografia, e o token não foi gravado. Quem instalou o sistema precisa configurá-la — refazer o cadastro aqui não resolve.":
+    {
+      es: "Esta instalación no tiene la clave maestra de cifrado, y el token no se guardó. Quien instaló el sistema necesita configurarla — repetir el registro aquí no resuelve.",
+    },
+  "Não consegui gravar agora. Tente de novo em instantes.": {
+    es: "No pude guardar ahora. Inténtalo de nuevo en unos instantes.",
+  },
+
   // ─── Configurações → Conversões (0213) e o convidado da agenda (0212) ───
   //
   // Estas duas telas entraram na mesma leva do painel de Meta Ads e ficaram sem
@@ -6690,6 +7035,16 @@ export const DICIONARIO: Traducoes = {
   "Em andamento": { es: "En curso" },
   "Escreva um título para a tarefa.": { es: "Escribe un título para la tarea." },
   "Não foi possível salvar a tarefa.": { es: "No se pudo guardar la tarea." },
+
+  // ─── app/api/v1/tasks/**/route.ts (mensagens que chegam cruas ao formulário — sem showApiError) ───
+  "Tarefa não encontrada.": { es: "Tarea no encontrada." },
+  "O negócio ou contato vinculado não existe.": {
+    es: "El negocio o contacto vinculado no existe.",
+  },
+  "Erro ao salvar a tarefa.": { es: "Error al guardar la tarea." },
+  "Erro ao listar as tarefas.": { es: "Error al listar las tareas." },
+  "Erro ao apagar a tarefa.": { es: "Error al borrar la tarea." },
+
   "Baixa": { es: "Baja" },
   "Média": { es: "Media" },
   "Alta": { es: "Alta" },
@@ -6711,7 +7066,7 @@ export const DICIONARIO: Traducoes = {
       es: "Esta acción es irreversible. Mensajes, conversaciones, negocios, contactos, citas y pedidos de",
     },
   "serão apagados de vez.": { es: "serán borrados definitivamente." },
-  Digite: { es: "Escriba" },
+  Digite: { es: "Escribe" },
   "para confirmar": { es: "para confirmar" },
   "Apagando…": { es: "Borrando…" },
   "Apagar de vez": { es: "Borrar definitivamente" },
@@ -6725,18 +7080,25 @@ export const DICIONARIO: Traducoes = {
     es: "El nombre escrito no coincide con el nombre de la organización.",
   },
   "Digite o nome da organização para confirmar.": {
-    es: "Escriba el nombre de la organización para confirmar.",
+    es: "Escribe el nombre de la organización para confirmar.",
   },
   "Não consegui apagar os dados agora.": { es: "No pude borrar los datos ahora." },
   "Sua sessão expirou. Entre de novo para continuar.": {
-    es: "Su sesión expiró. Entre de nuevo para continuar.",
+    es: "Tu sesión expiró. Entra de nuevo para continuar.",
   },
   "Não consegui identificar sua empresa. Recarregue a página.": {
-    es: "No pude identificar su empresa. Recargue la página.",
+    es: "No pude identificar tu empresa. Recarga la página.",
   },
   "Confirme o código do seu aplicativo de duas etapas e tente de novo.": {
-    es: "Confirme el código de su aplicación de dos pasos e inténtelo de nuevo.",
+    es: "Confirma el código de tu aplicación de dos pasos e inténtalo de nuevo.",
   },
+  "Só quem administra esta empresa pode mudar a marca.": {
+    es: "Solo quien administra esta empresa puede cambiar la marca.",
+  },
+  "A alteração não chegou ao banco — nada foi mudado. Tente de novo.": {
+    es: "El cambio no llegó a la base de datos — no se modificó nada. Inténtalo de nuevo.",
+  },
+  "Não consegui salvar a marca agora.": { es: "No pude guardar la marca ahora." },
 
   // ─── Importar leads de planilha (extraído do PR #418) ───
   "Importar leads de uma planilha": { es: "Importar leads desde una planilla" },
@@ -6748,6 +7110,604 @@ export const DICIONARIO: Traducoes = {
   "leads criados": { es: "leads creados" },
   "contatos novos": { es: "contactos nuevos" },
   "Colunas que não reconheci:": { es: "Columnas que no reconocí:" },
+  // Mensagens de erro de lib/leads/planilha.ts e app/api/v1/leads/import/route.ts
+  "A planilha precisa de uma coluna com o nome do negócio ou do contato. Encontrei: ": {
+    es: "La planilla necesita una columna con el nombre del negocio o del contacto. Encontré: ",
+  },
+  "sem nome do negócio nem do contato": { es: "sin nombre del negocio ni del contacto" },
+  "valor não reconhecido (": { es: "valor no reconocido (" },
+  " — escreva assim: 1.200,00": { es: " — escríbalo así: 1.200,00" },
+  "telefone não reconhecido (": { es: "teléfono no reconocido (" },
+  " — o negócio entrou sem contato": { es: " — el negocio entró sin contacto" },
+  "Envie o arquivo como multipart/form-data.": {
+    es: "Envía el archivo como multipart/form-data.",
+  },
+  "Envie o arquivo no campo 'file'.": { es: "Envía el archivo en el campo 'file'." },
+  "Escolha o funil e a etapa de destino.": { es: "Elige el embudo y la etapa de destino." },
+  "Arquivo maior que ": { es: "Archivo mayor que " },
+  "A planilha tem": { es: "La planilla tiene" },
+  "linhas; o limite é": { es: "líneas; el límite es" },
+  "por importação.": { es: "por importación." },
+  "o contato não pôde ser criado — o negócio entrou sem ele": {
+    es: "el contacto no pudo ser creado — el negocio entró sin él",
+  },
+  "linha recusada pelo banco": { es: "línea rechazada por la base de datos" },
+  // Mensagens de erro de app/api/v1/products/import/route.ts
+  "Formato não suportado — envie um arquivo .csv. No Excel use 'Salvar como' → 'CSV UTF-8'.": {
+    es: "Formato no soportado — envía un archivo .csv. En Excel usa 'Guardar como' → 'CSV UTF-8'.",
+  },
+  "produtos por importação — divida a planilha.": {
+    es: "productos por importación — divide la planilla.",
+  },
+  // Mensagens de erro de lib/contacts/csv.ts e app/api/v1/contacts/import/route.ts
+  "cabeçalho sem coluna de telefone nem e-mail": {
+    es: "cabecera sin columna de teléfono ni e-mail",
+  },
+  "e-mail inválido: ": { es: "e-mail inválido: " },
+  "telefone inválido: ": { es: "teléfono inválido: " },
+  " (use DDI+DDD+número, ex.: +5511999998888)": {
+    es: " (usa código de país+código de área+número, ej.: +5511999998888)",
+  },
+  "linha sem telefone nem e-mail": { es: "línea sin teléfono ni e-mail" },
+  "Cabeçalho inválido:": { es: "Cabecera inválida:" },
+  "linhas por importação — divida a planilha.": {
+    es: "líneas por importación — divide la planilla.",
+  },
+  "CPF inválido: ": { es: "CPF inválido: " },
+  "dados inválidos": { es: "datos inválidos" },
+  // ─── Fase A: mensagens de erro de rotas de API (codemod + revisão manual) ───
+  "A decisão não pôde ser registrada. Nada foi enviado ao cliente.": { es: "La decisión no pudo ser registrada. No se envió nada al cliente." },
+  "A etapa escolhida para o gatilho não existe mais neste funil — escolha outra.": { es: "La etapa elegida para el disparador ya no existe en este embudo — elige otra." },
+  "A proposta mudou desde que você a leu. Confira a nova antes de decidir.": { es: "La propuesta cambió desde que la leíste. Revisa la nueva antes de decidir." },
+  "A régua do abandono precisa ser um número inteiro de horas entre 1 e 2160.": { es: "La regla de abandono debe ser un número entero de horas entre 1 y 2160." },
+  "Alguém assumiu esta conversa agora — recarregue e tente de novo.": { es: "Alguien asumió esta conversación ahora — recarga e intenta de nuevo." },
+  "Antes de fazer a IA parar no limite, salve \"Me avisar\" — assim o aviso já ": { es: "Antes de hacer que la IA se detenga en el límite, guarda \"Avisarme\" — así el aviso ya " },
+  "Assistente não encontrado nesta organização.": { es: "Asistente no encontrado en esta organización." },
+  "Assumiu a conversa e pausou o atendimento automático": { es: "Asumió la conversación y pausó la atención automática" },
+  "Assumiu o atendimento desta conversa": { es: "Asumió la atención de esta conversación" },
+  "Atendimento devolvido, mas o sinal de retomada do acompanhamento falhou — tente de novo.": { es: "Atención devuelta, pero la señal de reanudación del seguimiento falló — intenta de nuevo." },
+  "Atendimento devolvido ao agente com o registro do que a equipe decidiu": {
+    es: "Atención devuelta al agente con el registro de lo que el equipo decidió",
+  },
+  "Atendimento devolvido ao agente": { es: "Atención devuelta al agente" },
+  "Body JSON inválido.": { es: "Body JSON inválido." },
+  "Body inválido.": { es: "Body inválido." },
+  "Cole o conteúdo do material antes de criar.": { es: "Pega el contenido del material antes de crear." },
+  "Consulta inválida.": { es: "Consulta inválida." },
+  "Credential referenciada (FK ON DELETE RESTRICT). Remova as versões antes.": { es: "Credential referenciada (FK ON DELETE RESTRICT). Elimina las versiones antes." },
+  "Credential é usada por uma versão publicada de agent. Despublique antes de deletar.": { es: "La credential es usada por una versión publicada de agent. Despublica antes de eliminar." },
+  "Cursor inválido.": { es: "Cursor inválido." },
+  "Dê um nome ao material (2 a 120 caracteres).": { es: "Ponle un nombre al material (2 a 120 caracteres)." },
+  "Erro ao ativar a versão da memória.": { es: "Error al activar la versión de la memoria." },
+  "Erro ao duplicar versão.": { es: "Error al duplicar versión." },
+  "Erro ao gravar o conteúdo do material.": { es: "Error al grabar el contenido del material." },
+  "Erro ao guardar o conteúdo do material.": { es: "Error al guardar el contenido del material." },
+  "Erro ao listar execuções.": { es: "Error al listar ejecuciones." },
+  "Erro ao publicar versão da memória.": { es: "Error al publicar versión de la memoria." },
+  "Escolha a etapa do funil que dispara este fluxo antes de publicar.": { es: "Elige la etapa del embudo que dispara este flujo antes de publicar." },
+  "Esta automação não tem mais nenhuma ação de webhook — não há o que reenviar.": { es: "Esta automatización ya no tiene ninguna acción de webhook — no hay nada que reenviar." },
+  "Esta conversa está encerrada — não há atendimento automático a pausar.": { es: "Esta conversación está cerrada — no hay atención automática que pausar." },
+  "Esta sugestão já foi decidida.": { es: "Esta sugerencia ya fue decidida." },
+  "Esta sugestão venceu pelo prazo.": { es: "Esta sugerencia venció por el plazo." },
+  "Este canal é o oficial (API da plataforma): ele não tem sessão de WhatsApp para reiniciar. Se parou de entregar, atualize a credencial na tela do canal oficial.": { es: "Este canal es el oficial (API de la plataforma): no tiene sesión de WhatsApp para reiniciar. Si dejó de entregar, actualiza la credencial en la pantalla del canal oficial." },
+  "Este negócio não tem contato, então não há proposta do agente.": { es: "Este negocio no tiene contacto, así que no hay propuesta del agente." },
+  "Este número foi excluído da Central de Conexões — reconectar não o traz de volta. Conecte um número para voltar a atender.": { es: "Este número fue eliminado de la Central de Conexiones — reconectar no lo trae de vuelta. Conecta un número para volver a atender." },
+  "Falha ao processar o envio do arquivo.": { es: "Falla al procesar el envío del archivo." },
+  "Filtros inválidos.": { es: "Filtros inválidos." },
+  "Header Idempotency-Key é obrigatório.": { es: "El header Idempotency-Key es obligatorio." },
+  "JSON inválido.": { es: "JSON inválido." },
+  "Já existe um produto com esse código.": { es: "Ya existe un producto con ese código." },
+  "Já existe uma credential com este label e provider.": { es: "Ya existe una credential con este label y provider." },
+  "Já existe uma atualização em andamento.": { es: "Ya hay una actualización en curso." },
+  "Lead foi modificado por outro usuário. Recarregue e tente novamente.": { es: "El lead fue modificado por otro usuario. Recarga e intenta de nuevo." },
+  "Liberou a conversa de volta para a fila": { es: "Liberó la conversación de vuelta a la cola" },
+  "Material não encontrado.": { es: "Material no encontrado." },
+  "Move cross-pipeline não é permitido. Clone o lead para o pipeline alvo.": { es: "Mover entre pipelines no está permitido. Clona el lead hacia el pipeline destino." },
+  "Nada para alterar.": { es: "Nada para modificar." },
+  "Nenhum arquivo foi enviado.": { es: "Ningún archivo fue enviado." },
+  "Nenhum lead acessível na operação.": { es: "Ningún lead accesible en la operación." },
+  "Não achei nenhum par pergunta/resposta no texto. Use uma linha ## Pergunta: e uma ## Resposta: por item.": { es: "No encontré ningún par pregunta/respuesta en el texto. Usa una línea ## Pregunta: y una ## Respuesta: por ítem." },
+  "Não foi possível gravar.": { es: "No fue posible grabar." },
+  "Não foi possível guardar o segredo com segurança: a chave de cifra desta instalação não está ativa. Quem administra o servidor resolve rodando o update.sh, que gera e ativa a chave.": { es: "No fue posible guardar el secreto con seguridad: la clave de cifrado de esta instalación no está activa. Quien administra el servidor lo resuelve ejecutando el update.sh, que genera y activa la clave." },
+  "Não foi possível guardar o segredo com segurança: a chave de cifra desta instalação não está ativa. Quem administra o servidor resolve rodando o update.sh, que gera e ativa a chave. Enquanto isso, você pode criar a fonte sem segredo.": { es: "No fue posible guardar el secreto con seguridad: la clave de cifrado de esta instalación no está activa. Quien administra el servidor lo resuelve ejecutando el update.sh, que genera y activa la clave. Mientras tanto, puedes crear la fuente sin secreto." },
+  "Não foi possível guardar o segredo do webhook com segurança: a chave de cifra desta instalação não está ativa. Quem administra o servidor resolve rodando o update.sh, que gera e ativa a chave.": { es: "No fue posible guardar el secreto del webhook con seguridad: la clave de cifrado de esta instalación no está activa. Quien administra el servidor lo resuelve ejecutando el update.sh, que genera y activa la clave." },
+  "Não foi possível guardar o segredo do webhook com segurança: a chave de cifra desta instalação não está ativa. Quem administra o servidor resolve rodando o update.sh, que gera e ativa a chave. Enquanto isso, você pode criar a ação sem segredo.": { es: "No fue posible guardar el secreto del webhook con seguridad: la clave de cifrado de esta instalación no está activa. Quien administra el servidor lo resuelve ejecutando el update.sh, que genera y activa la clave. Mientras tanto, puedes crear la acción sin secreto." },
+  "Não foi possível validar o responsável agora. Tente novamente em instantes.": { es: "No fue posible validar al responsable ahora. Intenta de nuevo en unos instantes." },
+  "Esse funil não está mais na sua lista. Recarregue a página e tente de novo.": {
+    es: "Ese embudo ya no está en tu lista. Recarga la página e intenta de nuevo.",
+  },
+  "Não sei ler esse tipo de arquivo. Envie PDF, Markdown (.md) ou texto (.txt).": { es: "No sé leer ese tipo de archivo. Envía PDF, Markdown (.md) o texto (.txt)." },
+  "não consegui extrair texto deste PDF. Se ele for só imagens escaneadas, não há letra nenhuma para ler — envie uma versão com texto selecionável.": {
+    es: "no conseguí extraer texto de este PDF. Si son solo imágenes escaneadas, no hay ninguna letra para leer — envía una versión con texto seleccionable.",
+  },
+  "o arquivo não tem texto nenhum para indexar": { es: "el archivo no tiene ningún texto para indexar" },
+  "Não é possível desativar o agent default da organização.": { es: "No es posible desactivar el agent default de la organización." },
+  "Não é possível revogar o último admin do tenant.": { es: "No es posible revocar al último admin del tenant." },
+  "O WhatsApp (WAHA) não está configurado neste ambiente (faltam WAHA_API_BASE_URL e/ou WAHA_API_KEY) — sem ele o número não pode ser desconectado do aparelho.": { es: "El WhatsApp (WAHA) no está configurado en este ambiente (faltan WAHA_API_BASE_URL y/o WAHA_API_KEY) — sin él el número no puede ser desconectado del aparato." },
+  "O WhatsApp (WAHA) não está configurado neste ambiente: faltam WAHA_API_BASE_URL e/ou WAHA_API_KEY. Configure-as e tente de novo.": { es: "El WhatsApp (WAHA) no está configurado en este ambiente: faltan WAHA_API_BASE_URL y/o WAHA_API_KEY. Configúralas e intenta de nuevo." },
+  "O cabeçalho aceita imagem JPG ou PNG.": { es: "El encabezado acepta imagen JPG o PNG." },
+  "O caso não está aguardando resposta do atendente (awaiting_human).": { es: "El caso no está esperando respuesta del agente (awaiting_human)." },
+  "O funil que você escolheu como vizinho não está mais na lista. Recarregue a página.": { es: "El embudo que elegiste como vecino ya no está en la lista. Recarga la página." },
+  "O modelo em uso não sabe usar as ferramentas do CRM — o agente conversa, mas não registra nada no funil.": { es: "El modelo en uso no sabe usar las herramientas del CRM — el agente conversa, pero no registra nada en el embudo." },
+  "O próximo passo precisa ter de 3 a 500 caracteres.": { es: "El próximo paso debe tener de 3 a 500 caracteres." },
+  "O router precisa estar ativo (is_active=true) para ser testado.": { es: "El router debe estar activo (is_active=true) para ser probado." },
+  "Os funis desta lista estão empatados na ordenação. Recarregue a página e mova o funil para outro lugar.": { es: "Los embudos de esta lista están empatados en el orden. Recarga la página y mueve el embudo a otro lugar." },
+  "Payload inválido.": { es: "Payload inválido." },
+  "Produto não encontrado.": { es: "Producto no encontrado." },
+  "Query inválida.": { es: "Query inválida." },
+  "Responsável não é um atendente ativo desta organização.": { es: "El responsable no es un agente activo de esta organización." },
+  "Retomada de contato descartada — decisão registrada": { es: "Reanudación de contacto descartada — decisión registrada" },
+  "Salve este token agora — ele não será mostrado novamente.": { es: "Guarda este token ahora — no se mostrará de nuevo." },
+  "Só o próprio atendente ou um manager pode alterar esta disponibilidade.": { es: "Solo el propio agente o un manager puede modificar esta disponibilidad." },
+  "Transferiu a conversa para outro atendente": { es: "Transfirió la conversación a otro agente" },
+  "cifra indisponível nesta instalação (GUC app.nuvemshop_oauth_key ausente) — o token não foi gravado": { es: "cifrado no disponible en esta instalación (GUC app.nuvemshop_oauth_key ausente) — el token no fue grabado" },
+  "cifra indisponível nesta instalação — a chave não foi gravada": { es: "cifrado no disponible en esta instalación — la clave no fue grabada" },
+  "cursor inválido.": { es: "cursor inválido." },
+  "draft_graph ausente — monte o fluxo antes de publicar.": { es: "draft_graph ausente — arma el flujo antes de publicar." },
+  "encerrada pelo prazo": { es: "cerrada por el plazo" },
+  "está de pé quando a parada começar a valer, 72 horas depois de você armá-la.": { es: "está en pie cuando la parada empiece a valer, 72 horas después de que la actives." },
+  "falha ao ler": { es: "falla al leer" },
+  "filtros inválidos": { es: "filtros inválidos" },
+  "pointer_id inválido.": { es: "pointer_id inválido." },
+  "priority inválido (0..1000).": { es: "priority inválido (0..1000)." },
+  "status inválido.": { es: "status inválido." },
+
+  // ─── Fase B: handlers compartidos REST/MCP (contacts/_handler.ts) ───
+  "Contato anonimizado — edição bloqueada (LGPD).": {
+    es: "Contacto anonimizado — edición bloqueada (LGPD).",
+  },
+  "Nenhum campo para atualizar.": { es: "Ningún campo para actualizar." },
+  "Contato não encontrado após update.": { es: "Contacto no encontrado después del update." },
+  "Não foi possível excluir: o contato ainda tem registros vinculados.": {
+    es: "No fue posible eliminar: el contacto todavía tiene registros vinculados.",
+  },
+
+  // ─── Fase B: handlers compartidos REST/MCP (leads/_handler.ts) ───
+  "Um lead tem um dono: informe owner_user_id OU owner_agent_id.": {
+    es: "Un lead tiene un dueño: informa owner_user_id U owner_agent_id.",
+  },
+  "Falha ao criar lead.": { es: "Falla al crear lead." },
+  "Stage não pertence ao pipeline informado.": {
+    es: "El stage no pertenece al pipeline informado.",
+  },
+  "Move cross-pipeline não é permitido.": { es: "Mover entre pipelines no está permitido." },
+  "Lead foi modificado concorrentemente.": { es: "El lead fue modificado de forma concurrente." },
+  "leads por bulk.": { es: "leads por lote." },
+  "Esta sugestão já foi": { es: "Esta sugerencia ya fue" },
+  "decidida": { es: "decidida" },
+  "Informe o motivo da perda.": { es: "Indica el motivo de la pérdida." },
+  "Pipeline não tem stage de fechamento como ganho.": {
+    es: "El pipeline no tiene stage de cierre como ganado.",
+  },
+  "Pipeline não tem stage de fechamento como perda.": {
+    es: "El pipeline no tiene stage de cierre como perdido.",
+  },
+  "Perdido —": { es: "Perdido —" },
+  "(negócio removido)": { es: "(negocio eliminado)" },
+
+  // ─── Fase B: vocabulario de dominio persistido (reason de crm_lead_activities) ───
+  //
+  // Estas frases nunca chegam por t() estático — o backend as gera como
+  // `reason` de atividade, o valor é PERSISTIDO no banco, e o frontend
+  // (LeadTimeline.tsx, TimelineView.tsx, CRMSidePanel.tsx) as traduz na
+  // LEITURA com `t(item.reason)`. A chave aqui tem de bater byte a byte com
+  // o texto que o backend grava — nunca traduza só um pedaço.
+  "Não enviei: o contato pediu para parar de receber mensagens": {
+    es: "No envié: el contacto pidió dejar de recibir mensajes",
+  },
+  "Não enviei: fora da janela de horário permitida": {
+    es: "No envié: fuera de la ventana de horario permitida",
+  },
+  "Não enviei: limite de ritmo de envio atingido": {
+    es: "No envié: límite de ritmo de envío alcanzado",
+  },
+  "Não enviei: orçamento de IA esgotado": { es: "No envié: presupuesto de IA agotado" },
+  "Não enviei: número ainda em aquecimento": { es: "No envié: número todavía en calentamiento" },
+  "Não enviei: a mensagem prometia algo que não posso garantir": {
+    es: "No envié: el mensaje prometía algo que no puedo garantizar",
+  },
+  "Não enviei: a mensagem usava termos internos do sistema que o cliente não deve ler": {
+    es: "No envié: el mensaje usaba términos internos del sistema que el cliente no debe leer",
+  },
+  "A sugestão de retomar contato venceu sem decisão": {
+    es: "La sugerencia de retomar contacto venció sin decisión",
+  },
+  "primeiro checkpoint sem compromisso, objeção ou próxima ação": {
+    es: "primer checkpoint sin compromiso, objeción o próxima acción",
+  },
+  "só reescreveu o resumo — não muda o que fazer a seguir": {
+    es: "solo reescribió el resumen — no cambia lo que hacer a continuación",
+  },
+  "Sem resposta além do prazo deste estágio": { es: "Sin respuesta más allá del plazo de esta etapa" },
+  "Parado há muito tempo — sem resposta": { es: "Detenido hace mucho tiempo — sin respuesta" },
+  "Voltou a ter movimento": { es: "Volvió a tener movimiento" },
+  "Essa etapa não faz parte deste funil. Recarregue a página e tente de novo.": {
+    es: "Esa etapa no forma parte de este embudo. Recarga la página e intenta de nuevo.",
+  },
+  "Etapa não encontrada.": { es: "Etapa no encontrada." },
+  "Uma pessoa devolveu o negócio para onde ele estava antes do assistente": {
+    es: "Una persona devolvió el negocio a donde estaba antes del asistente",
+  },
+  "Uma pessoa levou o negócio para outra etapa, diferente da que o assistente escolheu": {
+    es: "Una persona llevó el negocio a otra etapa, distinta de la que el asistente eligió",
+  },
+
+  // ─── Conversations + Messages: handlers compartidos REST/MCP ───
+  "Contato bloqueou o atendimento.": { es: "El contacto bloqueó la atención." },
+  "Contato anonimizado não pode ser compartilhado.": {
+    es: "Un contacto anonimizado no puede ser compartido.",
+  },
+  "Contato sem telefone para envio como cartão.": {
+    es: "El contacto no tiene teléfono para enviarlo como tarjeta.",
+  },
+  "Telefone inválido para envio como cartão.": { es: "Teléfono inválido para enviarlo como tarjeta." },
+  "Informe metadata.shared_contact_id ou metadata.shared_contact com telefone.": {
+    es: "Indica metadata.shared_contact_id o metadata.shared_contact con teléfono.",
+  },
+  "A mensagem citada não é desta conversa.": {
+    es: "El mensaje citado no es de esta conversación.",
+  },
+  "Este número foi excluído da Central de Conexões.": {
+    es: "Este número fue eliminado de la Central de Conexiones.",
+  },
+  "Contato sem telefone para envio WhatsApp.": {
+    es: "El contacto no tiene teléfono para el envío por WhatsApp.",
+  },
+  "No active organization.": { es: "No hay organización activa." },
+  "Nenhum agente publicado para sugerir resposta.": {
+    es: "Ningún agente publicado para sugerir respuesta.",
+  },
+  "Contato bloqueado/anonimizado.": { es: "Contacto bloqueado/anonimizado." },
+  "A IA não gerou um rascunho.": { es: "La IA no generó un borrador." },
+  "Erro ao gerar rascunho.": { es: "Error al generar borrador." },
+  "Não é possível rebaixar o último admin do tenant.": {
+    es: "No es posible degradar al último admin del tenant.",
+  },
+  "Já é membro desta organização.": { es: "Ya es miembro de esta organización." },
+
+  // ─── lib/mcp/tools/pacotes.ts (níveis de risco de uma capacidade) ───
+  "Só consulta": { es: "Solo consulta" },
+  "Altera dados": { es: "Modifica datos" },
+  "Efeito que não dá para desfazer": { es: "Efecto que no se puede deshacer" },
+  "O agente apenas lê a informação. Nada muda no sistema.": {
+    es: "El agente solo lee la información. Nada cambia en el sistema.",
+  },
+  "O agente muda alguma coisa no sistema. Você consegue ver o que mudou e desfazer pela tela.": {
+    es: "El agente cambia algo en el sistema. Puedes ver qué cambió y deshacerlo desde la pantalla.",
+  },
+  "O agente faz algo que sai do sistema ou não volta atrás — como falar com o cliente de verdade. Precisa ser ligado por você, uma a uma.": {
+    es: "El agente hace algo que sale del sistema o no tiene vuelta atrás — como hablar con el cliente de verdad. Tiene que ser activado por ti, una por una.",
+  },
+
+  // ─── lib/mcp/tools/catalogo/*.ts (capacidades do agente — rotulo/explicacao/oQueToca) ───
+  "Abre a ficha completa de um cliente: dados de contato, histórico e por onde ele chegou até a empresa.": {
+    es: "Abre la ficha completa de un cliente: datos de contacto, historial y por dónde llegó hasta la empresa.",
+  },
+  "Abre os detalhes de uma conversa: quem está atendendo, marcadores aplicados e há quanto tempo o cliente espera.": {
+    es: "Abre los detalles de una conversación: quién está atendiendo, etiquetas aplicadas y hace cuánto tiempo espera el cliente.",
+  },
+  "Abre os detalhes de uma oportunidade de venda: etapa atual, responsável, marcadores e valor do negócio.": {
+    es: "Abre los detalles de una oportunidad de venta: etapa actual, responsable, etiquetas y valor del negocio.",
+  },
+  "Abre um chamado e mostra tudo que aconteceu nele, inclusive a decisão que a pessoa tomou e o texto que ela escreveu ao decidir.": {
+    es: "Abre un caso y muestra todo lo que pasó en él, incluida la decisión que la persona tomó y el texto que escribió al decidir.",
+  },
+  "Abre um endereço novo para o site da empresa mandar contatos direto para um funil. A partir daí ele passa a receber gente de fora sozinho.": {
+    es: "Abre una dirección nueva para que el sitio de la empresa mande contactos directo a un embudo. A partir de ahí empieza a recibir gente de afuera solo.",
+  },
+  "Acrescenta uma coluna nova no fim do funil, quando o jeito de trabalhar da empresa tem um passo que ainda não está no quadro.": {
+    es: "Agrega una columna nueva al final del embudo, cuando la forma de trabajar de la empresa tiene un paso que todavía no está en el tablero.",
+  },
+  "Adiciona ou remove marcadores numa conversa, cliente ou oportunidade, para organizar e filtrar a operação depois.": {
+    es: "Agrega o quita etiquetas en una conversación, cliente u oportunidad, para organizar y filtrar la operación después.",
+  },
+  "Agenda da equipe": { es: "Agenda del equipo" },
+  "Agendar um retorno para o cliente": { es: "Agendar un retorno para el cliente" },
+  "Altera dados de uma oportunidade de venda: valor do negócio, responsável e informações colhidas na conversa.": {
+    es: "Modifica datos de una oportunidad de venta: valor del negocio, responsable e información recogida en la conversación.",
+  },
+  "Anota o que aconteceu num horário que já passou: a pessoa foi atendida, ou não apareceu.": {
+    es: "Anota lo que pasó en un horario que ya pasó: la persona fue atendida, o no se presentó.",
+  },
+  "Anotar uma regra aprendida": { es: "Anotar una regla aprendida" },
+  "Aplicar marcadores": { es: "Aplicar etiquetas" },
+  "Aprendizado do assistente": { es: "Aprendizaje del asistente" },
+  "Arquivar uma etapa do funil": { es: "Archivar una etapa del embudo" },
+  "Base de conhecimento": { es: "Base de conocimiento" },
+  "Cadastro de clientes": { es: "Registro de clientes" },
+  "Cancelar um retorno agendado": { es: "Cancelar un retorno agendado" },
+  "Catálogo da loja": { es: "Catálogo de la tienda" },
+  "Chamados para uma pessoa": { es: "Casos para una persona" },
+  "Chamar um atendente humano": { es: "Llamar a un agente humano" },
+  "Compras do cliente": { es: "Compras del cliente" },
+  "Confirma o horário que estava esperando a resposta da pessoa, para a equipe saber que ela vem mesmo.": {
+    es: "Confirma el horario que estaba esperando la respuesta de la persona, para que el equipo sepa que va a venir de verdad.",
+  },
+  "Confirmar um horário combinado": { es: "Confirmar un horario acordado" },
+  "Consultar as regras da empresa": { es: "Consultar las reglas de la empresa" },
+  "Consultar o que a empresa já sabe": { es: "Consultar lo que la empresa ya sabe" },
+  "Cria uma sugestão de retomar o contato com um cliente que esfriou, para uma pessoa aprovar antes de qualquer envio.": {
+    es: "Crea una sugerencia de retomar el contacto con un cliente que se enfrió, para que una persona la apruebe antes de cualquier envío.",
+  },
+  "Criar etapa no funil": { es: "Crear etapa en el embudo" },
+  "Criar uma entrada automática de contatos": { es: "Crear una entrada automática de contactos" },
+  "Deixa escrito no chamado o que mudou desde que ele foi aberto, para a pessoa que for atender não precisar começar do zero.": {
+    es: "Deja escrito en el caso lo que cambió desde que se abrió, para que la persona que lo atienda no tenga que empezar de cero.",
+  },
+  "Desmarca um horário combinado e devolve esse horário para outra pessoa poder pegar, o que não dá para desfazer.": {
+    es: "Cancela un horario acordado y devuelve ese horario para que otra persona pueda tomarlo — esto no se puede deshacer.",
+  },
+  "Desmarca um retorno que ainda não aconteceu, para o agente não insistir com quem já respondeu.": {
+    es: "Cancela un retorno que todavía no pasó, para que el agente no insista con quien ya respondió.",
+  },
+  "Desmarcar um compromisso": { es: "Cancelar un compromiso" },
+  "Devolve a conversa para o atendimento automático depois que uma pessoa atendeu, levando junto o que ficou combinado com o cliente. Só uma pessoa pode acionar.": {
+    es: "Devuelve la conversación a la atención automática después de que una persona atendió, llevando lo que quedó acordado con el cliente. Solo una persona puede activarlo.",
+  },
+  "Direcionar conversa para alguém": { es: "Dirigir conversación a alguien" },
+  "Encerrar o negócio como ganho ou perdido": { es: "Cerrar el negocio como ganado o perdido" },
+  "Encerrar um chamado com o desfecho": { es: "Cerrar un caso con el desenlace" },
+  "Encontra um cliente pelo nome, telefone ou e-mail, para o agente saber com quem está falando antes de responder.": {
+    es: "Encuentra un cliente por el nombre, teléfono o email, para que el agente sepa con quién está hablando antes de responder.",
+  },
+  "Entrada automática de contatos": { es: "Entrada automática de contactos" },
+  "Envia uma mensagem de WhatsApp para o cliente. Ele recebe de verdade, no celular dele, e não dá para desfazer.": {
+    es: "Envía un mensaje de WhatsApp al cliente. Lo recibe de verdad, en su celular, y no se puede deshacer.",
+  },
+  "Equipe de atendimento": { es: "Equipo de atención" },
+  "Faz uma origem voltar a receber contatos, ou parar. Desligada, o formulário do seu site continua no ar e ninguém do outro lado é avisado.": {
+    es: "Hace que una fuente vuelva a recibir contactos, o que se detenga. Apagada, el formulario de tu sitio sigue en línea y nadie del otro lado es avisado.",
+  },
+  "Faz uma regra passar a rodar sozinha, sempre que o gatilho dela acontecer, ou parar de rodar. Ligada, ela pode falar com clientes de verdade.": {
+    es: "Hace que una regla empiece a correr sola, cada vez que su gatillo ocurra, o que deje de correr. Encendida, puede hablar con clientes de verdad.",
+  },
+  "Fecha a oportunidade dizendo se ela foi ganha ou perdida e por quê, para o que já acabou parar de ser cobrado.": {
+    es: "Cierra la oportunidad diciendo si fue ganada o perdida y por qué, para que lo que ya terminó deje de aparecer pendiente.",
+  },
+  "Fecha um chamado deixando registrado como ele terminou, para ele parar de ocupar a fila de quem atende. Não dá para reabrir por aqui.": {
+    es: "Cierra un caso dejando registrado cómo terminó, para que deje de ocupar la fila de quien atiende. No se puede reabrir por aquí.",
+  },
+  "Funil de vendas": { es: "Embudo de ventas" },
+  "Guarda um aprendizado que vale para todos os atendimentos, marcado como escrito pelo assistente para você distinguir do que anotou.": {
+    es: "Guarda un aprendizaje que vale para todas las atenciones, marcado como escrito por el asistente para que distingas de lo que tú anotaste.",
+  },
+  "Interrompe o atendimento automático e chama uma pessoa, entregando um resumo do que já aconteceu na conversa.": {
+    es: "Interrumpe la atención automática y llama a una persona, entregando un resumen de lo que ya pasó en la conversación.",
+  },
+  "Ler o histórico da conversa": { es: "Leer el historial de la conversación" },
+  "Ler um chamado e o que a pessoa decidiu": { es: "Leer un caso y lo que la persona decidió" },
+  "Ligar ou desligar uma entrada de contatos": { es: "Activar o desactivar una entrada de contactos" },
+  "Ligar ou desligar uma regra automática": { es: "Activar o desactivar una regla automática" },
+  "Lista as oportunidades abertas que passaram do prazo sem movimento, das mais críticas para as menos urgentes — e, junto, as pessoas que estão esperando sem que nada esteja marcado para acontecer.": {
+    es: "Lista las oportunidades abiertas que pasaron el plazo sin movimiento, de las más críticas a las menos urgentes — y, junto, las personas que están esperando sin que nada esté marcado para pasar.",
+  },
+  "Lista as oportunidades de venda de um funil, com a etapa em que cada uma está e quem é o responsável por ela.": {
+    es: "Lista las oportunidades de venta de un embudo, con la etapa en la que está cada una y quién es el responsable de ella.",
+  },
+  "Lista as pessoas do time e o que cada uma pode fazer aqui dentro, para o agente saber para quem passar um atendimento.": {
+    es: "Lista a las personas del equipo y lo que cada una puede hacer aquí dentro, para que el agente sepa a quién pasarle una atención.",
+  },
+  "Lista os assuntos que já foram passados para uma pessoa resolver, com o estado de cada um, para o agente não pedir duas vezes a mesma coisa.": {
+    es: "Lista los asuntos que ya fueron pasados a una persona para resolver, con el estado de cada uno, para que el agente no pida dos veces la misma cosa.",
+  },
+  "Lista os compromissos com hora marcada de um cliente ou de um dia, com a situação de cada um: marcado, realizado ou desmarcado.": {
+    es: "Lista los compromisos con hora marcada de un cliente o de un día, con la situación de cada uno: marcado, realizado o cancelado.",
+  },
+  "Lista os textos que a empresa já escreveu para responder as situações de sempre, com o atalho de cada um.": {
+    es: "Lista los textos que la empresa ya escribió para responder a las situaciones de siempre, con el atajo de cada uno.",
+  },
+  "Listar conversas": { es: "Listar conversaciones" },
+  "Lê as mensagens já trocadas com o cliente, para o agente responder sem pedir que ele repita o que já contou.": {
+    es: "Lee los mensajes ya intercambiados con el cliente, para que el agente responda sin pedirle que repita lo que ya contó.",
+  },
+  "Lê as políticas e combinados que valem para todo atendimento, para o assistente seguir a regra da casa em vez de inventar uma.": {
+    es: "Lee las políticas y acuerdos que valen para toda atención, para que el asistente siga la regla de la casa en vez de inventar una.",
+  },
+  "Marca um horário para o agente voltar a falar com o cliente, para que a conversa não morra sem resposta.": {
+    es: "Marca un horario para que el agente vuelva a hablar con el cliente, para que la conversación no muera sin respuesta.",
+  },
+  "Marcar consulta ou sessão": { es: "Marcar consulta o sesión" },
+  "Mostra as colunas de um funil na ordem em que aparecem no quadro, para o agente saber onde pode colocar cada negócio.": {
+    es: "Muestra las columnas de un embudo en el orden en que aparecen en el tablero, para que el agente sepa dónde puede poner cada negocio.",
+  },
+  "Mostra as conversas em andamento, quem está cuidando de cada uma e a posição de cada cliente na fila de espera.": {
+    es: "Muestra las conversaciones en curso, quién está a cargo de cada una y la posición de cada cliente en la fila de espera.",
+  },
+  "Mostra as melhorias que o sistema sugeriu a partir dos atendimentos, com o motivo de cada uma. Aprovar continua sendo decisão sua.": {
+    es: "Muestra las mejoras que el sistema sugirió a partir de las atenciones, con el motivo de cada una. Aprobar sigue siendo decisión tuya.",
+  },
+  "Mostra o que a empresa deixou configurado para acontecer sozinho, o que dispara cada regra e se ela está ligada.": {
+    es: "Muestra lo que la empresa dejó configurado para pasar solo, qué dispara cada regla y si está activada.",
+  },
+  "Mostra o que este cliente já comprou, quanto pagou e como está a entrega, para o assistente não prometer prazo no escuro nem repetir uma oferta já aceita.": {
+    es: "Muestra lo que este cliente ya compró, cuánto pagó y cómo va la entrega, para que el asistente no prometa un plazo a ciegas ni repita una oferta ya aceptada.",
+  },
+  "Mostra o que rodou sozinho nos últimos tempos e o que deu errado, para descobrir o que parou de funcionar sem ninguém perceber.": {
+    es: "Muestra lo que corrió solo en los últimos tiempos y lo que salió mal, para descubrir qué dejó de funcionar sin que nadie lo notara.",
+  },
+  "Mostra os funis de venda existentes e suas etapas, para o agente saber onde pode colocar uma oportunidade.": {
+    es: "Muestra los embudos de venta existentes y sus etapas, para que el agente sepa dónde puede poner una oportunidad.",
+  },
+  "Mostra os horários em que um atendente pode receber, já descontando as folgas dele, o que ele tem marcado e os compromissos da agenda pessoal.": {
+    es: "Muestra los horarios en que un agente puede recibir, ya descontando sus días libres, lo que tiene marcado y los compromisos de la agenda personal.",
+  },
+  "Mostra os retornos combinados com o cliente: o que está marcado, o que já aconteceu e o que foi desmarcado.": {
+    es: "Muestra los retornos acordados con el cliente: lo que está marcado, lo que ya pasó y lo que fue cancelado.",
+  },
+  "Mostra os tipos de atendimento que dá para marcar, quanto cada um dura e como é feito, para o atendente de IA falar do que existe de verdade.": {
+    es: "Muestra los tipos de atención que se pueden marcar, cuánto dura cada uno y cómo se hace, para que el agente de IA hable de lo que existe de verdad.",
+  },
+  "Mostra os últimos contatos que entraram por uma origem e quais informações vieram, para descobrir por que algo não chegou como devia.": {
+    es: "Muestra los últimos contactos que entraron por una fuente y qué información llegó, para descubrir por qué algo no llegó como debía.",
+  },
+  "Mostra por onde chegam sozinhos os contatos vindos do site ou de outro sistema, se cada uma está ligada e quando recebeu pela última vez.": {
+    es: "Muestra por dónde llegan solos los contactos que vienen del sitio o de otro sistema, si cada una está activada y cuándo recibió por última vez.",
+  },
+  "Mostra quais marcadores a empresa já usa e em quantas conversas, para o agente reaproveitar em vez de inventar outro parecido.": {
+    es: "Muestra qué etiquetas usa la empresa y en cuántas conversaciones, para que el agente las reutilice en vez de inventar otra parecida.",
+  },
+  "Mostra quais materiais estão no acervo da empresa e se foram processados, para saber se faltou conteúdo ou se algo falhou.": {
+    es: "Muestra qué materiales están en el acervo de la empresa y si fueron procesados, para saber si faltó contenido o si algo falló.",
+  },
+  "Mostra quais pessoas da equipe estão em atendimento neste momento, quantas conversas cada uma já tem e quem ainda tem espaço para receber mais uma.": {
+    es: "Muestra qué personas del equipo están en atención en este momento, cuántas conversaciones tiene cada una y quién todavía tiene espacio para recibir una más.",
+  },
+  "Mostra quantas pessoas estão esperando atendimento agora e há quanto tempo, para priorizar quem espera mais.": {
+    es: "Muestra cuántas personas están esperando atención ahora y hace cuánto tiempo, para priorizar a quien espera más.",
+  },
+  "Mostra quem pediu para exportar ou apagar os próprios dados e qual o prazo, para o assistente parar de insistir com quem pediu para sair.": {
+    es: "Muestra quién pidió exportar o borrar sus propios datos y cuál es el plazo, para que el asistente deje de insistir con quien pidió salir.",
+  },
+  "Move a oportunidade para outra etapa do funil, registrando o avanço da negociação ou a perda do negócio.": {
+    es: "Mueve la oportunidad a otra etapa del embudo, registrando el avance de la negociación o la pérdida del negocio.",
+  },
+  "Move um compromisso já marcado para outro horário, mantendo o mesmo cliente e o mesmo tipo de atendimento.": {
+    es: "Mueve un compromiso ya marcado a otro horario, manteniendo el mismo cliente y el mismo tipo de atención.",
+  },
+  "Organização da operação": { es: "Organización de la operación" },
+  "Passa a conversa para um atendente, transfere para outra pessoa ou devolve o cliente para a fila de espera.": {
+    es: "Pasa la conversación a un agente, la transfiere a otra persona o devuelve al cliente a la fila de espera.",
+  },
+  "Pega uma resposta pronta e troca as lacunas pelos dados do cliente, avisando se sobrou alguma sem preencher. Não envia nada.": {
+    es: "Toma una respuesta lista y cambia los espacios en blanco por los datos del cliente, avisando si quedó alguno sin llenar. No envía nada.",
+  },
+  "Preencher uma resposta pronta": { es: "Completar una respuesta lista" },
+  "Privacidade e dados do cliente": { es: "Privacidad y datos del cliente" },
+  "Procura a resposta nos materiais que você cadastrou, para o assistente responder com a informação da sua empresa em vez de inventar.": {
+    es: "Busca la respuesta en los materiales que registraste, para que el asistente responda con la información de tu empresa en vez de inventar.",
+  },
+  "Procura um produto no catálogo da loja e devolve o preço exato e o que está disponível, para o assistente responder com o valor cadastrado em vez de estimar.": {
+    es: "Busca un producto en el catálogo de la tienda y devuelve el precio exacto y lo que está disponible, para que el asistente responda con el valor registrado en vez de estimar.",
+  },
+  "Quando o cliente diz o e-mail, o nome ou o telefone dele na conversa, guarda essa informação para uma pessoa conferir antes de entrar na ficha.": {
+    es: "Cuando el cliente dice su email, nombre o teléfono en la conversación, guarda esa información para que una persona la confirme antes de que entre en la ficha.",
+  },
+  "Registra uma nova oportunidade de venda no funil, para que o interesse demonstrado pelo cliente não se perca.": {
+    es: "Registra una nueva oportunidad de venta en el embudo, para que el interés demostrado por el cliente no se pierda.",
+  },
+  "Registrar o que aconteceu num chamado": { es: "Registrar lo que pasó en un caso" },
+  "Registrar se a pessoa veio ou faltou": { es: "Registrar si la persona vino o faltó" },
+  "Regras automáticas": { es: "Reglas automáticas" },
+  "Regras da empresa": { es: "Reglas de la empresa" },
+  "Remarcar um compromisso": { es: "Reprogramar un compromiso" },
+  "Renomear ou reordenar uma etapa": { es: "Renombrar o reordenar una etapa" },
+  "Reserva um horário do atendente para receber o cliente. A pessoa passa a contar com esse horário, então não é um registro interno.": {
+    es: "Reserva un horario del agente para recibir al cliente. La persona pasa a contar con ese horario, así que no es un registro interno.",
+  },
+  "Respostas prontas": { es: "Respuestas listas" },
+  "Retomar o atendimento automático": { es: "Retomar la atención automática" },
+  "Retornos e acompanhamento": { es: "Retornos y seguimiento" },
+  "Sugerir retomar contato com quem sumiu": { es: "Sugerir retomar contacto con quien desapareció" },
+  "Time de atendimento": { es: "Equipo de atención" },
+  "Tira uma coluna do quadro e leva os negócios que estavam nela para outra coluna que você escolher. O histórico continua guardado.": {
+    es: "Saca una columna del tablero y lleva los negocios que estaban en ella a otra columna que elijas. El historial se sigue guardando.",
+  },
+  "Troca o nome de uma coluna do funil, muda o lugar dela na ordem ou define em qual delas o negócio é dado como fechado ou perdido.": {
+    es: "Cambia el nombre de una columna del embudo, cambia su lugar en el orden o define en cuál de ellas el negocio se da como cerrado o perdido.",
+  },
+  "Ver a fila de atendimento": { es: "Ver la fila de atención" },
+  "Ver as entradas automáticas de contatos": { es: "Ver las entradas automáticas de contactos" },
+  "Ver as regras automáticas": { es: "Ver las reglas automáticas" },
+  "Ver as respostas prontas": { es: "Ver las respuestas listas" },
+  "Ver horários livres na agenda": { es: "Ver horarios libres en la agenda" },
+  "Ver o que a empresa atende": { es: "Ver lo que la empresa atiende" },
+  "Ver o que as regras dispararam": { es: "Ver lo que las reglas dispararon" },
+  "Ver o que chegou por uma entrada": { es: "Ver lo que llegó por una entrada" },
+  "Ver os chamados em aberto": { es: "Ver los casos abiertos" },
+  "Ver os compromissos marcados": { es: "Ver los compromisos marcados" },
+  "Ver os marcadores em uso": { es: "Ver las etiquetas en uso" },
+  "Ver os materiais cadastrados": { es: "Ver los materiales registrados" },
+  "Ver os retornos de um cliente": { es: "Ver los retornos de un cliente" },
+  "Ver pedidos de privacidade": { es: "Ver pedidos de privacidad" },
+  "Ver quem esfriou e quem ficou sem próximo passo": { es: "Ver quién se enfrió y quién se quedó sin próximo paso" },
+  "Ver quem pode assumir agora": { es: "Ver quién puede asumir ahora" },
+  "Ver quem trabalha na empresa": { es: "Ver quién trabaja en la empresa" },
+  "Ver uma conversa": { es: "Ver una conversación" },
+
+  // ─── lib/ai/agents/uso-de-capacidades.ts (painel "Uso das capacidades") ───
+  "Capacidade removida do sistema": { es: "Capacidad eliminada del sistema" },
+  "Ligada há pouco tempo. Ainda não houve atendimento em que ela fosse útil — volte aqui depois de alguns dias.": {
+    es: "Activada hace poco tiempo. Todavía no hubo una atención en la que fuera útil — vuelve aquí dentro de unos días.",
+  },
+  "O agente usou esta capacidade sem ela estar ligada nesta configuração. Ou ela foi desligada depois de já ter sido usada, ou é o pedido de ajuda humana — esse o sistema oferece sozinho quando o repasse para uma pessoa está ativado.": {
+    es: "El agente usó esta capacidad sin que estuviera activada en esta configuración. O fue desactivada después de haber sido usada, o es el pedido de ayuda humana — ese el sistema lo ofrece solo cuando el traspaso a una persona está activado.",
+  },
+  "Só foi usada nos seus testes. Nenhum atendimento real precisou dela ainda.": {
+    es: "Solo fue usada en tus pruebas. Ninguna atención real la necesitó todavía.",
+  },
+
+  // ─── lib/ai/guardrails/lista-de-conferencia.ts (Painel de Segurança) ───
+  "Não prometer checar a agenda sem checar de verdade": {
+    es: "No prometer revisar la agenda sin revisarla de verdad",
+  },
+  "Se a pessoa respondeu STOP, SAIR ou pediu para não receber mais, nada é enviado a ela.": {
+    es: "Si la persona respondió STOP, SALIR o pidió no recibir más, no se le envía nada.",
+  },
+  "Contato anonimizado a pedido não recebe mensagem, e prospecção sem base legal não sai.": {
+    es: "Un contacto anonimizado a pedido no recibe mensajes, y la prospección sin base legal no sale.",
+  },
+  "Espaça as mensagens para o seu número não parecer robô e ser bloqueado pelo WhatsApp.": {
+    es: "Espacia los mensajes para que tu número no parezca un robot y sea bloqueado por WhatsApp.",
+  },
+  "Fora da janela de 24 horas, só modelo aprovado sai — é o que o próprio WhatsApp permite.": {
+    es: "Fuera de la ventana de 24 horas, solo sale una plantilla aprobada — es lo que el propio WhatsApp permite.",
+  },
+  "Evita mandar a mesma frase idêntica para muita gente, que é o padrão que denuncia disparo em massa.": {
+    es: "Evita mandar la misma frase idéntica a mucha gente, que es el patrón que delata el envío masivo.",
+  },
+  "Barra a mensagem em que o assistente inventa desconto, valor ou data de entrega.": {
+    es: "Bloquea el mensaje en el que el asistente inventa un descuento, un valor o una fecha de entrega.",
+  },
+  "Uma segunda leitura, feita por um modelo, para pegar a promessa escrita de um jeito que a regra fixa não reconhece.": {
+    es: "Una segunda lectura, hecha por un modelo, para detectar la promesa escrita de una forma que la regla fija no reconoce.",
+  },
+  "Impede o \"vou pedir para o responsável te ligar\" quando nenhum chamado foi aberto de verdade.": {
+    es: "Impide el \"le voy a pedir al responsable que te llame\" cuando ningún caso fue abierto de verdad.",
+  },
+  "Barra nome de ferramenta, nome de tabela e código de erro na mensagem que o cliente lê.": {
+    es: "Bloquea nombre de herramienta, nombre de tabla y código de error en el mensaje que lee el cliente.",
+  },
+  "Barra o \"vou verificar/confirmar o horário\" quando o assistente ainda não chamou a ferramenta de agenda nesta resposta — a promessa só sai depois de checar de verdade.": {
+    es: "Bloquea el \"voy a verificar/confirmar el horario\" cuando el asistente todavía no llamó a la herramienta de agenda en esta respuesta — la promesa solo sale después de revisar de verdad.",
+  },
+  "Se o cliente pergunta se está falando com um robô, a resposta não pode enganar.": {
+    es: "Si el cliente pregunta si está hablando con un robot, la respuesta no puede engañar.",
+  },
+  "Lê a mensagem que chega e reconhece quem está tentando fazer o assistente ignorar as suas instruções.": {
+    es: "Lee el mensaje que llega y reconoce a quien está intentando hacer que el asistente ignore sus instrucciones.",
+  },
+  "Quem pediu para parar tem o direito de ser deixado em paz — e insistir é infração, não estratégia.": {
+    es: "Quien pidió parar tiene el derecho de que lo dejen en paz — e insistir es infracción, no estrategia.",
+  },
+  "É obrigação legal. Apagar dados é irreversível por desenho, e escrever para quem foi apagado desfaria isso.": {
+    es: "Es obligación legal. Borrar datos es irreversible por diseño, y escribirle a quien fue borrado deshacería eso.",
+  },
+  "É o que impede seu número de ser bloqueado — e o número é o seu negócio.": {
+    es: "Es lo que impide que tu número sea bloqueado — y el número es tu negocio.",
+  },
+  "Quem impõe é o WhatsApp, não nós. Desligar aqui não libera nada: a mensagem seria recusada lá, ou cobrada.": {
+    es: "Quien lo impone es WhatsApp, no nosotros. Desactivar esto aquí no libera nada: el mensaje sería rechazado allá, o cobrado.",
+  },
+  "Texto idêntico em massa é o gatilho de spam do WhatsApp — mesmo risco do ritmo de envio.": {
+    es: "El texto idéntico en masa es el gatillo de spam de WhatsApp — mismo riesgo que el ritmo de envío.",
+  },
+  "Uma promessa escrita obriga o seu negócio. A conferência é uma regra fixa, não custa nada e não tem troca a oferecer.": {
+    es: "Una promesa escrita obliga a tu negocio. La verificación es una regla fija, no cuesta nada y no tiene nada que ofrecer a cambio.",
+  },
+  "É promessa que só você pode cumprir, e o cliente fica esperando. Regra fixa, sem custo.": {
+    es: "Es una promesa que solo tú puedes cumplir, y el cliente se queda esperando. Regla fija, sin costo.",
+  },
+  "É a conferência que derrubou o vazamento medido de 30% para zero. Desligar reabre exatamente o defeito que ela existe para fechar.": {
+    es: "Es la verificación que bajó la fuga medida del 30% a cero. Desactivarla reabre exactamente el defecto que existe para cerrar.",
+  },
+  "É a mesma promessa vazia do 'vou pedir pro responsável', só que sobre agenda: o cliente fica esperando uma confirmação que nunca foi checada. Regra fixa, sem custo.": {
+    es: "Es la misma promesa vacía del 'le voy a pedir al responsable', solo que sobre la agenda: el cliente se queda esperando una confirmación que nunca fue revisada. Regla fija, sin costo.",
+  },
+  "Esconder que é um assistente é enganar o cliente.": {
+    es: "Ocultar que es un asistente es engañar al cliente.",
+  },
+  "+1 consulta ao modelo por mensagem enviada": { es: "+1 consulta al modelo por mensaje enviado" },
+  "+1 consulta ao modelo por mensagem recebida": { es: "+1 consulta al modelo por mensaje recibido" },
 
   // ─── Relatório de atividades (/app/activities) ───
   //
@@ -6775,6 +7735,11 @@ export const DICIONARIO: Traducoes = {
   "A lista mostra só os mais recentes.": { es: "La lista muestra solo los más recientes." },
   "No período houve": { es: "En el período hubo" },
   "acontecimentos.": { es: "sucesos." },
+
+  // ─── lib/ai/pontos/resolver.ts (avisos do painel de Provedores de IA) ───
+  "Este ponto usa o modelo definido na versão publicada do agente; a escolha do painel não se aplica.": {
+    es: "Este punto usa el modelo definido en la versión publicada del agente; la elección del panel no se aplica.",
+  },
 };
 
 /**

--- a/lib/i18n/dicionario.ts
+++ b/lib/i18n/dicionario.ts
@@ -6798,8 +6798,16 @@ export const DICIONARIO: Traducoes = {
   "sem controle de estoque": { es: "sin control de stock" },
   // Mensajes de error de importación de planilha (lib/catalogo/planilha.ts)
   "A planilha está vazia.": { es: "La planilla está vacía." },
+  // Uma frase por combinação do que falta: a recusa NOMEIA a coluna ausente, e
+  // pedir a coluna que a pessoa já tem é o que faz ela desistir da importação.
   "A planilha precisa de uma coluna de nome e de preço. Encontrei: ": {
     es: "La planilla necesita una columna de nombre y de precio. Encontré: ",
+  },
+  "A planilha precisa de uma coluna de nome. Encontrei: ": {
+    es: "La planilla necesita una columna de nombre. Encontré: ",
+  },
+  "A planilha precisa de uma coluna de preço. Encontrei: ": {
+    es: "La planilla necesita una columna de precio. Encontré: ",
   },
   "sem nome do produto": { es: "sin nombre del producto" },
   "preço não reconhecido (": { es: "precio no reconocido (" },

--- a/lib/leads/encerramento.ts
+++ b/lib/leads/encerramento.ts
@@ -202,10 +202,9 @@ export async function encerraDemanda(
     // O rótulo do tipo já diz "Demanda encerrada" na tela; o reason acrescenta o
     // DESFECHO e, na perda, o motivo — repetir o rótulo aqui deixaria a linha
     // com a mesma frase duas vezes (ver `motivoLegivel` em retorno-crm.ts).
-    reason:
-      input.desfecho === "won"
-        ? traduzir("Ganho", ctx.idioma ?? "pt-BR")
-        : `${traduzir("Perdido —", ctx.idioma ?? "pt-BR")} ${input.motivo}`,
+    // Canônico em português: quem traduz é a LEITURA (`t(item.reason)`). Ver o
+    // bloco "vocabulario de dominio persistido" em `lib/i18n/dicionario.ts`.
+    reason: input.desfecho === "won" ? "Ganho" : `Perdido — ${input.motivo}`,
     payload: {
       desfecho: input.desfecho,
       from_stage_id: (lead as { stage_id: string }).stage_id,

--- a/lib/leads/encerramento.ts
+++ b/lib/leads/encerramento.ts
@@ -23,6 +23,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Actor, HandlerCtx } from "@/lib/api/handlers/types";
 import { ApiError } from "@/lib/api/types";
 import { audit } from "@/lib/audit";
+import { traduzir } from "@/lib/i18n/dicionario";
 import { emitLeadActivity } from "@/lib/leads/activity-emitter";
 import { registraFalhaDeAtividade } from "@/lib/leads/activity-write-failure";
 
@@ -80,7 +81,7 @@ export async function encerraDemanda(
       "validation_failed",
       undefined,
       ctx.requestId,
-      "Informe o motivo da perda.",
+      traduzir("Informe o motivo da perda.", ctx.idioma ?? "pt-BR"),
     );
   }
 
@@ -95,7 +96,13 @@ export async function encerraDemanda(
     throw new ApiError(500, "internal_error", undefined, ctx.requestId, selErr.message);
   }
   if (!lead) {
-    throw new ApiError(404, "not_found", undefined, ctx.requestId, "Lead não encontrado.");
+    throw new ApiError(
+      404,
+      "not_found",
+      undefined,
+      ctx.requestId,
+      traduzir("Lead não encontrado.", ctx.idioma ?? "pt-BR"),
+    );
   }
 
   if ((lead as { status: string }).status === input.desfecho) {
@@ -123,9 +130,12 @@ export async function encerraDemanda(
       input.desfecho === "won" ? "pipeline_no_won_stage" : "pipeline_no_lost_stage",
       undefined,
       ctx.requestId,
-      input.desfecho === "won"
-        ? "Pipeline não tem stage de fechamento como ganho."
-        : "Pipeline não tem stage de fechamento como perda.",
+      traduzir(
+        input.desfecho === "won"
+          ? "Pipeline não tem stage de fechamento como ganho."
+          : "Pipeline não tem stage de fechamento como perda.",
+        ctx.idioma ?? "pt-BR",
+      ),
     );
   }
 
@@ -192,7 +202,10 @@ export async function encerraDemanda(
     // O rótulo do tipo já diz "Demanda encerrada" na tela; o reason acrescenta o
     // DESFECHO e, na perda, o motivo — repetir o rótulo aqui deixaria a linha
     // com a mesma frase duas vezes (ver `motivoLegivel` em retorno-crm.ts).
-    reason: input.desfecho === "won" ? "Ganho" : `Perdido — ${input.motivo}`,
+    reason:
+      input.desfecho === "won"
+        ? traduzir("Ganho", ctx.idioma ?? "pt-BR")
+        : `${traduzir("Perdido —", ctx.idioma ?? "pt-BR")} ${input.motivo}`,
     payload: {
       desfecho: input.desfecho,
       from_stage_id: (lead as { stage_id: string }).stage_id,

--- a/lib/leads/planilha.test.ts
+++ b/lib/leads/planilha.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { lerPlanilhaDeLeads } from "./planilha";
+
+/**
+ * `traduzir()` real só troca a CHAVE que bate byte a byte com uma entrada do
+ * dicionário; o resto degrada para o próprio texto. Ver o comentário gêmeo em
+ * `lib/catalogo/planilha.test.ts` — de lá veio o bug real que motivou este
+ * arquivo: um parêntese de fechamento colado DENTRO da chave traduzida não bate
+ * com a entrada do dicionário (que não tem o parêntese), e a mensagem sai meio
+ * em português. Um mock que traduz QUALQUER string não pega esse descasamento.
+ */
+const DICIONARIO_FAKE: Record<string, string> = {
+  "A planilha está vazia.": "LA PLANILLA ESTÁ VACÍA.",
+  "A planilha precisa de uma coluna com o nome do negócio ou do contato. Encontrei: ":
+    "LA PLANILLA NECESITA UNA COLUMNA CON EL NOMBRE DEL NEGOCIO O DEL CONTACTO. ENCONTRÉ: ",
+  "nenhuma coluna": "NINGUNA COLUMNA",
+  "sem nome do negócio nem do contato": "SIN NOMBRE DEL NEGOCIO NI DEL CONTACTO",
+  "valor não reconhecido (": "VALOR NO RECONOCIDO (",
+  " — escreva assim: 1.200,00": " — ESCRÍBALO ASÍ: 1.200,00",
+  "telefone não reconhecido (": "TELÉFONO NO RECONOCIDO (",
+  " — o negócio entrou sem contato": " — EL NEGOCIO ENTRÓ SIN CONTACTO",
+};
+const gritar = (texto: string): string => DICIONARIO_FAKE[texto] ?? texto;
+
+describe("lerPlanilhaDeLeads — mensagens de erro passam por t()", () => {
+  it("planilha vazia", () => {
+    const resultado = lerPlanilhaDeLeads("", gritar);
+    expect(resultado).toEqual({ erro: "LA PLANILLA ESTÁ VACÍA." });
+  });
+
+  it("sem coluna de nome nem de contato", () => {
+    const csv = "telefone\n11999999999\n";
+    const resultado = lerPlanilhaDeLeads(csv, gritar);
+    expect(resultado).toEqual({
+      erro: "LA PLANILLA NECESITA UNA COLUMNA CON EL NOMBRE DEL NEGOCIO O DEL CONTACTO. ENCONTRÉ: telefone.",
+    });
+  });
+
+  it("linha sem nome de negócio nem de contato", () => {
+    const csv = "nome,telefone\n,11999999999\n";
+    const resultado = lerPlanilhaDeLeads(csv, gritar);
+    if ("erro" in resultado) throw new Error("não deveria ser erro de planilha inteira");
+    expect(resultado.erros[0]!.motivo).toBe("SIN NOMBRE DEL NEGOCIO NI DEL CONTACTO");
+  });
+
+  it("valor não reconhecido — traduz por completo, incluindo o texto após o valor cru", () => {
+    const csv = "nome,valor\nNegócio,abc\n";
+    const resultado = lerPlanilhaDeLeads(csv, gritar);
+    if ("erro" in resultado) throw new Error("não deveria ser erro de planilha inteira");
+    expect(resultado.erros[0]!.motivo).toBe('VALOR NO RECONOCIDO ("abc") — ESCRÍBALO ASÍ: 1.200,00');
+  });
+
+  it("telefone não reconhecido — traduz por completo", () => {
+    const csv = "nome,telefone\nNegócio,abc\n";
+    const resultado = lerPlanilhaDeLeads(csv, gritar);
+    if ("erro" in resultado) throw new Error("não deveria ser erro de planilha inteira");
+    expect(resultado.erros[0]!.motivo).toBe(
+      'TELÉFONO NO RECONOCIDO ("abc") — EL NEGOCIO ENTRÓ SIN CONTACTO',
+    );
+    // Telefone ilegível não derruba a linha: o lead entra mesmo assim.
+    expect(resultado.leads).toHaveLength(1);
+  });
+
+  it("sem função t: comportamento idêntico ao de antes (degrada para o texto original)", () => {
+    const csv = "nome,valor\nNegócio,abc\n";
+    const resultado = lerPlanilhaDeLeads(csv);
+    if ("erro" in resultado) throw new Error("não deveria ser erro de planilha inteira");
+    expect(resultado.erros[0]!.motivo).toBe('valor não reconhecido ("abc") — escreva assim: 1.200,00');
+  });
+});

--- a/lib/leads/planilha.ts
+++ b/lib/leads/planilha.ts
@@ -97,9 +97,13 @@ export interface ResultadoDaLeitura {
 /** A origem gravada em `crm_leads.source` — vocabulário, não string solta. */
 export const ORIGEM_DA_PLANILHA = "importacao_planilha";
 
-export function lerPlanilhaDeLeads(conteudo: string): ResultadoDaLeitura | { erro: string } {
+export function lerPlanilhaDeLeads(
+  conteudo: string,
+  t?: (text: string) => string,
+): ResultadoDaLeitura | { erro: string } {
+  const _t = t || ((x) => x);
   const linhas = parseCsv(conteudo).filter((l) => l.some((c) => c.trim() !== ""));
-  if (linhas.length === 0) return { erro: "A planilha está vazia." };
+  if (linhas.length === 0) return { erro: _t("A planilha está vazia.") };
 
   const cabecalho = linhas[0]!;
   const mapa = new Map<number, string>();
@@ -116,8 +120,9 @@ export function lerPlanilhaDeLeads(conteudo: string): ResultadoDaLeitura | { err
   if (!campos.has("titulo") && !campos.has("contato")) {
     return {
       erro:
-        "A planilha precisa de uma coluna com o nome do negócio ou do contato. " +
-        `Encontrei: ${cabecalho.filter((c) => c.trim()).join(", ") || "nenhuma coluna"}.`,
+        _t("A planilha precisa de uma coluna com o nome do negócio ou do contato. Encontrei: ") +
+        (cabecalho.filter((c) => c.trim()).join(", ") || _t("nenhuma coluna")) +
+        ".",
     };
   }
 
@@ -138,7 +143,7 @@ export function lerPlanilhaDeLeads(conteudo: string): ResultadoDaLeitura | { err
     // com o mesmo título — indistinguíveis no funil, que é onde eles vivem.
     const title = (valor("titulo").replace(/\s+/g, " ") || nomeDoContato).slice(0, 200);
     if (title.length < 2) {
-      erros.push({ linha: numeroNaPlanilha, motivo: "sem nome do negócio nem do contato" });
+      erros.push({ linha: numeroNaPlanilha, motivo: _t("sem nome do negócio nem do contato") });
       continue;
     }
 
@@ -148,7 +153,8 @@ export function lerPlanilhaDeLeads(conteudo: string): ResultadoDaLeitura | { err
       // O valor cru entra na mensagem: quem vai corrigir precisa achar a célula.
       erros.push({
         linha: numeroNaPlanilha,
-        motivo: `valor não reconhecido ("${valorTexto}") — escreva assim: 1.200,00`,
+        motivo:
+          _t("valor não reconhecido (") + `"${valorTexto}"` + ")" + _t(" — escreva assim: 1.200,00"),
       });
       continue;
     }
@@ -161,7 +167,11 @@ export function lerPlanilhaDeLeads(conteudo: string): ResultadoDaLeitura | { err
       // aviso fica, senão o número some sem ninguém saber.
       erros.push({
         linha: numeroNaPlanilha,
-        motivo: `telefone não reconhecido ("${telefoneTexto}") — o negócio entrou sem contato`,
+        motivo:
+          _t("telefone não reconhecido (") +
+          `"${telefoneTexto}"` +
+          ")" +
+          _t(" — o negócio entrou sem contato"),
       });
     }
 

--- a/scripts/lint-channels.ts
+++ b/scripts/lint-channels.ts
@@ -195,6 +195,19 @@ const KNOWN_DEBT: { reason: string; files: string[] }[] = [
       "workers/ai-response-worker.ts",
     ],
   },
+  {
+    reason:
+      "`lib/i18n/dicionario.ts` guarda, como CHAVE de tradução, a cópia de tela " +
+      "verbatim das rotas do grupo 'Texto VISÍVEL ao usuário' acima " +
+      "(`app/api/v1/onboarding/whatsapp/session/route.ts` e pares) — a varredura " +
+      "de cobertura do espanhol centraliza toda string visível para traduzir, " +
+      "dívida já registrada incluída. Reescrever essa cópia para tirar o nome do " +
+      "provider é a MESMA mudança de comportamento observável que a entrada " +
+      "irmã já recusa fazer nas Fases 0–2 — só que agora duplicada aqui porque " +
+      "o dicionário é espelho, não fonte. Sai junto com a Fase 3 do seam, quando " +
+      "a cópia de tela na fonte deixar de nomear o provider.",
+    files: ["lib/i18n/dicionario.ts"],
+  },
 ];
 
 const DEBT = new Set(KNOWN_DEBT.flatMap((g) => g.files));

--- a/tests/unit/agenda-nao-traduz-o-nome-que-o-operador-deu.test.ts
+++ b/tests/unit/agenda-nao-traduz-o-nome-que-o-operador-deu.test.ts
@@ -1,0 +1,177 @@
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join, sep } from "node:path";
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+/**
+ * O NOME QUE O OPERADOR DEU A UM TIPO DE ATENDIMENTO NÃO É TRADUZIDO.
+ *
+ * ─── O defeito, achado por @JowaniOrantes no PR #600 ────────────────────────
+ *
+ * `calendar_appointments.title` é gravado como `input.title ?? tipo.name`
+ * (`app/api/v1/agenda/agendamentos/_handler.ts`), e `tipo.name` é o nome que o
+ * operador cadastrou em Tipos de agendamento. É dado dele, não rótulo nosso.
+ *
+ * A tradução da Agenda (commit `08257eed`, já na main antes do #600) passou
+ * esse campo por `t()`. Numa clínica com um tipo chamado "Retorno" a agenda em
+ * espanhol mostrava "Seguimiento" — palavra que não está em lugar nenhum do
+ * cadastro dela, e que ela não consegue procurar. Dado do operador sai como ele
+ * escreveu, em qualquer idioma; é a mesma regra que já vale para nome de funil,
+ * rótulo de etapa e conteúdo de mensagem.
+ *
+ * ─── O que este guarda cobre, e o que NÃO cobre ─────────────────────────────
+ *
+ * Cobre a superfície da Agenda e os DOIS campos que a `Agendamento`
+ * (`components/agenda/tipos.ts`) declara como texto livre vindo do banco:
+ * `titulo` e `tipo`. É decidível estaticamente porque os nomes são fixos.
+ *
+ * NÃO cobre a classe inteira — "`t()` aplicado a valor que veio do banco" é
+ * indecidível no geral, e a árvore tem outras chamadas `t(<valor de runtime>)`
+ * que são legítimas (vocabulário NOSSO resolvido em runtime, como
+ * `t(activityLabel(item.type))`). Separar as duas exige saber a origem do dado,
+ * que o AST não tem. Este guarda prende os dois campos onde o defeito foi
+ * medido; a classe geral é problema de outro passe.
+ */
+
+const RAIZ = join(__dirname, "..", "..");
+
+/** A superfície onde a `Agendamento` pode ser renderizada. */
+const AREAS = ["components/agenda", "app/app/agenda", "app/app/settings/tenant/agenda"];
+
+/**
+ * Dentro dessas áreas, só os arquivos que MEXEM com `Agendamento`.
+ *
+ * Sem este corte o guarda acusava `t(desfecho.titulo)` em
+ * `AvisoDaConexaoGoogle.tsx` — um `Record` de rótulos NOSSOS que por acaso tem
+ * um campo com o mesmo nome. Medido: 3 falsos positivos, todos ali. O nome do
+ * campo sozinho não diz de quem é o dado; quem diz é o tipo que o arquivo
+ * manuseia, e é isso que o `\bAgendamento\b` aproxima sem precisar do
+ * type-checker (que exigiria compilar o projeto inteiro dentro de um teste).
+ */
+const USA_O_TIPO = /\bAgendamento\b/;
+
+/**
+ * Os campos de `Agendamento` que carregam texto do operador.
+ *
+ * `quemSeraAtendido` (nome do contato) e `local` também são dado, mas nunca
+ * passaram por `t()` — entram aqui porque a próxima pessoa a mexer na tela não
+ * tem por que saber disso de cor.
+ */
+const CAMPOS_DO_OPERADOR = ["titulo", "tipo", "quemSeraAtendido", "local"];
+
+function nomeDaChamada(no: ts.CallExpression): string {
+  const alvo = no.expression;
+  if (ts.isIdentifier(alvo)) return alvo.text;
+  if (ts.isPropertyAccessExpression(alvo)) return alvo.name.text;
+  return "";
+}
+
+interface Sitio {
+  local: string;
+  trecho: string;
+}
+
+/**
+ * Devolve os sítios acusados e quantas chamadas a `t()` foram visitadas — o
+ * segundo número separa "não achei defeito" de "não olhei nada".
+ */
+function varrer(fontes: { rel: string; texto: string }[]): { sitios: Sitio[]; chamadas: number } {
+  const sitios: Sitio[] = [];
+  let chamadas = 0;
+
+  for (const { rel, texto } of fontes) {
+    const fonte = ts.createSourceFile(rel, texto, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+    const visita = (no: ts.Node): void => {
+      if (ts.isCallExpression(no) && ["t", "traduzir"].includes(nomeDaChamada(no))) {
+        chamadas += 1;
+        const arg = no.arguments[0];
+        if (arg && !ts.isStringLiteral(arg) && !ts.isNoSubstitutionTemplateLiteral(arg)) {
+          // Só o acesso a PROPRIEDADE conta: `t(tipoDoNo(x))` resolve
+          // vocabulário nosso e não pode ser acusado.
+          const lidos: string[] = [];
+          const olha = (n: ts.Node): void => {
+            if (ts.isPropertyAccessExpression(n) && CAMPOS_DO_OPERADOR.includes(n.name.text)) {
+              lidos.push(n.name.text);
+            }
+            ts.forEachChild(n, olha);
+          };
+          olha(arg);
+          if (lidos.length > 0) {
+            const linha = fonte.getLineAndCharacterOfPosition(no.getStart()).line + 1;
+            sitios.push({
+              local: `${rel}:${linha}`,
+              trecho: no.getText(fonte).replace(/\s+/g, " ").slice(0, 100),
+            });
+          }
+        }
+      }
+      ts.forEachChild(no, visita);
+    };
+    visita(fonte);
+  }
+  return { sitios, chamadas };
+}
+
+function fontesDaAgenda(): { rel: string; texto: string }[] {
+  const saida = execFileSync("git", ["ls-files", ...AREAS], {
+    cwd: RAIZ,
+    encoding: "utf8",
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  return saida
+    .split("\n")
+    .filter((p) => /\.tsx?$/.test(p) && !/\.test\.tsx?$/.test(p))
+    .map((rel) => ({ rel, texto: readFileSync(join(RAIZ, rel.split("/").join(sep)), "utf8") }))
+    .filter(({ texto }) => USA_O_TIPO.test(texto));
+}
+
+describe("a Agenda mostra o nome que o operador cadastrou", () => {
+  const fontes = fontesDaAgenda();
+  const { sitios, chamadas } = varrer(fontes);
+
+  it("nenhum campo de texto do operador passa por t()", () => {
+    expect(
+      sitios.map((s) => `${s.local} → ${s.trecho}`),
+      `${sitios.length} sítio(s) traduzem dado do operador: "Retorno" vira ` +
+        '"Seguimiento" e a pessoa não acha na agenda dela o nome que cadastrou',
+    ).toEqual([]);
+  });
+
+  it("a varredura enxergou a superfície da Agenda (não é sonda cega)", () => {
+    expect(fontes.length, "nenhum arquivo da Agenda foi lido").toBeGreaterThan(4);
+    expect(chamadas, "nenhuma chamada a t() foi visitada").toBeGreaterThan(50);
+  });
+
+  it("a varredura acusa o defeito quando ele existe (controle positivo)", () => {
+    const comDefeito = `
+      const a = <span>{t(agendamento.titulo)}</span>;
+      const b = <span>{a.tipo ? t(a.tipo) : t("Agendamento")}</span>;
+      const c = <span>{t("Agendamento")}</span>;
+      const d = <span>{t(tipoDoNo(no.kind))}</span>;
+    `;
+    const achado = varrer([{ rel: "sintetico.tsx", texto: comDefeito }]);
+    // Linhas 2 e 3 são o defeito; `t("Agendamento")` (rótulo nosso) e
+    // `t(tipoDoNo(...))` (vocabulário nosso em runtime) NÃO podem ser acusados
+    // — senão o guarda proibiria traduzir a própria tela.
+    expect(achado.sitios.map((s) => s.local)).toEqual(["sintetico.tsx:2", "sintetico.tsx:3"]);
+  });
+
+  it("a Agenda continua traduzida — o par do «não faça X»", () => {
+    // Sem este caso, arrancar `t()` da Agenda inteira satisfaria o guarda de
+    // cima e devolveria a tela em português para quem escolheu espanhol.
+    //
+    // O PISO É BAIXO DE PROPÓSITO. Medido nesta branch: **57** chamadas
+    // `t("literal")` dentro de `fontes` — que é um RECORTE (só os arquivos que
+    // mexem com `Agendamento`), não a Agenda inteira, onde são 140. Este caso
+    // existe para provar que a sonda enxerga `t()`, não para medir cobertura:
+    // um piso colado no número de hoje reprova o próximo PR que mover um
+    // componente de lugar, e aí alguém o afrouxa sem ler o porquê.
+    const literais = fontes.reduce(
+      (soma, { texto }) => soma + (texto.match(/(?<![\w$.])t\(\s*["'`]/g) ?? []).length,
+      0,
+    );
+    expect(literais, "a Agenda perdeu as chamadas t() dos rótulos dela").toBeGreaterThan(30);
+  });
+});

--- a/tests/unit/o-que-o-banco-guarda-fica-canonico.test.ts
+++ b/tests/unit/o-que-o-banco-guarda-fica-canonico.test.ts
@@ -1,0 +1,197 @@
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join, sep } from "node:path";
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+/**
+ * O QUE VAI PARA O BANCO FICA NO VOCABULÁRIO CANÔNICO; A TELA TRADUZ NA LEITURA.
+ *
+ * ─── O defeito que este guarda mede ─────────────────────────────────────────
+ *
+ * `crm_lead_activities.reason` é a frase legível da linha do tempo, escrita
+ * pelo SISTEMA (assumiu, liberou, transferiu, pausou a IA, encerrou o negócio).
+ * Ela é gravada uma vez e lida para sempre, por quem quer que abra o negócio
+ * depois.
+ *
+ * A varredura de espanhol do PR #600 passou seis desses sítios de ESCRITA por
+ * `t()`, gravando o idioma de quem clicou. Numa organização bilíngue — que é o
+ * caso que a própria feature cria — o histórico vira mistura: metade das linhas
+ * em português, metade em espanhol, e nenhuma das duas metades traduz para quem
+ * lê no outro idioma, porque a chave gravada em espanhol não existe no
+ * dicionário (a chave É o texto em português).
+ *
+ * A intenção do #600 — quem usa espanhol lê espanhol — não some com isso: ela é
+ * atendida na LEITURA, por `t(item.reason)`, que o MESMO PR acrescentou. É a
+ * doutrina que ele escreveu no dicionário, no bloco "vocabulario de dominio
+ * persistido"; o que faltava era aplicá-la nos seis sítios.
+ *
+ * ─── Por que um guarda de AST e não seis testes de comportamento ────────────
+ *
+ * Os seis são rotas com Supabase, RLS e RPC no meio: seis testes de
+ * comportamento custariam seis dublês e ainda assim não alcançariam o SÉTIMO
+ * sítio — a próxima atividade que alguém emitir. O que se quer proteger é a
+ * classe, e a classe é estrutural: nenhum `reason`/`motivo` de atividade passa
+ * por tradução na escrita.
+ *
+ * O par do «não faça X» está no fim do arquivo: a leitura TEM de traduzir. Sem
+ * ele, "nunca traduza reason" seria satisfeito arrancando a tradução dos dois
+ * lados — e o espanhol voltaria a ver português.
+ */
+
+const RAIZ = join(__dirname, "..", "..");
+
+/** As duas portas por onde uma frase chega a `crm_lead_activities.reason`. */
+const EMISSORES = new Set(["emitLeadActivity", "registrarTrocaDeComando"]);
+
+/** O campo muda de nome entre as duas portas; o destino é a mesma coluna. */
+const CAMPOS_PERSISTIDOS = new Set(["reason", "motivo"]);
+
+function nomeDaChamada(no: ts.CallExpression): string {
+  const alvo = no.expression;
+  if (ts.isIdentifier(alvo)) return alvo.text;
+  if (ts.isPropertyAccessExpression(alvo)) return alvo.name.text;
+  return "";
+}
+
+/** `t(...)`, `traduzir(...)` ou o `_t(...)` dos módulos que recebem `t` opcional. */
+function ehChamadaDeTraducao(no: ts.Node): boolean {
+  return ts.isCallExpression(no) && ["t", "_t", "traduzir"].includes(nomeDaChamada(no));
+}
+
+function contemTraducao(no: ts.Node): boolean {
+  if (ehChamadaDeTraducao(no)) return true;
+  let achou = false;
+  ts.forEachChild(no, (f) => {
+    if (!achou && contemTraducao(f)) achou = true;
+  });
+  return achou;
+}
+
+interface Sitio {
+  local: string;
+  trecho: string;
+}
+
+/**
+ * Devolve os sítios de escrita e quantas chamadas a emissor foram visitadas —
+ * o segundo número existe para separar "nenhum defeito" de "sonda cega".
+ */
+function varrer(fontes: { rel: string; texto: string }[]): {
+  comTraducao: Sitio[];
+  emissoresVistos: number;
+} {
+  const comTraducao: Sitio[] = [];
+  let emissoresVistos = 0;
+
+  for (const { rel, texto } of fontes) {
+    const fonte = ts.createSourceFile(rel, texto, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+    const visita = (no: ts.Node): void => {
+      if (ts.isCallExpression(no) && EMISSORES.has(nomeDaChamada(no))) {
+        emissoresVistos += 1;
+        for (const arg of no.arguments) {
+          if (!ts.isObjectLiteralExpression(arg)) continue;
+          for (const prop of arg.properties) {
+            if (!ts.isPropertyAssignment(prop) || !prop.name) continue;
+            const campo = ts.isIdentifier(prop.name)
+              ? prop.name.text
+              : ts.isStringLiteral(prop.name)
+                ? prop.name.text
+                : "";
+            if (!CAMPOS_PERSISTIDOS.has(campo)) continue;
+            if (contemTraducao(prop.initializer)) {
+              const linha = fonte.getLineAndCharacterOfPosition(prop.getStart()).line + 1;
+              comTraducao.push({
+                local: `${rel}:${linha}`,
+                trecho: prop.getText(fonte).replace(/\s+/g, " ").slice(0, 120),
+              });
+            }
+          }
+        }
+      }
+      ts.forEachChild(no, visita);
+    };
+    visita(fonte);
+  }
+  return { comTraducao, emissoresVistos };
+}
+
+function fontesDoProduto(): { rel: string; texto: string }[] {
+  // `git ls-files` em vez de andar no disco: arquivo não rastreado ainda não
+  // existe para o CI, e um `.next`/`node_modules` esquecido não entra na conta.
+  const saida = execFileSync("git", ["ls-files", "app", "lib", "workers"], {
+    cwd: RAIZ,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return saida
+    .split("\n")
+    .filter((p) => /\.tsx?$/.test(p) && !/\.test\.tsx?$/.test(p))
+    .map((rel) => ({ rel, texto: readFileSync(join(RAIZ, rel.split("/").join(sep)), "utf8") }));
+}
+
+describe("o reason da linha do tempo é gravado no vocabulário canônico", () => {
+  const { comTraducao, emissoresVistos } = varrer(fontesDoProduto());
+
+  it("nenhuma escrita de atividade passa reason/motivo por t()", () => {
+    expect(
+      comTraducao.map((s) => `${s.local} → ${s.trecho}`),
+      `${comTraducao.length} atividade(s) gravam o idioma de quem clicou em ` +
+        "crm_lead_activities.reason — numa organização bilíngue o histórico vira " +
+        "mistura, e a frase em espanhol não bate com nenhuma chave na leitura",
+    ).toEqual([]);
+  });
+
+  it("a varredura alcança os emissores de verdade (não é sonda cega)", () => {
+    // Ausência só vale se a sonda cobre a categoria: se um rename fizer
+    // `emitLeadActivity` deixar de ser reconhecido, o teste de cima ficaria
+    // verde por não ter olhado nada.
+    expect(
+      emissoresVistos,
+      "a varredura não encontrou chamadas a emitLeadActivity/registrarTrocaDeComando",
+    ).toBeGreaterThan(20);
+  });
+
+  it("a varredura enxerga o defeito quando ele existe (controle positivo)", () => {
+    const comDefeito = `
+      await emitLeadActivity(db, { leadId: "x", reason: t("Ganho"), payload: {} });
+      await registrarTrocaDeComando({ tipo: "conversation_claimed", motivo: traduzir("Assumiu", idioma) });
+      await emitLeadActivity(db, { leadId: "y", reason: \`Perdido — \${motivo}\` });
+    `;
+    const achado = varrer([{ rel: "sintetico.ts", texto: comDefeito }]);
+    expect(achado.emissoresVistos).toBe(3);
+    // Os dois primeiros são o defeito; o terceiro é a forma CERTA e não pode
+    // ser acusada — senão o guarda proibiria gravar a frase canônica.
+    expect(achado.comTraducao.map((s) => s.local)).toEqual(["sintetico.ts:2", "sintetico.ts:3"]);
+  });
+});
+
+describe("a intenção do #600 sobrevive: quem lê em espanhol vê espanhol", () => {
+  const TELAS = [
+    "components/kanban/LeadTimeline.tsx",
+    "components/inbox/CRMSidePanel.tsx",
+    "components/contacts/TimelineView.tsx",
+  ] as const;
+
+  it.each(TELAS)("%s traduz o reason na LEITURA", (rel) => {
+    const texto = readFileSync(join(RAIZ, rel.split("/").join(sep)), "utf8");
+    const fonte = ts.createSourceFile(rel, texto, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+
+    let traduzReason = false;
+    const visita = (no: ts.Node): void => {
+      if (ehChamadaDeTraducao(no) && ts.isCallExpression(no)) {
+        const arg = no.arguments[0];
+        if (arg && /reason/i.test(arg.getText(fonte))) traduzReason = true;
+      }
+      ts.forEachChild(no, visita);
+    };
+    visita(fonte);
+
+    expect(
+      traduzReason,
+      `${rel} deixou de traduzir o reason na leitura — como a escrita é canônica ` +
+        "em português, quem escolheu espanhol passa a ver a linha do tempo em português",
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Traz o **PR #600 do @JowaniOrantes** — varredura de cobertura do espanhol em 202 arquivos — mais os consertos da triagem.

## Por que este não é um `git merge` do branch dele

O PR original trazia `.qa-backups/pre-baseline-20260903-213944.dump`, **1.180.884 bytes** de um Supabase local. Um commit posterior de remoção **não tira o blob da história**, então a árvore foi reconstruída sem ele, num commit com a **autoria do autor** e a razão escrita no corpo. Os 42 commits dele viraram um; a autoria não.

O conteúdo era lixo de QA, não incidente — sondado antes de decidir: `ai_provider_credentials` e `channel_sessions` com **zero linhas** (nem chave de IA nem webhook secret), 1 hash bcrypt de domínio sintético `@empresa-demo.com`, 114 refresh tokens daquela instância local, 179 linhas de auditoria.

## O que ele achou, e vale mais que os consertos

**Um defeito vivo na `main` de hoje**: o nome que o operador deu a um tipo de atendimento estava sendo traduzido — "Retorno" virando "Seguimiento" na Agenda. Introduzido pelo commit `08257eed`, nenhum gate pegava, e ele o nomeou no próprio fragmento. Dado do usuário passando por dicionário é uma classe que quase ninguém procura.

## O que a triagem confirmou

- **Zero** códigos de erro embrulhados em `t()`. Parser de parênteses sobre os 295 arquivos `.ts` de `app/`: 1.028 chamadas `fail()`, 973 com literal, 51 com identificador, **0 com `t()`**. Contrato de API preservado.
- **Zero** `const t` em escopo de módulo em `app/**` (165 declarações, todas indentadas). Não existe vazamento de idioma entre tenants.
- A entrada nova na allowlist do `lint-channels` é **necessária**: removê-la deixa o gate `exit=1` nomeando `lib/i18n/dicionario.ts`.

## Os consertos que entram

**1. Uma regressão em pt-BR — a única do PR.** `lib/catalogo/planilha.ts`: na `main` a recusa da planilha **nomeia a coluna que falta** (`faltando.map(...).join(" e de ")`); no PR virou um literal fixo. Quem tem `nome` e não tem preço recebia um pedido pela coluna que já tem — em pt-BR, num fluxo de primeira impressão. Restaurada a construção dinâmica **mantendo a tradução**, com uma chave por combinação (montar por pedaços entregaria frase torta em espanhol).

**2. Texto traduzido parava no banco.** Três sítios passaram a gravar em `crm_lead_activities.reason` no idioma de quem clicou (`claim`, `release`, `encerramento`). Na `main` a coluna guardava o vocabulário canônico e **a tela traduzia na leitura**; numa organização bilíngue o histórico viraria uma mistura que já não traduz. O `t()` sai da **escrita** e fica na **leitura** — a intenção do autor (*quem usa espanhol vê espanhol*) sobrevive inteira, porque o próprio PR adicionou a tradução na leitura.

**3. A classe que ele achou sobrevivia em cinco linhas que o PR não toca.** `agendamentos/_handler.ts:165` grava `title: input.title ?? tipo.name` — o título cai no nome que o operador cadastrou. Os cinco: `GradeDaAgenda.tsx:362` e `:707`, `HistoricoDaAgenda.tsx:195` e `:197`, `_client.tsx:679`. O fallback `t("Agendamento")` continua traduzindo — esse é rótulo nosso. **Só agora o fragmento dele ("todos os casos foram corrigidos") é verdade.**

O guarda novo varre por AST e traz o par obrigatório: um controle positivo sintético que prova que a sonda acusa o defeito quando ele existe e **não** acusa `t("Agendamento")` nem `t(tipoDoNo(...))`, e um caso que impede o atalho de arrancar `t()` da Agenda inteira. O piso desse último (`>30`) foi **medido**, não chutado — 57 no recorte que o teste lê, 140 na Agenda inteira; baixo de propósito, porque piso colado no número de hoje reprova o próximo PR que mover um componente de lugar.

Discriminância: devolver `t(c.titulo)` a `GradeDaAgenda.tsx:710` reprova 1 caso, nomeando o arquivo:linha.

**4. O `.gitignore` não cobria a classe do dump.** A doutrina já estava escrita duas linhas acima (`.qa-vps/` guarda TOTP, `backups/` guarda cópia do `.env` com service role key) — só o padrão faltava, porque `backups/` não casa com `.qa-backups/`. Entram `.qa-backups/` e `*.dump`, provados por `git check-ignore -v` nos dois sentidos, com controle negativo.

## O que virou issue

**#603** — o guardião `i18n-espanhol-cobre-a-tela.test.ts` só coleta `ts.isStringLiteral`, então toda chave dinâmica é invisível, e nada proíbe `t()` sobre dado do operador (o cego que deixou o `08257eed` passar). São **164 sítios** de `t(<valor de runtime>)` em 106 expressões distintas. O gate proposto está descrito lá, com a régua de "tem de ficar vermelho hoje contra a `main`".

## Versão

**patch → 1.15.2** — o operador não precisa fazer nada.

Fecha o #600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8DiyLVGChP5UaXLbMcV9J
