### PR TITLE
feat(EPIC-03): balão do inbox mostra a origem — Celular, Automação, Você

### DIFF
--- a/components/inbox/MessageBubble.tsx
+++ b/components/inbox/MessageBubble.tsx
@@ -57,9 +57,19 @@ export function MessageBubble({ message, debugCitations, onResponder, citada }: 
   const citations = extractCitations(message.metadata);
   const showCitationButton =
     isOutbound && aiGenerated && (debugCitations ?? false);
+  // De quem sai esta linha. `external_device` é a resposta pelo CELULAR —
+  // o operador atendeu pelo telefone, fora do CRM, e a ingestão do canal
+  // carimba isto ao trazer a mensagem para cá.
+  // Antes isto voltava null e a bolha ficava sem nome: o dono lia a conversa
+  // como se tudo tivesse sido digitado no CRM, e o painel de fricção
+  // (por_humano_fora) contava um atendimento que a tela nunca mostrou.
   const senderLabel = (() => {
     if (!isOutbound) return null;
     if (message.sent_via === "ai") return "IA";
+    if (message.sent_via === "external_device") return "Celular";
+    if (message.sent_via === "automation") return "Automação";
+    if (message.sent_via === "user") return "Você";
+    if (message.sent_via === "crm") return "Você";
     return null;
   })();
 

--- a/lib/types/messaging.ts
+++ b/lib/types/messaging.ts
@@ -71,7 +71,11 @@ export interface Message {
   media_mime: string | null;
   media_size_bytes: number | null;
   media_storage_path: string | null;
-  sent_via: "user" | "ai" | "system";
+  // Espelha o CHECK do banco (baseline.sql:1664): 'crm', 'external_device',
+  // 'automation', 'ai', 'user', 'system'. O tipo da UI listava só três e o
+  // TypeScript aceitava "external_device" só porque o dado vinha do Supabase
+  // sem cast — a tela então não conseguia nem NOMEAR o valor para exibi-lo.
+  sent_via: "user" | "ai" | "system" | "external_device" | "automation" | "crm";
   sent_by_user_id: string | null;
   sent_at: string;
   delivered_at: string | null;


### PR DESCRIPTION
# O que este PR faz

A bolha do inbox passa a dizer **de onde saiu** cada mensagem enviada: **Celular**, **Automação**, **Você** — além do **IA** que já existia.

O caso que motivou: quando alguém responde o cliente pelo WhatsApp do próprio telefone, a mensagem chega ao histórico sem rótulo nenhum. Quem lê a conversa depois entende que tudo foi digitado no CRM. O produto **já sabe** distinguir esse caso — a função de métrica separa `por_humano_fora` de `por_humano_no_sistema` —, mas a tela não mostrava.

## Por que o dado não chegava à tela

`lib/types/messaging.ts` declarava:

```ts
sent_via: "user" | "ai" | "system";
```

O CHECK do banco (`messages_sent_via_check`, em `supabase/baseline.sql`) aceita seis:

```
'crm', 'external_device', 'automation', 'ai', 'user', 'system'
```

Enquanto o tipo não nomeava `external_device`, a tela não conseguia sequer testá-lo — o valor chegava do banco sem cast e o TypeScript o tratava como impossível. O tipo agora espelha o CHECK.

## O que muda na tela

| `sent_via` | Rótulo |
|---|---|
| `ai` | IA (como já era, com o ícone) |
| `external_device` | **Celular** |
| `automation` | **Automação** |
| `user` / `crm` | **Você** |

Sem migration, sem dependência nova, sem mudança de contrato. Dois arquivos, +15/-1.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado (0 errors; os 344 warnings são pré-existentes)
- [x] `pnpm lint:channels` ok
- [ ] `pnpm test:unit` — não rodei a suíte completa localmente; ver "Evidências"
- [x] RLS testada, se toca tabela tenant-aware — n/a, não toca tabela
- [x] Audit log emitido, se há mutação relevante — n/a, não há mutação
- [x] Zod valida todo input externo novo — n/a, sem input novo
- [x] Sem `console.log` esquecido
- [x] Mudança de schema — n/a, nenhuma
- [x] Doc atualizada se mudou contrato — n/a, contrato inalterado

## Evidências

Rodados nesta mudança, todos verdes:

- `pnpm typecheck` — 0 erros
- `pnpm lint` — 0 errors (344 warnings, todos pré-existentes na `main`)
- `pnpm lint:channels` — `ok (62 arquivos de dívida conhecida, nenhum novo)`

`lint:channels` **reprovou a primeira versão deste PR**, e com razão: o comentário que eu havia escrito nomeava os módulos de provider, o que a doutrina `restricao-de-canal` proíbe fora de `lib/channels/`. Reescrevi o comentário sem nomeá-los e o gate passou.

**Não rodei `pnpm test:unit` completo** — deixo com o CI, que roda a suíte inteira aqui de qualquer forma. A mudança não toca lógica testada: é uma cadeia de comparações de string num componente de apresentação, mais o tipo passando a listar valores que o banco já aceitava.

**Prova de tela:** também não tenho — exigiria WAHA com sessão ativa e um número respondendo de fora. Fica com o mantenedor, como o CONTRIBUTING prevê.

## Notas para a revisão

1. **`user` e `crm` recebem o mesmo rótulo ("Você")** porque, do ponto de vista de quem lê a conversa, os dois querem dizer "digitado aqui dentro". Se a distinção interessar, é trocar uma linha.
2. **Não mexi no ícone.** Só `IA` tem ícone hoje; `Celular` poderia ganhar um, mas isso é escolha de design e preferi não decidir sozinho.
3. **`system` continua sem rótulo** (cai no `return null`), como antes.
