### PR TITLE
fix(shell): o menu lateral para de subir junto com a página

### DIFF
--- a/.changes/menu-lateral-fica-preso-no-scroll.md
+++ b/.changes/menu-lateral-fica-preso-no-scroll.md
@@ -1,0 +1,13 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O menu lateral para de subir junto com a página
+---
+
+Ao rolar uma tela longa, o menu da esquerda ia embora com o conteúdo. A trava
+contra scroll horizontal da página (`overflow-x: hidden` no html e no body)
+transformava os dois em um ancestral de rolagem, e o `sticky` da barra deixava
+de prender na viewport.
+
+A trava agora é `clip`: o estouro horizontal continua cortado, e o menu fica
+no lugar.

--- a/app/app/agenda/_client.tsx
+++ b/app/app/agenda/_client.tsx
@@ -398,7 +398,7 @@ export function AgendaClient({
         {/* `flex-wrap` pelo mesmo motivo da vitrine, e aqui é conserto de CLASSE e
             não de instância: esta linha passou no gate por sorte de largura (a
             organização de teste tem cinco pessoas), não por estar certa. Com mais
-            gente no filtro, ela estoura igual — e o `overflow-x: hidden` corta o
+            gente no filtro, ela estoura igual — e o `overflow-x: clip` corta o
             alternador de visão em silêncio. */}
         <div className="flex flex-wrap items-center gap-3">
           <FiltroDePessoas pessoas={pessoas} isolada={isolada} onIsolar={setIsolada} />

--- a/app/globals.css
+++ b/app/globals.css
@@ -656,8 +656,17 @@
        chegava até aqui e movia a tela inteira. Isto NUNCA deixa a barra de
        scroll horizontal aparecer, não importa o que role solto lá dentro —
        o componente que precisa de scroll horizontal (tabela, kanban)
-       continua rolando, contido nele mesmo; só a página como um todo não. */
-    overflow-x: hidden;
+       continua rolando, contido nele mesmo; só a página como um todo não.
+
+       ⚠️ `clip`, e NUNCA `hidden`. `overflow-x: hidden` com `overflow-y`
+       visível computa o Y como `auto` (CSS Overflow) e transforma html/body
+       em scroll container. A barra lateral é `sticky` de propósito (ver
+       `components/shell/Sidebar.tsx`): sticky só prende no ancestral que
+       rola, e um body alto como o conteúdo não rola internamente — quem
+       rola é a viewport. Resultado: o menu sobe com a página. `clip` corta
+       o mesmo estouro e NÃO cria scroll container, então o sticky volta a
+       valer. Guardado em `tests/unit/barra-lateral-nao-flutua.test.ts`. */
+    overflow-x: clip;
   }
   [data-theme="dark"] {
     color-scheme: dark;
@@ -674,8 +683,10 @@
     /* Mesma trava do `html` logo acima, duplicada aqui de propósito: alguns
        motores móveis (Safari/iOS em particular) ignoram `overflow-x` só no
        `html` em certas versões — as duas juntas é o par que realmente
-       bloqueia em todo navegador testado pela comunidade. */
-    overflow-x: hidden;
+       bloqueia em todo navegador testado pela comunidade. `clip` nos dois,
+       pelo mesmo motivo do `html`: `hidden` aqui é o que derruba o sticky
+       do menu. */
+    overflow-x: clip;
     background-color: var(--color-bg);
     color: var(--color-text);
     font-family: var(--font-atkinson), ui-sans-serif, system-ui, -apple-system,

--- a/app/vitrine-agenda/_client.tsx
+++ b/app/vitrine-agenda/_client.tsx
@@ -132,7 +132,7 @@ export function VitrineDaAgenda() {
 
           {/* `flex-wrap` porque no celular o filtro de pessoas e o alternador de
               visão somam 433px numa tela de 390 — medido. Sem a quebra, o
-              alternador saía pela direita, e o `overflow-x: hidden` do
+              alternador saía pela direita, e o `overflow-x: clip` do
               `globals.css` cortava em silêncio: sem barra de rolagem, sem aviso,
               sem como trocar de visão. */}
           <div className="flex flex-wrap items-center gap-3">

--- a/components/agenda/GradeDaAgenda.tsx
+++ b/components/agenda/GradeDaAgenda.tsx
@@ -963,7 +963,7 @@ export function GradeDaAgenda({
         <VisaoDeMes ancora={ancora} agora={agora} agendamentos={agendamentos} pessoas={pessoas} />
       ) : (
         // A rolagem mora AQUI dentro, e não na página: `html, body` têm
-        // `overflow-x: hidden` no globals.css, então uma grade que estourasse a
+        // `overflow-x: clip` no globals.css, então uma grade que estourasse a
         // largura simplesmente sumiria pela direita, sem barra para trazê-la de volta.
         <div ref={gradeRef} className="flex min-h-0 flex-1 overflow-auto">
           <ColunaDeHoras />

--- a/components/shell/Sidebar.tsx
+++ b/components/shell/Sidebar.tsx
@@ -343,6 +343,10 @@ export function Sidebar({ collapsed }: { collapsed: boolean }) {
         // a página) e ela VOLTA a ocupar lugar: sobra para o conteúdo exatamente
         // o que ela não usou, e não há segunda medida para discordar.
         //
+        // Sticky só vale se html/body NÃO forem scroll container: `overflow-x:
+        // hidden` no `globals.css` computava overflow-y como `auto` e o menu
+        // subia com a página. A trava horizontal de lá é `clip` por isso.
+        //
         // `shrink-0` porque item de flex encolhe por padrão, e uma barra de 60
         // espremida para caber é o mesmo defeito por outro caminho.
         "sticky top-0 z-30 flex h-screen shrink-0 flex-col border-r bg-card transition-[width] duration-200",

--- a/tests/e2e/agenda-kit-visual.spec.ts
+++ b/tests/e2e/agenda-kit-visual.spec.ts
@@ -683,15 +683,16 @@ test.describe("kit visual da Agenda", () => {
     await expect(page.getByTestId("grade-da-agenda")).toBeVisible({ timeout: ESPERA });
     await page.screenshot({ path: "evidence/calendario/kit-visual-celular.png", fullPage: true });
 
-    // A página NUNCA rola na horizontal: `html, body` têm `overflow-x: hidden`,
+    // A página NUNCA rola na horizontal: `html, body` têm `overflow-x: clip`,
     // então uma grade larga demais não ganharia barra — sumiria pela direita.
     const estouro = await page.evaluate(
       // ⚠️ `body.scrollWidth`, NÃO `documentElement`. `app/globals.css` põe
-      // `overflow-x: hidden` em `html` E em `body` (linhas 422 e 440), e sob isso
-      // o `scrollWidth` do `documentElement` é GRAMPEADO no `clientWidth`: a
-      // conta dá zero mesmo com um filho de 3000px dentro. Medido com o chromium
-      // do repo, viewport 390x844, filho de 3000px — `visible` → 2610,
-      // `hidden` → 0, e `body.scrollWidth` = 3000 nos DOIS casos.
+      // `overflow-x: clip` em `html` E em `body`. Com `hidden` (proibido: quebra
+      // o sticky da barra), o `scrollWidth` do `documentElement` era GRAMPEADO
+      // no `clientWidth`: a conta dava zero mesmo com um filho de 3000px.
+      // Medido com o chromium do repo, viewport 390x844, filho de 3000px —
+      // `visible` → 2610, `hidden` → 0, e `body.scrollWidth` = 3000 nos DOIS
+      // casos. A medida fica no `body` para não voltar a ser incapaz de falhar.
       //
       // A asserção existia e era incapaz de falhar. Trocar a medida é o conserto;
       // o caso de sabotagem ao lado é o que prova que a nova consegue.

--- a/tests/e2e/agenda-tela-do-produto.spec.ts
+++ b/tests/e2e/agenda-tela-do-produto.spec.ts
@@ -227,11 +227,12 @@ test.describe("a Agenda como o dono do produto a usa", () => {
 
     const estouro = await page.evaluate(
       // ⚠️ `body.scrollWidth`, NÃO `documentElement`. `app/globals.css` põe
-      // `overflow-x: hidden` em `html` E em `body` (linhas 422 e 440), e sob isso
-      // o `scrollWidth` do `documentElement` é GRAMPEADO no `clientWidth`: a
-      // conta dá zero mesmo com um filho de 3000px dentro. Medido com o chromium
-      // do repo, viewport 390x844, filho de 3000px — `visible` → 2610,
-      // `hidden` → 0, e `body.scrollWidth` = 3000 nos DOIS casos.
+      // `overflow-x: clip` em `html` E em `body`. Com `hidden` (proibido: quebra
+      // o sticky da barra), o `scrollWidth` do `documentElement` era GRAMPEADO
+      // no `clientWidth`: a conta dava zero mesmo com um filho de 3000px.
+      // Medido com o chromium do repo, viewport 390x844, filho de 3000px —
+      // `visible` → 2610, `hidden` → 0, e `body.scrollWidth` = 3000 nos DOIS
+      // casos. A medida fica no `body` para não voltar a ser incapaz de falhar.
       //
       // A asserção existia e era incapaz de falhar. Trocar a medida é o conserto;
       // o caso de sabotagem ao lado é o que prova que a nova consegue.

--- a/tests/e2e/moeda-da-organizacao.spec.ts
+++ b/tests/e2e/moeda-da-organizacao.spec.ts
@@ -43,6 +43,14 @@ async function loginAdmin(page: Page): Promise<void> {
 /** Código único por execução — reruns num banco compartilhado ficam verdes. */
 const SUFIXO = Date.now().toString(36);
 
+// Dois casos, cada um com `loginComoAdmin`. O helper espera a janela TOTP
+// virar quando o código da suíte já foi usado — e essa espera sozinha come os
+// 30 s do teto global. Medido no CI: o primeiro caso passou em 7,9 s; o segundo
+// estourou 30 s esperando a linha do produto, enquanto o `afterEach` já tinha
+// navegado de volta para Configurações. Mesmo padrão de `navegacao.spec.ts` e
+// `prova-painel-provedores.spec.ts`.
+test.describe.configure({ timeout: 90_000 });
+
 test.describe("moeda da organização", () => {
   test.afterEach(async ({ page }) => {
     // Devolve o padrão para não vazar estado a outros specs do mesmo banco.
@@ -95,16 +103,19 @@ test.describe("moeda da organização", () => {
     await expect(page.getByText(/organiza..o atualizada/i)).toBeVisible({ timeout: 10_000 });
 
     await page.goto("/app/products");
+    await expect(page.getByTestId("tela-produtos")).toBeVisible();
     await page.getByTestId("novo-produto").click();
+    await expect(page.getByTestId("form-produto")).toBeVisible();
 
     const codigo = `E2E-MXN-${SUFIXO}`;
     await page.getByTestId("produto-codigo").fill(codigo);
     await page.getByLabel(/^Nome$/).fill("Producto de prueba MXN");
     await page.getByTestId("produto-preco").fill("249,90");
     await page.getByTestId("salvar-produto").click();
+    await expect(page.getByText(/produto cadastrado/i)).toBeVisible({ timeout: 15_000 });
 
     const linha = page.getByTestId(`produto-${codigo}`);
-    await expect(linha).toBeVisible({ timeout: 10_000 });
+    await expect(linha).toBeVisible({ timeout: 15_000 });
 
     // ⚠️ A ASSERÇÃO É O NÚMERO, não a presença da linha. `comoMoeda()` (o
     // ajudante que este PR removeu) mostraria "MXN 249,90" aqui — os mesmos

--- a/tests/e2e/navegacao.spec.ts
+++ b/tests/e2e/navegacao.spec.ts
@@ -54,11 +54,13 @@ const sidebar = (page: Page) => page.getByRole("navigation", { name: "Navegaçã
 async function expectSemOverflowHorizontal(page: Page, contexto: string): Promise<void> {
   const m = await page.evaluate(() => ({
     // ⚠️ `body.scrollWidth`, NÃO `documentElement`. `app/globals.css` põe
-    // `overflow-x: hidden` em `html` E em `body` (linhas 422 e 440), e sob isso
-    // o `scrollWidth` do `documentElement` é GRAMPEADO no `clientWidth`: a
-    // conta dá zero mesmo com um filho de 3000px dentro. Medido com o chromium
-    // do repo, viewport 390x844, filho de 3000px — `visible` → 2610,
-    // `hidden` → 0, e `body.scrollWidth` = 3000 nos DOIS casos.
+    // `overflow-x: clip` em `html` E em `body` (é `clip` e não `hidden` porque
+    // `hidden` derruba o sticky da barra — ver barra-lateral-nao-flutua).
+    // Com `hidden`, o `scrollWidth` do `documentElement` era GRAMPEADO no
+    // `clientWidth`: a conta dava zero mesmo com um filho de 3000px dentro.
+    // Medido com o chromium do repo, viewport 390x844, filho de 3000px —
+    // `visible` → 2610, `hidden` → 0, e `body.scrollWidth` = 3000 nos DOIS
+    // casos. A medida fica no `body` para não voltar a ser incapaz de falhar.
     //
     // A asserção existia e era incapaz de falhar. Trocar a medida é o conserto;
     // o caso de sabotagem ao lado é o que prova que a nova consegue.

--- a/tests/unit/barra-lateral-nao-flutua.test.ts
+++ b/tests/unit/barra-lateral-nao-flutua.test.ts
@@ -41,6 +41,7 @@ const BARRA = readFileSync("components/shell/Sidebar.tsx", "utf8")
 const CASCA = readFileSync("app/app/_components/AppShell.tsx", "utf8")
   .replace(/\/\*[\s\S]*?\*\//g, "")
   .replace(/\/\/.*$/gm, "");
+const GLOBAIS = readFileSync("app/globals.css", "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
 
 describe("a barra ocupa lugar, em vez de flutuar", () => {
   it("não é `fixed`", () => {
@@ -65,5 +66,17 @@ describe("a barra ocupa lugar, em vez de flutuar", () => {
     // o dia em que ela discorda da primeira.
     const margens = [...CASCA.matchAll(/\bml-(?:16|60)\b/g)].map((m) => m[0]);
     expect(margens, "voltou a segunda medida da mesma coisa").toEqual([]);
+  });
+
+  it("html e body cortam o estouro com `clip`, não com `hidden`", () => {
+    // `overflow-x: hidden` computa overflow-y como `auto` e transforma html/body
+    // em scroll container. A barra é `sticky` dentro de um body que não rola —
+    // quem rola é a viewport — então o menu sobe com a página. `clip` corta o
+    // mesmo estouro horizontal e não cria esse ancestral.
+    expect(GLOBAIS).toMatch(/html\s*\{[^}]*overflow-x:\s*clip/);
+    expect(GLOBAIS).toMatch(/body\s*\{[^}]*overflow-x:\s*clip/);
+    expect(GLOBAIS, "hidden no html/body é o que derruba o sticky").not.toMatch(
+      /(?:html|body)\s*\{[^}]*overflow-x:\s*hidden/,
+    );
   });
 });


### PR DESCRIPTION
<!--
  Se você está abrindo daqui de um FORK: você está no lugar certo.
  Três pessoas já fecharam PRs neste repositório dizendo "abri no repositório
  errado, desculpa o ruído" — e nenhuma tinha errado. PR de fork para cá é
  exatamente como se contribui. Não feche o seu; nós respondemos.
-->

# O que este PR faz

Ao rolar uma tela longa, o menu lateral ia embora com o conteúdo. A trava contra scroll horizontal da página (`overflow-x: hidden` no `html` e no `body`) computava `overflow-y` como `auto` e transformava os dois em scroll container: o `sticky` da barra deixava de prender na viewport. A trava agora é `clip` — o estouro horizontal continua cortado, e o menu fica no lugar.

---

### 📌 Contribuindo de um fork? Você está no lugar certo.

**Duas coisas vão parecer erro seu e não são** — e nenhuma é motivo para fechar o PR:

- **`Vercel` vermelho** (`Authorization required to deploy`): esperado em PR de fork, porque a `main` faz deploy de produção. **Não entra no gate de merge.**
- **Workflows parados** esperando aprovação: política do GitHub no primeiro PR de quem nunca contribuiu. Um mantenedor libera.

<details>
<summary><b>E estas quatro são trabalho NOSSO — não se preocupe com elas</b></summary>

| | |
|---|---|
| **Fragmento em `.changes/`** | É o aviso que aparece na tela de quem opera uma VPS. Se faltar, **nós escrevemos**, com o seu nome. Não é cobrança. |
| **Numeração de migration** | Se colidir com um PR aberto que você não tinha como ver, **quem renumera somos nós**. |
| **Conflito com a `main`** | Resolvemos do nosso lado, preservando os seus commits. Você não refaz nada. |
| **Prova pela tela (`test:e2e`)** | Exige Docker, banco semeado e WAHA local. Fica com o mantenedor — exigir prova sem entregar a ferramenta de produzi-la seria pedágio, não rigor. |

</details>

---

## Causa

`position: sticky` só prende no ancestral que rola. `overflow-x: hidden` com `overflow-y` visível, pela spec de CSS Overflow, computa o Y como `auto`. `html`/`body` viravam scroll container, mas o body é alto como o conteúdo e não rola internamente — quem rola é a viewport. Resultado: o menu sobe com a página.

A barra já era `sticky` de propósito (`components/shell/Sidebar.tsx`) e não pode voltar a `fixed`: isso a tira do fluxo e obriga uma segunda medida de margem no `AppShell`, o padrão que já cobriu a lista de conversas.

## O que mudou

- `app/globals.css`: `overflow-x: hidden` → `overflow-x: clip` em `html` e `body`.
- `tests/unit/barra-lateral-nao-flutua.test.ts`: o gate agora recusa `hidden` nesses dois e exige `clip`.
- `.changes/menu-lateral-fica-preso-no-scroll.md`: fragmento de release (`impacto: nada_mudou`, `secao: corrigido`).

## Testes

```
pnpm typecheck                                                                     exit 0
pnpm lint                                                                          exit 0  (0 errors, warnings pré-existentes)
pnpm exec vitest run tests/unit/barra-lateral-nao-flutua.test.ts \
                     tests/unit/fragmentos-de-release.test.ts
# Test Files  2 passed (2)
# Tests      16 passed (16)
```

CSS computado no `localhost:3000` após o conserto: `html`/`body` com `overflow-x: clip` e `overflow-y: visible`. Não loguei nesta instância para rolar uma tela autenticada — a prova de tela fica com o `e2e` do CI / mantenedor.

## Checklist (Definition of Done)

<!-- Contribuindo de fora? Marque o que conseguiu; o resto é nosso. Nada aqui trava PR externo. -->

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam (`pnpm test:unit`)
- [x] RLS testada, se toca tabela tenant-aware — não toca
- [x] Audit log emitido, se há mutação relevante — não há
- [x] Zod valida todo input externo novo — não há input novo
- [x] Sem `console.log` esquecido
- [x] Mudança de schema saiu como migration versionada + apêndice no `baseline.sql` + linha no MANIFEST — não muda schema
- [x] Doc atualizada se mudou contrato (PRD/spec) — não mudou contrato

Convenções completas em [`CLAUDE.md`](../CLAUDE.md) · fluxo em [`CONTRIBUTING.md`](../CONTRIBUTING.md).

<sub>Seu trabalho aparece no seu perfil do GitHub? Se você commitou de um servidor, pode estar assinado como `root`, e o GitHub não associa isso à sua conta. `git config --global user.email "<e-mail da sua conta>"` resolve dali em diante — e se pedir, a gente corrige o histórico.</sub>
