### PR TITLE
feat(agent): atraso humano + "digitando…" antes da 1ª bolha do turno

### DIFF
--- a/lib/agent-engine/agent/atraso-humano.ts
+++ b/lib/agent-engine/agent/atraso-humano.ts
@@ -1,0 +1,108 @@
+/**
+ * O TEMPO QUE UMA PESSOA LEVA PARA RESPONDER — e por que ele é feature.
+ *
+ * ─── O defeito ──────────────────────────────────────────────────────────────
+ *
+ * O agente responde no instante em que o modelo termina de gerar. Do lado do
+ * cliente, no WhatsApp, isso é inconfundível: a resposta chega junto com o "✓✓"
+ * da mensagem que ele acabou de mandar. Nenhum atendente humano lê, pensa e
+ * digita um parágrafo em 200ms — e o cliente sabe disso. Reportado pelo dono de
+ * um tenant real (sítio de eventos): "responde rápido demais, parece robô".
+ *
+ * O produto é um agente que ATENDE junto com humanos. Ser identificável como
+ * máquina na primeira troca é perda de conversão, não detalhe estético.
+ *
+ * ─── A fórmula, e por que estes números ─────────────────────────────────────
+ *
+ *   atraso = clamp(NOTAR + POR_CARACTERE × comprimento, MINIMO, MAXIMO)
+ *
+ * `NOTAR` (900ms) é a parcela que NÃO depende do texto: ver a notificação,
+ * abrir a conversa, ler o que o cliente escreveu. Ela existe separada do termo
+ * proporcional porque mesmo um "Sim!" tem esse custo — sem ela, respostas
+ * curtas voltariam a sair instantâneas, que é exatamente o defeito.
+ *
+ * `POR_CARACTERE` (22ms ≈ 45 caracteres/s) é digitação DELIBERADAMENTE mais
+ * rápida que a real (um bom digitador faz ~8 c/s no celular). Não é erro de
+ * calibração: em velocidade real, um parágrafo de 400 caracteres pediria 50
+ * segundos, e um cliente esperando 50s conclui que ninguém vai responder.
+ * O objetivo é "não é instantâneo", não "é indistinguível de humano" — a
+ * segunda meta custa o atendimento.
+ *
+ * `MINIMO` (1200ms) é o piso do throttle anti-ban do WAHA (CLAUDE.md: 1 msg /
+ * 1.2s). Um atraso "humano" menor que o piso que o anti-ban já impõe seria
+ * decoração que não muda nada. `MAXIMO` (7500ms) é o teto: acima disso o
+ * silêncio deixa de ler como "está digitando" e passa a ler como "caiu".
+ *
+ * ─── Onde ele NÃO entra ─────────────────────────────────────────────────────
+ *
+ * Este atraso é do TURNO, antes da PRIMEIRA bolha. O intervalo ENTRE bolhas
+ * continua sendo o jitter anti-ban (1.2s + ≤800ms) que já existia — são coisas
+ * diferentes com donos diferentes, e somá-las numa só apagaria o throttle que
+ * protege o número de banimento.
+ */
+import type { Logger } from '../obs/logger';
+
+/** Ver o cabeçalho: a parcela que não depende do tamanho do texto. */
+export const ATRASO_NOTAR_MS = 900;
+
+/** ≈45 caracteres/s — rápido de propósito; ver o cabeçalho. */
+export const MS_POR_CARACTERE = 22;
+
+/** Piso do throttle anti-ban do WAHA (CLAUDE.md). Abaixo dele o atraso não significa nada. */
+export const ATRASO_MINIMO_MS = 1200;
+
+/** Acima disto o silêncio lê como queda, não como digitação. */
+export const ATRASO_MAXIMO_MS = 7500;
+
+/**
+ * Quanto esperar antes de mandar `texto`, em ms. Pura — é o que a torna
+ * testável sem relógio e sem canal.
+ */
+export function calcularAtrasoHumano(texto: string): number {
+  const comprimento = (texto ?? '').trim().length;
+  const bruto = ATRASO_NOTAR_MS + MS_POR_CARACTERE * comprimento;
+  return Math.min(ATRASO_MAXIMO_MS, Math.max(ATRASO_MINIMO_MS, bruto));
+}
+
+export interface EsperaHumanaArgs {
+  /** O corpo que vai sair — é o tamanho DELE que dita a espera. */
+  texto: string;
+  sleep: (ms: number) => Promise<void>;
+  log: Logger;
+  /**
+   * Acende o "digitando…" no aparelho do cliente. OPCIONAL: canal que não sabe
+   * sinalizar presença simplesmente espera, e o ganho principal (não responder
+   * instantaneamente) continua valendo.
+   */
+  sinalizarDigitando?: () => Promise<void>;
+}
+
+/**
+ * Acende o "digitando…" e espera. Devolve os ms esperados.
+ *
+ * ⚠️ A PRESENÇA FALHA MACIO, E ISSO NÃO É NEGOCIÁVEL. "digitando…" é decoração;
+ * a mensagem é o produto. WAHA fora do ar, sessão que não está WORKING ou engine
+ * que não implementa presença viram uma linha de log e o envio segue — deixar
+ * uma chamada decorativa derrubar entrega seria trocar o produto pelo enfeite.
+ *
+ * A ordem também é o produto: sinalizar DEPOIS de esperar entregaria ao cliente
+ * os segundos de silêncio sem a explicação visual que os torna naturais.
+ */
+export async function esperarComoHumano(args: EsperaHumanaArgs): Promise<number> {
+  const ms = calcularAtrasoHumano(args.texto);
+
+  if (args.sinalizarDigitando !== undefined) {
+    try {
+      await args.sinalizarDigitando();
+    } catch (err) {
+      // Sem corpo de erro e sem texto da mensagem: `lib/logger.ts` proíbe
+      // conteúdo de conversa no log, e a resposta do canal pode carregá-lo.
+      args.log.warn('não consegui sinalizar "digitando" (segue o envio)', {
+        error: err instanceof Error ? err.name : 'unknown',
+      });
+    }
+  }
+
+  await args.sleep(ms);
+  return ms;
+}

--- a/lib/agent-engine/agent/inbound-turn.ts
+++ b/lib/agent-engine/agent/inbound-turn.ts
@@ -117,6 +117,7 @@ import { loadChannelProvider, runBeforeSend } from '../guardrails/before-send';
 import { isStatusSendable } from '../../channels/meta/template-binding';
 import { capabilitiesOf } from '@/lib/channels/capabilities';
 import { renderTemplateBody } from '@/lib/channels/meta/render-template';
+import { esperarComoHumano } from './atraso-humano';
 import { sendInBubbles } from './split-message';
 import type { DisclosureMode } from '../guardrails/disclosure/template';
 import { decidePromise } from '../guardrails/promise/engine';
@@ -1881,6 +1882,14 @@ async function executarTurnoDoAgente(
   // (`internal_vocabulary_leak`): 1º veto no turno ensina o modelo a reescrever; persistir
   // solta o envio com registro. Por turno (closure), nunca cross-turno.
   let internalVocabularyVetoCount = 0;
+  // A pausa humana (atraso-humano.ts) já foi paga NESTE turno? Por turno
+  // (closure), como os contadores acima. O turno pode passar pela cadeia
+  // `before_send` mais de uma vez — o modelo pode chamar `send_message` várias
+  // vezes, e os fail-safes de promessa/vocabulário re-rodam a cadeia inteira.
+  // Sem este flag, cada passagem cobraria do cliente uma espera nova, e um
+  // turno com dois vetos ficaria mudo por mais de 20 segundos: o conserto do
+  // "rápido demais" viraria o defeito simétrico, mais caro que o original.
+  let jaEsperouComoHumano = false;
   // Cap de envio (warm-up/diário) vetado neste turno — capturado aqui porque o veto
   // não empurra outcome nenhum a `outcomes` (ver comentário no ponto de captura, mais
   // abaixo). Diferente da janela horária (checada ANTES do modelo rodar, linha ~1233):
@@ -2251,6 +2260,28 @@ async function executarTurnoDoAgente(
                 maxChars: agentConfig?.splitMaxChars ?? 600,
                 sleep: deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms))),
                 jitter: () => 1200 + Math.floor(Math.random() * 800), // piso no throttle anti-ban (1.2s) — bolhas são mensagens físicas
+                // ANTES da 1ª bolha: "digitando…" + espera proporcional ao texto.
+                // É o conserto do "responde rápido demais" (ver atraso-humano.ts).
+                // NÃO substitui o jitter acima: aquele é throttle anti-ban entre
+                // mensagens físicas, este é a pausa humana do turno. Só uma vez
+                // por TURNO — o flag impede que um re-run do fail-safe (veto de
+                // promessa/vocabulário) cobre a espera de novo do mesmo cliente.
+                antesDaPrimeira: async (primeiraBolha: string): Promise<void> => {
+                  if (jaEsperouComoHumano) return;
+                  jaEsperouComoHumano = true;
+                  const ms = await esperarComoHumano({
+                    texto: primeiraBolha,
+                    sleep: deps.sleep ?? ((s) => new Promise((resolve) => setTimeout(resolve, s))),
+                    log: runLog,
+                    ...(channel.signalTyping
+                      ? {
+                          sinalizarDigitando: (): Promise<void> =>
+                            channel.signalTyping!({ tenantId, conversationId: input.conversationId }),
+                        }
+                      : {}),
+                  });
+                  runLog.info('atraso humano antes da 1ª bolha', { atraso_ms: ms });
+                },
                 send: (bubble): Promise<ChannelSendResult> => {
                   seq += 1;
                   return channel.send({

--- a/lib/agent-engine/agent/split-message.ts
+++ b/lib/agent-engine/agent/split-message.ts
@@ -111,6 +111,24 @@ export interface SendInBubblesOpts<T extends BubbleOutcome = BubbleOutcome> {
   sleep: (ms: number) => Promise<void>;
   /** ms de jitter humano entre bolhas (só entre, não antes da 1ª). */
   jitter: () => number;
+  /**
+   * Roda UMA vez, antes do 1º envio, recebendo a 1ª bolha — é o gancho do
+   * atraso humano do turno ("digitando…" + espera proporcional; ver
+   * `atraso-humano.ts`).
+   *
+   * Recebe a 1ª BOLHA, não o corpo inteiro, e a diferença é a que se vê no
+   * aparelho: quem escreve em bolhas manda a primeira assim que ela fica
+   * pronta, não depois de digitar as cinco. Dimensionar a espera pelo corpo
+   * todo faria uma resposta longa e picotada ficar parada no teto antes da
+   * primeira palavra aparecer.
+   *
+   * UMA vez, e não por bolha, porque entre bolhas já existe o jitter anti-ban:
+   * chamá-lo a cada uma somaria duas esperas na mesma pausa.
+   *
+   * OPCIONAL — sem ele o comportamento é exatamente o de antes, que é o que
+   * mantém os demais chamadores (`followup-turn`, testes) intactos.
+   */
+  antesDaPrimeira?: (primeiraBolha: string) => Promise<void>;
 }
 
 /**
@@ -134,7 +152,10 @@ export async function sendInBubbles<T extends BubbleOutcome>(
   if (bubbles.length === 0) return opts.send(body); // corpo vazio: deixa o canal decidir
   let last: T | undefined;
   for (let i = 0; i < bubbles.length; i++) {
-    if (i > 0) await opts.sleep(opts.jitter());
+    // Antes da 1ª: o atraso humano do turno. Entre as demais: o jitter anti-ban
+    // que já existia. Nunca os dois na mesma pausa.
+    if (i === 0) await opts.antesDaPrimeira?.(bubbles[0]!);
+    else await opts.sleep(opts.jitter());
     last = await opts.send(bubbles[i]!);
     if (!OK_KINDS.has(last.kind)) return last; // veto/bloqueio/falha: para aqui
   }

--- a/lib/agent-engine/channel-adapter.ts
+++ b/lib/agent-engine/channel-adapter.ts
@@ -101,6 +101,20 @@ export interface ChannelAdapter {
    * canal direto — a implementação lê o espelho durável do watchdog (F2-14).
    */
   sessionHealth(channelSessionId: string): Promise<ChannelSessionHealth>;
+  /**
+   * Acende o "digitando…" na conversa, antes da 1ª mensagem do turno.
+   *
+   * OPCIONAL de propósito, por duas razões distintas. A primeira é de canal:
+   * nem todo canal tem indicador de presença, e quem chama testa a presença do
+   * método em vez de perguntar qual é. A segunda é de compatibilidade: os
+   * dublês de `ChannelAdapter` espalhados pelos testes não precisam ganhar um
+   * método por causa de um enfeite.
+   *
+   * Sinalizar é decoração — a espera proporcional que a acompanha
+   * (`agent/atraso-humano.ts`) é o que conserta o "responde rápido demais".
+   * Um canal sem presença ainda recebe o conserto inteiro menos o indicador.
+   */
+  signalTyping?(input: { tenantId: string; conversationId: string }): Promise<void>;
   /** o que o canal suporta agora (estático por canal na v1). */
   capabilities(): ChannelCapabilities;
   /** custo por mensagem do canal. */

--- a/lib/agent-engine/edge/channel/waha-adapter.ts
+++ b/lib/agent-engine/edge/channel/waha-adapter.ts
@@ -21,6 +21,8 @@ import type {
   ChannelSessionHealth,
 } from '../../channel-adapter';
 
+import { sinalizarDigitando } from '@/lib/messaging/presenca';
+
 import { CrmTransportError, type CrmEdgeConfig } from '../crm/mcp-client';
 import { sendTurnMessage, SendToolError } from '../crm/send-message';
 import { SESSION_HEALTHY_STATUS } from '../crm/session-watchdog';
@@ -65,6 +67,26 @@ export class WahaChannelAdapter implements ChannelAdapter {
       }
       throw err;
     }
+  }
+
+  /**
+   * "digitando…" antes da 1ª bolha do turno.
+   *
+   * Mesma disciplina do `send`: o message-plane NÃO fala com o transporte
+   * direto (regra dura nº 4) — quem resolve sessão e endereço é a borda do CRM,
+   * pelas mesmas funções que o envio usa. Duas maneiras de descobrir por qual
+   * número falar divergiriam, e o sintoma seria o indicador numa conversa e a
+   * mensagem noutra.
+   *
+   * Sem `try/catch` aqui de propósito: o ponto único de falha-macio é
+   * `esperarComoHumano`, que engole e loga. Engolir nos dois lugares esconderia
+   * o erro do log que o vigia.
+   */
+  async signalTyping(input: { tenantId: string; conversationId: string }): Promise<void> {
+    await sinalizarDigitando(this.crmCfg.supabase, {
+      organizationId: input.tenantId,
+      conversationId: input.conversationId,
+    });
   }
 
   async sessionHealth(channelSessionId: string): Promise<ChannelSessionHealth> {

--- a/lib/channels/adapters/waha.ts
+++ b/lib/channels/adapters/waha.ts
@@ -106,6 +106,19 @@ export const wahaAdapter: ChannelAdapter = {
   },
 
   /**
+   * "digitando…" no aparelho do cliente, antes da 1ª bolha do turno da IA.
+   *
+   * Transporte não configurado é NOOP, não erro — mesmo critério do `send`
+   * logo abaixo: numa instalação sem o container de pé o produto não pode
+   * parar por causa de um indicador decorativo.
+   */
+  async signalTyping(input: { sessionRef: string; recipient: string }): Promise<void> {
+    const client = getWahaClient();
+    if (!client) return;
+    await client.setPresence(input.sessionRef, input.recipient, "typing");
+  },
+
+  /**
    * Pergunta ao transporte se a conexão está de pé.
    *
    * Três desfechos, e a diferença entre eles é o que o operador vai FAZER:

--- a/lib/channels/types.ts
+++ b/lib/channels/types.ts
@@ -229,6 +229,29 @@ export interface ChannelAdapter {
   templates?: ChannelTemplateOps;
 
   /**
+   * Acende o "digitando…" na conversa do cliente.
+   *
+   * Existe porque o agente de IA responde no instante em que o modelo termina,
+   * e isso é inconfundivelmente robótico do lado de quem recebe. O conserto tem
+   * duas metades — esperar um tempo proporcional ao texto (que é de quem envia,
+   * e vale em qualquer canal) e MOSTRAR que está digitando (que é do canal, e é
+   * esta). Ver `lib/agent-engine/agent/atraso-humano.ts`.
+   *
+   * OPCIONAL como os demais: canal que não sabe sinalizar presença não
+   * implementa, e quem chama testa a presença do método em vez de perguntar
+   * QUAL provider é. Sem ele o cliente ainda ganha a espera — que é a parte do
+   * conserto que carrega o valor.
+   *
+   * LANÇA quando o transporte recusa, e é de propósito: a decisão de engolir é
+   * de quem chama (o indicador é decoração; a mensagem é o produto), e engolir
+   * aqui esconderia de todo chamador futuro que a chamada nem chega.
+   */
+  signalTyping?(input: ChannelTenantScope & {
+    sessionRef: string;
+    recipient: string;
+  }): Promise<void>;
+
+  /**
    * A conexão está de pé AGORA? Pergunta feita ao transporte, não ao banco.
    *
    * Existe porque o banco guarda o último estado que alguém CONTOU, e a falha

--- a/lib/messaging/presenca.ts
+++ b/lib/messaging/presenca.ts
@@ -1,0 +1,107 @@
+/**
+ * "digitando…" — a metade do atraso humano que é do CANAL.
+ *
+ * ─── O que este módulo é ────────────────────────────────────────────────────
+ *
+ * A borda entre "o turno do agente quer sinalizar presença" e "o canal sabe
+ * como". Ele NÃO decide se deve sinalizar (isso é do turno), não espera (isso é
+ * de `lib/agent-engine/agent/atraso-humano.ts`) e não sabe o nome de nenhum
+ * provider — pede o adapter e testa se ele implementa o método.
+ *
+ * ─── Por que a resolução do destino é a MESMA do envio ──────────────────────
+ *
+ * O ref da sessão sai de `resolveSessionRef` e o endereço de `resolveRecipient`
+ * — as mesmas duas funções que `app/api/v1/messages/_handler.ts` usa para
+ * mandar a mensagem. Uma segunda maneira de descobrir "por qual número, para
+ * qual endereço" divergiria da primeira no dia em que uma delas mudasse, e o
+ * sintoma seria "digitando…" aparecendo numa conversa e a mensagem saindo
+ * noutra. Endereçamento tem uma fonte só.
+ *
+ * ─── Silêncio é o desfecho normal ───────────────────────────────────────────
+ *
+ * Conversa que sumiu, sessão fora do ar, contato sem endereço, canal que não
+ * sabe sinalizar, transporte não configurado: todos terminam sem chamada e sem
+ * erro. Nenhum deles é defeito — são o estado corriqueiro de uma instalação
+ * real, e transformá-los em exceção encheria o log de ruído sobre o normal.
+ *
+ * O que este módulo NÃO engole é a recusa do transporte: se o canal foi
+ * chamado e disse não, o erro sobe. Quem chama (`esperarComoHumano`) é que
+ * decide falhar macio, num ponto só e com teste próprio.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import {
+  CHANNEL_SESSION_REF_COLUMNS,
+  DEFAULT_CHANNEL_PROVIDER,
+  getAdapter,
+  resolveSessionRef,
+  type ChannelSessionRef,
+} from "@/lib/channels";
+
+/** Único estado em que o canal pode falar agora — mesmo critério do handler de envio. */
+const SESSAO_SAUDAVEL = "WORKING";
+
+interface ConversaParaPresenca {
+  is_group: boolean;
+  group_chat_id: string | null;
+  contacts: {
+    phone_number: string | null;
+    wa_identity: string | null;
+    wa_lid: string | null;
+  } | null;
+  channel_sessions: (ChannelSessionRef & { status: string }) | null;
+}
+
+export interface SinalizarDigitandoInput {
+  /**
+   * De FONTE CONFIÁVEL (row do job, cookie, token do webhook) — nunca do corpo
+   * de um payload externo. Este módulo usa um client de service role, que
+   * bypassa RLS: sem este filtro, um id de conversa vazado acenderia
+   * "digitando…" no número de outro tenant.
+   */
+  organizationId: string;
+  conversationId: string;
+}
+
+export async function sinalizarDigitando(
+  supabase: SupabaseClient,
+  input: SinalizarDigitandoInput,
+): Promise<void> {
+  const { data } = await supabase
+    .from("conversations")
+    .select(
+      `is_group, group_chat_id, contacts:contact_id(phone_number, wa_identity, wa_lid), ` +
+        `channel_sessions:channel_session_id(${CHANNEL_SESSION_REF_COLUMNS}, status)`,
+    )
+    .eq("id", input.conversationId)
+    .eq("organization_id", input.organizationId)
+    .maybeSingle();
+
+  const conversa = data as unknown as ConversaParaPresenca | null;
+  if (!conversa) return;
+
+  const sessao = conversa.channel_sessions;
+  // Sessão fora do ar: o canal recusaria de qualquer forma, e perguntar custa
+  // uma ida à rede dentro do caminho de resposta ao cliente.
+  if (!sessao || sessao.status !== SESSAO_SAUDAVEL) return;
+
+  const adapter = getAdapter(sessao.provider ?? DEFAULT_CHANNEL_PROVIDER);
+  // Testa a presença do método — nunca pergunta QUAL provider é (invariante 1
+  // da doutrina de restrição de canal).
+  if (!adapter.signalTyping) return;
+
+  const recipient = adapter.resolveRecipient({
+    isGroup: conversa.is_group,
+    groupChatId: conversa.group_chat_id,
+    phoneNumber: conversa.contacts?.phone_number,
+    waIdentity: conversa.contacts?.wa_identity,
+    waLid: conversa.contacts?.wa_lid,
+  });
+  if (!recipient) return;
+
+  await adapter.signalTyping({
+    organizationId: input.organizationId,
+    sessionRef: resolveSessionRef(sessao),
+    recipient,
+  });
+}

--- a/lib/waha/client.ts
+++ b/lib/waha/client.ts
@@ -463,6 +463,52 @@ export class WahaClient {
   }
 
   /**
+   * O "digitando…" (e o "gravando…") no aparelho do cliente.
+   *
+   * ─── O contrato, e por que ele é diferente do resto deste arquivo ─────────
+   *
+   * A sessão vai no CAMINHO (`/api/{session}/presence`), não no corpo — ao
+   * contrário de `sendText`/`sendMedia`, que a levam no corpo. Não é escolha
+   * nossa: é como a doc do WAHA especifica a família de presença (a mesma que
+   * expõe `GET /api/{session}/presence/{chatId}`). Uniformizar "para ficar
+   * consistente" daria 404 em silêncio, e como quem chama falha macio, o
+   * sintoma seria um "digitando…" que nunca acende e nenhum erro em lugar
+   * nenhum.
+   *
+   * Valores aceitos: `online` e `offline` (sem `chatId`), `typing`, `recording`
+   * e `paused` (com `chatId`). Aqui só os que precisam de chat entram no tipo —
+   * `online`/`offline` mudariam a assinatura (o `chatId` sai) e ninguém os usa.
+   *
+   * ─── LANÇA, e isso é de propósito ────────────────────────────────────────
+   *
+   * A decisão de falhar macio é de QUEM CHAMA, não daqui: este cliente reporta
+   * o que aconteceu (mesmo `waha_<status>` dos demais métodos) e o chamador —
+   * `esperarComoHumano` — engole e loga. Engolir aqui esconderia de todo
+   * chamador futuro que a chamada nem sequer é suportada pelo engine.
+   *
+   * ⚠️ Nem todo engine implementa presença de fato. No NOWEB (o default deste
+   * produto) há relato de a chamada ser aceita e não surtir efeito visível. É
+   * mais um motivo para o atraso de tempo — e não o indicador — ser a parte do
+   * recurso que carrega o valor: o "digitando…" é bônus quando o engine
+   * coopera, nunca a condição do conserto.
+   */
+  async setPresence(
+    session: string,
+    chatId: string,
+    presence: "typing" | "recording" | "paused",
+  ): Promise<void> {
+    const res = await this.fetchComTeto(
+      `${this.baseUrl}/api/${encodeURIComponent(session)}/presence`,
+      {
+        method: "POST",
+        headers: { "X-Api-Key": this.apiKey, "Content-Type": "application/json" },
+        body: JSON.stringify({ chatId, presence }),
+      },
+    );
+    if (!res.ok) throw new Error(`waha_${res.status}`);
+  }
+
+  /**
    * Confere se o número existe no WhatsApp e devolve o chatId canônico.
    * Obrigatório antes de vcard em BR — o nono dígito do CRM nem sempre bate com o wa_id.
    */

--- a/lib/waha/presenca-digitando.test.ts
+++ b/lib/waha/presenca-digitando.test.ts
@@ -1,0 +1,99 @@
+/**
+ * O CONTRATO DE PRESENÇA, PROVADO CONTRA UM RECEIVER DE VERDADE.
+ *
+ * Mock não serve aqui: o que este teste precisa afirmar é o formato EXATO do
+ * pedido que sai pela rede (método, caminho, cabeçalho, corpo). Um dublê que
+ * devolve `{ok:true}` fica verde com o caminho errado, o verbo errado e o corpo
+ * errado — e a falha só apareceria na VPS do cliente, como um "digitando…" que
+ * nunca acende e que ninguém liga a este código, porque a chamada falha macio.
+ *
+ * Contrato de origem (docs do WAHA, seção Presence):
+ *   POST /api/{session}/presence   body: { chatId, presence }
+ *   presence ∈ online | offline | typing | recording | paused
+ *   `typing` e `paused` exigem `chatId`; `online`/`offline` não o levam.
+ */
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { WahaClient } from "./client";
+
+interface PedidoRecebido {
+  method: string;
+  url: string;
+  apiKey: string | undefined;
+  body: unknown;
+}
+
+let receiver: Server;
+let urlBase = "";
+let recebidos: PedidoRecebido[] = [];
+/** Status que o receiver devolve — trocado por teste. */
+let statusDaVez = 200;
+
+beforeAll(async () => {
+  receiver = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const cru = Buffer.concat(chunks).toString("utf8");
+      recebidos.push({
+        method: req.method ?? "",
+        url: req.url ?? "",
+        apiKey: req.headers["x-api-key"] as string | undefined,
+        body: cru === "" ? null : JSON.parse(cru),
+      });
+      res.writeHead(statusDaVez, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: statusDaVez < 300 }));
+    });
+  });
+  await new Promise<void>((r) => receiver.listen(0, "127.0.0.1", r));
+  urlBase = `http://127.0.0.1:${(receiver.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((r) => receiver.close(() => r()));
+});
+
+function limpar(): void {
+  recebidos = [];
+  statusDaVez = 200;
+}
+
+describe("WahaClient.setPresence", () => {
+  it("POSTa em /api/{session}/presence com chatId + presence, e a chave no header", async () => {
+    limpar();
+    const client = new WahaClient(urlBase, "chave-hash-sha512");
+
+    await client.setPresence("sessao-do-tenant", "5527999998888@c.us", "typing");
+
+    expect(recebidos).toHaveLength(1);
+    const p = recebidos[0]!;
+    expect(p.method).toBe("POST");
+    // A sessão vai no CAMINHO, não no corpo — é o que a doc do WAHA especifica
+    // para presença (ao contrário de /api/sendText, que a leva no corpo).
+    expect(p.url).toBe("/api/sessao-do-tenant/presence");
+    expect(p.body).toEqual({ chatId: "5527999998888@c.us", presence: "typing" });
+    // Chave NUNCA em query string (CLAUDE.md) — sempre header.
+    expect(p.apiKey).toBe("chave-hash-sha512");
+    expect(p.url).not.toContain("chave-hash-sha512");
+  });
+
+  it("escapa o nome da sessão no caminho", async () => {
+    limpar();
+    const client = new WahaClient(urlBase, "k");
+    await client.setPresence("sessão com espaço", "1@c.us", "paused");
+    expect(recebidos[0]!.url).toBe("/api/sess%C3%A3o%20com%20espa%C3%A7o/presence");
+  });
+
+  it("status de erro vira throw `waha_<status>` — quem chama decide falhar macio", async () => {
+    limpar();
+    statusDaVez = 422;
+    const client = new WahaClient(urlBase, "k");
+
+    // Lança, e o CORPO da resposta não entra na mensagem (doutrina do
+    // cabeçalho de client.ts: resposta de terceiro não atravessa nossa borda).
+    await expect(client.setPresence("s", "1@c.us", "typing")).rejects.toThrow("waha_422");
+  });
+});

--- a/tests/unit/agent-atraso-humano.test.ts
+++ b/tests/unit/agent-atraso-humano.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ATRASO_MAXIMO_MS,
+  ATRASO_MINIMO_MS,
+  calcularAtrasoHumano,
+  esperarComoHumano,
+} from "@/lib/agent-engine/agent/atraso-humano";
+import type { Logger } from "@/lib/agent-engine/obs/logger";
+
+/** Logger de teste — guarda as linhas em vez de escrever em stdout. */
+function logDeTeste(): Logger & { linhas: Array<{ nivel: string; msg: string }> } {
+  const linhas: Array<{ nivel: string; msg: string }> = [];
+  return {
+    linhas,
+    info: (msg) => linhas.push({ nivel: "info", msg }),
+    warn: (msg) => linhas.push({ nivel: "warn", msg }),
+    error: (msg) => linhas.push({ nivel: "error", msg }),
+  };
+}
+
+describe("calcularAtrasoHumano", () => {
+  it("resposta de duas palavras espera o PISO, não uma eternidade", () => {
+    // O defeito que este módulo conserta é o oposto (resposta instantânea), mas
+    // a correção não pode criar o defeito simétrico: "Oi, tudo bem?" com 8s de
+    // espera lê como travamento, não como humano.
+    expect(calcularAtrasoHumano("Oi, tudo bem?")).toBe(ATRASO_MINIMO_MS);
+  });
+
+  it("parágrafo longo é limitado pelo TETO", () => {
+    const paragrafo = "a".repeat(4000);
+    expect(calcularAtrasoHumano(paragrafo)).toBe(ATRASO_MAXIMO_MS);
+  });
+
+  it("entre piso e teto, o atraso CRESCE com o tamanho do texto", () => {
+    const curta = calcularAtrasoHumano("Temos sim, o sítio está livre nessa data.");
+    const media = calcularAtrasoHumano(
+      "Temos sim, o sítio está livre nessa data. O pacote de casamento inclui " +
+        "a cerimônia no jardim, o salão climatizado e a suíte dos noivos.",
+    );
+    expect(media).toBeGreaterThan(curta);
+    expect(media).toBeLessThanOrEqual(ATRASO_MAXIMO_MS);
+  });
+
+  it("o piso não fica abaixo do piso anti-ban de 1,2s", () => {
+    // Doutrina WAHA (CLAUDE.md): throttle 1 msg/1.2s. Um atraso "humano" menor
+    // que o piso do anti-ban seria decoração que não protege nada.
+    expect(ATRASO_MINIMO_MS).toBeGreaterThanOrEqual(1200);
+    expect(calcularAtrasoHumano("")).toBeGreaterThanOrEqual(1200);
+  });
+
+  it("devolve inteiro de milissegundos (é argumento de setTimeout)", () => {
+    expect(Number.isInteger(calcularAtrasoHumano("um texto de tamanho médio aqui"))).toBe(true);
+  });
+});
+
+describe("esperarComoHumano", () => {
+  it("sinaliza 'digitando' ANTES de esperar — a ordem é o produto", async () => {
+    const ordem: string[] = [];
+    const sinalizarDigitando = vi.fn(async () => {
+      ordem.push("digitando");
+    });
+    const sleep = vi.fn(async () => {
+      ordem.push("espera");
+    });
+
+    await esperarComoHumano({
+      texto: "Claro! Vou conferir a agenda do sítio para essa data.",
+      sleep,
+      log: logDeTeste(),
+      sinalizarDigitando,
+    });
+
+    // Esperar primeiro e só depois mostrar "digitando" entregaria os três
+    // segundos de silêncio que o dono do produto reclamou.
+    expect(ordem).toEqual(["digitando", "espera"]);
+  });
+
+  it("espera exatamente o que a fórmula calculou", async () => {
+    const texto = "Claro! Vou conferir a agenda do sítio para essa data.";
+    const sleep = vi.fn(async () => undefined);
+
+    await esperarComoHumano({ texto, sleep, log: logDeTeste() });
+
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(calcularAtrasoHumano(texto));
+  });
+
+  it("presença que FALHA não derruba o envio nem encurta a espera", async () => {
+    // "digitando" é decoração; a mensagem é o produto. Um WAHA fora do ar, uma
+    // sessão que não está WORKING ou um engine que não implementa presença não
+    // podem virar mensagem não entregue.
+    const texto = "Claro! Vou conferir a agenda do sítio para essa data.";
+    const sleep = vi.fn(async () => undefined);
+    const log = logDeTeste();
+
+    await expect(
+      esperarComoHumano({
+        texto,
+        sleep,
+        log,
+        sinalizarDigitando: async () => {
+          throw new Error("waha_500");
+        },
+      }),
+    ).resolves.toBeDefined();
+
+    expect(sleep).toHaveBeenCalledWith(calcularAtrasoHumano(texto));
+    expect(log.linhas.some((l) => l.nivel === "warn")).toBe(true);
+  });
+
+  it("canal que não sabe sinalizar presença apenas espera", async () => {
+    const sleep = vi.fn(async () => undefined);
+    await esperarComoHumano({ texto: "Bom dia!", sleep, log: logDeTeste() });
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it("devolve os ms esperados, para o log do turno poder afirmá-los", async () => {
+    const texto = "Uma resposta de tamanho médio para o cliente do sítio.";
+    const ms = await esperarComoHumano({ texto, sleep: async () => undefined, log: logDeTeste() });
+    expect(ms).toBe(calcularAtrasoHumano(texto));
+  });
+});

--- a/tests/unit/agent-split-send.test.ts
+++ b/tests/unit/agent-split-send.test.ts
@@ -22,6 +22,46 @@ describe("sendInBubbles", () => {
     expect(out.kind).toBe("sent");
   });
 
+  it("chama `antesDaPrimeira` UMA vez, antes do 1º envio, com a 1ª bolha", async () => {
+    // O atraso humano é do TURNO, não de cada bolha: entre bolhas já existe o
+    // jitter anti-ban. Chamá-lo por bolha somaria duas esperas na mesma pausa.
+    const ordem: string[] = [];
+    const send = vi.fn(async (b: string) => {
+      ordem.push(`send:${b}`);
+      return { kind: "sent", messageId: "m" };
+    });
+    const antesDaPrimeira = vi.fn(async (b: string) => {
+      ordem.push(`antes:${b}`);
+    });
+    const text = "Bolha um aqui.\n\nBolha dois aqui.\n\nBolha três aqui.";
+
+    await sendInBubbles(text, {
+      enabled: true,
+      maxChars: 20,
+      send,
+      sleep: async () => undefined,
+      jitter: () => 0,
+      antesDaPrimeira,
+    });
+
+    expect(antesDaPrimeira).toHaveBeenCalledTimes(1);
+    expect(ordem[0]).toBe("antes:Bolha um aqui.");
+    expect(ordem[1]).toBe("send:Bolha um aqui.");
+  });
+
+  it("sem `antesDaPrimeira` o comportamento é o de sempre", async () => {
+    const send = vi.fn(async () => ({ kind: "sent", messageId: "m" }));
+    const out = await sendInBubbles("texto", {
+      enabled: false,
+      maxChars: 600,
+      send,
+      sleep: async () => undefined,
+      jitter: () => 0,
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(out.kind).toBe("sent");
+  });
+
   it("para no primeiro envio não-sent (veto/falha) e devolve esse outcome", async () => {
     const send = vi
       .fn()

--- a/tests/unit/messaging-presenca-digitando.test.ts
+++ b/tests/unit/messaging-presenca-digitando.test.ts
@@ -1,0 +1,128 @@
+/**
+ * O "digitando…" atravessa o MESMO caminho de resolução do envio.
+ *
+ * Este teste dubla só o transporte HTTP (`getWahaClient`). Tudo entre a conversa
+ * e o adapter é código real: a leitura escopada por `organization_id`, o
+ * `resolveSessionRef` (que sabe de que coluna sai o ref de cada provider) e o
+ * `resolveRecipient` (que sabe virar contato em endereço). Dublar o meio faria o
+ * teste ficar verde com uma segunda maneira, divergente, de descobrir por qual
+ * número falar — que é exatamente o defeito que a doutrina de canal proíbe.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const setPresence = vi.fn(async () => undefined);
+/** null = transporte não configurado (env ausente), como numa VPS sem WAHA. */
+let clienteDoTransporte: { setPresence: typeof setPresence } | null = { setPresence };
+
+vi.mock("@/lib/waha/client", async (original) => ({
+  ...(await original<typeof import("@/lib/waha/client")>()),
+  getWahaClient: () => clienteDoTransporte,
+}));
+
+import { sinalizarDigitando } from "@/lib/messaging/presenca";
+
+interface LinhaDeConversa {
+  is_group: boolean;
+  group_chat_id: string | null;
+  contacts: { phone_number: string | null; wa_identity: string | null; wa_lid: string | null } | null;
+  channel_sessions:
+    | { provider: string; waha_session_name: string | null; meta_phone_number_id: string | null; zernio_account_id: string | null; status: string }
+    | null;
+}
+
+let linha: LinhaDeConversa | null = null;
+/** Todo par (coluna, valor) que a leitura filtrou — a prova do escopo de tenant. */
+let filtros: Array<[string, unknown]> = [];
+
+function supabaseDeTeste(): never {
+  const chain = {
+    select: () => chain,
+    eq: (col: string, val: unknown) => {
+      filtros.push([col, val]);
+      return chain;
+    },
+    maybeSingle: async () => ({ data: linha, error: null }),
+  };
+  return { from: () => chain } as never;
+}
+
+const CONVERSA_NORMAL: LinhaDeConversa = {
+  is_group: false,
+  group_chat_id: null,
+  contacts: { phone_number: "+5527999998888", wa_identity: null, wa_lid: null },
+  channel_sessions: {
+    provider: "waha",
+    waha_session_name: "sessao-do-sitio",
+    meta_phone_number_id: null,
+    zernio_account_id: null,
+    status: "WORKING",
+  },
+};
+
+beforeEach(() => {
+  setPresence.mockClear();
+  clienteDoTransporte = { setPresence };
+  linha = structuredClone(CONVERSA_NORMAL);
+  filtros = [];
+});
+
+describe("sinalizarDigitando", () => {
+  it("acende 'digitando' no número da sessão e no endereço do contato", async () => {
+    await sinalizarDigitando(supabaseDeTeste(), { organizationId: "org-1", conversationId: "conv-1" });
+
+    expect(setPresence).toHaveBeenCalledTimes(1);
+    expect(setPresence).toHaveBeenCalledWith("sessao-do-sitio", "5527999998888@c.us", "typing");
+  });
+
+  it("a leitura da conversa é escopada por organization_id", async () => {
+    // Multi-tenancy (CLAUDE.md): quem usa service role filtra a organização à
+    // mão, de fonte confiável. Sem esta linha, um id de conversa vazado
+    // acenderia "digitando" no número de outro tenant.
+    await sinalizarDigitando(supabaseDeTeste(), { organizationId: "org-1", conversationId: "conv-1" });
+    expect(filtros).toContainEqual(["organization_id", "org-1"]);
+    expect(filtros).toContainEqual(["id", "conv-1"]);
+  });
+
+  it("sessão que não está WORKING não recebe chamada de presença", async () => {
+    linha!.channel_sessions!.status = "SCAN_QR_CODE";
+    await sinalizarDigitando(supabaseDeTeste(), { organizationId: "org-1", conversationId: "conv-1" });
+    expect(setPresence).not.toHaveBeenCalled();
+  });
+
+  it("conversa inexistente não chama o canal e não lança", async () => {
+    linha = null;
+    await expect(
+      sinalizarDigitando(supabaseDeTeste(), { organizationId: "org-1", conversationId: "sumiu" }),
+    ).resolves.toBeUndefined();
+    expect(setPresence).not.toHaveBeenCalled();
+  });
+
+  it("contato sem endereço possível não vira chamada ao canal", async () => {
+    linha!.contacts = { phone_number: null, wa_identity: null, wa_lid: null };
+    await sinalizarDigitando(supabaseDeTeste(), { organizationId: "org-1", conversationId: "conv-1" });
+    expect(setPresence).not.toHaveBeenCalled();
+  });
+
+  it("transporte não configurado (VPS sem o container) é no-op, não erro", async () => {
+    clienteDoTransporte = null;
+    await expect(
+      sinalizarDigitando(supabaseDeTeste(), { organizationId: "org-1", conversationId: "conv-1" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("canal que não sabe sinalizar presença é no-op", async () => {
+    // O adapter do canal intermediado não implementa `signalTyping`. Quem chama
+    // testa a presença do método — nunca pergunta QUAL provider é.
+    linha!.channel_sessions = {
+      provider: "meta_cloud",
+      waha_session_name: null,
+      meta_phone_number_id: "123456",
+      zernio_account_id: null,
+      status: "WORKING",
+    };
+    await expect(
+      sinalizarDigitando(supabaseDeTeste(), { organizationId: "org-1", conversationId: "conv-1" }),
+    ).resolves.toBeUndefined();
+    expect(setPresence).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problema

Dono de um tenant real (sítio de eventos) reportou que o agente de IA
"responde rápido demais, sem humanizar o serviço" — no WhatsApp a
resposta chega junto com o "✓✓" da mensagem que o cliente acabou de
mandar. Nenhum atendente humano lê, pensa e digita um parágrafo em
200ms, e o cliente percebe isso como robô, o que é perda de conversão
num produto que promete atendimento junto com humanos.

## O que mudou

- `lib/agent-engine/agent/atraso-humano.ts` (novo): `calcularAtrasoHumano`
  (pura, testável) — `clamp(900ms + 22ms×caractere, 1200ms, 7500ms)`. O
  piso de 1200ms é o mesmo do throttle anti-ban do WAHA (CLAUDE.md); o
  teto de 7500ms evita que o silêncio leia como "caiu" em vez de
  "digitando". `esperarComoHumano` sinaliza presença (se o canal
  suportar) e espera, com fail-soft total: falha ao sinalizar presença
  vira log e nunca derruba o envio.
- `lib/messaging/presenca.ts` (novo): resolve sessão/destinatário pela
  MESMA rota que o envio de mensagem já usa (`resolveSessionRef` /
  `resolveRecipient`), escopado por `organization_id` de fonte
  confiável — nunca uma segunda forma de descobrir "por qual número
  falar".
- `lib/waha/client.ts`: `WahaClient.setPresence` — `POST
  /api/{session}/presence`, contrato real do WAHA (sessão no caminho,
  não no corpo).
- `lib/channels/types.ts` + `lib/channels/adapters/waha.ts`: novo
  método opcional `signalTyping` no adapter de transporte.
- `lib/agent-engine/channel-adapter.ts` +
  `lib/agent-engine/edge/channel/waha-adapter.ts`: mesmo método,
  espelhado no adapter do message-plane (que nunca fala com WAHA
  direto — só com a borda do CRM), respeitando a regra dura nº 4.
- `lib/agent-engine/agent/split-message.ts`: novo hook opcional
  `antesDaPrimeira`, chamado UMA vez com a 1ª bolha, antes do 1º envio
  — nunca substitui o jitter anti-ban já existente entre bolhas.
- `lib/agent-engine/agent/inbound-turn.ts`: liga o hook à pausa
  humana, com flag por turno para não cobrar a espera de novo se a
  cadeia de `before_send` reprocessar (veto de promessa/vocabulário).

## Por que a pausa é maior que o indicador de presença

O "digitando…" é decoração — nem todo engine WAHA (NOWEB, o default) o
torna visível de fato. A espera proporcional ao texto é a parte que
carrega o valor, e funciona em qualquer canal, com ou sem indicador.

## Teste manual

Não fiz teste ponta-a-ponta com WAHA real (fora do escopo desta
sessão). A cobertura é por unit test (fórmula pura + fail-soft +
escopo de tenant) — ver plano de testes abaixo.

## Plano de testes

- [x] `pnpm typecheck` — zero erros
- [x] `pnpm lint` — zero erros (warnings pré-existentes, nenhum nos
      arquivos tocados além do padrão já presente no repo)
- [x] `pnpm test:unit` — testes novos passam; as 12 falhas da suíte já
      existem na `main` sem estas mudanças (confirmado isolando com
      `git stash` e rodando `leads-import-route.test.ts` e
      `rascunho-superado-nao-e-regravado.test.ts` limpos)
- [x] `lib/waha/presenca-digitando.test.ts` prova o contrato HTTP real
      do WAHA contra um receiver de verdade, não um mock
- [ ] `pnpm test:db` — não rodei; esta mudança não toca schema/RLS
- [ ] QA visual em ambiente fresco — não fiz; esta feature não tem UI
      própria (só efeito no WhatsApp), fora do escopo do ambiente
      Playwright/fresh-VPS descrito na doutrina de QA Visual