### PR TITLE
fix(kit): a conferência de imagens do instalador segue o IMG_NS (@galeonel, do #605)

### DIFF
--- a/.changes/ghcr-status-segue-o-namespace-configurado.md
+++ b/.changes/ghcr-status-segue-o-namespace-configurado.md
@@ -1,0 +1,15 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A conferência de imagens do instalador passa a olhar o registro que a instalação usa
+---
+
+Antes de baixar as imagens, o instalador confere se as três existem e são
+públicas. Essa conferência olhava sempre para o registro do projeto, mesmo em
+instalações configuradas para usar outro — então ela dizia "está tudo publicado"
+depois de conferir pacotes que não eram os que a instalação ia baixar, e o erro
+só aparecia mais tarde, na hora de subir. Agora ela olha o mesmo registro que a
+instalação usa.
+
+Nada muda para quem não trocou o registro: continua conferindo os mesmos
+pacotes, com o mesmo resultado.

--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -469,16 +469,29 @@ ultima_versao_publicada() {
 # repositório público não muda isso. Enquanto ninguém trocar a visibilidade na
 # mão, o `docker compose pull` de toda VPS é negado — e como `pull` de serviço
 # com `image:` falha a operação inteira, a instalação morre no passo de subir.
+#
+# ⚠️ O DONO E O REGISTRO SAEM DO `IMG_NS`, NUNCA DE UM LITERAL. Achado por
+# @galeonel no PR #605: as duas URLs abaixo tinham `melgarafael` cravado. Num
+# fork que troca o `IMG_NS`, isso faz o pré-voo conferir os pacotes do UPSTREAM
+# enquanto `gravar_imagens` escreve no `.env` do cliente as referências do FORK
+# — a sonda mede um caminho e o usuário usa outro, que é a falha-em-verde do
+# passe 5 da triagem.
+#
+# E o literal escapava da catraca por acidente: `namespace-das-imagens.test.ts`
+# procura a string contígua `ghcr.io/melgarafael`, e a URL do token a parte em
+# `ghcr.io/token?scope=repository:melgarafael/`.
 ghcr_status() {
-  local img="$1" tag="$2" tok
+  local img="$1" tag="$2" tok registry owner
+  registry="${IMG_NS%%/*}"
+  owner="${IMG_NS#*/}"
   tok="$(curl -fsS --max-time 6 \
-          "https://ghcr.io/token?scope=repository:melgarafael/${img}:pull&service=ghcr.io" 2>/dev/null \
+          "https://${registry}/token?scope=repository:${owner}/${img}:pull&service=${registry}" 2>/dev/null \
         | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')" || true
   if [ -z "$tok" ]; then printf '000'; return 0; fi
   curl -s -o /dev/null --max-time 6 -w '%{http_code}' \
     -H "Authorization: Bearer $tok" \
     -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json' \
-    "https://ghcr.io/v2/melgarafael/${img}/manifests/${tag}" 2>/dev/null || printf '000'
+    "https://${registry}/v2/${owner}/${img}/manifests/${tag}" 2>/dev/null || printf '000'
 }
 
 # As TRÊS imagens existem e são públicas nesta referência?

--- a/tests/unit/namespace-das-imagens.test.ts
+++ b/tests/unit/namespace-das-imagens.test.ts
@@ -65,9 +65,25 @@ const RECADO_AO_FORK =
   "Publicando as próprias imagens? Troque o namespace em três lugares, e só neles: " +
   "IMG_NS em hostgator-setup-kit/_common.sh, o default das três linhas `image:` de " +
   "docker-compose.prod.yml, e as três *_IMAGE de .env.hostgator.example. Depois " +
-  "atualize NAMESPACE_DESTE_REPO neste arquivo. Nenhum OUTRO arquivo do repo " +
-  "repete esse valor — todos derivam de IMG_NS, e a catraca no fim deste arquivo " +
-  "existe para que continue assim.";
+  "atualize NAMESPACE_DESTE_REPO neste arquivo, e a URL do repositório em " +
+  "install.sh, comecar.sh, _common.sh e nos três Dockerfiles (os casos abaixo " +
+  "prendem os seis). Todo o resto deriva de IMG_NS.";
+
+/*
+ * ⚠️ ESTA FRASE JÁ FOI FALSA, e a falsidade custava caro a quem a seguia.
+ *
+ * Ela dizia "troque em três lugares, e só neles — nenhum OUTRO arquivo do repo
+ * repete esse valor". @galeonel seguiu à risca (PR #605) e descobriu que
+ * `ghcr_status`, em `_common.sh`, tinha `melgarafael` cravado nas duas URLs: o
+ * fork ficava com o pré-voo conferindo os pacotes do UPSTREAM enquanto
+ * `gravar_imagens` escrevia no `.env` do cliente as referências do FORK.
+ *
+ * A catraca não pegava por acidente de forma: ela procura a string contígua
+ * `ghcr.io/melgarafael`, e a URL do token parte o valor em
+ * `ghcr.io/token?scope=repository:melgarafael/`. Instrução que promete mais do
+ * que o gate confere é pior que instrução nenhuma — quem a segue conclui que
+ * terminou.
+ */
 
 function imgNs(): string {
   const m = COMUM.match(/^IMG_NS="([^"]+)"$/m);
@@ -143,6 +159,62 @@ describe("o default do compose diz o mesmo que o kit", () => {
 });
 
 describe("o kit aponta para o que o CI realmente publica", () => {
+  it("os defaults de código e os labels de origem apontam para este repositório", () => {
+    const repo = "https://github.com/melgarafael/DeskcommCRM";
+    for (const script of ["install.sh", "comecar.sh"]) {
+      const texto = fs.readFileSync(path.join(RAIZ, "hostgator-setup-kit", script), "utf8");
+      expect(texto).toContain(`REPO_URL="\${REPO_URL:-${repo}.git}"`);
+    }
+    expect(COMUM).toContain(`local url="\${1:-${repo}.git}" ref`);
+    for (const dockerfile of ["Dockerfile", "Dockerfile.worker", "Dockerfile.scheduler"]) {
+      expect(fs.readFileSync(path.join(RAIZ, dockerfile), "utf8")).toContain(
+        `org.opencontainers.image.source="${repo}"`,
+      );
+    }
+  });
+
+  it.each([undefined, "registry.example/outro-dono"])(
+    "ghcr_status consulta token e manifesto no IMG_NS (%s)",
+    (namespace) => {
+      const ns = namespace ?? imgNs();
+      const [registry, owner] = ns.split("/");
+      const saida = execFileSync(
+        "bash",
+        [
+          "-c",
+          `
+        source hostgator-setup-kit/_common.sh
+        if [ -n "$1" ]; then IMG_NS="$1"; fi
+        curl() {
+          local arg
+          for arg in "$@"; do
+            case "$arg" in
+              https://*/token[?]*) printf '%s\\n' "$arg" >> "$log"; printf '{"token":"teste"}'; return;;
+              https://*/v2/*) printf '%s\\n' "$arg" >> "$log"; printf '200'; return;;
+            esac
+          done
+          return 1
+        }
+        log=$(mktemp)
+        trap 'rm -f "$log"' EXIT
+        # O dublê registra em arquivo porque a função captura stdout do curl.
+        ghcr_status deskcommcrm 1.2.3
+        printf '\\n'
+        cat "$log"
+      `,
+          "teste",
+          namespace ?? "",
+        ],
+        { cwd: RAIZ, encoding: "utf8" },
+      );
+      expect(saida.trim().split("\n")).toEqual([
+        "200",
+        `https://${registry}/token?scope=repository:${owner}/deskcommcrm:pull&service=${registry}`,
+        `https://${registry}/v2/${owner}/deskcommcrm/manifests/1.2.3`,
+      ]);
+    },
+  );
+
   it("o registry do kit é o mesmo do workflow de publicação", () => {
     const m = PUBLICA.match(/^\s*REGISTRY:\s*(\S+)$/m);
     expect(m, "não achei `REGISTRY:` em .github/workflows/publish-image.yml").not.toBeNull();


### PR DESCRIPTION
Extrai a **metade genérica** do PR #605 (@galeonel), que foi abrir a configuração do fork dele e esbarrou num defeito nosso — e num texto nosso que afirmava o contrário.

## O defeito

`ghcr_status()` tinha `melgarafael` cravado nas duas URLs (token e manifesto), enquanto `IMG_NS` é o que `gravar_imagens` escreve no `.env` de **todo** cliente (`_common.sh:614-618`, chamado por `update.sh:230-233`).

Numa instalação com outro registro, o pré-voo — que é quem decide se aquela versão é usável (`trio_publicado`) — conferia os pacotes do **upstream** enquanto o `.env` recebia as referências do **outro**. A sonda mede um caminho e o usuário usa outro: é a *falha-em-verde* do passe 5 do nosso próprio procedimento de triagem.

Medido com um dublê de `curl` e `IMG_NS="ghcr.io/erradissimo"`:

```
antes → https://ghcr.io/token?scope=repository:melgarafael/deskcommcrm:pull&service=ghcr.io
        https://ghcr.io/v2/melgarafael/deskcommcrm/manifests/9.9.9
depois→ https://ghcr.io/token?scope=repository:erradissimo/deskcommcrm:pull&service=ghcr.io
        https://ghcr.io/v2/erradissimo/deskcommcrm/manifests/9.9.9
```

## Por que a catraca não pegava

Por acidente de **forma**. O `namespace-das-imagens.test.ts` procura a string contígua `ghcr.io/melgarafael`; a URL do token parte o valor em `ghcr.io/token?scope=repository:melgarafael/`.

E é por isso que o `RECADO_AO_FORK` — a frase que este projeto mostra a quem faz fork — dizia:

> *"Troque o namespace em três lugares, e só neles… **Nenhum OUTRO arquivo do repo repete esse valor** — todos derivam de IMG_NS."*

**Era falso**, e o @galeonel seguiu a instrução à risca. A frase agora diz a verdade (a URL do repositório também muda, em seis lugares), e o comentário registra por que ela já foi falsa: instrução que promete mais do que o gate confere é pior que instrução nenhuma, porque quem a segue conclui que terminou.

## O que entra junto

Os dois casos que ele escreveu, com as constantes do **upstream**:

- o `it.each([undefined, "registry.example/outro-dono"])`, que roda o shell de verdade com um dublê de `curl` e prende as duas URLs ao `IMG_NS`;
- a âncora dos **seis** `REPO_URL`/labels OCI — que não tinha guarda nenhuma na `main`, então trocar um e esquecer os outros passava verde.

## Discriminância

Devolvendo o literal ao `ghcr_status` (`numstat 2 2`, só o fonte):

```
× ghcr_status consulta token e manifesto no IMG_NS (registry.example/outro-dono)
  Tests  1 failed | 15 passed (16)
```

**Um** reprovado, como previsto antes de rodar — e o caso com o nosso próprio `IMG_NS` continua verde, porque ali as URLs coincidem. É exatamente por isso que o literal sobreviveu tanto tempo.

Fragmento: `nada_mudou` / `corrigido`. Nada muda para quem não trocou o registro.

O que **não** entra deste PR está explicado no #605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8DiyLVGChP5UaXLbMcV9J
