### PR TITLE
docs(release): os fragmentos dos dois consertos do instalador (#619, #620)

### DIFF
--- a/.changes/instalacao-nao-para-na-criacao-do-dono.md
+++ b/.changes/instalacao-nao-para-na-criacao-do-dono.md
@@ -1,0 +1,13 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A instalação não para mais no passo de criar o primeiro administrador
+---
+
+Instalar numa VPS podia falhar bem no fim, ao criar o primeiro administrador,
+com uma mensagem de erro do banco de dados. Quando acontecia, o banco já estava
+montado e as configurações já estavam gravadas — a instalação parava com tudo
+quase pronto e a tela oferecendo recomeçar do zero.
+
+O passo foi corrigido e o instalador passa a verificar isso sozinho antes de
+publicar uma versão nova, para que a falha não volte.

--- a/.changes/o-site-responde-atras-do-proxy-da-hospedagem.md
+++ b/.changes/o-site-responde-atras-do-proxy-da-hospedagem.md
@@ -1,0 +1,16 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O endereço responde mesmo quando a hospedagem usa nomes próprios de porta
+---
+
+Em hospedagens com painel próprio (EasyPanel, entre outras), a instalação podia
+terminar com tudo no ar por dentro e o endereço mostrando a página de erro do
+painel: o instalador supunha os nomes que a hospedagem dá às portas 80 e 443, e
+quando eles eram diferentes o roteamento simplesmente não acontecia — sem erro
+em lugar nenhum.
+
+Agora o instalador lê esses nomes da própria hospedagem e mostra quais
+encontrou. Quem já tinha escolhido os nomes à mão continua com a escolha; quem
+instalou antes e ficou com o endereço mudo pode rodar a instalação de novo para
+que ela os detecte.


### PR DESCRIPTION
Os PRs #619 e #620, de @maugarciasa, consertam duas falhas de instalação medidas em VPS real e mudam comportamento visível a quem opera uma VPS — então pedem fragmento em `.changes/` (DoD 17). Eles não vieram com um, e a triagem **conserta em vez de devolver**: os dois fragmentos entram aqui.

| fragmento | impacto | de onde vem |
|---|---|---|
| `instalacao-nao-para-na-criacao-do-dono` | `nada_mudou` / corrigido | #619 |
| `o-site-responde-atras-do-proxy-da-hospedagem` | `nada_mudou` / corrigido | #620 |

Escritos na linguagem de quem opera, sem número de versão — o número é calculado a partir do conjunto. Os dois são `nada_mudou` porque quem opera bem hoje não precisa fazer nada; o do proxy diz no corpo o que fazer para quem instalou antes e ficou com o endereço mudo.

**O crédito dos consertos é dos PRs originais** — aqui só entra o que declara o efeito no operador.

## Medido

Prévia do merge dos dois PRs sobre a `main` (`d69d708d`), na mesma árvore:

- `pnpm test:shell` — **todos os validadores passaram**, zero `✗`, com os testes novos dos dois PRs rodando;
- sabotagem do teste do #619 (crase reintroduzida no comentário do heredoc) → reprova com `✗ crase dentro do heredoc <<SQL`, provando que ele vigia;
- os dois PRs mesclam **sem conflito** entre si, apesar de tocarem os mesmos dois arquivos;
- `pnpm typecheck` — 0 erros; `pnpm test:unit` — 736 arquivos / 7924 casos, zero falhas;
- `pnpm release:conferir` reconhece os dois fragmentos novos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)