### PR TITLE
fix(worker): laço rápido do drain volta a montar o admin client

### DIFF
--- a/.changes/worker-drain-hyphenate-esm-cjs.md
+++ b/.changes/worker-drain-hyphenate-esm-cjs.md
@@ -1,0 +1,9 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O laço rápido do worker volta a montar o admin client
+---
+
+`@react-pdf/hyphenate` é ESM puro e não expunha a condição `require` no seu `exports`. Como o worker roda via `tsx` (CommonJS), qualquer import de `@react-pdf/renderer` (usado pela exportação de dados LGPD) derrubava `carregarDeps()` do drain loop com `ERR_PACKAGE_PATH_NOT_EXPORTED` — e como `register-handlers.ts` registra os 12 handlers do `event_log` num só import chain, isso tirava o laço rápido de TODOS eles, não só do LGPD, caindo pro cron de 1×/min como única rede de segurança.
+
+Patch (`patches/@react-pdf__hyphenate.patch`) acrescenta a condição `require` ao exports map — Node 22.12+/24 já sabe carregar ESM via `require()` quando o mapa permite. Provado no worker real: o warning "event-log drain OFF" some do log de boot.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM node:22-alpine AS deps
 WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@9.15.9 --activate
 COPY package.json pnpm-lock.yaml ./
+COPY patches ./patches
 RUN pnpm install --frozen-lockfile
 
 # ---- build: gera .next/standalone ----

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -16,6 +16,7 @@ ENV APP_VERSION=$APP_VERSION
 RUN corepack enable && corepack prepare pnpm@9.15.9 --activate
 
 COPY package.json pnpm-lock.yaml ./
+COPY patches ./patches
 RUN pnpm install --frozen-lockfile
 
 COPY . .

--- a/package.json
+++ b/package.json
@@ -134,6 +134,9 @@
       "fast-uri": "^3.1.7",
       "qs": "^6.16.0",
       "browserslist": "^4.28.8"
+    },
+    "patchedDependencies": {
+      "@react-pdf/hyphenate": "patches/@react-pdf__hyphenate.patch"
     }
   }
 }

--- a/patches/@react-pdf__hyphenate.patch
+++ b/patches/@react-pdf__hyphenate.patch
@@ -1,0 +1,20 @@
+diff --git a/package.json b/package.json
+index 477fe06e7938a695df193bb1af1d70880078ffad..eec05990630d10c1c22ae33c420dbc9199c093ca 100644
+--- a/package.json
++++ b/package.json
+@@ -11,11 +11,13 @@
+   "exports": {
+     ".": {
+       "types": "./lib/index.d.ts",
+-      "import": "./lib/index.js"
++      "import": "./lib/index.js",
++      "require": "./lib/index.js"
+     },
+     "./*": {
+       "types": "./lib/*.d.ts",
+-      "import": "./lib/*.js"
++      "import": "./lib/*.js",
++      "require": "./lib/*.js"
+     }
+   },
+   "typesVersions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,11 @@ overrides:
   qs: ^6.16.0
   browserslist: ^4.28.8
 
+patchedDependencies:
+  '@react-pdf/hyphenate':
+    hash: 7zbg3hcwdkwwiwo2qqqwdmolwi
+    path: patches/@react-pdf__hyphenate.patch
+
 importers:
 
   .:
@@ -6791,7 +6796,7 @@ snapshots:
       is-url: 1.2.4
       pdfkit: 0.20.1
 
-  '@react-pdf/hyphenate@0.1.0':
+  '@react-pdf/hyphenate@0.1.0(patch_hash=7zbg3hcwdkwwiwo2qqqwdmolwi)':
     dependencies:
       hyphen: 1.6.6
 
@@ -6870,7 +6875,7 @@ snapshots:
   '@react-pdf/textkit@7.0.1':
     dependencies:
       '@react-pdf/fns': 3.1.3
-      '@react-pdf/hyphenate': 0.1.0
+      '@react-pdf/hyphenate': 0.1.0(patch_hash=7zbg3hcwdkwwiwo2qqqwdmolwi)
       bidi-js: 1.0.3
       unicode-properties: 1.4.1
 

--- a/tests/unit/react-pdf-resolve-sob-tsx.test.ts
+++ b/tests/unit/react-pdf-resolve-sob-tsx.test.ts
@@ -1,0 +1,74 @@
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * `@react-pdf/hyphenate@0.1.0` é ESM puro (`"type":"module"`) e seu `exports`
+ * map só definia a condição `import`. Este repo não declara `"type":"module"`
+ * no `package.json` (CommonJS por padrão), e o worker roda via `tsx`
+ * (`Dockerfile.worker`), que resolve `node_modules` com `require()` nativo do
+ * Node — a mesma resolução que `register-handlers.ts` atravessa pra montar o
+ * admin client do drain loop (`lib/event-log/drain-loop.ts`). Sem a condição
+ * `require`, QUALQUER import estático de `@react-pdf/renderer` (usado pelo
+ * PDF de exportação LGPD, `lib/lgpd/pdf-renderer.tsx`) derrubava
+ * `carregarDeps()` com `ERR_PACKAGE_PATH_NOT_EXPORTED` — e como
+ * `register-handlers.ts` registra os 12 handlers num só import chain, UM
+ * pacote quebrado tirava o laço rápido de TODOS, não só do LGPD (medido em
+ * VPS, 2026-09-08: warn "event-log drain OFF" a cada boot do worker,
+ * handlers caindo pro cron de 1×/min).
+ *
+ * O conserto é `patches/@react-pdf__hyphenate.patch`
+ * (`pnpm.patchedDependencies` no `package.json`), que acrescenta a condição
+ * `require` ao `exports` do hyphenate — Node 22.12+/24 já sabe carregar ESM
+ * via `require()` quando o mapa permite (o pacote não usa top-level await).
+ * Confirmado nos dois sentidos: sem o patch este teste falha com o erro
+ * acima; com ele, passa.
+ *
+ * Mesma técnica de `import-puro-sem-env.test.ts` (processo FILHO com `tsx`
+ * de verdade), mas com uma virada que É o ponto do teste: `import()` DINÂMICO
+ * não serve aqui — ele entrega pro loader ESM nativo do Node, que sempre
+ * honra a condição `import` do exports map (nunca quebrou, patch ou não). O
+ * `tsx` intercepta `require()` GLOBALMENTE (o hook em `register-*.cjs`),
+ * inclusive dentro do código-fonte ESM de dependências que ELE PRÓPRIO já
+ * carregou — é assim que a resolução profunda de `@react-pdf/textkit`
+ * atravessa o hook do `tsx` e bate no exports map do hyphenate. Confirmado
+ * manualmente: `import()` no `--eval` passa sempre (falso-negativo); só
+ * `require()` reproduz o defeito e prova o patch.
+ */
+
+const RAIZ = join(__dirname, "..", "..");
+const TSX_CLI = join(RAIZ, "node_modules", "tsx", "dist", "cli.mjs");
+
+function requireNoTsx(modulo: string): { ok: boolean; erro: string } {
+  const script = `try{require(${JSON.stringify(modulo)});console.log("OK")}catch(e){console.log("ERRO:"+String(e&&e.message).split("\\n")[0])}`;
+  try {
+    const saida = execFileSync(process.execPath, [TSX_CLI, "--eval", script], {
+      cwd: RAIZ,
+      encoding: "utf8",
+      timeout: 60_000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { ok: saida.includes("OK"), erro: saida.trim() };
+  } catch (e) {
+    const bruto =
+      typeof e === "object" && e !== null && "stdout" in e
+        ? String((e as { stdout?: unknown }).stdout ?? "")
+        : "";
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, erro: `${bruto} ${msg}`.trim().slice(0, 400) };
+  }
+}
+
+describe("@react-pdf/renderer resolve sob tsx (CommonJS)", () => {
+  it("importa sem ERR_PACKAGE_PATH_NOT_EXPORTED", { timeout: 60_000 }, () => {
+    const r = requireNoTsx("@react-pdf/renderer");
+    expect(
+      r.ok,
+      `@react-pdf/renderer não importou sob tsx — provável regressão do patch ` +
+        `de @react-pdf/hyphenate (a condição "require" do exports map em ` +
+        `patches/@react-pdf__hyphenate.patch). Isto derruba carregarDeps() do ` +
+        `drain loop do worker E a exportação de dados LGPD. Saída: ${r.erro}`,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Resumo

- `@react-pdf/hyphenate@0.1.0` é ESM puro e só expunha a condição `import` no `exports` map. Este repo é CommonJS por padrão (sem `"type":"module"`) e o worker roda via `tsx` (`Dockerfile.worker`), que resolve `node_modules` com `require()` nativo — qualquer import estático de `@react-pdf/renderer` (usado por `lib/lgpd/pdf-renderer.tsx`, a exportação de dados LGPD) derrubava `carregarDeps()` do drain loop com `ERR_PACKAGE_PATH_NOT_EXPORTED`.
- Como `register-handlers.ts` registra os 12 handlers do `event_log` num só import chain, um pacote quebrado tirava o laço rápido de **todos eles**, não só do LGPD — caindo pro cron de 1×/min como única rede de segurança (o próprio `drain-loop.ts` já prevê e contém essa degradação, então não era outage, mas atrasava tudo que passa por `event_log`).
- Medido numa instalação real: warning `"event-log drain OFF — não consegui montar o admin client"` a cada boot do worker.

## O que muda

- `patches/@react-pdf__hyphenate.patch` (via `pnpm.patchedDependencies`): acrescenta a condição `require` ao `exports` map do hyphenate. Node 22.12+/24 já sabe carregar ESM via `require()` quando o mapa permite — o pacote não usa top-level await, então não há nada mais pra fazer.
- `Dockerfile` e `Dockerfile.worker`: `COPY patches ./patches` antes do `pnpm install --frozen-lockfile`. A otimização de cache de camada só copiava `package.json`+`pnpm-lock.yaml` primeiro, e o install falhava ali sem encontrar o patch referenciado.
- `tests/unit/react-pdf-resolve-sob-tsx.test.ts`: regressão via processo filho `tsx` real (mesma técnica de `import-puro-sem-env.test.ts`), usando `require()` explícito — `import()` dinâmico não serve de aparato aqui porque sempre passa pelo loader ESM nativo do Node, que já honrava a condição `import` e nunca detectaria a quebra (medido: o teste com `import()` passava sempre, patch ou não).

## Prova

- Aparato confirmado nos dois sentidos: falha sem o patch (`ERR_PACKAGE_PATH_NOT_EXPORTED`), passa com ele.
- `pnpm typecheck`, `pnpm lint`, `pnpm lint:channels`, `pnpm lint:role-rank` zerados.
- `pnpm test:unit`: zero regressão nova (comparado arquivo por arquivo contra a baseline sem este diff — mesmos 14 arquivos pré-existentes falhando, nenhum novo).
- Provado no worker real (rebuild + restart do container): o warning `"event-log drain OFF"` some do log de boot.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint` / `lint:channels` / `lint:role-rank`
- [x] `pnpm test:unit` (sem regressão nova vs. baseline)
- [x] Rebuild real da imagem `worker` + restart do container — log de boot sem o warning
- [x] `pnpm release:conferir` valida o fragmento `.changes/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)