### PR TITLE
fix: reconhecer webhook de leads do RD Station

### DIFF
--- a/.changes/2026-09-08-rdstation-webhook-envelope-leads.md
+++ b/.changes/2026-09-08-rdstation-webhook-envelope-leads.md
@@ -1,0 +1,21 @@
+---
+impacto: capacidade_nova
+secao: corrigido
+titulo: Webhook de captação agora reconhece o formato de lead do RD Station
+---
+
+Ao apontar um webhook do RD Station para uma fonte de captação de leads, os
+envios reais não viravam lead: o RD Station empacota os dados dentro de uma
+lista (`leads: [...]`), e o leitor de campos do webhook só olhava o nível de
+cima, então nome, e-mail e telefone chegavam "em branco" e a captação era
+recusada. O botão interno "Enviar lead de teste" funcionava porque manda os
+campos soltos — o que escondia o problema.
+
+Agora o webhook reconhece esse formato: extrai o nome, o e-mail e o telefone
+(inclusive quando o telefone vem no campo de celular do RD, e não no campo de
+telefone comercial, que costuma vir vazio) e cria o lead na fonte/funil/etapa
+configurados. Reenvio do mesmo evento pelo RD Station não gera lead duplicado.
+
+Os formatos que já funcionavam (campos soltos, Respondi) continuam iguais. Você
+não precisa fazer nada para adotar — a partir desta versão os leads do RD
+Station passam a entrar sozinhos.

--- a/app/api/v1/webhooks/in/[token]/route.ts
+++ b/app/api/v1/webhooks/in/[token]/route.ts
@@ -28,6 +28,11 @@ import {
   respondiLeadTitle,
   type RespondiMapped,
 } from "@/lib/webhooks/respondi";
+import {
+  isRdStationPayload,
+  mapRdStationPayload,
+  type RdStationMapped,
+} from "@/lib/webhooks/rdstation";
 import { origemDaPagina, registrarCaptacao } from "@/lib/webhooks/captacao";
 import { ipDoClienteParaInet } from "@/lib/http/ip-do-cliente";
 import { decryptWebhookSecret } from "@/lib/webhooks/secrets";
@@ -179,6 +184,15 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<NextRespons
     ? mapRespondiPayload(payload)
     : null;
 
+  // RD Station manda `{ leads: [ {...} ] }` — mesmo problema do Respondi (o
+  // mapeador genérico só lê chave de topo). Detecta a forma UMA vez; alimenta
+  // o idempotency key e o mapeamento de campos abaixo. Respondi tem
+  // precedência: um payload nunca é dos dois.
+  const rdStationMapped: RdStationMapped | null =
+    respondiMapped === null && isRdStationPayload(payload)
+      ? mapRdStationPayload(payload)
+      : null;
+
   // Idempotência (spec §5): `external_id` é campo reservado do envio — quem
   // integra via sistema (Zapier/n8n/loja) manda o ID único do disparo e o
   // reenvio automático (retry por timeout) NUNCA duplica o lead. O índice
@@ -201,7 +215,9 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<NextRespons
       // uuid de 36 chars, ~60× abaixo do limiar. É higiene de simetria: dois
       // ramos do mesmo `?:` produzindo a mesma coluna com regras diferentes é o
       // tipo de coisa que só aparece quando alguém manda um corpo fabricado.
-      : (respondiMapped?.externalId?.slice(0, 255) ?? null);
+      : (respondiMapped?.externalId?.slice(0, 255) ??
+        rdStationMapped?.externalId?.slice(0, 255) ??
+        null);
 
   const respondWithLead = (leadId: string): NextResponse => {
     if (isForm && source.redirect_to) {
@@ -240,8 +256,12 @@ export async function POST(req: NextRequest, ctx: RouteCtx): Promise<NextRespons
   //
   // O `respondiMapped ??` é do PR #326: sem ele o payload aninhado do Respondi
   // volta a cair no mapeador genérico, que é o defeito que aquele PR conserta.
+  // O `rdStationMapped ??` é a mesma figura para o envelope `leads[]` do RD
+  // Station (achado 2026-09-08). Ordem: Respondi, RD Station, genérico.
   const mapped =
-    respondiMapped ?? mapInboundPayload(externalId ? payloadForMapping : payload, fieldMap);
+    respondiMapped ??
+    rdStationMapped ??
+    mapInboundPayload(externalId ? payloadForMapping : payload, fieldMap);
   if (!mapped.phone) {
     const rawPhone = findRawPhoneIfUnnormalized(payload, fieldMap);
     if (rawPhone) mapped.source_metadata.raw_phone = rawPhone;

--- a/lib/webhooks/rdstation.test.ts
+++ b/lib/webhooks/rdstation.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+
+import { isRdStationPayload, mapRdStationPayload } from "@/lib/webhooks/rdstation";
+import { mapInboundPayload } from "@/lib/webhooks/inbound";
+import { isRespondiPayload } from "@/lib/webhooks/respondi";
+
+/**
+ * Envelope real do RD Station (RD Station Marketing / CDP "webhook de lead"),
+ * SANITIZADO: e-mail/telefone/nome/ids trocados por valores fictícios, mesma
+ * ESTRUTURA e mesmos NOMES DE CAMPO do payload de produção observado em
+ * 2026-09-08 (checkpoint JBA-RDSTATION-WEBHOOK-DIAGNOSTICO.txt).
+ */
+function rdEnvelope(overrides?: {
+  mobile_phone?: string | null;
+  personal_phone?: string | null;
+  phone?: string | null;
+  name?: string | null;
+  email?: string | null;
+  celular?: string | null;
+  eventUuid?: string | null;
+  id?: string | null;
+  withConversions?: boolean;
+}): Record<string, unknown> {
+  const o = overrides ?? {};
+  const withConversions = o.withConversions ?? true;
+  const eventUuid = o.eventUuid === undefined ? "22222222-2222-4222-8222-222222222222" : o.eventUuid;
+  const celular = o.celular === undefined ? "+55 (11) 98888-7777" : o.celular;
+  const content = {
+    event_type: "CONVERSION",
+    identificador: "jardim-bela-aurora",
+    conversion_identifier: "jardim-bela-aurora",
+    conversion_url: "https://viver.example.com.br/jardim-bela-aurora",
+    email_lead: o.email === undefined ? "maria.teste@example.com" : o.email,
+    Nome: o.name === undefined ? "Maria Teste" : o.name,
+    Celular: celular,
+    phone_lead: null,
+    ...(eventUuid
+      ? { __cdp__original_event: { event_uuid: eventUuid, event_batch_uuid: "33333333-3333-4333-8333-333333333333", event_type: "CONVERSION", event_family: "CDP" } }
+      : {}),
+  };
+  const lead: Record<string, unknown> = {
+    id: o.id === undefined ? "9999999999" : o.id,
+    uuid: "11111111-1111-4111-8111-111111111111",
+    name: o.name === undefined ? "Maria Teste" : o.name,
+    email: o.email === undefined ? "maria.teste@example.com" : o.email,
+    phone: o.phone === undefined ? null : o.phone,
+    personal_phone: o.personal_phone === undefined ? null : o.personal_phone,
+    mobile_phone: o.mobile_phone === undefined ? "+55 (11) 98888-7777" : o.mobile_phone,
+    company: null,
+    lead_stage: "Lead",
+    public_url: "http://app.rdstation.com.br/leads/public/11111111-1111-4111-8111-111111111111",
+    number_conversions: "2",
+    custom_fields: {},
+    ...(withConversions
+      ? { first_conversion: { content }, last_conversion: { content } }
+      : {}),
+  };
+  return { leads: [lead] };
+}
+
+/** Payload FLAT que o botão interno "Enviar lead de teste" e Zapier/n8n mandam. */
+const FLAT = {
+  name: "Fulano Teste",
+  email: "fulano@example.com",
+  phone: "+55 11 97777-6666",
+  utm_source: "instagram",
+};
+
+/** Forma mínima de um payload Respondi (não deve ser capturado pelo RD). */
+const RESPONDI = {
+  form: { form_id: "9FiY9mrO", form_name: "Imobiliárias e Incorporadoras" },
+  respondent: {
+    respondent_id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+    answers: { "Qual é o seu nome?": "Cicrano", "Qual é o seu melhor e-mail?": "cicrano@example.com" },
+  },
+};
+
+describe("isRdStationPayload — detecção estrita", () => {
+  it("reconhece o envelope leads[] com conversões", () => {
+    expect(isRdStationPayload(rdEnvelope())).toBe(true);
+  });
+
+  it("reconhece leads[] sem conversões mas com id + identidade", () => {
+    expect(isRdStationPayload(rdEnvelope({ withConversions: false }))).toBe(true);
+  });
+
+  it("aceita leads como STRING JSON válida (defensivo)", () => {
+    const env = rdEnvelope();
+    const asString = { leads: JSON.stringify(env.leads) };
+    expect(isRdStationPayload(asString)).toBe(true);
+  });
+
+  it("string JSON inválida em leads → false (cai no genérico)", () => {
+    expect(isRdStationPayload({ leads: "[{unterminated" })).toBe(false);
+  });
+
+  it("payload FLAT não é RD", () => {
+    expect(isRdStationPayload(FLAT)).toBe(false);
+  });
+
+  it("payload Respondi não é RD", () => {
+    expect(isRdStationPayload(RESPONDI)).toBe(false);
+  });
+
+  it("leads vazio / ausente / não-array → false", () => {
+    expect(isRdStationPayload({ leads: [] })).toBe(false);
+    expect(isRdStationPayload({ leads: null })).toBe(false);
+    expect(isRdStationPayload({})).toBe(false);
+    expect(isRdStationPayload({ leads: [{}] })).toBe(false); // objeto sem marcador RD
+  });
+});
+
+describe("mapRdStationPayload — extração de identidade", () => {
+  it("RD real com name + email + mobile_phone: extrai os três", () => {
+    const m = mapRdStationPayload(rdEnvelope());
+    expect(m.name).toBe("Maria Teste");
+    expect(m.email).toBe("maria.teste@example.com");
+    expect(m.phone).toBe("+5511988887777"); // mobile_phone normalizado (11 já tem o 9)
+  });
+
+  it("prioriza mobile_phone > personal_phone > Celular > phone", () => {
+    const m = mapRdStationPayload(
+      rdEnvelope({ mobile_phone: "+55 11 98888-0001", personal_phone: "+55 11 98888-0002", phone: "+55 11 3333-0003", celular: "+55 11 98888-0004" }),
+    );
+    expect(m.phone).toBe("+5511988880001");
+  });
+
+  it("mobile_phone ausente → cai para personal_phone", () => {
+    const m = mapRdStationPayload(rdEnvelope({ mobile_phone: null, personal_phone: "+55 11 98888-0002" }));
+    expect(m.phone).toBe("+5511988880002");
+  });
+
+  it("mobile_phone e personal_phone ausentes → cai para Celular da conversão", () => {
+    const m = mapRdStationPayload(rdEnvelope({ mobile_phone: null, personal_phone: null, celular: "+55 11 98888-0009" }));
+    expect(m.phone).toBe("+5511988880009");
+  });
+
+  it("RD com nome + email e SEM telefone em lugar nenhum: phone null, nome/email OK", () => {
+    const m = mapRdStationPayload(rdEnvelope({ mobile_phone: null, personal_phone: null, phone: null, celular: null }));
+    expect(m.name).toBe("Maria Teste");
+    expect(m.email).toBe("maria.teste@example.com");
+    expect(m.phone).toBeNull();
+    // regra da rota: !name && !phone && !email → 400. Aqui name+email presentes → segue e cria lead.
+    expect(!m.name && !m.phone && !m.email).toBe(false);
+  });
+
+  it("RD sem identidade nenhuma: name/phone/email todos null (rota rejeita com 400)", () => {
+    const m = mapRdStationPayload(rdEnvelope({ name: null, email: null, mobile_phone: null, personal_phone: null, phone: null, celular: null }));
+    expect(m.name).toBeNull();
+    expect(m.email).toBeNull();
+    expect(m.phone).toBeNull();
+    expect(!m.name && !m.phone && !m.email).toBe(true);
+  });
+
+  it("name/email caem para os rótulos da conversão quando o topo não traz", () => {
+    const env = rdEnvelope({ name: null, email: null });
+    // repõe só na conversão
+    const lead = (env.leads as Record<string, unknown>[])[0];
+    (lead.last_conversion as { content: Record<string, unknown> }).content.Nome = "Nome Da Conversao";
+    (lead.last_conversion as { content: Record<string, unknown> }).content.email_lead = "conv@example.com";
+    const m = mapRdStationPayload(env);
+    expect(m.name).toBe("Nome Da Conversao");
+    expect(m.email).toBe("conv@example.com");
+  });
+
+  it("metadados seguros preservados; blobs NÃO", () => {
+    const m = mapRdStationPayload(rdEnvelope());
+    expect(m.custom_fields.rd_lead_id).toBe("9999999999");
+    expect(m.custom_fields.rd_lead_stage).toBe("Lead");
+    expect(m.custom_fields.rd_conversion_identifier).toBe("jardim-bela-aurora");
+    expect(m.custom_fields.rd_event_uuid).toBe("22222222-2222-4222-8222-222222222222");
+    expect(m.custom_fields).not.toHaveProperty("traffic_source");
+    expect(m.custom_fields).not.toHaveProperty("user_agent");
+    expect(m.source_metadata).toEqual({});
+  });
+});
+
+describe("mapRdStationPayload — idempotência (externalId)", () => {
+  it("usa rdstation:evt:<event_uuid> quando há event_uuid", () => {
+    const m = mapRdStationPayload(rdEnvelope({ eventUuid: "abc1234a-0000-4000-8000-000000000000" }));
+    expect(m.externalId).toBe("rdstation:evt:abc1234a-0000-4000-8000-000000000000");
+  });
+
+  it("fallback rdstation:lead:<id> quando não há event_uuid", () => {
+    const m = mapRdStationPayload(rdEnvelope({ eventUuid: null, withConversions: false, id: "5035951450" }));
+    expect(m.externalId).toBe("rdstation:lead:5035951450");
+  });
+
+  it("o MESMO evento reenviado produz a MESMA externalId (dedup determinística)", () => {
+    const a = mapRdStationPayload(rdEnvelope({ eventUuid: "dedupe00-0000-4000-8000-000000000000" }));
+    const b = mapRdStationPayload(rdEnvelope({ eventUuid: "dedupe00-0000-4000-8000-000000000000" }));
+    expect(a.externalId).toBe(b.externalId);
+    expect(a.externalId).toBe("rdstation:evt:dedupe00-0000-4000-8000-000000000000");
+  });
+
+  it("sem event_uuid e sem id → externalId null (comportamento genérico, sem dedup)", () => {
+    const m = mapRdStationPayload(rdEnvelope({ eventUuid: null, withConversions: false, id: null }));
+    expect(m.externalId).toBeNull();
+  });
+});
+
+describe("telefone observado em produção: +55 (32) 9922-8971", () => {
+  it("normalizePhoneBR (via mapRdStationPayload) → forma canônica de CRM", () => {
+    const m = mapRdStationPayload(rdEnvelope({ mobile_phone: "+55 (32) 9922-8971" }));
+    // canonicalPhoneBR injeta o 9º dígito no celular BR (regra do produto).
+    expect(m.phone).toBe("+5532999228971");
+  });
+});
+
+describe("compatibilidade — o genérico e o Respondi seguem intactos", () => {
+  it("FLAT continua mapeando pelo genérico exatamente como antes", () => {
+    const g = mapInboundPayload(FLAT, {});
+    expect(g.name).toBe("Fulano Teste");
+    expect(g.email).toBe("fulano@example.com");
+    expect(g.phone).toBe("+5511977776666");
+  });
+
+  it("Respondi continua sendo Respondi e NÃO é RD", () => {
+    expect(isRespondiPayload(RESPONDI)).toBe(true);
+    expect(isRdStationPayload(RESPONDI)).toBe(false);
+  });
+
+  it("RD NÃO é Respondi", () => {
+    expect(isRespondiPayload(rdEnvelope())).toBe(false);
+  });
+});

--- a/lib/webhooks/rdstation.ts
+++ b/lib/webhooks/rdstation.ts
@@ -1,0 +1,176 @@
+/**
+ * Normalizador dedicado do RD Station — irmão de `lib/webhooks/respondi.ts`.
+ *
+ * ═══ O BUG, MEDIDO ═══
+ *
+ * O "webhook de lead" do RD Station (RD Station Marketing / CDP) manda o lead
+ * dentro de um envelope `{ "leads": [ { ... } ] }`. `mapInboundPayload`
+ * (inbound.ts) só olha CHAVE DE TOPO — objeto/array aninhado é descartado por
+ * desenho ("v1"). Resultado: `name`/`phone`/`email` batem `null` para os TRÊS,
+ * a rota devolve 400 "Nenhum campo mapeável" (depois de já ter gravado
+ * `webhook_events_log` e a linha `recusado` em `webhook_lead_captures`), e
+ * nenhum lead entra. Medido em produção (JBA, 2026-09-08): 5 recebimentos
+ * reais recusados, 0 lead. Ver `JBA-RDSTATION-WEBHOOK-DIAGNOSTICO.txt`.
+ *
+ * É o mesmo caso do Respondi (achado 2026-08-25), e a solução é a mesma:
+ * detecção ESTRITA da forma + normalizador dedicado, chamado ANTES do genérico
+ * e SEM tocar no genérico. Qualquer outro envio (flat, Zapier, n8n, o botão
+ * interno "Enviar lead de teste") segue `mapInboundPayload` inalterado.
+ *
+ * ═══ TELEFONE ═══
+ *
+ * O celular do formulário vem em `leads[0].mobile_phone` (fallback
+ * `personal_phone`, depois os rótulos `Celular` das conversões). O
+ * `leads[0].phone` do RD é o "telefone comercial" e chega `null` na esmagadora
+ * maioria dos envios — NUNCA usar a ausência dele como sinal de "sem telefone".
+ *
+ * ═══ ESCOPO ═══
+ *
+ * Só a RECEPÇÃO do webhook. NÃO integra com a API do RD Station.
+ *
+ * ═══ BATCH ═══
+ *
+ * O RD real observado manda 1 item em `leads[]`. Este módulo lê o PRIMEIRO
+ * item. `leads[]` com múltiplos itens está FORA deste fix — a rota
+ * (`webhooks/in/[token]`) cria 1 lead por request; suportar N exigiria mudança
+ * estrutural na rota. Documentado no checkpoint.
+ */
+import type { MappedLead } from "@/lib/webhooks/inbound";
+import { normalizePhoneBR } from "@/lib/webhooks/inbound";
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** String não-vazia (trim) ou null. */
+function str(v: unknown): string | null {
+  return typeof v === "string" && v.trim() ? v.trim() : null;
+}
+
+/**
+ * `leads[0]` resolvido. Aceita `leads` como array OU, defensivamente, como
+ * string JSON que parseia para um array (form-urlencoded, ou provedor que
+ * serializa o campo). `null` quando a forma não é a do RD.
+ */
+function primeiroLead(payload: unknown): Record<string, unknown> | null {
+  if (!isRecord(payload)) return null;
+  let leads: unknown = payload.leads;
+  if (typeof leads === "string") {
+    const s = leads.trim();
+    if (!s) return null;
+    try {
+      leads = JSON.parse(s);
+    } catch {
+      return null;
+    }
+  }
+  if (!Array.isArray(leads) || leads.length === 0) return null;
+  const first = leads[0];
+  return isRecord(first) ? first : null;
+}
+
+/** O `content` de `first_conversion` / `last_conversion`, ou `{}`. */
+function conversaoContent(
+  lead: Record<string, unknown>,
+  qual: "first_conversion" | "last_conversion",
+): Record<string, unknown> {
+  const c = lead[qual];
+  if (!isRecord(c)) return {};
+  return isRecord(c.content) ? c.content : {};
+}
+
+/** `__cdp__original_event.event_uuid` — o identificador por CONVERSÃO (last primeiro). */
+function cdpEventUuid(lead: Record<string, unknown>): string | null {
+  for (const qual of ["last_conversion", "first_conversion"] as const) {
+    const cdp = conversaoContent(lead, qual).__cdp__original_event;
+    if (isRecord(cdp)) {
+      const u = str(cdp.event_uuid);
+      if (u) return u;
+    }
+  }
+  return null;
+}
+
+export interface RdStationPayloadShape {
+  leads: unknown;
+}
+
+/**
+ * True só quando o payload tem a forma inconfundível do RD Station: uma chave
+ * `leads` (array, ou string JSON que parseia para array) cujo primeiro item é
+ * um objeto com PELO MENOS um marcador do RD — `id` string acompanhado de um
+ * campo de identidade, ou uma das conversões (`first_conversion`/
+ * `last_conversion`). Deliberadamente estrita para nunca capturar por engano
+ * um payload de outra origem (mesma postura de `isRespondiPayload`).
+ */
+export function isRdStationPayload(payload: unknown): payload is RdStationPayloadShape {
+  const lead = primeiroLead(payload);
+  if (!lead) return false;
+  const temConversao =
+    isRecord(lead.first_conversion) || isRecord(lead.last_conversion);
+  const temIdentidadeRd =
+    typeof lead.id === "string" &&
+    ("name" in lead || "email" in lead || "mobile_phone" in lead || "personal_phone" in lead);
+  return temConversao || temIdentidadeRd;
+}
+
+export interface RdStationMapped extends MappedLead {
+  externalId: string | null;
+}
+
+/**
+ * Extrai identidade + metadados seguros do envelope RD. Puro, sem I/O.
+ * Reusa `normalizePhoneBR` — o telefone chega mascarado ("+55 (32) 9922-8971").
+ */
+export function mapRdStationPayload(payload: unknown): RdStationMapped {
+  const lead = primeiroLead(payload) ?? {};
+  const first = conversaoContent(lead, "first_conversion");
+  const last = conversaoContent(lead, "last_conversion");
+
+  const name = str(lead.name) ?? str(last.Nome) ?? str(first.Nome);
+  const email =
+    str(lead.email) ?? str(last.email_lead) ?? str(first.email_lead);
+  const phoneRaw =
+    str(lead.mobile_phone) ??
+    str(lead.personal_phone) ??
+    str(last.Celular) ??
+    str(first.Celular) ??
+    str(lead.phone);
+
+  const custom_fields: Record<string, string> = {};
+  const setCf = (k: string, v: string | null): void => {
+    if (v !== null) custom_fields[k] = v;
+  };
+  // Só metadados úteis e seguros — nada de traffic_source/user_agent/blobs.
+  setCf("rd_lead_id", str(lead.id));
+  setCf("rd_lead_uuid", str(lead.uuid));
+  setCf("rd_lead_stage", str(lead.lead_stage));
+  setCf("rd_public_url", str(lead.public_url));
+  setCf("rd_number_conversions", str(lead.number_conversions));
+  setCf(
+    "rd_conversion_identifier",
+    str(last.conversion_identifier) ??
+      str(first.conversion_identifier) ??
+      str(last.identificador) ??
+      str(first.identificador),
+  );
+  setCf("rd_conversion_url", str(last.conversion_url) ?? str(first.conversion_url));
+  const evtUuid = cdpEventUuid(lead);
+  setCf("rd_event_uuid", evtUuid);
+
+  const leadId = str(lead.id);
+  const externalId = evtUuid
+    ? `rdstation:evt:${evtUuid}`
+    : leadId
+      ? `rdstation:lead:${leadId}`
+      : null;
+
+  return {
+    name,
+    phone: normalizePhoneBR(phoneRaw),
+    email,
+    custom_fields,
+    source_metadata: {},
+    externalId,
+  };
+}

--- a/tests/invariants/webhooks-inbound.test.ts
+++ b/tests/invariants/webhooks-inbound.test.ts
@@ -282,6 +282,7 @@ const WHIN_SOURCE_FORM = "dddddddd-5555-4000-8000-000000000002";
 const WHIN_SOURCE_INACTIVE = "dddddddd-5555-4000-8000-000000000003";
 const WHIN_SOURCE_SECRET = "dddddddd-5555-4000-8000-000000000004";
 const WHIN_SOURCE_RESPONDI = "dddddddd-5555-4000-8000-000000000005";
+const WHIN_SOURCE_RDSTATION = "dddddddd-5555-4000-8000-000000000006";
 // Fixture própria (namespace ffffffff, mesmo padrão de webhooks-rls.test.ts) —
 // org B só pra provar que o fallback por e-mail não cruza tenant.
 const WHIN_ORG_B = "ffffffff-0000-4000-8000-000000000101";
@@ -289,6 +290,8 @@ const WHIN_PIPELINE_B = "ffffffff-5555-4000-8000-000000000101";
 const WHIN_STAGE_B = "ffffffff-5555-4000-8000-000000000102";
 const WHIN_SOURCE_RESPONDI_B = "ffffffff-5555-4000-8000-000000000103";
 const TOKEN_RESPONDI_B = "wh-in-respondi-org-b-token-1234";
+const WHIN_SOURCE_RDSTATION_B = "ffffffff-5555-4000-8000-000000000104";
+const TOKEN_RDSTATION_B = "wh-in-rdstation-org-b-token-1234";
 const SECRET = "test-webhook-secret-abc123";
 const REDIRECT_TO = "https://example.com/obrigado";
 
@@ -298,6 +301,7 @@ const TOKEN_INACTIVE = "wh-in-inactive-token-1234";
 const TOKEN_SECRET = "wh-in-secret-token-1234";
 const TOKEN_UNKNOWN = "wh-in-does-not-exist-1234";
 const TOKEN_RESPONDI = "wh-in-respondi-token-1234";
+const TOKEN_RDSTATION = "wh-in-rdstation-token-1234";
 
 /** Fixture sanitizada — mesma FORMA do payload real do Respondi (webhook_events_log, 2026-08-25). */
 const RESPONDI_FIXTURE = JSON.parse(
@@ -375,6 +379,14 @@ beforeAll(() => {
     insert into public.webhook_sources
       (id, organization_id, name, path_token, default_pipeline_id, default_stage_id)
       values ('${WHIN_SOURCE_RESPONDI_B}', '${WHIN_ORG_B}', 'Respondi Org B', '${TOKEN_RESPONDI_B}', '${WHIN_PIPELINE_B}', '${WHIN_STAGE_B}')
+      on conflict do nothing;
+    insert into public.webhook_sources
+      (id, organization_id, name, path_token, default_pipeline_id, default_stage_id)
+      values ('${WHIN_SOURCE_RDSTATION}', '${GOV_ORG}', 'RD Station JBA (fixture)', '${TOKEN_RDSTATION}', '${GOV_PIPELINE}', '${GOV_STAGE}')
+      on conflict do nothing;
+    insert into public.webhook_sources
+      (id, organization_id, name, path_token, default_pipeline_id, default_stage_id)
+      values ('${WHIN_SOURCE_RDSTATION_B}', '${WHIN_ORG_B}', 'RD Station Org B', '${TOKEN_RDSTATION_B}', '${WHIN_PIPELINE_B}', '${WHIN_STAGE_B}')
       on conflict do nothing;
   `);
 });
@@ -1128,5 +1140,182 @@ describe("POST /api/v1/webhooks/in/[token] — classificação inicial (2026-08-
     const contact = rows(`select consent from public.contacts where id = '${lead.contact_id}'`)[0]!;
     const consent = contact.consent as { marketing: { granted_at: string | null } };
     expect(consent.marketing.granted_at).not.toBeNull();
+  });
+});
+
+/**
+ * POST /api/v1/webhooks/in/[token] — RD Station (envelope `leads[]`, achado 2026-09-08).
+ *
+ * Mesma figura do bloco Respondi acima: o payload real do RD Station vem em
+ * `{ leads: [ {...} ] }` e o mapeador GENÉRICO só lê chave de topo, então os
+ * três campos batiam null e a rota devolvia 400 — 5 recebimentos reais
+ * recusados, 0 lead (checkpoint JBA-RDSTATION-WEBHOOK-DIAGNOSTICO.txt). O
+ * normalizador dedicado (`lib/webhooks/rdstation.ts`) reconhece o envelope,
+ * extrai identidade dos caminhos comprovados e deriva a chave de idempotência
+ * `rdstation:evt:<event_uuid>` (fallback `rdstation:lead:<id>`), que reusa o
+ * índice `uniq_crm_leads_org_source_external` já existente — sem migration.
+ */
+function rdStationEnvelope(opts: {
+  name?: string | null;
+  email?: string | null;
+  mobilePhone?: string | null;
+  celular?: string | null;
+  eventUuid?: string | null;
+  leadId?: string;
+}) {
+  const eventUuid = opts.eventUuid === undefined ? "22222222-2222-4222-8222-000000000001" : opts.eventUuid;
+  const celular = opts.celular === undefined ? "+55 (11) 98888-7777" : opts.celular;
+  const content: Record<string, unknown> = {
+    event_type: "CONVERSION",
+    identificador: "jardim-bela-aurora",
+    conversion_identifier: "jardim-bela-aurora",
+    conversion_url: "https://viver.example.com.br/jardim-bela-aurora",
+    email_lead: opts.email === undefined ? "maria.rd@example.com" : opts.email,
+    Nome: opts.name === undefined ? "Maria RD" : opts.name,
+    Celular: celular,
+    phone_lead: null,
+  };
+  if (eventUuid) {
+    content.__cdp__original_event = {
+      event_uuid: eventUuid,
+      event_batch_uuid: "33333333-3333-4333-8333-000000000001",
+      event_type: "CONVERSION",
+      event_family: "CDP",
+    };
+  }
+  return {
+    leads: [
+      {
+        id: opts.leadId ?? "5035951450",
+        uuid: "11111111-1111-4111-8111-000000000001",
+        name: opts.name === undefined ? "Maria RD" : opts.name,
+        email: opts.email === undefined ? "maria.rd@example.com" : opts.email,
+        phone: null,
+        personal_phone: null,
+        mobile_phone: opts.mobilePhone === undefined ? "+55 (11) 98888-7777" : opts.mobilePhone,
+        lead_stage: "Lead",
+        public_url: "http://app.rdstation.com.br/leads/public/11111111-1111-4111-8111-000000000001",
+        number_conversions: "2",
+        custom_fields: {},
+        first_conversion: { content },
+        last_conversion: { content },
+      },
+    ],
+  };
+}
+
+describe("POST /api/v1/webhooks/in/[token] — RD Station (envelope leads[])", () => {
+  it("rd 1 — envelope real: cria contato + lead, nome/telefone/email dos caminhos do RD, external_id = rdstation:evt:*, metadados rd_*", async () => {
+    const res = await POST(
+      jsonReq(TOKEN_RDSTATION, rdStationEnvelope({ eventUuid: "aaaa0001-0000-4000-8000-000000000001", mobilePhone: "+55 (32) 9922-8971" })),
+      reqCtx(TOKEN_RDSTATION),
+    );
+    expect(res.status).toBe(200);
+    const leadId = ((await res.json()) as { data: { lead_id: string } }).data.lead_id;
+
+    const lead = rows(`select * from public.crm_leads where id = '${leadId}'`)[0]!;
+    expect(lead.source).toBe("webhook");
+    expect(lead.organization_id).toBe(GOV_ORG);
+    expect(lead.external_id).toBe("rdstation:evt:aaaa0001-0000-4000-8000-000000000001");
+    expect(lead.title).toBe("Maria RD");
+    const cf = lead.custom_fields as Record<string, unknown>;
+    expect(cf.rd_lead_id).toBe("5035951450");
+    expect(cf.rd_conversion_identifier).toBe("jardim-bela-aurora");
+    expect(cf.rd_event_uuid).toBe("aaaa0001-0000-4000-8000-000000000001");
+
+    const contact = rows(`select * from public.contacts where id = '${lead.contact_id}'`)[0]!;
+    // canonicalPhoneBR injeta o 9º dígito no celular BR.
+    expect(contact.phone_number).toBe("+5532999228971");
+    expect(contact.email).toBe("maria.rd@example.com");
+  });
+
+  it("rd 2 — MESMO event_uuid reenviado NÃO duplica: 200 com o lead existente", async () => {
+    const payload = rdStationEnvelope({ eventUuid: "aaaa0002-0000-4000-8000-000000000002", leadId: "5035999002" });
+    const first = await POST(jsonReq(TOKEN_RDSTATION, payload), reqCtx(TOKEN_RDSTATION));
+    const firstId = ((await first.json()) as { data: { lead_id: string } }).data.lead_id;
+
+    const second = await POST(jsonReq(TOKEN_RDSTATION, payload), reqCtx(TOKEN_RDSTATION));
+    expect(second.status).toBe(200);
+    const secondId = ((await second.json()) as { data: { lead_id: string } }).data.lead_id;
+    expect(secondId).toBe(firstId);
+
+    const count = rows(
+      `select count(*)::int as n from public.crm_leads where organization_id = '${GOV_ORG}' and external_id = 'rdstation:evt:aaaa0002-0000-4000-8000-000000000002'`,
+    )[0]!;
+    expect(count.n).toBe(1);
+  });
+
+  it("rd 3 — sem event_uuid: usa rdstation:lead:<id> como chave de idempotência", async () => {
+    const payload = rdStationEnvelope({ eventUuid: null, leadId: "5035999003" });
+    const res = await POST(jsonReq(TOKEN_RDSTATION, payload), reqCtx(TOKEN_RDSTATION));
+    expect(res.status).toBe(200);
+    const leadId = ((await res.json()) as { data: { lead_id: string } }).data.lead_id;
+    const lead = rows(`select external_id from public.crm_leads where id = '${leadId}'`)[0]!;
+    expect(lead.external_id).toBe("rdstation:lead:5035999003");
+  });
+
+  it("rd 4 — nome + email e SEM telefone em lugar nenhum: ainda cria lead (regra atual)", async () => {
+    const payload = rdStationEnvelope({
+      eventUuid: "aaaa0004-0000-4000-8000-000000000004",
+      leadId: "5035999004",
+      mobilePhone: null,
+      celular: null,
+    });
+    const res = await POST(jsonReq(TOKEN_RDSTATION, payload), reqCtx(TOKEN_RDSTATION));
+    expect(res.status).toBe(200);
+    const leadId = ((await res.json()) as { data: { lead_id: string } }).data.lead_id;
+    const lead = rows(`select * from public.crm_leads where id = '${leadId}'`)[0]!;
+    expect(lead.title).toBe("Maria RD");
+    expect(lead.contact_id).toBeNull(); // sem telefone → contato não é criado (mesma regra do genérico)
+  });
+
+  it("rd 5 — sem identidade nenhuma (nome/email/telefone ausentes): 400 invalid_request, sem lead", async () => {
+    const payload = rdStationEnvelope({
+      eventUuid: "aaaa0005-0000-4000-8000-000000000005",
+      leadId: "5035999005",
+      name: null,
+      email: null,
+      mobilePhone: null,
+      celular: null,
+    });
+    const res = await POST(jsonReq(TOKEN_RDSTATION, payload), reqCtx(TOKEN_RDSTATION));
+    expect(res.status).toBe(400);
+    const n = rows(
+      `select count(*)::int as n from public.crm_leads where organization_id = '${GOV_ORG}' and external_id = 'rdstation:evt:aaaa0005-0000-4000-8000-000000000005'`,
+    )[0]!;
+    expect(n.n).toBe(0);
+  });
+
+  it("rd 6 — isolamento: MESMO event_uuid em org A e org B cria DOIS leads distintos", async () => {
+    const uuid = "aaaa0006-0000-4000-8000-000000000006";
+    const resA = await POST(
+      jsonReq(TOKEN_RDSTATION, rdStationEnvelope({ eventUuid: uuid, leadId: "5035999006", email: "orga.rd@example.com" })),
+      reqCtx(TOKEN_RDSTATION),
+    );
+    const resB = await POST(
+      jsonReq(TOKEN_RDSTATION_B, rdStationEnvelope({ eventUuid: uuid, leadId: "5035999006", email: "orgb.rd@example.com" })),
+      reqCtx(TOKEN_RDSTATION_B),
+    );
+    expect(resA.status).toBe(200);
+    expect(resB.status).toBe(200);
+    const idA = ((await resA.json()) as { data: { lead_id: string } }).data.lead_id;
+    const idB = ((await resB.json()) as { data: { lead_id: string } }).data.lead_id;
+    expect(idA).not.toBe(idB);
+    const orgA = rows(`select organization_id from public.crm_leads where id = '${idA}'`)[0]!;
+    const orgB = rows(`select organization_id from public.crm_leads where id = '${idB}'`)[0]!;
+    expect(orgA.organization_id).toBe(GOV_ORG);
+    expect(orgB.organization_id).toBe(WHIN_ORG_B);
+  });
+
+  it("rd 7 — payload FLAT no mesmo endpoint continua caindo no mapeador genérico (sem regressão)", async () => {
+    const res = await POST(
+      jsonReq(TOKEN_RDSTATION, { nome: "Flat No RD Source", telefone: "11955550007" }),
+      reqCtx(TOKEN_RDSTATION),
+    );
+    expect(res.status).toBe(200);
+    const leadId = ((await res.json()) as { data: { lead_id: string } }).data.lead_id;
+    const lead = rows(`select external_id, title from public.crm_leads where id = '${leadId}'`)[0]!;
+    expect(lead.title).toBe("Flat No RD Source");
+    expect(lead.external_id).toBeNull(); // genérico sem external_id de topo
   });
 });


### PR DESCRIPTION
## Summary

- O "webhook de lead" do RD Station empacota tudo em `{ leads: [ {...} ] }`. O parser genérico (`lib/webhooks/inbound.ts`) só lê chave de topo → nome/e-mail/telefone batiam `null` e a rota devolvia **HTTP 400 "Nenhum campo mapeável"**. Medido no JBA (2026-09-08): **5 recebimentos reais recusados, 0 lead**. O botão "Enviar lead de teste" passava por mandar campos *flat* — o que escondia o problema.
- Mesmo caso do Respondi (achado 2026-08-25) → mesma solução: **normalizador dedicado + detecção estrita ANTES do genérico, sem tocar no genérico**.

### Mudanças

- **NOVO `lib/webhooks/rdstation.ts`**
  - `isRdStationPayload` — detecção estrita: `leads` array (ou string JSON que parseia p/ array); `leads[0]` objeto com marcador RD (`id` + identidade, ou `first_conversion`/`last_conversion`). Nunca captura payload alheio.
  - `mapRdStationPayload` — puro. `name = leads[0].name ?? {last,first}_conversion.content.Nome`; `email = leads[0].email ?? …email_lead`; `phone = normalizePhoneBR(leads[0].mobile_phone ?? personal_phone ?? …Celular ?? leads[0].phone)` (o `leads[0].phone` do RD é "telefone comercial" e chega `null` — não é sinal de ausência). Guarda só metadados úteis/seguros (`rd_lead_id`, `rd_conversion_identifier`, `rd_event_uuid`, …), nunca blobs.
- **`app/api/v1/webhooks/in/[token]/route.ts`** — cadeia `respondiMapped ?? rdStationMapped ?? mapInboundPayload(...)`. Respondi tem precedência; genérico e *flat* intactos.
- **Idempotência por evento**: `external_id = "rdstation:evt:<event_uuid>"` (fallback `"rdstation:lead:<id>"`), reusando `uniq_crm_leads_org_source_external` — **sem migration**. Reenvio do mesmo evento não duplica lead.
- **`tests/invariants/webhooks-inbound.test.ts`** (arquivo congelado) — bloco "RD Station (envelope leads[])", casos `rd 1..7`: criação + idempotência + sem-telefone cria lead + sem-identidade 400 + isolamento entre orgs + *flat* sem regressão. **Só adição de casos**; nenhum caso existente alterado. `DESKCOMM_GOV_INVARIANTS_EDIT=1`.

### Fora de escopo (gates separados, documentados)

- Troca do contrato HTTP `sem_campo_mapeavel` de 400 → 2xx (transversal).
- Suporte a `leads[]` com múltiplos itens (a rota cria 1 lead/request).
- Replay dos recebimentos recusados históricos (janela `webhook_events_log.raw_body` ~7 dias).
- Não altera WhatsApp/WAHA, agente, Flow A/follow-ups, Atlântica, schema.

## Test plan

- [x] `lib/webhooks/rdstation.test.ts` — 23 testes (detecção, extração, prioridade `mobile_phone` > `personal_phone` > `Celular` > `phone`, sem-telefone, sem-identidade, idempotência determinística, `+55 (32) 9922-8971` → `+5532999228971`)
- [x] `lib/webhooks/inbound.test.ts` (16) + `lib/webhooks/respondi.test.ts` (20) — sem regressão
- [x] tsc escopado (webhooks + route + type decls) — 0 erro
- [ ] **CI `invariants` (`pnpm test:db`)** — casos `rd 1..7` rodam contra Postgres real pela 1ª vez aqui
- [ ] CI `verify`, `build-and-size`, `e2e`, `imagens-ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jts9a6TqGWacRgtLQBhef2
