### PR TITLE
feat(followup): falta sem retorno após a régua de recuperação abre aviso na Central

### DIFF
--- a/.changes/aviso-no-show-recuperacao-esgotada.md
+++ b/.changes/aviso-no-show-recuperacao-esgotada.md
@@ -1,0 +1,19 @@
+---
+impacto: capacidade_nova
+secao: adicionado
+titulo: Falta sem retorno depois da régua de recuperação vira aviso na Central
+---
+
+Quando um cliente falta a um compromisso e a equipe confirma a falta, o sistema já matricula
+esse contato num fluxo de recuperação — as mensagens de reengajamento que tentam remarcar. Até
+agora, se a régua inteira era enviada e o cliente **nunca respondia**, o fluxo simplesmente
+terminava: o card ficava parado na mesma etapa e ninguém era avisado de que a recuperação tinha
+esgotado.
+
+Agora, quando isso acontece, abre um aviso na Central de avisos apontando para o compromisso —
+"Cliente faltou e não respondeu à recuperação" —, para alguém decidir o próximo passo e mover o
+card no funil. É um aviso por falta (o mesmo compromisso remarcado gera uma falta nova, e um
+aviso novo); reprocessar não duplica.
+
+O construtor de fluxo não move etapa por conta própria de propósito — faltar a uma visita não é
+o negócio esfriando, e quem decide isso continua sendo uma pessoa.

--- a/lib/followup/engine.ts
+++ b/lib/followup/engine.ts
@@ -41,6 +41,10 @@ import {
   type NodeResult,
 } from "./node-handlers";
 import { coletarEsperasAdaptativas, type EsperaAdaptativa, type TimingPlan } from "./timing-plan";
+import {
+  avisoDeRecuperacaoEsgotada,
+  type AvisoRecuperacaoEsgotada,
+} from "./no-show-recuperacao-esgotada";
 import { interpolarDestino, persistirRespostaFollowupSupabase } from "./persistir-resposta";
 
 const MAX_STEPS = 80;
@@ -125,6 +129,13 @@ export interface AdminClient {
   updateEnrollment(id: string, orgId: string, patch: EnrollmentPatch): Promise<void>;
   loadFlowPointerName(orgId: string, pointerId: string): Promise<string | null>;
   insertDeadInboxItem(item: { organization_id: string; title: string; body: string; ref_id: string }): Promise<void>;
+  /**
+   * Régua de recuperação de falta esgotada sem resposta — abre um item na
+   * Central referenciando o COMPROMISSO. Opcional: só a produção precisa; os
+   * adaptadores de teste que não exercitam no-show podem omitir. Ver
+   * `no-show-recuperacao-esgotada.ts`.
+   */
+  abrirAvisoRecuperacaoEsgotada?(item: AvisoRecuperacaoEsgotada): Promise<void>;
   persistirRespostaFollowup(input: {
     organization_id: string;
     contact_id: string;
@@ -447,6 +458,16 @@ async function applyResult(
       patch.outcome = result.outcome;
       if (result.cancel_reason) patch.cancel_reason = result.cancel_reason;
       break;
+  }
+
+  // Aviso ANTES do `status='completed'`, mesma ordem (e mesma razão) de
+  // `markDead`: se cair entre as duas escritas, o enrollment continua
+  // claimable e um tick futuro re-executa `complete` → re-tenta o aviso (o
+  // índice único da 0224 torna a repetição um no-op). A ordem inversa
+  // arriscaria o aviso NUNCA sair.
+  const avisoEsgotada = avisoDeRecuperacaoEsgotada(enrollment, result, isReplay);
+  if (avisoEsgotada) {
+    await db.abrirAvisoRecuperacaoEsgotada?.(avisoEsgotada);
   }
 
   await db.updateEnrollment(enrollment.id, enrollment.organization_id, patch);
@@ -827,6 +848,27 @@ export function createSupabaseAdminClient(admin: SupabaseClient): AdminClient {
         ref_id: item.ref_id,
       });
       if (error) throw new Error(error.message);
+    },
+    async abrirAvisoRecuperacaoEsgotada(item) {
+      const { error } = await admin.from("agent_inbox_items").insert({
+        organization_id: item.organization_id,
+        // Reusa o kind da 0224 (mesma família: "a recuperação desta falta
+        // precisa de olhar humano") — evita migration só para um rótulo, e a
+        // Central já sabe renderizar `ref_kind='appointment'`.
+        kind: "appointment_recovery_review",
+        severity: "warn",
+        title: "Cliente faltou e não respondeu à recuperação",
+        body:
+          "As mensagens de reengajamento pós-falta foram enviadas e o cliente não respondeu. " +
+          "Decida o próximo passo e mova o card no funil.",
+        ref_kind: "appointment",
+        ref_id: item.appointment_id,
+        appointment_revision: item.appointment_revision,
+      });
+      // 23505 = já há aviso para esta (compromisso, revisão): o índice único
+      // `inbox_appointment_revision_unique` (0224) garante um por revisão,
+      // inclusive depois de resolvido. Repetição é no-op, não erro.
+      if (error && error.code !== "23505") throw new Error(error.message);
     },
     async persistirRespostaFollowup(input) {
       await persistirRespostaFollowupSupabase(admin, input);

--- a/lib/followup/no-show-recuperacao-esgotada.test.ts
+++ b/lib/followup/no-show-recuperacao-esgotada.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import type { EnrollmentRow, NodeResult } from "./node-handlers";
+import { avisoDeRecuperacaoEsgotada } from "./no-show-recuperacao-esgotada";
+
+const enrollmentBase: EnrollmentRow = {
+  id: "enr-1",
+  organization_id: "org-1",
+  pointer_id: "ptr-1",
+  version_id: "ver-1",
+  contact_id: "contact-1",
+  conversation_id: "conv-1",
+  current_node_id: "r3",
+  status: "waiting_reply",
+  next_eval_at: null,
+  claimed_until: null,
+  attempts: 0,
+  max_attempts: 3,
+  last_error: null,
+  steps_taken: 6,
+  outcome: null,
+  cancel_reason: null,
+  started_at: "2026-09-09T12:00:00.000Z",
+  completed_at: null,
+  updated_at: "2026-09-09T12:00:00.000Z",
+  appointment_id: "appt-1",
+  appointment_revision: 2,
+};
+
+const esgotou: NodeResult = { kind: "complete", outcome: "exhausted" };
+
+describe("avisoDeRecuperacaoEsgotada", () => {
+  it("abre aviso quando a régua de no-show esgota sem resposta", () => {
+    expect(avisoDeRecuperacaoEsgotada(enrollmentBase, esgotou, false)).toEqual({
+      organization_id: "org-1",
+      appointment_id: "appt-1",
+      appointment_revision: 2,
+      ref_enrollment_id: "enr-1",
+    });
+  });
+
+  it("carrega revisão null quando o enrollment não tem (compat)", () => {
+    const semRev = { ...enrollmentBase, appointment_revision: null };
+    expect(avisoDeRecuperacaoEsgotada(semRev, esgotou, false)?.appointment_revision).toBeNull();
+  });
+
+  it("não avisa em replay — o reprocesso não reabre o aviso", () => {
+    expect(avisoDeRecuperacaoEsgotada(enrollmentBase, esgotou, true)).toBeNull();
+  });
+
+  it("não avisa quando o cliente respondeu (outcome replied) nem no ramo fora do alvo (outcome null)", () => {
+    expect(
+      avisoDeRecuperacaoEsgotada(enrollmentBase, { kind: "complete", outcome: "replied" }, false),
+    ).toBeNull();
+    expect(
+      avisoDeRecuperacaoEsgotada(
+        enrollmentBase,
+        { kind: "complete", outcome: null, cancel_reason: "fora do alvo" },
+        false,
+      ),
+    ).toBeNull();
+  });
+
+  it("não avisa quando o fluxo só avançou (não concluiu)", () => {
+    const avanco: NodeResult = {
+      kind: "advance",
+      next_node_id: "m3",
+      next_eval_at: new Date("2026-09-09T15:00:00.000Z"),
+    };
+    expect(avisoDeRecuperacaoEsgotada(enrollmentBase, avanco, false)).toBeNull();
+  });
+
+  it("não avisa quando o enrollment não veio de uma falta (sem appointment_id)", () => {
+    const semAppt = { ...enrollmentBase, appointment_id: null };
+    expect(avisoDeRecuperacaoEsgotada(semAppt, esgotou, false)).toBeNull();
+  });
+});

--- a/lib/followup/no-show-recuperacao-esgotada.ts
+++ b/lib/followup/no-show-recuperacao-esgotada.ts
@@ -1,0 +1,58 @@
+/**
+ * O laço de retorno do no-show quando a recuperação NÃO deu certo.
+ *
+ * `fn_appointment_recover` (migration 0224) matricula o contato num fluxo de
+ * `appointment_no_show` com o `appointment_id` fixado no enrollment. Se a régua
+ * chega ao fim e o cliente nunca respondeu, o enrollment conclui com outcome
+ * `exhausted` — e aí o card fica exatamente onde estava: o construtor de fluxo
+ * não move etapa, e não há turno do agente ao fim de uma régua de texto fixo
+ * para chamar `crm_move_lead_stage`.
+ *
+ * Sem sinal nenhum, isso é uma demanda que morreu em silêncio (invariante 4 do
+ * Sistema Vivo: nenhuma demanda sem próximo passo). O sinal é um item na Central
+ * de avisos, com o COMPROMISSO como referência — quem opera decide o próximo
+ * passo e move o card à mão. É a decisão registrada em relatório: "Aviso na
+ * Central + mover manual", em vez de uma feature de mover-etapa no construtor.
+ *
+ * Esta função é a REGRA (pura, testável sem banco); quem grava o item é o
+ * adaptador em `engine.ts` (`abrirAvisoRecuperacaoEsgotada`), no mesmo lugar e
+ * pelo mesmo motivo que `insertDeadInboxItem`.
+ */
+import type { EnrollmentRow, NodeResult } from "./node-handlers";
+
+export interface AvisoRecuperacaoEsgotada {
+  organization_id: string;
+  appointment_id: string;
+  /** A revisão do compromisso no momento da matrícula — o índice único da 0224
+   *  é por (compromisso, revisão, tipo), então remarcar gera uma falta nova e
+   *  um aviso novo, e reprocessar a mesma não duplica. */
+  appointment_revision: number | null;
+  /** Só para o log/correlação — o `ref_id` do item é o compromisso, não isto. */
+  ref_enrollment_id: string;
+}
+
+/**
+ * Deve abrir aviso? Só quando TODAS valem:
+ *  - o passo não é replay (senão um reprocesso abre o aviso de novo — o 23505 do
+ *    índice único cobre, mas nem chega lá);
+ *  - o enrollment terminou de verdade (`complete`) com outcome `exhausted` —
+ *    `replied` (cliente voltou, normalmente via `cancel_on_reply`) e o `custom`
+ *    do ramo "fora do alvo" (outcome `null`) não avisam;
+ *  - o enrollment carrega `appointment_id` — é o que distingue uma régua de
+ *    recuperação de falta de qualquer outro fluxo esgotado.
+ */
+export function avisoDeRecuperacaoEsgotada(
+  enrollment: EnrollmentRow,
+  result: NodeResult,
+  isReplay: boolean,
+): AvisoRecuperacaoEsgotada | null {
+  if (isReplay) return null;
+  if (result.kind !== "complete" || result.outcome !== "exhausted") return null;
+  if (!enrollment.appointment_id) return null;
+  return {
+    organization_id: enrollment.organization_id,
+    appointment_id: enrollment.appointment_id,
+    appointment_revision: enrollment.appointment_revision ?? null,
+    ref_enrollment_id: enrollment.id,
+  };
+}

--- a/lib/followup/turn-bridge.ts
+++ b/lib/followup/turn-bridge.ts
@@ -360,6 +360,22 @@ export function createPgAdminClient(pool: pg.Pool): TurnBridgeAdminClient {
         [item.organization_id, item.title, item.body, item.ref_id],
       );
     },
+    async abrirAvisoRecuperacaoEsgotada(item) {
+      // `on conflict do nothing` casa o índice parcial da 0224
+      // (inbox_appointment_revision_unique): repetir num reprocesso é no-op.
+      await pool.query(
+        `insert into agent_inbox_items
+           (organization_id, kind, severity, title, body, ref_kind, ref_id, appointment_revision)
+         values ($1, 'appointment_recovery_review', 'warn',
+                 'Cliente faltou e não respondeu à recuperação',
+                 'As mensagens de reengajamento pós-falta foram enviadas e o cliente não respondeu. Decida o próximo passo e mova o card no funil.',
+                 'appointment', $2, $3)
+         on conflict (organization_id, ref_id, appointment_revision, kind)
+           where ref_kind = 'appointment' and appointment_revision is not null
+           do nothing`,
+        [item.organization_id, item.appointment_id, item.appointment_revision],
+      );
+    },
     async persistirRespostaFollowup(input) {
       await persistirRespostaFollowupPg((sql, params) => pool.query(sql, params), input);
     },

--- a/tests/invariants/agenda-presenca-recuperacao.test.ts
+++ b/tests/invariants/agenda-presenca-recuperacao.test.ts
@@ -1,4 +1,5 @@
 import { completeTurnForEnrollment, createPgAdminClient } from "@/lib/followup/turn-bridge";
+import { runFollowupTick } from "@/lib/followup/engine";
 import { randomUUID } from "node:crypto";
 import pg from "pg";
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
@@ -306,6 +307,87 @@ describe("presença e recuperação transacionais", () => {
         await pool.query(
           "select count(*)::int n from agent_inbox_items where ref_id=$1 and kind='appointment_recovery_review'",
           [a.id],
+        )
+      ).rows[0].n,
+    ).toBe(1);
+  });
+  it("régua de recuperação esgotada sem resposta abre aviso na Central referenciando o compromisso", async () => {
+    await stopFlows();
+    // Fluxo mínimo que chega direto ao fim com outcome `exhausted` — o motor
+    // conclui num tick só e o hook de `no-show-recuperacao-esgotada` dispara.
+    const v = (
+      await pool.query(
+        "insert into followup_flow_versions(organization_id,graph) values($1,$2) returning id",
+        [
+          GOV_ORG,
+          {
+            nodes: [
+              { id: "t", type: "trigger", label: "Falta", position: { x: 0, y: 0 }, config: {} },
+              { id: "end", type: "end", label: "Fim", position: { x: 0, y: 1 }, config: { outcome: "exhausted" } },
+            ],
+            edges: [{ id: "e", source: "t", target: "end", priority: 0, condition: { type: "always" } }],
+          },
+        ],
+      )
+    ).rows[0].id;
+    const p = (
+      await pool.query(
+        "insert into followup_flow_pointers(organization_id,name,status,active_version_id,trigger_config) values($1,'Recuperação esgotável '||gen_random_uuid(),'active',$2,$3) returning id",
+        [GOV_ORG, v, { kind: "appointment_no_show", cancel_on_reply: false }],
+      )
+    ).rows[0].id;
+    const agent = (
+      await pool.query(
+        "insert into ai_agents(organization_id,name,system_prompt) values($1,'Recuperação esgotável '||gen_random_uuid(),'Prompt') returning id",
+        [GOV_ORG],
+      )
+    ).rows[0].id;
+    await pool.query(
+      "insert into ai_agent_versions(organization_id,agent_id,version_number,system_prompt,provider,model,channel_session_id,status,followup) values($1,$2,1,'Prompt','anthropic','claude-sonnet-4-6',$3,'published',$4)",
+      [GOV_ORG, agent, GOV_SESSION, { enabled: true, flow_pointer_ids: [p] }],
+    );
+
+    const a = await fixture();
+    await change(a.id);
+    const rec = await recover(a.id);
+    expect(rec.result).toBe("started");
+
+    // O enrollment recém-criado pode estar a alguns ms no futuro para o Postgres
+    // (ver followup-relogio.ts) — força-o a devido antes do tick.
+    await pool.query(
+      "update followup_enrollments set next_eval_at = now() - interval '1 second' where id = $1",
+      [rec.enrollment_id],
+    );
+
+    await runFollowupTick(
+      { db: createPgAdminClient(pool), clock: () => new Date(), enqueueJob: async () => {} },
+      { limit: 10 },
+    );
+
+    const enr = (
+      await pool.query("select status, outcome from followup_enrollments where id = $1", [rec.enrollment_id])
+    ).rows[0];
+    expect(enr).toMatchObject({ status: "completed", outcome: "exhausted" });
+
+    const aviso = (
+      await pool.query(
+        "select severity, ref_kind, appointment_revision::int rev from agent_inbox_items where organization_id=$1 and ref_id=$2 and kind='appointment_recovery_review'",
+        [GOV_ORG, a.id],
+      )
+    ).rows;
+    expect(aviso).toHaveLength(1);
+    expect(aviso[0]).toMatchObject({ severity: "warn", ref_kind: "appointment", rev: 2 });
+
+    // Idempotente: reprocessar o mesmo passo não abre um segundo aviso.
+    await runFollowupTick(
+      { db: createPgAdminClient(pool), clock: () => new Date(), enqueueJob: async () => {} },
+      { limit: 10 },
+    );
+    expect(
+      (
+        await pool.query(
+          "select count(*)::int n from agent_inbox_items where organization_id=$1 and ref_id=$2 and kind='appointment_recovery_review'",
+          [GOV_ORG, a.id],
         )
       ).rows[0].n,
     ).toBe(1);


### PR DESCRIPTION
## O quê

Quando `fn_appointment_recover` (0224) matricula um contato num fluxo de `appointment_no_show` e a régua esgota **sem o cliente responder**, o enrollment concluía com outcome `exhausted` e o card ficava parado — sem sinal para ninguém. O construtor de fluxo não move etapa, e não há turno do agente ao fim de uma régua de texto fixo.

Agora o motor abre um item na Central de avisos (`agent_inbox_items` kind `appointment_recovery_review`, `ref_kind='appointment'`) apontando para o compromisso. Decisão de produto (relatório do dono): "aviso na Central + mover manual", não uma feature de mover-etapa no construtor — faltar a uma visita não é o negócio esfriando.

## Como

- `lib/followup/no-show-recuperacao-esgotada.ts` — a regra pura (só avisa em `complete`/`exhausted`, não-replay, com `appointment_id`).
- `engine.ts` — hook em `applyResult` **antes** do `status='completed'` (mesma ordem/razão de `markDead`: se cair no meio, re-tick re-tenta; o índice único torna repetição no-op). Adaptador Supabase. Método **opcional** no `AdminClient` — fakes de teste que não exercitam no-show não mudam.
- `turn-bridge.ts` — adaptador pg-puro (`on conflict do nothing` no índice parcial da 0224).

**Sem migration**: reusa kind, colunas (`appointment_revision`) e índice único `inbox_appointment_revision_unique` da 0224.

## Testes

- Unit da regra pura (`no-show-recuperacao-esgotada.test.ts`).
- Invariante em `agenda-presenca-recuperacao.test.ts`: dirige um fluxo `appointment_no_show` até `exhausted` e confere o aviso (severity/ref_kind/revisão) + idempotência de reprocesso.

Verificado local: `vitest lib/followup` (439 verdes) + eslint limpo. typecheck completo e `test:db` não rodam na máquina de origem (OOM) — ficam com `verify` e `invariants` do CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uaiWm6rGNXDWXdEZZTRf1