### PR TITLE
fix(channels): encurta nome de sessão WAHA para caber no limite de 54 chars

### DIFF
--- a/supabase/baseline.sql
+++ b/supabase/baseline.sql
@@ -22580,7 +22580,7 @@ begin
   if channel.id is null then
    insert into public.channel_sessions(organization_id,waha_session_name,display_name,engine,webhook_path_token,
      webhook_secret_encrypted,status,last_status_change_at,consecutive_health_fails,daily_message_limit,metadata)
-   values(p_org,'org_'||replace(p_org::text,'-','')||'_'||replace(gen_random_uuid()::text,'-',''),p_display_name,'NOWEB',
+   values(p_org,'org_'||left(replace(p_org::text,'-',''),8)||'_'||replace(gen_random_uuid()::text,'-',''),p_display_name,'NOWEB',
      replace(gen_random_uuid()::text,'-',''),'\x00'::bytea,'STARTING',now(),0,250,
      case when p_onboarding then '{"onboarding":true}'::jsonb else '{}'::jsonb end) returning * into channel;
   end if;
@@ -23179,7 +23179,7 @@ begin
   if channel.id is null then
    insert into public.channel_sessions(organization_id,waha_session_name,display_name,engine,webhook_path_token,
      webhook_secret_encrypted,status,last_status_change_at,consecutive_health_fails,daily_message_limit,metadata)
-   values(p_org,'org_'||replace(p_org::text,'-','')||'_'||replace(gen_random_uuid()::text,'-',''),p_display_name,'NOWEB',
+   values(p_org,'org_'||left(replace(p_org::text,'-',''),8)||'_'||replace(gen_random_uuid()::text,'-',''),p_display_name,'NOWEB',
      replace(gen_random_uuid()::text,'-',''),'\x00'::bytea,'STARTING',now(),0,250,
      '{"ai_gate":"allowlist","ai_gate_mode":"pre_go_live","ai_test_phone_numbers":[]}'::jsonb
      || case when p_onboarding then '{"onboarding":true}'::jsonb else '{}'::jsonb end) returning * into channel;

--- a/supabase/migrations/20260908201043_0231_encurta_nome_sessao_waha.sql
+++ b/supabase/migrations/20260908201043_0231_encurta_nome_sessao_waha.sql
@@ -1,0 +1,68 @@
+-- 0231 — encurta o nome de sessão WAHA gerado em fn_reserve_channel_connection.
+-- Forward-only: 0230 já aplicada. Bug confirmado também no main do GitHub
+-- (não é específico desta VPS): o nome gerado tinha 69 caracteres
+-- ('org_' + uuid da organização sem hífens + '_' + uuid aleatório sem hífens),
+-- e o WAHA rejeita qualquer nome de sessão acima de 54 caracteres — toda
+-- tentativa de conectar um WhatsApp novo falhava com HTTP 400
+-- "name must be shorter than or equal to 54 characters".
+-- Única mudança: o prefixo do org_id cai de 32 para 8 caracteres (o mesmo
+-- tamanho já usado no match de onboarding logo acima, linha
+-- "waha_session_name='org_'||left(p_org::text,8)"). A unicidade continua
+-- garantida pelo uuid aleatório de 32 caracteres no final — waha_session_name
+-- é usado só como chave opaca em todo o código (nunca é quebrado de volta pra
+-- extrair o org_id; a coluna organization_id já cobre isso).
+create or replace function public.fn_reserve_channel_connection(p_org uuid,p_key uuid,p_hash text,p_display_name text default null,p_onboarding boolean default false)
+returns jsonb language plpgsql security definer set search_path=public as $$
+declare receipt public.channel_connection_requests; channel public.channel_sessions; token uuid:=gen_random_uuid();
+begin
+ if auth.uid() is null or not public.fn_role_at_least(p_org,'admin') or not public.fn_support_write_allowed(p_org)
+ then raise exception 'connection_forbidden' using errcode='42501';end if;
+ if not public.fn_session_mfa_proven() then raise exception 'connection_mfa_required' using errcode='42501';end if;
+ if p_key is null or p_hash is null or length(p_hash)<>64 or length(coalesce(p_display_name,''))>100 then
+  raise exception 'connection_invalid_request' using errcode='22023';end if;
+ perform pg_advisory_xact_lock(hashtextextended(p_org::text,2281));
+ delete from public.channel_connection_requests where organization_id=p_org and idempotency_key=p_key
+  and state='succeeded' and updated_at<now()-interval '24 hours';
+ select * into receipt from public.channel_connection_requests where organization_id=p_org and idempotency_key=p_key for update;
+ if found then
+  if receipt.request_hash<>p_hash then raise exception 'idempotency_conflict' using errcode='22023';end if;
+  if receipt.state='succeeded' then
+   select * into channel from public.channel_sessions where organization_id=p_org and id=receipt.channel_session_id;
+   return jsonb_build_object('replay',true,'channel',to_jsonb(channel),'receipt_id',receipt.id);
+  end if;
+  if receipt.state='processing' and receipt.lease_until>now() then
+   raise exception 'connection_in_progress' using errcode='55P03';end if;
+  select * into channel from public.channel_sessions where organization_id=p_org and id=receipt.channel_session_id for update;
+  if not found then raise exception 'connection_reservation_missing' using errcode='P0002';end if;
+ else
+  if p_onboarding then
+   select * into channel from public.channel_sessions where organization_id=p_org and provider='waha'
+    and (metadata->>'onboarding'='true' or waha_session_name='org_'||left(p_org::text,8))
+    order by created_at limit 1 for update;
+  end if;
+  if channel.id is null then
+   insert into public.channel_sessions(organization_id,waha_session_name,display_name,engine,webhook_path_token,
+     webhook_secret_encrypted,status,last_status_change_at,consecutive_health_fails,daily_message_limit,metadata)
+   values(p_org,'org_'||left(replace(p_org::text,'-',''),8)||'_'||replace(gen_random_uuid()::text,'-',''),p_display_name,'NOWEB',
+     replace(gen_random_uuid()::text,'-',''),'\x00'::bytea,'STARTING',now(),0,250,
+     '{"ai_gate":"allowlist","ai_gate_mode":"pre_go_live","ai_test_phone_numbers":[]}'::jsonb
+     || case when p_onboarding then '{"onboarding":true}'::jsonb else '{}'::jsonb end) returning * into channel;
+  end if;
+  if exists(select 1 from public.channel_connection_requests where organization_id=p_org and channel_session_id=channel.id
+    and (state='processing' and lease_until>now())) then raise exception 'connection_in_progress' using errcode='55P03';end if;
+  insert into public.channel_connection_requests(organization_id,idempotency_key,request_hash,channel_session_id)
+   values(p_org,p_key,p_hash,channel.id) returning * into receipt;
+ end if;
+ if exists(select 1 from public.channel_connection_requests where organization_id=p_org and channel_session_id=channel.id
+   and id<>receipt.id and (state='processing' and lease_until>now())) then raise exception 'connection_in_progress' using errcode='55P03';end if;
+ update public.channel_connection_requests set state='processing',lease_token=token,lease_until=now()+interval '5 minutes',
+  remote_created=false,updated_at=now() where organization_id=p_org and id=receipt.id;
+ -- Não ressuscita antes da pós-condição remota. Arquivado permanece invisível
+ -- até finish; falha conserva identidade e estado FAILED para reparo.
+ update public.channel_sessions set status='STARTING',status_reason='connection_pending',last_status_change_at=now()
+  where organization_id=p_org and id=channel.id returning * into channel;
+ return jsonb_build_object('replay',false,'channel',to_jsonb(channel),'receipt_id',receipt.id,'lease_token',token);
+end;
+$$;
+revoke all on function public.fn_reserve_channel_connection(uuid,uuid,text,text,boolean) from public,anon;
+grant execute on function public.fn_reserve_channel_connection(uuid,uuid,text,text,boolean) to authenticated;

--- a/supabase/migrations/MANIFEST.md
+++ b/supabase/migrations/MANIFEST.md
@@ -285,3 +285,4 @@ To re-apply on a fresh Supabase project, replay the migrations in version order 
 | `20260907050000` | `0229_mfa_e_lgpd_agenda` | MFA nas quatro ações humanas, ordem de locks LGPD/agenda e footprint de avisos de presença/Meet na redação; baseline e backfill idempotentes. |
 
 | `20260907060000` | `0230_reserva_pre_go_live` | A reserva transacional de novos canais WAHA preserva o pré-go-live da plataforma; retry mantém política e identidade existentes. Forward-fix da integração, sem alterar 0228 aplicada. |
+| `20260908201043` | `0231_encurta_nome_sessao_waha` | Nome de sessao WAHA gerado caia de 69 para 45 caracteres — WAHA rejeita nomes acima de 54, toda conexao nova de WhatsApp falhava com HTTP 400. |


### PR DESCRIPTION
## Problema

`fn_reserve_channel_connection` gera o nome da sessão WAHA assim:

```sql
'org_'||replace(p_org::text,'-','')||'_'||replace(gen_random_uuid()::text,'-','')
```

= `org_` (4) + uuid da organização sem hífens (32) + `_` (1) + uuid
aleatório sem hífens (32) = **69 caracteres**.

O WAHA valida o nome da sessão com `@MaxLength(54)` (ou equivalente) e
responde `400 Bad Request` — `"name must be shorter than or equal to
54 characters"` — para qualquer nome acima disso. Como o resultado
tem sempre 69 caracteres (uuid tem tamanho fixo), **toda** tentativa
de conectar um WhatsApp novo por QR falha, em qualquer organização,
de forma 100% reprodutível.

No app isso aparece como `connection_repair_required` / HTTP 400 na
tela de Conexões, sem nenhuma pista de que a causa é o comprimento do
nome.

## Fix

O prefixo do org_id cai de 32 para 8 caracteres — o mesmo tamanho já
usado no match de reuso de canal de onboarding, algumas linhas acima
na mesma função (`waha_session_name='org_'||left(p_org::text,8)`).
Resultado: 45 caracteres, dentro do limite.

A unicidade continua garantida pelo uuid aleatório de 32 caracteres no
final — confirmei que `waha_session_name` é usado só como chave opaca
em buscas por igualdade em toda a base de código (`grep` em `app/`,
`lib/`, `scripts/`); nada faz parsing do nome pra extrair o org_id de
volta (a coluna `organization_id`, já presente na mesma linha, cobre
essa necessidade).

Dois arquivos, mesma mudança:
- `supabase/baseline.sql` — instalação nova.
- `supabase/migrations/20260908201043_0231_encurta_nome_sessao_waha.sql` — instalação existente (forward-only, `CREATE OR REPLACE FUNCTION`, sem mudança de assinatura).

## Test plan

- [x] Reproduzido em produção: toda tentativa de "Conectar novo
      WhatsApp" retornava `connection_repair_required` / 400.
- [x] `grep` confirmando que `waha_session_name` nunca é parseado de
      volta em nenhum arquivo do repo (só igualdade).
- [x] Migration aplicada numa instalação existente (via `psql -f`);
      `select count(*) from channel_sessions where
      length(waha_session_name) > 54` volta a `0`.
- [x] Após o fix, "Conectar novo WhatsApp" gera o QR code normalmente
      (sem mais o erro 400).
- [ ] CI deste repo (não rodei localmente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)