### PR TITLE
fix(marca): logo escuro/colorido não some mais no tema escuro

### DIFF
--- a/.changes/logo-escuro-nao-some-mais.md
+++ b/.changes/logo-escuro-nao-some-mais.md
@@ -1,0 +1,19 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: "Logo escuro/colorido não some mais no tema escuro"
+---
+
+Um logo pensado para fundo claro (a maioria do que se sobe em `/admin/marca`
+e `/app/settings/marca`) ficava ilegível no tema escuro: o fundo da barra
+lateral e da tela de entrada é quase preto (`--color-surface` escuro), e um
+logo escuro sobre quase-preto não tem contraste nenhum.
+
+Agora a barra lateral, a tela de entrada e a prévia da própria tela de marca
+mostram o logo sobre um chip branco arredondado quando o tema é escuro — a
+mesma lógica que já existe para o texto dos botões, aplicada ao logo. No tema
+claro nada muda: o chip só aparece quando o fundo por trás dele é escuro.
+
+Quem já tinha um logo pensado para fundo escuro (raro, mas possível) passa a
+ver uma moldura branca de sobra em vez de nada — troca aceita, porque o pior
+caso "moldura desnecessária" é sempre melhor que o pior caso "logo invisível".

--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -64,13 +64,20 @@ export default async function PublicLayout({ children }: { children: React.React
                 "primeira <img> da página", e uma asserção de negação com seletor
                 largo passa sozinha assim que outra imagem entra na tela.
               */}
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                data-testid="logo-da-fachada"
-                src={marca.logoUrl}
-                alt={marca.nome}
-                className="h-10 w-auto max-w-[12rem] object-contain"
-              />
+              {/* O chip `dark:bg-white` é o mesmo da barra lateral
+                (`components/shell/Sidebar.tsx`): esta tela também respeita
+                `data-theme` (o `ThemeProvider` embrulha a raiz inteira, login
+                incluso), então um logo escuro contra `--color-surface` escuro tem
+                o mesmo problema de contraste aqui. */}
+              <div className="rounded-md dark:bg-white dark:px-3 dark:py-2 dark:shadow-sm">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  data-testid="logo-da-fachada"
+                  src={marca.logoUrl}
+                  alt={marca.nome}
+                  className="h-10 w-auto max-w-[12rem] object-contain"
+                />
+              </div>
             </div>
           )}
           {children}

--- a/components/branding/CampoDeLogo.tsx
+++ b/components/branding/CampoDeLogo.tsx
@@ -313,18 +313,35 @@ export function CampoDeLogo({
                 style={{ backgroundColor: fundo }}
               >
                 {emVigor ? (
-                  // <img> e não next/image pelo mesmo motivo da barra lateral e da
-                  // tela de acesso: a URL é do projeto de quem hospeda, e
-                  // `next/image` exige allowlist de domínios fechada em BUILD — a
-                  // imagem pré-buildada do self-host recusaria o domínio do
-                  // operador. Altura fixa e largura livre para não distorcer arte
-                  // de proporção desconhecida.
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    src={emVigor}
-                    alt={nomeEmVigor}
-                    className="max-h-12 w-auto max-w-full object-contain"
-                  />
+                  // O chip claro na aparência escura é o MESMO que a barra
+                  // lateral e a tela de entrada aplicam de verdade
+                  // (`components/shell/Sidebar.tsx`, `app/(public)/layout.tsx`):
+                  // esta prévia deixaria de ser prévia se mostrasse o logo cru
+                  // onde o app real desenha um chip por baixo. Aqui não dá pra
+                  // usar a variante `dark:` do Tailwind — as duas caixas
+                  // renderizam lado a lado no MESMO tema real, simulando os
+                  // dois via `style` — então a condição é o rótulo da caixa, não
+                  // o tema da página.
+                  <span
+                    className={
+                      rotulo === t("Aparência escura")
+                        ? "rounded-md bg-white px-2 py-1 shadow-sm"
+                        : undefined
+                    }
+                  >
+                    {/* <img> e não next/image pelo mesmo motivo da barra lateral e da
+                      tela de acesso: a URL é do projeto de quem hospeda, e
+                      `next/image` exige allowlist de domínios fechada em BUILD — a
+                      imagem pré-buildada do self-host recusaria o domínio do
+                      operador. Altura fixa e largura livre para não distorcer arte
+                      de proporção desconhecida. */}
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={emVigor}
+                      alt={nomeEmVigor}
+                      className="max-h-12 w-auto max-w-full object-contain"
+                    />
+                  </span>
                 ) : (
                   <span
                     className="text-sm font-semibold tracking-tight"

--- a/components/shell/Sidebar.tsx
+++ b/components/shell/Sidebar.tsx
@@ -119,13 +119,26 @@ export function SidebarContent({
         )}
       >
         {logo && !collapsed ? (
-          // <img> em vez de next/image de propósito: a URL vem de quem hospeda
-          // (banco ou .env), e next/image exige allowlist de domínios fechada em
-          // build — a imagem pré-buildada rejeitaria o domínio do self-hoster.
-          // Altura fixa e largura livre porque a arte enviada tem proporção
-          // desconhecida; forçar as duas distorceria o logo de quem configurou.
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={logo} alt={nome} className="h-7 w-auto max-w-[10rem] object-contain" />
+          // Chip claro só no tema escuro: a arte enviada é de quem hospeda, sem
+          // garantia de que tenha contraste contra `--color-surface` escuro
+          // (`#1d1c17`). Sem isto, todo logo escuro/colorido — a maioria do que
+          // se sobe pensando em fundo claro — some no tema escuro (issue: logo
+          // da Dra. Mariana Nascimento, azul-marinho sobre quase-preto). O chip
+          // é condicional ao TEMA, não à cor do logo (não dá pra inspecionar
+          // pixel de uma URL externa em server component), então ele aparece
+          // para qualquer logo — inclusive um já pensado pra fundo escuro, que
+          // fica com uma moldura branca de sobra. Troca aceita: pior caso
+          // "moldura desnecessária" é sempre melhor que pior caso "logo
+          // invisível".
+          <div className="rounded-md dark:bg-white dark:px-2 dark:py-1 dark:shadow-sm">
+            {/* <img> em vez de next/image de propósito: a URL vem de quem hospeda
+              (banco ou .env), e next/image exige allowlist de domínios fechada em
+              build — a imagem pré-buildada rejeitaria o domínio do self-hoster.
+              Altura fixa e largura livre porque a arte enviada tem proporção
+              desconhecida; forçar as duas distorceria o logo de quem configurou. */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={logo} alt={nome} className="h-7 w-auto max-w-[10rem] object-contain" />
+          </div>
         ) : (
           <span className={cn("font-semibold tracking-tight", collapsed && "sr-only")}>{nome}</span>
         )}


### PR DESCRIPTION
# O que este PR faz

Um logo pensado para fundo claro (a maioria do que se sobe em `/admin/marca`
e `/app/settings/marca`) fica sem contraste nenhum no tema escuro, onde
`--color-surface` é quase preto (`#1d1c17`). Achado configurando a marca de
um cliente real (logo azul-marinho sobre fundo transparente, tema escuro
ativado): o logo simplesmente sumia na barra lateral e na tela de entrada.

Este PR desenha um chip branco arredondado atrás do logo **só quando o tema é
escuro**, nos três lugares onde o logo é renderizado: barra lateral
(`components/shell/Sidebar.tsx`), tela de entrada (`app/(public)/layout.tsx`)
e a prévia da própria tela de marca (`components/branding/CampoDeLogo.tsx`,
que já mostrava "como fica nos dois temas" — agora a prévia reflete o chip de
verdade, e não o logo cru).

A condição é o **tema**, não a cor do logo — não dá para inspecionar os
pixels de uma URL externa num server component. Consequência aceita: quem já
tinha um logo pensado para fundo escuro ganha uma moldura branca de sobra em
vez de nada. Pior caso "moldura desnecessária" é sempre melhor que pior caso
"logo invisível".

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado (nenhum warning novo nos 3 arquivos tocados)
- [x] Testes relevantes existem e passam — `tests/unit/branding.test.ts`
      (29 testes, o guardião de vazamento de marca no código) roda limpo
      contra a mudança
- [ ] RLS testada — não aplicável, não toca schema/tabela
- [ ] Audit log emitido — não aplicável, não há mutação nova
- [x] Zod valida todo input externo — nenhum input novo
- [x] Sem `console.log` esquecido
- [ ] Mudança de schema — não aplicável
- [x] Doc atualizada — fragmento em `.changes/logo-escuro-nao-some-mais.md`
- [x] Provado pela tela: testado com Playwright num ambiente real (login +
      `/admin/marca` + upload de logo real + toggle de tema), print antes/depois
      confirmando o chip aparecendo só no tema escuro

Convenções completas em `CLAUDE.md` · fluxo em `CONTRIBUTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
