### PR TITLE
feat(inbox): o balão mostra de onde saiu a mensagem — Celular, Automação, Você

### DIFF
--- a/.changes/inbox-rotulo-origem-mensagem.md
+++ b/.changes/inbox-rotulo-origem-mensagem.md
@@ -1,0 +1,14 @@
+---
+impacto: capacidade_nova
+secao: adicionado
+titulo: O balão do atendimento mostra de onde saiu cada mensagem
+---
+
+O balão de uma mensagem enviada agora identifica a origem dela: **Celular** para
+a resposta dada pelo WhatsApp do telefone (fora do CRM), **Automação** para o que
+saiu de uma regra, **Você** para o que foi digitado no CRM e **IA** para o agente.
+
+Antes, só a IA era identificada. A resposta dada pelo celular chegava à conversa
+sem rótulo e parecia ter sido digitada no CRM — enquanto o painel de atividade já
+contava esse atendimento como feito por fora. Agora a conversa mostra o que o
+painel sempre soube.

--- a/components/inbox/MessageBubble.test.tsx
+++ b/components/inbox/MessageBubble.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * O balão diz de quem saiu a mensagem.
+ *
+ * `external_device` é a resposta dada pelo WhatsApp do CELULAR (fora do CRM) —
+ * antes ela chegava à bolha sem rótulo, indistinguível do que foi digitado no
+ * CRM. Este teste prende os seis valores de `sent_via` ao rótulo certo, mais o
+ * caso que NÃO leva rótulo (mensagem recebida).
+ *
+ * Sem provider de idioma o `t()` degrada para a chave (pt-BR), então o texto
+ * esperado é o português — o espanhol é coberto por i18n-espanhol-cobre-a-tela.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { MessageBubble } from "./MessageBubble";
+import type { Message } from "@/lib/types/messaging";
+
+function msg(over: Partial<Message> = {}): Message {
+  return {
+    id: "m1",
+    organization_id: "org1",
+    conversation_id: "c1",
+    channel_session_id: "s1",
+    contact_id: "ct1",
+    external_id: null,
+    type: "text",
+    direction: "outbound",
+    status: "sent",
+    ack: null,
+    error_code: null,
+    error_message: null,
+    body: "corpo da mensagem",
+    media_url: null,
+    media_mime: null,
+    media_size_bytes: null,
+    media_storage_path: null,
+    sent_via: "user",
+    sent_by_user_id: null,
+    sent_at: "2026-09-08T12:00:00.000Z",
+    delivered_at: null,
+    read_at: null,
+    metadata: {},
+    edited_at: null,
+    revoked_at: null,
+    reply_to_message_id: null,
+    created_at: "2026-09-08T12:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("MessageBubble — rótulo de origem", () => {
+  it("resposta pelo celular (external_device) mostra 'Celular'", () => {
+    render(<MessageBubble message={msg({ sent_via: "external_device" })} />);
+    expect(screen.getByText("Celular")).toBeInTheDocument();
+  });
+
+  it("automação mostra 'Automação'", () => {
+    render(<MessageBubble message={msg({ sent_via: "automation" })} />);
+    expect(screen.getByText("Automação")).toBeInTheDocument();
+  });
+
+  it("digitada no CRM (user) mostra 'Você'", () => {
+    render(<MessageBubble message={msg({ sent_via: "user" })} />);
+    expect(screen.getByText("Você")).toBeInTheDocument();
+  });
+
+  it("crm também mostra 'Você'", () => {
+    render(<MessageBubble message={msg({ sent_via: "crm" })} />);
+    expect(screen.getByText("Você")).toBeInTheDocument();
+  });
+
+  it("IA continua mostrando 'IA' (comportamento preservado)", () => {
+    render(<MessageBubble message={msg({ sent_via: "ai" })} />);
+    expect(screen.getByText("IA")).toBeInTheDocument();
+  });
+
+  it("mensagem recebida (inbound) não leva rótulo de origem", () => {
+    render(
+      <MessageBubble message={msg({ sent_via: "external_device", direction: "inbound" })} />,
+    );
+    expect(screen.queryByText("Celular")).not.toBeInTheDocument();
+  });
+
+  it("system não inventa rótulo", () => {
+    render(<MessageBubble message={msg({ sent_via: "system" })} />);
+    for (const rotulo of ["Celular", "Automação", "Você", "IA"]) {
+      expect(screen.queryByText(rotulo)).not.toBeInTheDocument();
+    }
+  });
+});

--- a/components/inbox/MessageBubble.tsx
+++ b/components/inbox/MessageBubble.tsx
@@ -57,9 +57,18 @@ export function MessageBubble({ message, debugCitations, onResponder, citada }: 
   const citations = extractCitations(message.metadata);
   const showCitationButton =
     isOutbound && aiGenerated && (debugCitations ?? false);
+  // De quem saiu esta linha. `external_device` é a resposta pelo CELULAR — o
+  // operador atendeu pelo WhatsApp do telefone, fora do CRM, e o ingest carimba
+  // aqui. Antes isto voltava null para tudo que não fosse IA, e a bolha ficava
+  // sem nome: o dono lia a conversa como se tudo tivesse sido digitado no CRM.
+  // Os rótulos passam por t() no render (ver dicionario.ts para o espanhol).
   const senderLabel = (() => {
     if (!isOutbound) return null;
     if (message.sent_via === "ai") return "IA";
+    if (message.sent_via === "external_device") return "Celular";
+    if (message.sent_via === "automation") return "Automação";
+    if (message.sent_via === "user") return "Você";
+    if (message.sent_via === "crm") return "Você";
     return null;
   })();
 

--- a/lib/types/messaging.ts
+++ b/lib/types/messaging.ts
@@ -71,7 +71,11 @@ export interface Message {
   media_mime: string | null;
   media_size_bytes: number | null;
   media_storage_path: string | null;
-  sent_via: "user" | "ai" | "system";
+  // Espelha o CHECK do banco (messages_sent_via_check): 'crm', 'external_device',
+  // 'automation', 'ai', 'user', 'system'. O tipo listava só três e o TypeScript
+  // aceitava os demais só porque o dado vem do Supabase sem cast — a tela então
+  // não conseguia nem NOMEAR o valor para exibi-lo (ver MessageBubble).
+  sent_via: "user" | "ai" | "system" | "external_device" | "automation" | "crm";
   sent_by_user_id: string | null;
   sent_at: string;
   delivered_at: string | null;


### PR DESCRIPTION
## O quê

O balão de uma mensagem enviada passa a identificar a origem dela: **Celular** (resposta pelo WhatsApp do telefone, fora do CRM), **Automação**, **Você** (digitada no CRM) e **IA** (como já era).

## Por quê

`Message.sent_via` na UI listava só `user | ai | system`, mas o banco aceita seis valores (CHECK `messages_sent_via_check`: `crm`, `external_device`, `automation`, `ai`, `user`, `system`). Como o tipo não nomeava `external_device`, a tela não conseguia nem exibi-lo: a resposta dada pelo celular chegava à bolha **sem rótulo**, e o dono lia a conversa como se tudo tivesse sido digitado no CRM — enquanto o painel de atividade (`por_humano_fora`) já contava esse atendimento como feito por fora. A tela passa a mostrar o que o painel sempre soube.

Não é hipótese: numa instalação real, `select sent_via, count(*) from messages group by 1` já retorna **6 mensagens `external_device`** que estavam sem rótulo até aqui.

## Como

- `lib/types/messaging.ts`: alarga `sent_via` para espelhar o CHECK do banco.
- `components/inbox/MessageBubble.tsx`: mapeia os seis valores para o rótulo. `external_device` é carimbado por `lib/waha/ingest.ts` (linhas 622, 850) e `lib/channels/zernio/ingest.ts`.
- Os rótulos passam por `t()`; `Automação` e `Você` já tinham tradução no dicionário, então o espanhol sai correto **sem tocar i18n**.
- `.changes/`: fragmento `capacidade_nova` / `adicionado`.

## Provas (local)

- `pnpm typecheck` limpo; `eslint` nos arquivos tocados limpo.
- `components/inbox/MessageBubble.test.tsx` (novo): cobre os seis ramos de `sent_via` mais a mensagem recebida (sem rótulo). O mapa foi sabotado e a suíte ficou vermelha, confirmando que o teste guarda.
- `tests/unit/i18n-espanhol-cobre-a-tela` segue verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
