### PR TITLE
fix(api): timeout de requisição carrega motivo explícito, não a mensagem genérica do navegador

### DIFF
--- a/.changes/timeout-de-requisicao-diz-o-que-houve.md
+++ b/.changes/timeout-de-requisicao-diz-o-que-houve.md
@@ -1,0 +1,7 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Uma requisição que demora demais não vira mais um erro genérico na tela
+---
+
+Quando uma chamada à API não respondia a tempo, o navegador mostrava um erro genérico ("signal is aborted without reason") em vez de dizer que foi um tempo esgotado. Agora o motivo do cancelamento vem explícito, com o mesmo nome que o resto do produto já usa para timeout — quem lida com o erro consegue reconhecê-lo, e quem só vê a tela entende o que aconteceu.

--- a/lib/api/client.test.ts
+++ b/lib/api/client.test.ts
@@ -95,4 +95,31 @@ describe("apiClient", () => {
     const headers = fetchMock.mock.calls[0]![1].headers as Record<string, string>;
     expect(headers["Idempotency-Key"]).toBe("custom-key-123");
   });
+
+  it("t8: timeout carrega um motivo descritivo — não a mensagem genérica do navegador", async () => {
+    // `fetch` real, ligado a um signal abortado, rejeita com o `.reason` desse
+    // signal — é esse contrato que este mock reproduz.
+    fetchMock.mockImplementation(
+      (_url: string, init: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener("abort", () => reject(init.signal.reason), { once: true });
+        }),
+    );
+
+    const err: unknown = await apiClient
+      .get("/x", { timeoutMs: 5 })
+      .catch((e: unknown) => e);
+
+    // `DOMException` não é `instanceof Error` no Node — checa `.name`/`.message`
+    // diretamente, que é a mesma superfície que qualquer chamador consulta.
+    const e = err as { name: string; message: string };
+    // O bug: `AbortController.abort()` sem argumento sintetiza um DOMException
+    // cuja MENSAGEM LITERAL é "signal is aborted without reason" — foi isso
+    // que chegou à tela como "Runtime AbortError". Trava as duas pontas: o
+    // motivo tem nome reconhecível (mesma convenção de `lib/waha/client.ts`)
+    // e a mensagem genérica do navegador não aparece mais.
+    expect(e.name).toBe("TimeoutError");
+    expect(e.message).not.toMatch(/aborted without reason/i);
+    expect(e.message).toMatch(/\d+ms/);
+  }, 10_000);
 });

--- a/lib/api/client.test.ts
+++ b/lib/api/client.test.ts
@@ -116,8 +116,9 @@ describe("apiClient", () => {
     // O bug: `AbortController.abort()` sem argumento sintetiza um DOMException
     // cuja MENSAGEM LITERAL é "signal is aborted without reason" — foi isso
     // que chegou à tela como "Runtime AbortError". Trava as duas pontas: o
-    // motivo tem nome reconhecível (mesma convenção de `lib/waha/client.ts`)
-    // e a mensagem genérica do navegador não aparece mais.
+    // motivo tem nome reconhecível (a mesma convenção de `TimeoutError` que o
+    // cliente HTTP da camada de canal já usa) e a mensagem genérica do
+    // navegador não aparece mais.
     expect(e.name).toBe("TimeoutError");
     expect(e.message).not.toMatch(/aborted without reason/i);
     expect(e.message).toMatch(/\d+ms/);

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -125,7 +125,19 @@ async function request<T>(
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     const timeoutController = new AbortController();
-    const timer = setTimeout(() => timeoutController.abort(), timeoutMs);
+    // Motivo explícito, não `abort()` puro: sem ele o navegador sintetiza um
+    // `DOMException` cuja MENSAGEM é "signal is aborted without reason" — que
+    // chegava ao usuário como erro de runtime, sem dizer que foi um timeout.
+    // `name: "TimeoutError"` segue a convenção já em vigor no repo para timeout
+    // de fetch (`lib/waha/client.ts:191`, que usa `AbortSignal.timeout()` — cujo
+    // motivo nativo tem exatamente esse nome), então quem já checa
+    // `err.name === "TimeoutError"` (`lib/ai/credenciais/erro-de-validacao.ts`)
+    // também reconhece este.
+    const timer = setTimeout(() => {
+      timeoutController.abort(
+        new DOMException(`A requisição não respondeu em ${timeoutMs}ms.`, "TimeoutError"),
+      );
+    }, timeoutMs);
     const signal = combineSignals([timeoutController.signal, opts.signal]);
 
     try {

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -129,8 +129,8 @@ async function request<T>(
     // `DOMException` cuja MENSAGEM é "signal is aborted without reason" — que
     // chegava ao usuário como erro de runtime, sem dizer que foi um timeout.
     // `name: "TimeoutError"` segue a convenção já em vigor no repo para timeout
-    // de fetch (`lib/waha/client.ts:191`, que usa `AbortSignal.timeout()` — cujo
-    // motivo nativo tem exatamente esse nome), então quem já checa
+    // de fetch: o cliente HTTP da camada de canal usa `AbortSignal.timeout()`,
+    // cujo motivo nativo tem exatamente esse nome. Assim quem já checa
     // `err.name === "TimeoutError"` (`lib/ai/credenciais/erro-de-validacao.ts`)
     // também reconhece este.
     const timer = setTimeout(() => {


### PR DESCRIPTION
## O que muda

Uma requisição que estourava o timeout do `apiClient` (`lib/api/client.ts`) chegava ao usuário como um erro de runtime sem explicação: **"AbortError: signal is aborted without reason"**.

## Causa raiz

O timeout é implementado à mão com `AbortController` + `setTimeout`:

```ts
const timer = setTimeout(() => timeoutController.abort(), timeoutMs);
```

`abort()` sem argumento faz o navegador sintetizar um `DOMException` cuja **mensagem literal** é "signal is aborted without reason" — não diz que foi um timeout, só que "foi abortado sem motivo".

O resto do repositório já tem a convenção certa para isso: `lib/waha/client.ts` usa `AbortSignal.timeout()`, cujo motivo nativo do navegador tem `.name === "TimeoutError"` e mensagem descritiva ("signal timed out"). Há inclusive código que já checa esse nome (`lib/ai/credenciais/erro-de-validacao.ts:53-54`, `lib/waha/client.ts:194`). O `lib/api/client.ts` reimplementou o timeout manualmente (provavelmente para poder combiná-lo com um `AbortSignal` opcional vindo do chamador, via `combineSignals`) e não deu um motivo ao abort.

## Como está consertado

```ts
const timer = setTimeout(() => {
  timeoutController.abort(
    new DOMException(`A requisição não respondeu em ${timeoutMs}ms.`, "TimeoutError"),
  );
}, timeoutMs);
```

Mesmo `name` que a convenção já estabelecida no repo usa, mensagem que cita o prazo. Nenhum outro comportamento muda — a lógica de retry, o `combineSignals` e o resto do fluxo continuam iguais.

## Como foi medido

`lib/api/client.test.ts` (novo caso, t8): mocka `fetch` para rejeitar com `signal.reason` quando o signal aborta (o mesmo contrato do `fetch` real), força um `timeoutMs` de 5ms, e verifica que o erro final tem `name === "TimeoutError"` e que a mensagem **não** contém "aborted without reason".

**Sabotagem:** voltando ao `abort()` sem argumento, o caso novo reprova (a mensagem volta a ser a genérica do navegador). Com o conserto, passa.

- `pnpm typecheck` — zerado
- `pnpm lint` nos arquivos tocados — zerado
- `pnpm test:unit` — 742/743 arquivos passam; o único vermelho (`tests/unit/leads-import-route.test.ts`, 11 casos) já falhava antes desta branch, conferido rodando o arquivo com as mudanças guardadas no stash.

## Checklist

- [x] `pnpm typecheck` passa zerado
- [x] `pnpm lint` zerado
- [x] Teste novo existe, passa, e reprova sem o conserto (sabotagem)
- [ ] RLS / audit log / rate limit — não se aplicam (mudança client-side, sem tabela nem rota nova)
- [x] Zod em input externo — não se aplica (nenhum input novo)
- [x] Sem `console.log` esquecido
- [ ] Env vars novas — nenhuma
- [ ] Migration — não toca schema
- [x] Fragmento em `.changes/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
