### PR TITLE
feat(ia): a Central resolve todos os avisos de uma vez, e o aviso sai como foi gravado (@rafaelbatistazz, do #622)

### DIFF
--- a/.changes/central-de-avisos-resolver-todos.md
+++ b/.changes/central-de-avisos-resolver-todos.md
@@ -1,0 +1,18 @@
+---
+impacto: capacidade_nova
+secao: adicionado
+titulo: Central de avisos ganha o botão "Marcar todos resolvidos"
+---
+
+A Central de avisos (`/app/ai/inbox`) só resolvia aviso por aviso. Com a lista acumulando —
+144 abertos numa instalação real — a única saída era clicar item a item. Agora, na aba
+"Abertos", o botão **Marcar todos resolvidos** fecha todos de uma vez: uma única atualização
+escopada à sua organização, registrada na auditoria com a contagem. Se o lote falhar, a tela
+avisa e pede para conferir a lista — nada é fechado em silêncio.
+
+No mesmo passe, o título e o texto de cada aviso deixaram de passar pelo tradutor da
+interface. Eles são escritos no momento do evento e carregam nome de cliente, número e o que
+você cadastrou; quem usa o sistema em espanhol passa a ler o aviso exatamente como ele foi
+gravado. Os rótulos da tela seguem traduzidos.
+
+Trabalho original de @rafaelbatistazz.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -596,6 +596,7 @@ jobs:
         inbox-abas-espelham-o-comando.spec.ts
         moeda-da-organizacao.spec.ts
         zona-de-perigo-apaga-dados-de-teste.spec.ts
+        central-avisos-resolver-em-lote.spec.ts
 
       FORA_DO_CI: >-
         vps-fresh-onboarding.spec.ts

--- a/app/api/v1/ai/inbox/resolve-all/route.ts
+++ b/app/api/v1/ai/inbox/resolve-all/route.ts
@@ -1,0 +1,85 @@
+import { requireSupportWrite } from "@/lib/impersonate/support";
+/**
+ * Épico Operação Visível (F1) — resolve de uma vez TODOS os avisos abertos da org.
+ *
+ * POST sem corpo. A Central só resolvia item a item (`[id]/route.ts`), e uma
+ * instalação real chegou a 144 abertos: a única saída era clicar 144 vezes.
+ *
+ * ─── Por que não há Zod aqui, se a doutrina manda validar todo input ───────
+ *
+ * Porque NÃO HÁ input externo. Não há corpo lido, não há query, não há
+ * parâmetro de rota: a organização vem do cookie validado contra as
+ * memberships (`requireRole` → `resolveActiveOrg`) e o ator vem do JWT
+ * (`getUser`). O único predicado do `update` — a própria org e `status='open'`
+ * — é resolvido no servidor. Um `z.object({}).strict()` sobre um corpo que
+ * ninguém lê validaria nada e criaria um modo de falha novo. Se um dia esta
+ * rota aceitar um recorte (um `kind`, uma faixa de data), ele nasce com Zod.
+ *
+ * ─── O audit não leva resource_id, e isso é o conserto de um bug ──────────
+ *
+ * `api_audit_log.resource_id` é `uuid`. Um rótulo como `"bulk"` ali devolve
+ * `invalid input syntax for type uuid`, e como o audit é fire-and-forget a
+ * mutação segue verde enquanto a trilha some — exatamente o modo de falha que
+ * o cabeçalho de `lib/audit/index.ts` documenta, e que
+ * `tests/unit/audit-resource-id-e-uuid` reprova. O lote não tem UM recurso: o
+ * campo vai nulo e a contagem vai no metadata, o mesmo desenho de
+ * `app/api/v1/leads/bulk/route.ts`.
+ *
+ * Rodada sem efeito (nenhum aviso aberto) não audita: não houve mutação, e
+ * auditar o vazio é a mesma poluição que a doutrina já barrou nos crons.
+ */
+import { randomUUID } from "node:crypto";
+
+import { ok, fail } from "@/lib/api/wrappers";
+import { audit } from "@/lib/audit";
+import { requireRole } from "@/lib/auth/require-role";
+import { traduzir } from "@/lib/i18n/dicionario";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(): Promise<Response> {
+  const supportDenied = await requireSupportWrite();
+  if (supportDenied) return supportDenied;
+
+  const requestId = randomUUID();
+
+  // Mesmo piso do aviso avulso (`agent` — spec 13 §4, viewer é read-only). O
+  // lote é mais largo, mas não é mais destrutivo: resolver não apaga nada,
+  // reabrir continua permitido, e a linha resolvida segue visível na aba
+  // "Resolvidos". Subir para `manager` exigiria gatear o botão em `manager`
+  // também — senão a tela oferece ao atendente o que a rota recusa.
+  const authz = await requireRole("agent", { requestId, resource: "agent_inbox_items" });
+  if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
+  const { user: authUser, org } = authz;
+
+  // Service role bypassa RLS: o filtro por organização é EXPLÍCITO e vem da org
+  // ativa resolvida do cookie, nunca do corpo. Sem ele o update alcançaria os
+  // avisos de todos os tenants da instalação.
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("agent_inbox_items")
+    .update({ status: "resolved" })
+    .eq("organization_id", org.orgId)
+    .eq("status", "open")
+    .select("id");
+  if (error) {
+    return fail("internal_error", t("Falha ao resolver os avisos."), 500, { requestId });
+  }
+
+  const count = data?.length ?? 0;
+  if (count > 0) {
+    await audit({
+      action: "ai.inbox_item_status_changed",
+      actorUserId: authUser.id,
+      organizationId: org.orgId,
+      resourceType: "agent_inbox_items",
+      resourceId: null,
+      requestId,
+      metadata: { status: "resolved", bulk: true, count },
+    });
+  }
+
+  return ok({ resolved_count: count }, { requestId });
+}

--- a/app/app/ai/inbox/_components/AgentInboxList.tsx
+++ b/app/app/ai/inbox/_components/AgentInboxList.tsx
@@ -128,11 +128,21 @@ function InboxRow({
         {t(SEVERITY_LABEL[item.severity])}
       </Badge>
       <div className="min-w-0 flex-1 basis-48 break-words">
-        <p className="text-sm font-medium">{t(item.title)}</p>
+        {/* TÍTULO E CORPO SAEM COMO VIERAM — nunca por t().
+            São LINHAS de `agent_inbox_items`, escritas pelo runtime no momento do
+            evento e recheadas com dado de gente: nome do cliente, número, motivo do
+            handoff, o que o operador cadastrou. É a mesma regra que já vale para nome
+            de funil, rótulo de etapa e conteúdo de mensagem — e a mesma que o PR #600
+            aplicou à Agenda. Passar isso pelo dicionário não traduz nada (a chave é a
+            frase inteira, que nunca casa) e, quando casa, troca a palavra que a pessoa
+            cadastrou por outra que ela não sabe procurar.
+            O que continua traduzido é o que é NOSSO: severidade, rótulo do kind,
+            orientação e rótulo do destino. */}
+        <p className="text-sm font-medium">{item.title}</p>
         <p className="text-xs text-muted-foreground">
           {kindLabel(item.kind, t)} · {when}
         </p>
-        {item.body ? <p className="mt-1 text-xs text-muted-foreground">{t(item.body)}</p> : null}
+        {item.body ? <p className="mt-1 text-xs text-muted-foreground">{item.body}</p> : null}
         {item.destination.orientacao ? <p className="mt-2 text-xs text-muted-foreground">{t(item.destination.orientacao)}</p> : null}
         {item.destination.estado === "disponivel" ? (
           <Button asChild size="sm" variant="link" className="mt-1 h-auto whitespace-normal px-0 text-left">

--- a/app/app/ai/inbox/_components/AgentInboxList.tsx
+++ b/app/app/ai/inbox/_components/AgentInboxList.tsx
@@ -9,7 +9,12 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { useAgentInbox, useUpdateInboxItem, type AgentInboxItem } from "@/hooks/ai/useAgentInbox";
+import {
+  useAgentInbox,
+  useResolveAllInboxItems,
+  useUpdateInboxItem,
+  type AgentInboxItem,
+} from "@/hooks/ai/useAgentInbox";
 import { kindLabel, SEVERITY_LABEL, type AgentInboxSeverity } from "@/lib/ai/agent-inbox-copy";
 import { Bell, Check } from "@/lib/ui/icons";
 import { useT } from "@/hooks/i18n/useT";
@@ -28,17 +33,31 @@ export function AgentInboxList({ canResolve }: { canResolve: boolean }) {
   const acessoNegado = error instanceof ApiError && (error.status === 401 || error.status === 403);
   const data = acessoNegado ? undefined : cachedData;
   const update = useUpdateInboxItem();
+  const resolveAll = useResolveAllInboxItems();
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-4">
-      <Tabs value={tab} onValueChange={(v) => setTab(v as "open" | "resolved")}>
-        <TabsList>
-          <TabsTrigger value="open">
-            {t("Abertos")}{data ? ` (${data.open_count})` : ""}
-          </TabsTrigger>
-          <TabsTrigger value="resolved">{t("Resolvidos")}</TabsTrigger>
-        </TabsList>
-      </Tabs>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <Tabs value={tab} onValueChange={(v) => setTab(v as "open" | "resolved")}>
+          <TabsList>
+            <TabsTrigger value="open">
+              {t("Abertos")}{data ? ` (${data.open_count})` : ""}
+            </TabsTrigger>
+            <TabsTrigger value="resolved">{t("Resolvidos")}</TabsTrigger>
+          </TabsList>
+        </Tabs>
+        {canResolve && tab === "open" && data && data.items.length > 0 ? (
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={resolveAll.isPending}
+            onClick={() => resolveAll.mutate()}
+          >
+            <Check size={14} aria-hidden />
+            {t("Marcar todos resolvidos")}
+          </Button>
+        ) : null}
+      </div>
 
       {isError ? (
         <div role="alert" className="flex flex-wrap items-center gap-3 rounded-lg border border-border p-4 text-sm">
@@ -47,6 +66,10 @@ export function AgentInboxList({ canResolve }: { canResolve: boolean }) {
         </div>
       ) : null}
       {update.isError ? <p role="alert" className="text-sm text-destructive">{t("Não foi possível atualizar este aviso. Tente novamente.")}</p> : null}
+      {/* O lote pode falhar depois de resolver PARTE dos avisos: a mensagem manda
+          conferir a lista em vez de afirmar que nada mudou. Sem isto o clique em
+          "Marcar todos resolvidos" não deixaria rastro nenhum quando errasse. */}
+      {resolveAll.isError ? <p role="alert" className="text-sm text-destructive">{t("Não foi possível resolver todos os avisos. Confira a lista e tente novamente.")}</p> : null}
 
       {isLoading ? (
         <div className="space-y-2">

--- a/hooks/ai/useAgentInbox.ts
+++ b/hooks/ai/useAgentInbox.ts
@@ -45,3 +45,21 @@ export function useUpdateInboxItem() {
     onSettled: () => qc.invalidateQueries({ queryKey: ["agent-inbox"] }),
   });
 }
+
+/**
+ * Resolve TODOS os avisos abertos da organização de uma vez.
+ *
+ * Não recebe ids: quem decide o conjunto é o servidor, a partir da org do
+ * cookie. Mandar a lista da tela seria pior — a tela carrega no máximo 50, e
+ * "marcar todos" com 144 abertos precisa alcançar os 144.
+ */
+export function useResolveAllInboxItems() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => apiClient.post<{ data: { resolved_count: number } }>(
+      "/api/v1/ai/inbox/resolve-all",
+      {},
+    ),
+    onSettled: () => qc.invalidateQueries({ queryKey: ["agent-inbox"] }),
+  });
+}

--- a/lib/i18n/dicionario.ts
+++ b/lib/i18n/dicionario.ts
@@ -1924,6 +1924,11 @@ export const DICIONARIO: Traducoes = {
   "Limite mensal (US$)": { es: "Límite mensual (US$)" },
   "Linha do tempo do aprendizado": { es: "Línea de tiempo del aprendizaje" },
   "Marcar resolvido": { es: "Marcar resuelto" },
+  "Marcar todos resolvidos": { es: "Marcar todos como resueltos" },
+  "Não foi possível resolver todos os avisos. Confira a lista e tente novamente.": {
+    es: "No se pudieron resolver todos los avisos. Revisa la lista e inténtalo de nuevo.",
+  },
+  "Falha ao resolver os avisos.": { es: "Fallo al resolver los avisos." },
   "Me avisar ao passar de": { es: "Avisarme al pasar de" },
   "Melhorias que você aprovou": { es: "Mejoras que aprobaste" },
   "Memória da IA": { es: "Memoria de la IA" },

--- a/tests/e2e/central-avisos-resolver-em-lote.spec.ts
+++ b/tests/e2e/central-avisos-resolver-em-lote.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * "MARCAR TODOS RESOLVIDOS" PELA TELA, COMO O OPERADOR FAZ.
+ *
+ * Prova três coisas que o unitário não prova, porque as três moram entre o
+ * clique e o banco: que o botão está lá e é alcançável; que o lote fecha os
+ * abertos DAQUELA organização e só dela; e que o título do aviso continua
+ * saindo como foi gravado quando a interface está em espanhol (issue #603).
+ *
+ * Trabalho original de @rafaelbatistazz no PR #622.
+ */
+import { randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+
+import { createClient } from "@supabase/supabase-js";
+import { test, expect, type Page, type TestInfo } from "@playwright/test";
+
+import { credenciaisSupabaseDeTeste } from "../../scripts/lib/env-de-teste";
+
+const credentials = credenciaisSupabaseDeTeste();
+const db = createClient(credentials.url, credentials.serviceRole, {
+  auth: { persistSession: false },
+});
+const password = `Local-${randomUUID()}!`;
+
+/** Título com dado de gente dentro — é assim que o runtime grava de verdade. */
+const TITULO = (n: number) => `Fernando Rocha ${n} pediu para falar com uma pessoa`;
+const TITULO_VIZINHA = "Aviso da organização vizinha";
+const QUANTOS = 6;
+
+let usuario = { id: "", email: "" };
+const orgs: string[] = [];
+
+async function insert(table: string, value: Record<string, unknown>) {
+  const { data, error } = await db.from(table).insert(value).select("id").single();
+  if (error) throw error;
+  return data.id as string;
+}
+
+async function login(page: Page) {
+  await page.goto("/login");
+  await page.getByLabel(/e-?mail/i).fill(usuario.email);
+  await page.getByLabel(/senha/i).fill(password);
+  await page.getByRole("button", { name: /entrar/i }).click();
+  await page.waitForURL(/\/app(?:\/|$)/, { timeout: 60_000 });
+}
+
+const linha = (page: Page, titulo: string) =>
+  page.getByTestId("inbox-item").filter({ hasText: titulo });
+
+async function evidencia(page: Page, info: TestInfo, nome: string) {
+  const diretorio = info.outputPath(nome);
+  mkdirSync(diretorio, { recursive: true });
+  await page.screenshot({ path: `${diretorio}/central.png`, fullPage: true });
+}
+
+test.beforeAll(async () => {
+  const email = `lote-${randomUUID()}@invariant.test`;
+  const { data, error } = await db.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  });
+  if (error || !data.user) throw error;
+  usuario = { id: data.user.id, email };
+
+  for (const n of [0, 1]) {
+    const org = await insert("organizations", {
+      slug: `lote-${randomUUID()}`,
+      legal_name: `Lote ${n}`,
+      display_name: `Lote ${n}`,
+      onboarded_at: new Date().toISOString(),
+    });
+    orgs.push(org);
+  }
+  const membro = await db.from("user_organizations").insert({
+    organization_id: orgs[0],
+    user_id: usuario.id,
+    role: "agent",
+    accepted_at: new Date().toISOString(),
+  });
+  if (membro.error) throw membro.error;
+
+  for (let i = 0; i < QUANTOS; i += 1) {
+    await insert("agent_inbox_items", {
+      organization_id: orgs[0],
+      kind: "handoff",
+      severity: "warn",
+      title: TITULO(i),
+      body: `Motivo: contrato. Cliente: Fernando Rocha ${i}.`,
+      status: "open",
+    });
+  }
+  await insert("agent_inbox_items", {
+    organization_id: orgs[1],
+    kind: "handoff",
+    severity: "warn",
+    title: TITULO_VIZINHA,
+    status: "open",
+  });
+});
+
+test.afterAll(async () => {
+  for (const id of orgs) {
+    const r = await db.from("organizations").delete().eq("id", id);
+    if (r.error) throw r.error;
+  }
+  const r = await db.auth.admin.deleteUser(usuario.id);
+  if (r.error) throw r.error;
+});
+
+test("um clique fecha os abertos da minha organização e não encosta na vizinha", async ({
+  page,
+}, info) => {
+  test.setTimeout(180_000);
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await login(page);
+  await page.goto("/app/ai/inbox");
+
+  await expect(linha(page, TITULO(0))).toBeVisible();
+  await expect(page.getByTestId("inbox-item")).toHaveCount(QUANTOS);
+  await evidencia(page, info, "antes");
+
+  await page.getByRole("button", { name: "Marcar todos resolvidos" }).click();
+
+  await expect(page.getByText("Nenhum aviso em aberto")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole("button", { name: "Marcar todos resolvidos" })).toHaveCount(0);
+  await evidencia(page, info, "depois");
+
+  await page.getByRole("tab", { name: "Resolvidos" }).click();
+  await expect(page.getByTestId("inbox-item")).toHaveCount(QUANTOS);
+
+  // O que o service role NÃO podia alcançar: a organização vizinha.
+  const vizinha = await db
+    .from("agent_inbox_items")
+    .select("status")
+    .eq("organization_id", orgs[1]);
+  if (vizinha.error) throw vizinha.error;
+  expect(vizinha.data.map((l) => l.status)).toEqual(["open"]);
+});
+
+test("em espanhol, o título do aviso continua o que foi gravado (issue #603)", async ({
+  page,
+}) => {
+  test.setTimeout(120_000);
+  const reabre = await db
+    .from("agent_inbox_items")
+    .update({ status: "open" })
+    .eq("organization_id", orgs[0]);
+  if (reabre.error) throw reabre.error;
+  const idioma = await db.auth.admin.updateUserById(usuario.id, {
+    user_metadata: { locale: "es" },
+  });
+  if (idioma.error) throw idioma.error;
+
+  await login(page);
+  await page.goto("/app/ai/inbox");
+
+  // O rótulo NOSSO traduz…
+  await expect(page.getByRole("button", { name: "Marcar todos como resueltos" })).toBeVisible();
+  // …e o dado sai como veio.
+  await expect(linha(page, TITULO(0))).toBeVisible();
+});

--- a/tests/unit/central-avisos-destino.test.tsx
+++ b/tests/unit/central-avisos-destino.test.tsx
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { AgentInboxList } from "@/app/app/ai/inbox/_components/AgentInboxList";
-import { useAgentInbox, useUpdateInboxItem, type AgentInboxItem } from "@/hooks/ai/useAgentInbox";
+import { useAgentInbox, useResolveAllInboxItems, useUpdateInboxItem, type AgentInboxItem } from "@/hooks/ai/useAgentInbox";
 import { ApiError } from "@/lib/api/types";
-vi.mock("@/hooks/ai/useAgentInbox", () => ({ useAgentInbox: vi.fn(), useUpdateInboxItem: vi.fn() }));
+vi.mock("@/hooks/ai/useAgentInbox", () => ({ useAgentInbox: vi.fn(), useUpdateInboxItem: vi.fn(), useResolveAllInboxItems: vi.fn() }));
 vi.mock("@/hooks/i18n/useT", () => ({ useT: () => (s: string) => s }));
 vi.mock("@/hooks/i18n/useLocaleDeData", () => ({ useLocaleDeData: () => undefined }));
 const mutate = vi.fn();
@@ -11,7 +11,7 @@ const item: AgentInboxItem = { id: "aviso", kind: "handoff", severity: "warn", t
 function dados(value = item) {
   vi.mocked(useAgentInbox).mockReturnValue({ data: { items: [value], open_count: 1 }, isLoading: false } as ReturnType<typeof useAgentInbox>);
 }
-beforeEach(() => { vi.clearAllMocks(); dados(); vi.mocked(useUpdateInboxItem).mockReturnValue({ mutate, isPending: false } as unknown as ReturnType<typeof useUpdateInboxItem>); });
+beforeEach(() => { vi.clearAllMocks(); dados(); vi.mocked(useUpdateInboxItem).mockReturnValue({ mutate, isPending: false } as unknown as ReturnType<typeof useUpdateInboxItem>); vi.mocked(useResolveAllInboxItems).mockReturnValue({ mutate: vi.fn(), isPending: false } as unknown as ReturnType<typeof useResolveAllInboxItems>); });
 describe("Central: navegação separada da resolução", () => {
   it("contexto é link, clique não muda status; resolver chama uma vez", () => {
     render(<AgentInboxList canResolve />);

--- a/tests/unit/central-avisos-mostra-o-aviso-como-veio.test.tsx
+++ b/tests/unit/central-avisos-mostra-o-aviso-como-veio.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * O AVISO APARECE COMO FOI GRAVADO; O QUE É NOSSO CONTINUA TRADUZIDO.
+ *
+ * ## O defeito (issue #603), achado por @rafaelbatistazz no PR #622
+ *
+ * `AgentInboxList` renderizava `{t(item.title)}` e `{t(item.body)}`.
+ * `agent_inbox_items.title/body` são LINHAS: o runtime as escreve no instante
+ * do evento, recheadas com dado de gente — nome do cliente, número do WhatsApp,
+ * motivo do handoff, o nome que o operador cadastrou. Passar isso pelo
+ * dicionário é o mesmo erro que o PR #600 corrigiu na Agenda: na maioria das
+ * vezes não traduz nada (a chave é a frase inteira e nunca casa) e, quando
+ * casa, troca a palavra que a pessoa cadastrou por outra que ela não consegue
+ * procurar.
+ *
+ * ## Por que renderizar, e não varrer o AST
+ *
+ * A varredura estática guardaria a CHAMADA (`t(` aplicado a `item.title`), e a
+ * chamada tem mil disfarces: `t(item.title ?? "")`, `t(String(item.title))`,
+ * um helper `rotulo(item)` que traduz lá dentro. O que importa é o texto que
+ * chega ao olho. Aqui o `t` de mentira PREFIXA tudo que passa por ele; então o
+ * título sem prefixo é prova de que não passou, e o rótulo COM prefixo é prova
+ * de que a tela continua traduzida — o par do "não faça X", sem o qual arrancar
+ * `t()` da tela inteira satisfaria este arquivo.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { AgentInboxList } from "@/app/app/ai/inbox/_components/AgentInboxList";
+import {
+  useAgentInbox,
+  useResolveAllInboxItems,
+  useUpdateInboxItem,
+  type AgentInboxItem,
+} from "@/hooks/ai/useAgentInbox";
+
+vi.mock("@/hooks/ai/useAgentInbox", () => ({
+  useAgentInbox: vi.fn(),
+  useUpdateInboxItem: vi.fn(),
+  useResolveAllInboxItems: vi.fn(),
+}));
+/** Todo texto que passar pelo tradutor sai marcado. O que não passar, sai cru. */
+vi.mock("@/hooks/i18n/useT", () => ({ useT: () => (texto: string) => `ES:${texto}` }));
+vi.mock("@/hooks/i18n/useLocaleDeData", () => ({ useLocaleDeData: () => undefined }));
+
+/** Título e corpo como o runtime os grava: frase inteira, com dado de gente dentro. */
+const TITULO = "Fernando Rocha pediu para falar com uma pessoa";
+const CORPO = "Motivo: pergunta sobre contrato. Cliente: Fernando Rocha (+55 11 99999-0000).";
+
+const aviso: AgentInboxItem = {
+  id: "aviso-1",
+  kind: "handoff",
+  severity: "warn",
+  title: TITULO,
+  body: CORPO,
+  ref_kind: "conversation",
+  ref_id: "conversa-1",
+  status: "open",
+  created_at: new Date().toISOString(),
+  destination: { estado: "disponivel", href: "/app/inbox/conversa-1", rotulo: "Abrir conversa" },
+};
+
+const resolverTodos = vi.fn();
+
+function lista(itens: AgentInboxItem[] = [aviso], extra: Record<string, unknown> = {}) {
+  vi.mocked(useAgentInbox).mockReturnValue({
+    data: { items: itens, open_count: itens.length },
+    isLoading: false,
+    ...extra,
+  } as unknown as ReturnType<typeof useAgentInbox>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  lista();
+  vi.mocked(useUpdateInboxItem).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof useUpdateInboxItem>);
+  vi.mocked(useResolveAllInboxItems).mockReturnValue({
+    mutate: resolverTodos,
+    isPending: false,
+  } as unknown as ReturnType<typeof useResolveAllInboxItems>);
+});
+
+describe("Central de avisos: o dado sai como veio", () => {
+  it("título e corpo do aviso chegam ao olho SEM passar pelo tradutor", () => {
+    render(<AgentInboxList canResolve />);
+
+    expect(screen.getByText(TITULO)).toBeVisible();
+    expect(screen.getByText(CORPO)).toBeVisible();
+    expect(
+      screen.queryByText(`ES:${TITULO}`),
+      "o título do aviso foi pelo dicionário: quem lê em espanhol deixa de ver o que foi gravado",
+    ).toBeNull();
+    expect(screen.queryByText(`ES:${CORPO}`)).toBeNull();
+  });
+
+  it("o que é NOSSO continua traduzido — o par do «não faça X»", () => {
+    // Sem este caso, arrancar t() da tela inteira deixaria o de cima verde e
+    // devolveria a Central em português para quem escolheu espanhol.
+    render(<AgentInboxList canResolve />);
+
+    expect(screen.getByText("ES:atenção"), "severidade").toBeVisible();
+    expect(
+      screen.getByText(/^ES:O assistente passou um atendimento para um humano/),
+      "rótulo do kind",
+    ).toBeVisible();
+    expect(screen.getByRole("link", { name: "ES:Abrir conversa" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "ES:Marcar resolvido" })).toBeVisible();
+  });
+});
+
+describe("Central de avisos: resolver todos de uma vez", () => {
+  it("o botão aparece na aba Abertos para quem pode resolver e dispara uma chamada só", () => {
+    render(<AgentInboxList canResolve />);
+
+    fireEvent.click(screen.getByRole("button", { name: "ES:Marcar todos resolvidos" }));
+    expect(resolverTodos).toHaveBeenCalledOnce();
+  });
+
+  it("quem não pode resolver não recebe o botão do lote", () => {
+    render(<AgentInboxList canResolve={false} />);
+    expect(screen.queryByRole("button", { name: "ES:Marcar todos resolvidos" })).toBeNull();
+  });
+
+  it("sem aviso aberto não há lote a resolver", () => {
+    lista([]);
+    render(<AgentInboxList canResolve />);
+    expect(screen.queryByRole("button", { name: "ES:Marcar todos resolvidos" })).toBeNull();
+  });
+
+  it("na aba Resolvidos o botão some — ele fecha abertos, não reabre nada", () => {
+    render(<AgentInboxList canResolve />);
+    // Radix ativa a aba no mouseDown/focus, não no `click` sintético.
+    const aba = screen.getByRole("tab", { name: "ES:Resolvidos" });
+    fireEvent.mouseDown(aba);
+    fireEvent.focus(aba);
+    expect(aba).toHaveAttribute("aria-selected", "true");
+    expect(screen.queryByRole("button", { name: "ES:Marcar todos resolvidos" })).toBeNull();
+  });
+
+  it("lote que falha deixa rastro na tela e não afirma que fechou nada", () => {
+    // O laço de retorno (invariante 7 do Sistema Vivo): o lote pode falhar
+    // depois de resolver PARTE dos avisos. Sem esta mensagem o clique some sem
+    // efeito visível e a pessoa clica de novo achando que não pegou.
+    vi.mocked(useResolveAllInboxItems).mockReturnValue({
+      mutate: resolverTodos,
+      isPending: false,
+      isError: true,
+    } as unknown as ReturnType<typeof useResolveAllInboxItems>);
+    render(<AgentInboxList canResolve />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Não foi possível resolver todos");
+    expect(screen.getByText(TITULO), "a lista some junto com o erro").toBeVisible();
+  });
+});

--- a/tests/unit/central-avisos-resolver-em-lote.test.ts
+++ b/tests/unit/central-avisos-resolver-em-lote.test.ts
@@ -1,0 +1,177 @@
+/**
+ * RESOLVER TODOS OS AVISOS SÓ ALCANÇA A ORGANIZAÇÃO DE QUEM CLICOU.
+ *
+ * ## Por que uma tabela de mentira em vez de espiar as chamadas
+ *
+ * O jeito barato de "provar" escopo é gravar os `.eq()` e conferir que
+ * `["organization_id", org]` está na lista. Isso guarda a CHAMADA, não o
+ * efeito: um `.eq("organization_id", …)` aplicado ao lugar errado, ou um
+ * `.or()` acrescentado depois dele, satisfaz a asserção e continua resolvendo o
+ * aviso do vizinho. O `admin` daqui é service role — ele bypassa RLS, então o
+ * único filtro que existe é o que a rota escreve, e o teste tem de medir o que
+ * SOBROU na tabela.
+ *
+ * Por isso a fixture é uma tabelinha em memória que APLICA os predicados: se a
+ * rota perder o filtro de organização, a linha da outra org muda de status e o
+ * caso estoura; se perder o `status = 'open'`, a contagem sobe e estoura
+ * também. Nenhum dos dois é visível espiando argumento.
+ *
+ * ## O que mais está preso aqui
+ *
+ * `resourceId: null` no audit. `api_audit_log.resource_id` é `uuid`; um rótulo
+ * como `"bulk"` faz o insert falhar com `invalid input syntax for type uuid` —
+ * e o audit é fire-and-forget, então a mutação de 144 linhas seguiria verde com
+ * a trilha PERDIDA. O modo de falha está documentado no cabeçalho de
+ * `lib/audit/index.ts`; aqui ele fica preso.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST } from "@/app/api/v1/ai/inbox/resolve-all/route";
+import { audit } from "@/lib/audit";
+import { requireRole } from "@/lib/auth/require-role";
+import { requireSupportWrite } from "@/lib/impersonate/support";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+vi.mock("@/lib/auth/require-role", () => ({ requireRole: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
+vi.mock("@/lib/impersonate/support", () => ({ requireSupportWrite: vi.fn(async () => null) }));
+vi.mock("@/lib/audit", () => ({ audit: vi.fn(async () => {}) }));
+
+const ORG = "11111111-1111-4111-8111-111111111111";
+const OUTRA_ORG = "99999999-9999-4999-8999-999999999999";
+const ATOR = "22222222-2222-4222-8222-222222222222";
+
+interface Linha {
+  id: string;
+  organization_id: string;
+  status: "open" | "ack" | "resolved";
+}
+
+let tabela: Linha[];
+let erroDoBanco: { message: string } | null;
+
+/** Cliente de mentira que APLICA os `.eq()` — o efeito é o que se mede. */
+function adminFalso() {
+  return {
+    from(nome: string) {
+      expect(nome).toBe("agent_inbox_items");
+      const filtros: Array<[keyof Linha, unknown]> = [];
+      let patch: Partial<Linha> | null = null;
+      const cadeia = {
+        update(p: Partial<Linha>) {
+          patch = p;
+          return cadeia;
+        },
+        eq(coluna: keyof Linha, valor: unknown) {
+          filtros.push([coluna, valor]);
+          return cadeia;
+        },
+        select() {
+          if (erroDoBanco) return Promise.resolve({ data: null, error: erroDoBanco });
+          const alvo = tabela.filter((linha) => filtros.every(([c, v]) => linha[c] === v));
+          if (patch) for (const linha of alvo) Object.assign(linha, patch);
+          return Promise.resolve({ data: alvo.map((l) => ({ id: l.id })), error: null });
+        },
+      };
+      return cadeia;
+    },
+  };
+}
+
+const abertosDe = (org: string) =>
+  tabela.filter((l) => l.organization_id === org && l.status === "open").map((l) => l.id);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  erroDoBanco = null;
+  tabela = [
+    { id: "a1", organization_id: ORG, status: "open" },
+    { id: "a2", organization_id: ORG, status: "open" },
+    { id: "a3", organization_id: ORG, status: "resolved" },
+    { id: "b1", organization_id: OUTRA_ORG, status: "open" },
+  ];
+  vi.mocked(requireSupportWrite).mockResolvedValue(null);
+  vi.mocked(requireRole).mockResolvedValue({
+    ok: true,
+    org: { orgId: ORG, role: "agent", name: "Org" },
+    user: { id: ATOR, idioma: "pt-BR" },
+  } as Awaited<ReturnType<typeof requireRole>>);
+  vi.mocked(createAdminClient).mockReturnValue(
+    adminFalso() as unknown as ReturnType<typeof createAdminClient>,
+  );
+});
+
+describe("POST /api/v1/ai/inbox/resolve-all", () => {
+  it("resolve os abertos da org de quem chamou e NÃO encosta na outra organização", async () => {
+    const resposta = await POST();
+
+    expect(resposta.status).toBe(200);
+    expect((await resposta.json()).data).toEqual({ resolved_count: 2 });
+    expect(abertosDe(ORG), "sobrou aviso aberto na org de quem clicou").toEqual([]);
+    expect(
+      abertosDe(OUTRA_ORG),
+      "o lote alcançou a organização vizinha — o service role bypassa RLS, o filtro é a única cerca",
+    ).toEqual(["b1"]);
+    // A linha já resolvida não entra na conta: `status = 'open'` é predicado, não enfeite.
+    expect(tabela.find((l) => l.id === "a3")!.status).toBe("resolved");
+  });
+
+  it("audita UMA vez, com a contagem, sem resource_id e correlacionado ao X-Request-Id", async () => {
+    const resposta = await POST();
+    const requestId = resposta.headers.get("X-Request-Id");
+
+    expect(requestId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(audit).toHaveBeenCalledExactlyOnceWith({
+      action: "ai.inbox_item_status_changed",
+      actorUserId: ATOR,
+      organizationId: ORG,
+      resourceType: "agent_inbox_items",
+      // `uuid` no banco: um rótulo aqui derruba o insert e a trilha some em silêncio.
+      resourceId: null,
+      requestId,
+      metadata: { status: "resolved", bulk: true, count: 2 },
+    });
+  });
+
+  it("rodada sem nada aberto responde zero e NÃO audita (não houve mutação)", async () => {
+    tabela = tabela.map((l) => ({ ...l, status: "resolved" as const }));
+    const resposta = await POST();
+
+    expect((await resposta.json()).data).toEqual({ resolved_count: 0 });
+    expect(audit).not.toHaveBeenCalled();
+  });
+
+  it("erro do banco vira 500 e não afirma que resolveu nada", async () => {
+    erroDoBanco = { message: "boom" };
+    const resposta = await POST();
+
+    expect(resposta.status).toBe(500);
+    expect((await resposta.json()).error.code).toBe("internal_error");
+    expect(audit).not.toHaveBeenCalled();
+    expect(abertosDe(ORG)).toEqual(["a1", "a2"]);
+  });
+
+  it("acompanhamento somente-leitura é barrado ANTES de o service role existir", async () => {
+    vi.mocked(requireSupportWrite).mockResolvedValue(
+      new Response(null, { status: 403 }) as Awaited<ReturnType<typeof requireSupportWrite>>,
+    );
+    const resposta = await POST();
+
+    expect(resposta.status).toBe(403);
+    expect(createAdminClient).not.toHaveBeenCalled();
+    expect(abertosDe(ORG)).toEqual(["a1", "a2"]);
+  });
+
+  it.each([401, 403])("sem papel suficiente (%i) o banco não é tocado", async (status) => {
+    vi.mocked(requireRole).mockResolvedValue({
+      ok: false,
+      response: new Response(null, { status }),
+    } as Awaited<ReturnType<typeof requireRole>>);
+    const resposta = await POST();
+
+    expect(resposta.status).toBe(status);
+    expect(requireRole).toHaveBeenCalledWith("agent", expect.any(Object));
+    expect(createAdminClient).not.toHaveBeenCalled();
+    expect(abertosDe(ORG)).toEqual(["a1", "a2"]);
+  });
+});


### PR DESCRIPTION
Resgate do **PR #622**, que @rafaelbatistazz fechou **3min34s** depois de abrir, com a frase "aberto no repo errado, cancelando" — depois de ter recebido só o comentário do robô. **Ele não tinha errado.** O trabalho é dele; nós é que perdemos.

## O que entra

**1. Resolver em lote na Central de Avisos.** Hoje só existe item a item (`app/api/v1/ai/inbox/[id]/route.ts`). O autor citou **144 avisos abertos** numa instalação real dele — e ninguém clica 144 vezes, então os avisos deixam de ser lidos.

**2. O aviso sai como foi gravado.** `AgentInboxList` passava `{t(item.title)}` e `{t(item.body)}` pelo tradutor. Esses dois campos são **linhas de `agent_inbox_items`**, escritas pelo runtime com dado de gente dentro — nome do cliente, número, motivo do handoff. É o "Cego" da issue **#603**, e o mesmo defeito que o #600 corrigiu na Agenda. Conserto que ele trouxe de graça, sem ninguém pedir.

## O que consertamos além do que ele trouxe — e as quatro são falha nossa

| o que faltava | consequência |
|---|---|
| `requireSupportWrite()` | um acompanhamento **somente-leitura** fecharia os 144 avisos do cliente |
| `resourceId: "bulk"` → nulo | `api_audit_log.resource_id` é `uuid`; `"bulk"` estoura e, como audit é fire-and-forget, **a mutação segue verde com a trilha perdida**. A forma original teria ficado vermelha em `audit-resource-id-e-uuid` — gate que já existia |
| laço de retorno (DoD 13, invariante 7) | o clique sumia sem rastro quando o lote falhava no meio |
| espanhol dos rótulos novos | `i18n-espanhol-cobre-a-tela` cobra |

Nenhuma dessas estava documentada onde um contribuidor de fora pudesse ver.

## RBAC

`agent`, o mesmo do aviso avulso. O lote é mais largo, não mais destrutivo — não apaga, reabrir segue permitido, a linha fica visível em "Resolvidos", e a contagem vai para a auditoria. Subir para `manager` obrigaria a gatear o botão em `manager` também, senão a tela oferece ao atendente o que a rota recusa.

## Testes — o PR não trazia nenhum

- `tests/unit/central-avisos-resolver-em-lote.test.ts` (7 casos). A fixture **aplica os predicados** numa tabela em memória, então mede o efeito e não os argumentos: o aviso de outra organização fica lá e o teste confere que **não mudou de status**.
- `tests/unit/central-avisos-mostra-o-aviso-como-veio.test.tsx` (7 casos). O `t` de mentira **prefixa** tudo que passa por ele: título sem prefixo prova que não passou; rótulo **com** prefixo é o par do "não faça X" — sem ele, arrancar `t()` da Central inteira ficaria verde.
- `tests/e2e/central-avisos-resolver-em-lote.spec.ts`, registrada em `SPECS_PARTE_3`.

### Sabotagem — previsto × observado

| linha sabotada (a perda **silenciosa**) | previsto | observado |
|---|---|---|
| `.eq("organization_id", org.orgId)` do UPDATE | 2 casos, 1 arquivo | **igual**, os dois nomes previstos |
| `resourceId: null` → `"bulk"` | 2 casos, 2 arquivos | **igual** |
| restaurar `t(item.title)` | 1 caso | **2** — previsão errada, registrada |

O erro na terceira: o caso do laço de retorno também assere o título para provar que a lista não some junto com o erro, e está acoplado à mesma propriedade.

## Gates

```
pnpm typecheck        exit 0
pnpm lint             exit 0   (343 warnings, nenhum novo)
pnpm lint:channels    exit 0   (62 arquivos de dívida conhecida, nenhum novo)
pnpm test:unit        exit 0   Test Files 738 passed (738) · Tests 7928 passed | 1 expected fail (7929)
pnpm release:conferir exit 0   1.17.0 + minor = 1.18.0
```

**NÃO MEDIDO:** `pnpm build` não completou nesta máquina (compilou em 19min e travou em `Running TypeScript` sem `BUILD_ID`, a 0% de CPU — assinatura conhecida de processo longo morto no ambiente local); sem controle na `main`, não separei ambiente de mudança, e por isso quem prova o build aqui é o `build-and-size` do CI. A spec e2e **não executou** (falta `.env.e2e`/build); quem a executa é o job `e2e`. `test:db` não rodado — não há mudança de schema, mas o `invariants` é obrigatório e não foi exercitado localmente.

## Uma pergunta que fica para o autor

"Todos" resolve tudo que está **aberto no servidor**, e a lista carrega no máximo 50 com o contador podendo marcar 144 — então "todos" já significa mais do que está na tela. Portamos como ele escreveu, em vez de inventar um recorte por timestamp. @rafaelbatistazz, era isso mesmo?

🤖 Generated with [Claude Code](https://claude.com/claude-code)