### PR TITLE
fix(api): GET /api/v1/contacts aceita Bearer de api_tokens, alem da sessao

### DIFF
--- a/app/api/v1/contacts/route.test.ts
+++ b/app/api/v1/contacts/route.test.ts
@@ -1,0 +1,209 @@
+/**
+ * GET /api/v1/contacts — dois modos de autenticação.
+ *
+ * a) sessão de navegador → `requireRole("viewer", …)` (mesmo gate do resto de
+ *    `/api/v1/*`).
+ * b) `Authorization: Bearer dsk_…` → `validateBearerToken()` (`lib/mcp/auth.ts`),
+ *    o MESMO autenticador que o MCP server usa para `api_tokens`.
+ *
+ * `organization_id` nunca vem do cliente: no modo sessão vem do cookie
+ * validado contra memberships (`requireRole`); no modo Bearer vem da LINHA DO
+ * TOKEN no banco (`validateBearerToken`). Isto é o que a suíte prova.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { fail } from "@/lib/api/wrappers";
+import { requireRole } from "@/lib/auth/require-role";
+import type { AuthUser } from "@/lib/auth/types";
+import { isPublicPath } from "@/lib/auth/public-paths";
+import { McpAuthError, extractBearer } from "@/lib/mcp/auth";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { listContactsHandler } from "./_handler";
+
+vi.mock("@/lib/auth/require-role", () => ({ requireRole: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
+vi.mock("./_handler", () => ({
+  listContactsHandler: vi.fn(async () => ({ contacts: [], cursor: null, has_more: false })),
+  createContactHandler: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp/auth", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/mcp/auth")>("@/lib/mcp/auth");
+  return { ...actual, validateBearerToken: vi.fn() };
+});
+
+// Precisa vir DEPOIS do vi.mock acima — pega a versão mockada de validateBearerToken.
+const { validateBearerToken } = await import("@/lib/mcp/auth");
+
+const ORG_ID = "22222222-2222-4222-8222-222222222222";
+const OUTRA_ORG = "33333333-3333-4333-8333-333333333333";
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+
+const FAKE_SESSION_CLIENT = { session: true } as never;
+const FAKE_ADMIN_CLIENT = { admin: true } as never;
+
+function req(url = "http://localhost/api/v1/contacts", headers?: HeadersInit) {
+  return new NextRequest(url, { headers });
+}
+
+function sessaoOk(): void {
+  const user: AuthUser = {
+    id: USER_ID,
+    email: "a@example.com",
+    full_name: null,
+    avatar_url: null,
+    is_platform_admin: false,
+    idioma: "pt-BR" as const,
+    organizations: [{ organization_id: ORG_ID, organization_name: "Org", role: "viewer" }],
+  };
+  vi.mocked(requireRole).mockResolvedValue({
+    ok: true,
+    user,
+    org: { orgId: ORG_ID, name: "Org", role: "viewer" },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(createClient).mockResolvedValue(FAKE_SESSION_CLIENT);
+  vi.mocked(createAdminClient).mockReturnValue(FAKE_ADMIN_CLIENT);
+});
+
+describe("GET /api/v1/contacts — sessão de navegador", () => {
+  it("sessão válida → 200, lista contatos da org ativa (client de cookie)", async () => {
+    sessaoOk();
+    const { GET } = await import("./route");
+    const res = await GET(req());
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(listContactsHandler).mock.calls[0]?.[0]).toBe(FAKE_SESSION_CLIENT);
+    expect(vi.mocked(listContactsHandler).mock.calls[0]?.[1]).toMatchObject({
+      organization_id: ORG_ID,
+      actor: { type: "user", id: USER_ID },
+    });
+  });
+
+  it("sem sessão e sem Bearer → 401, repassa a resposta de requireRole", async () => {
+    vi.mocked(requireRole).mockResolvedValue({
+      ok: false,
+      response: fail("unauthenticated", "Auth required.", 401, {}),
+    });
+    const { GET } = await import("./route");
+    const res = await GET(req());
+
+    expect(res.status).toBe(401);
+    expect(listContactsHandler).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/v1/contacts — Bearer (integrações externas)", () => {
+  function tokenOk(over: Partial<{ organizationId: string; scopes: string[]; role: string }> = {}) {
+    vi.mocked(validateBearerToken).mockResolvedValue({
+      organizationId: over.organizationId ?? ORG_ID,
+      role: (over.role ?? "agent") as never,
+      actor: { type: "ai_agent", id: "run-1", role: (over.role ?? "agent") as never, api_token_id: "tok-1" },
+      apiTokenId: "tok-1",
+      scopes: over.scopes ?? ["mcp:read"],
+    });
+  }
+
+  it("Bearer válido com scope mcp:read → 200, org resolvida do TOKEN (client admin)", async () => {
+    tokenOk({ organizationId: ORG_ID });
+    const { GET } = await import("./route");
+    const res = await GET(req("http://localhost/api/v1/contacts", { authorization: "Bearer dsk_abc_def" }));
+
+    expect(res.status).toBe(200);
+    expect(requireRole).not.toHaveBeenCalled();
+    expect(vi.mocked(listContactsHandler).mock.calls[0]?.[0]).toBe(FAKE_ADMIN_CLIENT);
+    expect(vi.mocked(listContactsHandler).mock.calls[0]?.[1]).toMatchObject({
+      organization_id: ORG_ID,
+      actor: { type: "ai_agent", api_token_id: "tok-1" },
+    });
+  });
+
+  it("Bearer inválido/revogado → 401, nenhuma chamada ao handler", async () => {
+    vi.mocked(validateBearerToken).mockRejectedValue(
+      new McpAuthError(-32001, 401, "Token not recognized."),
+    );
+    const { GET } = await import("./route");
+    const res = await GET(req("http://localhost/api/v1/contacts", { authorization: "Bearer dsk_xxx_yyy" }));
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("unauthenticated");
+    expect(listContactsHandler).not.toHaveBeenCalled();
+  });
+
+  it("Bearer sem o header Authorization → cai no modo sessão (não trata string vazia como token)", async () => {
+    sessaoOk();
+    const { GET } = await import("./route");
+    const res = await GET(req());
+
+    expect(res.status).toBe(200);
+    expect(validateBearerToken).not.toHaveBeenCalled();
+    expect(requireRole).toHaveBeenCalled();
+  });
+
+  it("Bearer válido SEM scope mcp:read → 403, nenhuma chamada ao handler", async () => {
+    tokenOk({ scopes: [] });
+    const { GET } = await import("./route");
+    const res = await GET(req("http://localhost/api/v1/contacts", { authorization: "Bearer dsk_abc_def" }));
+
+    expect(res.status).toBe(403);
+    expect(listContactsHandler).not.toHaveBeenCalled();
+  });
+
+  it("token de UMA organização nunca lê contatos de OUTRA — organization_id vem do token, não do cliente", async () => {
+    // Mesmo que a chamada tente insinuar outra org via querystring, o schema de
+    // query não aceita `organization_id` — e o handler só recebe o que o TOKEN
+    // resolveu no banco.
+    tokenOk({ organizationId: ORG_ID });
+    const { GET } = await import("./route");
+    const res = await GET(
+      req(`http://localhost/api/v1/contacts?organization_id=${OUTRA_ORG}`, {
+        authorization: "Bearer dsk_abc_def",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(listContactsHandler).mock.calls[0]?.[1]).toMatchObject({
+      organization_id: ORG_ID,
+    });
+  });
+
+  it("extractBearer não confunde header ausente com token vazio", () => {
+    expect(extractBearer(null)).toBeNull();
+    expect(extractBearer("")).toBeNull();
+    expect(extractBearer("Bearer ")).toBeNull();
+  });
+});
+
+/**
+ * ⭐ O DEFEITO QUE OS TESTES ACIMA NÃO PEGAM.
+ *
+ * `proxy.ts` roda ANTES de qualquer route handler e responde 401 sozinho para
+ * quem não tem cookie de sessão — inclusive Bearer válido — a menos que o path
+ * esteja em `PUBLIC_PATHS` (lib/auth/public-paths.ts). Os testes acima chamam
+ * `GET()` direto, sem passar pelo proxy, e por isso ficam verdes mesmo que o
+ * path não esteja na lista — foi exatamente isso que aconteceu em produção
+ * (medido: Bearer correto, 401 "Authentication required", a mensagem do PROXY,
+ * não da rota). Este teste é o único que prova a integração das duas camadas.
+ */
+describe("GET /api/v1/contacts — alcançável sem cookie (proxy)", () => {
+  it("está em PUBLIC_PATHS — senão o proxy barra o Bearer antes da rota decidir", () => {
+    expect(
+      isPublicPath("/api/v1/contacts"),
+      "sem esta entrada, todo Bearer válido recebe 401 do proxy.ts antes de chegar " +
+        "em app/api/v1/contacts/route.ts — o 401 vem com a mensagem genérica do proxy " +
+        '("Authentication required"), não com a da rota.',
+    ).toBe(true);
+  });
+
+  it("NÃO libera sub-rotas que ainda não suportam Bearer", () => {
+    expect(isPublicPath("/api/v1/contacts/algum-id")).toBe(false);
+    expect(isPublicPath("/api/v1/contacts/import")).toBe(false);
+  });
+});

--- a/app/api/v1/contacts/route.ts
+++ b/app/api/v1/contacts/route.ts
@@ -7,12 +7,15 @@ import { requireSupportWrite } from "@/lib/impersonate/support";
  */
 import { randomUUID } from "node:crypto";
 import { type NextRequest } from "next/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 import { ApiError } from "@/lib/api/types";
 import { ok, fail } from "@/lib/api/wrappers";
+import type { Actor } from "@/lib/api/handlers/types";
 import { requireRole } from "@/lib/auth/require-role";
-import { loadAuthUser, resolveActiveOrg } from "@/lib/auth/server";
+import { extractBearer, validateBearerToken, ensureRole, ensureScope, McpAuthError } from "@/lib/mcp/auth";
 import { traduzir } from "@/lib/i18n/dicionario";
+import type { Idioma } from "@/lib/i18n/idiomas";
 import {
   contactCreateSchema,
   contactListQuerySchema,
@@ -20,23 +23,98 @@ import {
   type ContactCreate,
 } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 
 import { listContactsHandler, createContactHandler } from "./_handler";
 
 export const dynamic = "force-dynamic";
 
+/**
+ * Resolução de identidade para GET /api/v1/contacts — dois modos, uma fonte
+ * de verdade cada:
+ *
+ *  a) Sessão de navegador (cookie) → `requireRole("viewer", …)`, o MESMO gate
+ *     usado no resto de `/api/v1/*` (rank efetivo do banco + MFA de sessão).
+ *  b) `Authorization: Bearer dsk_…` → `validateBearerToken()` (`lib/mcp/auth.ts`),
+ *     o autenticador de `api_tokens` que o MCP server já usa. `organization_id`
+ *     vem da LINHA DO TOKEN no banco — nunca de query/body do cliente — então
+ *     não existe caminho para um Bearer de uma org ler contatos de outra.
+ *
+ * Erro de token (ausente/inválido/revogado/expirado) fecha em 401; token válido
+ * sem o scope `mcp:read` (ou role abaixo de `viewer`) fecha em 403. Nenhum dos
+ * dois ramos loga o header ou o plaintext do token.
+ *
+ * ⚠️ NÃO BASTA implementar isto aqui: o `proxy.ts` global roda ANTES de
+ * qualquer route handler e só reconhece cookie de sessão — sem uma entrada em
+ * `lib/auth/public-paths.ts` para `/api/v1/contacts`, todo Bearer recebe 401
+ * do proxy antes de chegar neste arquivo. Ver o comentário lá.
+ */
+type ContactsAuth =
+  | { ok: true; organizationId: string; actor: Actor; supabase: SupabaseClient; idioma?: Idioma }
+  | { ok: false; response: Response };
+
+async function resolveContactsAuth(req: NextRequest, requestId: string): Promise<ContactsAuth> {
+  const authHeader = req.headers.get("authorization");
+
+  if (extractBearer(authHeader)) {
+    let auth;
+    try {
+      auth = await validateBearerToken(authHeader);
+    } catch (err) {
+      if (err instanceof McpAuthError) {
+        return {
+          ok: false,
+          response: fail(
+            err.httpStatus === 401 ? "unauthenticated" : "forbidden",
+            err.message,
+            err.httpStatus,
+            { requestId },
+          ),
+        };
+      }
+      throw err;
+    }
+
+    try {
+      ensureScope(auth.scopes, "mcp:read");
+      ensureRole(auth.role, "viewer");
+    } catch (err) {
+      if (err instanceof McpAuthError) {
+        return {
+          ok: false,
+          response: fail("forbidden_role", err.message, err.httpStatus, { requestId }),
+        };
+      }
+      throw err;
+    }
+
+    // organization_id vem do TOKEN (fonte confiável), nunca do cliente.
+    return {
+      ok: true,
+      organizationId: auth.organizationId,
+      actor: auth.actor,
+      supabase: createAdminClient(),
+    };
+  }
+
+  const authz = await requireRole("viewer", { requestId, resource: "contacts" });
+  if (!authz.ok) return { ok: false, response: authz.response };
+  return {
+    ok: true,
+    organizationId: authz.org.orgId,
+    actor: { type: "user", id: authz.user.id },
+    supabase: await createClient(),
+    idioma: authz.user.idioma,
+  };
+}
+
 export async function GET(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
-  const supabase = await createClient();
-  const {
-    data: { user },
-    error: authErr,
-  } = await supabase.auth.getUser();
-  if (authErr || !user) {
-    return fail("unauthenticated", "Auth required.", 401, { requestId });
-  }
-  const authUser = await loadAuthUser();
-  const t = (texto: string) => traduzir(texto, authUser?.idioma ?? "pt-BR");
+
+  const auth = await resolveContactsAuth(req, requestId);
+  if (!auth.ok) return auth.response;
+  const { organizationId, actor, supabase, idioma } = auth;
+  const t = (texto: string) => traduzir(texto, idioma ?? "pt-BR");
 
   const url = new URL(req.url);
   const qsParsed = contactListQuerySchema.safeParse({
@@ -55,16 +133,14 @@ export async function GET(req: NextRequest): Promise<Response> {
     });
   }
 
-  const orgId = authUser ? (await resolveActiveOrg(authUser))?.orgId : undefined;
-
   try {
     const { contacts, cursor, has_more } = await listContactsHandler(
       supabase,
       {
-        organization_id: orgId ?? "",
-        actor: { type: "user", id: user.id },
+        organization_id: organizationId,
+        actor,
         requestId,
-        idioma: authUser?.idioma,
+        idioma,
       },
       qsParsed.data,
     );

--- a/lib/auth/public-paths.ts
+++ b/lib/auth/public-paths.ts
@@ -39,6 +39,16 @@ export const PUBLIC_PATHS: RegExp[] = [
   /^\/api\/v1\/integrations\/nuvemshop\/callback$/,
   /^\/api\/internal\//,
   /^\/api\/mcp(\/.*)?$/,
+  // GET /api/v1/contacts aceita SESSÃO ou Bearer `dsk_...` (api_tokens) — a
+  // MESMA dualidade de `/api/mcp` acima. Sem esta entrada, o proxy responde
+  // 401 antes de o Bearer chegar à rota, porque `getUser()` aqui só enxerga
+  // cookie. A auth de verdade (sessão OU token, org nunca vinda do cliente)
+  // mora DENTRO da rota (`app/api/v1/contacts/route.ts`), igual aos casos de
+  // `/api/v1/system/agent` e `/api/v1/cron/` acima — "público" aqui quer dizer
+  // "o proxy não decide", não "sem autenticação". Ancorado com `$`: só o
+  // `GET` da listagem, não `/api/v1/contacts/[id]` nem `/import`, que ainda
+  // não têm suporte a Bearer.
+  /^\/api\/v1\/contacts$/,
   /^\/_next\//,
   /^\/favicon\.ico$/,
   // O ícone da aba (`app/icon.tsx`), que o `<head>` de TODA página pede —


### PR DESCRIPTION
## Problema

`GET /api/v1/contacts` só reconhece sessão de navegador. Um `Authorization: Bearer <token>` válido (`api_tokens`) recebe 401, por duas causas empilhadas:

1. A rota só chama `supabase.auth.getUser()` (client de cookie) — nunca lê o header `Authorization`.
2. Mesmo corrigindo (1), `proxy.ts` roda ANTES de qualquer route handler e só reconhece cookie de sessão: sem entrada em `PUBLIC_PATHS`, ele responde 401 (`"Authentication required"`) antes de o Bearer alcançar a rota. Medido em produção: a mensagem genérica do proxy, não a da rota.

`/api/mcp` já resolveu exatamente esse par de problemas para o MCP server (`lib/mcp/auth.ts` + entrada em `PUBLIC_PATHS`) — este PR estende o mesmo padrão, já testado em produção, para o REST endpoint de contatos.

## Correção

- **`app/api/v1/contacts/route.ts`**: `GET` resolve identidade em dois modos:
  - sessão → `requireRole("viewer", …)`, o mesmo gate do resto de `/api/v1/*`;
  - `Authorization: Bearer dsk_…` → `validateBearerToken()` / `ensureScope()` / `ensureRole()` (`lib/mcp/auth.ts`), o mesmo autenticador que `/api/mcp` já usa para `api_tokens`.

  `organization_id` nunca vem do cliente: no modo Bearer vem da linha do token no banco (`validateBearerToken`), fechando qualquer acesso cruzado entre organizações. Token ausente/inválido/revogado/expirado → 401; token válido sem o scope `mcp:read` → 403. Paginação, filtros e formato de resposta não mudam.

- **`lib/auth/public-paths.ts`**: nova entrada `/^\/api\/v1\/contacts$/`, ancorada — só o `GET` exato da listagem, não `/api/v1/contacts/[id]` nem `/import`, que ainda não têm suporte a Bearer. Mesmo padrão já usado por `/api/mcp`, `/api/v1/cron/*` e `/api/v1/system/agent`: "público" aqui quer dizer "o proxy não decide", a autenticação real continua dentro da rota.

- **`app/api/v1/contacts/route.test.ts`** (novo): cobre sessão válida, ausência de auth, Bearer válido/inválido/sem-scope, isolamento entre organizações, e a integração proxy+rota — esse último é o único teste que teria pego o defeito #2, já que chamar `GET()` direto (como os demais) não passa pelo `proxy.ts`.

## Validação

- `pnpm typecheck`, `pnpm test:unit -- app/api/v1/contacts`, `pnpm build` — todos verdes.
- Testado ponta a ponta contra uma instância própria em produção (self-host): sem auth → 401; Bearer inválido → 401; Bearer válido com `mcp:read` → 200 (só contatos da própria org); Bearer válido sem `mcp:read` → 403; token de uma organização não enxerga contato de outra (isolamento cruzado confirmado com duas orgs reais).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit` (suíte de `app/api/v1/contacts`)
- [x] `pnpm build`
- [x] Smoke test manual contra instância própria: sessão, Bearer válido/inválido/sem-scope, isolamento entre organizações

🤖 Generated with [Claude Code](https://claude.com/claude-code)