### PR TITLE
fix(funil): campo de múltipla escolha volta a ser editável nas configurações

### DIFF
--- a/.changes/campo-de-multipla-escolha-volta-a-ser-editavel.md
+++ b/.changes/campo-de-multipla-escolha-volta-a-ser-editavel.md
@@ -1,0 +1,7 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Campo de múltipla escolha volta a ser editável nas configurações do funil
+---
+
+Um campo do funil do tipo "múltipla escolha" abria em Configurações → Funis com o seletor de tipo em branco e sem a lista de opções, como se estivesse corrompido — não dava para editá-lo, e trocar o tipo para tirar o branco rebaixava a escolha múltipla para escolha única. Agora a tela oferece todos os tipos que o sistema aceita e mostra as opções de qualquer campo de lista fechada.

--- a/app/app/settings/tenant/pipelines/_client.test.tsx
+++ b/app/app/settings/tenant/pipelines/_client.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * O editor de CAMPOS do funil — o que ele oferece e o que ele deixa editar.
+ *
+ * O defeito que estes testes trancam: a lista de tipos desta tela era digitada
+ * à mão e ficou menor que a de `customFieldSchema`. `multiselect` era aceito
+ * pelo schema, gravado pela API e desenhado no dossiê do contato, mas não
+ * existia aqui — então um campo desse tipo abria com o seletor EM BRANCO (nenhum
+ * `SelectItem` casava com o `value`) e sem a linha de opções, que só aparecia
+ * para `select`. Quem administrava via um campo aparentemente corrompido, sem
+ * como editar, e o conserto intuitivo (escolher um tipo qualquer para tirar o
+ * branco) rebaixava a escolha múltipla para escolha única.
+ *
+ * Por isso os testes medem o par: a tela OFERECE todo tipo que o schema aceita,
+ * e mostra as opções para TODO tipo de lista fechada — não só para `select`.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { customFieldSchema } from "@/lib/schemas/settings";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}));
+vi.mock("@/app/actions/settings/updatePipelineConfig", () => ({
+  updatePipelineConfig: vi.fn(async () => ({ ok: true })),
+}));
+// As duas seções irmãs falam com a API; este arquivo é sobre os CAMPOS.
+vi.mock("./_stages", () => ({
+  StagesSection: () => null,
+  ancoraDasEtapas: () => "etapas",
+}));
+vi.mock("./_mapping", () => ({
+  AgentMappingSection: () => null,
+  ancoraDoMapeamento: () => "mapeamento",
+}));
+
+// Polyfills que o Radix Select exige e o jsdom não tem.
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+window.HTMLElement.prototype.hasPointerCapture = vi.fn(() => false);
+window.HTMLElement.prototype.setPointerCapture = vi.fn();
+window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+import { PipelinesClient, TIPOS_DE_CAMPO, tipoTemOpcoes, type PipelineRow } from "./_client";
+
+/** Um funil de clínica: o campo que importa é a lista de procedimentos, e ela é múltipla. */
+const FUNIL: PipelineRow = {
+  id: "11111111-1111-4111-8111-111111111111",
+  name: "Tratamentos",
+  slug: "tratamentos",
+  vocabulary: { lead: "Paciente", deal: "Tratamento", won: "Fechado", lost: "Perdido" },
+  settings: {
+    fields: [
+      {
+        key: "procedimentos_de_interesse",
+        label: "Procedimentos de interesse",
+        type: "multiselect",
+        options: [
+          { value: "clareamento", label: "Clareamento Dental" },
+          { value: "implantes", label: "Implantes" },
+        ],
+      },
+    ],
+  },
+};
+
+describe("tipos de campo que a tela do funil oferece", () => {
+  it("oferece TODO tipo que o schema aceita — lista menor deixa campo salvo sem seletor", () => {
+    const doSchema = [...customFieldSchema.shape.type.options].sort();
+    const daTela = [...TIPOS_DE_CAMPO].sort();
+    expect(daTela).toEqual(doSchema);
+  });
+
+  it("mostra as opções para toda lista fechada, não só para `select`", () => {
+    expect(tipoTemOpcoes("select")).toBe(true);
+    expect(tipoTemOpcoes("multiselect")).toBe(true);
+    // Um tipo de texto livre não tem lista para editar.
+    expect(tipoTemOpcoes("text")).toBe(false);
+    expect(tipoTemOpcoes("date")).toBe(false);
+  });
+});
+
+describe("um campo multiselect já gravado", () => {
+  it("abre com o tipo à mostra, e não com o seletor em branco", () => {
+    render(<PipelinesClient pipelines={[FUNIL]} podeEditarConfig />);
+
+    const seletor = screen.getByLabelText(/Tipo do campo 1/i);
+    // O texto do gatilho do Radix é o rótulo do item casado. Vazio = nenhum
+    // `SelectItem` bateu com o `value`, que é exatamente o defeito.
+    expect(seletor.textContent?.trim()).toBe("multiselect");
+  });
+
+  it("deixa editar as opções — sem isso o campo fica só de leitura", () => {
+    render(<PipelinesClient pipelines={[FUNIL]} podeEditarConfig />);
+
+    const opcoes = screen.getByLabelText(/Opções do campo 1/i);
+    expect(opcoes).toHaveValue("Clareamento Dental, Implantes");
+  });
+});

--- a/app/app/settings/tenant/pipelines/_client.tsx
+++ b/app/app/settings/tenant/pipelines/_client.tsx
@@ -31,6 +31,30 @@ export interface PipelineRow {
   settings: Record<string, unknown> | null;
 }
 
+/**
+ * Os tipos de campo que esta tela oferece — DERIVADOS do schema, nunca
+ * reescritos à mão.
+ *
+ * Quando a lista era digitada aqui, ela encolheu sem ninguém ver: `multiselect`
+ * existia em `customFieldSchema`, era gravado pela API e aparecia no dossiê
+ * (`components/contacts/CustomFieldsEditor.tsx`), mas faltava nesta lista. O
+ * efeito para quem abria a tela era um campo que parecia corrompido — o
+ * `<Select>` recebia `value="multiselect"`, nenhum `SelectItem` casava, e o
+ * seletor ficava EM BRANCO. Pior: as opções do campo só apareciam para
+ * `select`, então um multiselect ficava sem como ser editado, e a saída óbvia
+ * (escolher um tipo para "consertar" o branco) transformava a escolha múltipla
+ * em escolha única.
+ *
+ * Derivar do schema faz a divergência deixar de ser possível: tipo novo lá
+ * nasce oferecido aqui.
+ */
+export const TIPOS_DE_CAMPO = customFieldSchema.shape.type.options;
+
+/** Tipos cujo valor sai de uma lista fechada — são os que mostram o campo de opções. */
+export function tipoTemOpcoes(tipo: CustomFieldDef["type"]): boolean {
+  return tipo === "select" || tipo === "multiselect";
+}
+
 function readLostReasons(settings: Record<string, unknown> | null): string[] {
   if (!settings) return [];
   const r = (settings as { lost_reasons?: unknown }).lost_reasons;
@@ -121,17 +145,6 @@ function PipelineEditor({ pipeline }: { pipeline: PipelineRow }) {
     });
   }
 
-  const TIPOS: CustomFieldDef["type"][] = [
-    "text",
-    "textarea",
-    "number",
-    "date",
-    "boolean",
-    "email",
-    "phone",
-    "url",
-    "select",
-  ];
 
   return (
     <div className="space-y-4 border-t border-border pt-6">
@@ -200,7 +213,7 @@ function PipelineEditor({ pipeline }: { pipeline: PipelineRow }) {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {TIPOS.map((tipo) => (
+                {TIPOS_DE_CAMPO.map((tipo) => (
                   <SelectItem key={tipo} value={tipo}>
                     {tipo}
                   </SelectItem>
@@ -216,7 +229,7 @@ function PipelineEditor({ pipeline }: { pipeline: PipelineRow }) {
             >
               <Trash size={14} aria-hidden />
             </Button>
-            {f.type === "select" && (
+            {tipoTemOpcoes(f.type) && (
               <Input
                 className="md:col-span-3"
                 aria-label={`${t("Opções do campo")} ${i + 1}`}


### PR DESCRIPTION
## O que muda

Um campo do funil do tipo `multiselect` era **impossível de editar** em Configurações → Funis.

A lista de tipos daquela tela (`TIPOS`) era digitada à mão e tinha ficado menor que a de `customFieldSchema` (`lib/schemas/settings.ts`). `multiselect` é aceito pelo schema, gravado pela API e desenhado no dossiê do contato (`components/contacts/CustomFieldsEditor.tsx`) — mas não existia nesta lista.

Dois sintomas, os dois em silêncio:

1. O `<Select>` recebia `value="multiselect"`, nenhum `SelectItem` casava, e o seletor abria **em branco**. Quem administrava lia isso como campo corrompido.
2. A linha de opções era condicionada a `f.type === "select"`, então as opções de um multiselect ficavam **invisíveis e não editáveis**.

E a saída intuitiva era a pior: escolher um tipo qualquer para tirar o branco rebaixava a escolha múltipla para escolha única, perdendo o que o campo era sem nenhum aviso.

Achado configurando um funil de clínica odontológica, onde o campo "Procedimentos de interesse" (19 opções) é o mais importante do funil — e era justamente o que não abria.

## Como está consertado

A lista deixa de ser digitada e passa a ser **derivada** do schema:

```ts
export const TIPOS_DE_CAMPO = customFieldSchema.shape.type.options;
```

Assim a divergência deixa de ser possível: tipo novo no schema nasce oferecido na tela. A condição da linha de opções vira `tipoTemOpcoes()`, que cobre toda lista fechada (`select` e `multiselect`).

## Como foi medido

`app/app/settings/tenant/pipelines/_client.test.tsx` (novo, 4 casos): renderiza a tela com um funil que tem um campo `multiselect` já gravado e cobre que (a) a tela oferece todo tipo que o schema aceita, (b) as opções aparecem para toda lista fechada, (c) o seletor abre com o tipo à mostra e não em branco, (d) as opções são editáveis.

**Sabotagem:** com a lista digitada de volta (sem `multiselect`) e a condição em `=== "select"`, os 4 casos reprovam. Com o conserto, passam.

- `pnpm typecheck` — zerado
- `pnpm lint` nos arquivos tocados — zerado
- `pnpm test:unit` — 742 arquivos passam. Há 1 arquivo vermelho, `tests/unit/leads-import-route.test.ts` (11 casos), que **já falhava antes desta branch** — conferido rodando o arquivo com as mudanças guardadas no stash: mesmas 11 falhas.

## Checklist

- [x] `pnpm typecheck` passa zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam (e reprovam sem o conserto)
- [ ] RLS — não se aplica (mudança só de tela)
- [ ] Audit log — não se aplica (não há mutação nova)
- [ ] Rate limit — não se aplica
- [ ] Zod em input externo — não se aplica (o parse já existia no `handleSave`)
- [x] Sem `console.log` esquecido
- [ ] Env vars novas — nenhuma
- [ ] Doc de contrato — sem mudança de contrato
- [ ] Migration — não toca schema
- [x] Fragmento em `.changes/` (`pnpm release:conferir` reconhece)
- [ ] Tela nova — não há tela nova

Sobre a prova pela tela: o defeito foi encontrado exatamente assim, abrindo `/app/settings/tenant/pipelines` numa instalação real com o campo gravado, e o teste novo reproduz esse mesmo render. Não subi Playwright para isto porque o sintoma é de render puro e o teste de componente o mede diretamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
