### PR TITLE
feat(ia): o modelo padrão da organização ganha tela

### DIFF
--- a/app/api/v1/ai/providers/route.test.ts
+++ b/app/api/v1/ai/providers/route.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { requireRole } from "@/lib/auth/require-role";
+import { requireSupportWrite } from "@/lib/impersonate/support";
+import { createClient } from "@/lib/supabase/server";
+import type { AuthUser } from "@/lib/auth/types";
+
+/**
+ * PATCH /api/v1/ai/providers — o padrão da organização ganha superfície.
+ *
+ * O padrão (`organizations.settings.llm`) decide o modelo de TODO ponto que não
+ * tem binding explícito — numa instalação recém-criada, 24 dos 25. Até aqui ele
+ * só era escrito de raspão, pela primeira publicação de um agente
+ * (`lib/ai/agents/first-publication.ts`), e não tinha tela nenhuma: violava o
+ * invariante 6 do Sistema Vivo ("toda configuração tem superfície").
+ *
+ * O caso que este arquivo existe para vigiar é o segundo: `settings` é um jsonb
+ * COMPARTILHADO — `branding`, `security` e o que mais vier moram nele. Escrever
+ * `{ llm: ... }` por cima apaga a marca da instalação e a política de MFA em
+ * silêncio, e o sintoma aparece dias depois, longe daqui.
+ */
+
+vi.mock("@/lib/auth/require-role", () => ({ requireRole: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("@/lib/audit", () => ({ audit: vi.fn(async () => undefined) }));
+vi.mock("@/lib/impersonate/support", () => ({ requireSupportWrite: vi.fn(async () => null) }));
+
+const ORG_ID = "22222222-2222-4222-8222-222222222222";
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+
+/** O que já vive em `settings` e não pode sumir quando o padrão é gravado. */
+const SETTINGS_EXISTENTES = {
+  branding: { app_name: "THOTH CRM", accent_hex: "#506d48" },
+  security: { mfa_required: false },
+  llm: { provider: "anthropic", default_model: "claude-sonnet-5" },
+};
+
+interface EstadoDoBanco {
+  atualizacao: Record<string, unknown> | null;
+  modeloExiste: boolean;
+}
+
+function stubDoBanco(estado: EstadoDoBanco) {
+  return {
+    from(tabela: string) {
+      if (tabela === "organizations") {
+        return {
+          select() {
+            return this;
+          },
+          eq() {
+            return this;
+          },
+          update(payload: Record<string, unknown>) {
+            estado.atualizacao = payload;
+            return this;
+          },
+          maybeSingle() {
+            return Promise.resolve({
+              data: estado.atualizacao
+                ? { settings: estado.atualizacao.settings }
+                : { settings: SETTINGS_EXISTENTES },
+              error: null,
+            });
+          },
+        };
+      }
+      if (tabela === "ai_models") {
+        return {
+          select() {
+            return this;
+          },
+          eq() {
+            return this;
+          },
+          maybeSingle() {
+            return Promise.resolve({
+              data: estado.modeloExiste ? { model_id: "gpt-5.4-mini" } : null,
+              error: null,
+            });
+          },
+        };
+      }
+      throw new Error(`tabela inesperada: ${tabela}`);
+    },
+  };
+}
+
+function autorizadoComoAdmin() {
+  const user: AuthUser = {
+    id: USER_ID,
+    email: "dono@example.com",
+    full_name: null,
+    avatar_url: null,
+    is_platform_admin: false,
+    idioma: "pt-BR" as const,
+  } as AuthUser;
+  vi.mocked(requireRole).mockResolvedValue({
+    ok: true,
+    user,
+    org: { orgId: ORG_ID, role: "admin" },
+  } as unknown as Awaited<ReturnType<typeof requireRole>>);
+}
+
+function requisicao(corpo: unknown) {
+  return new NextRequest("http://localhost/api/v1/ai/providers", {
+    method: "PATCH",
+    body: JSON.stringify(corpo),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("PATCH /api/v1/ai/providers — padrão da organização", () => {
+  let estado: EstadoDoBanco;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    estado = { atualizacao: null, modeloExiste: true };
+    vi.mocked(requireSupportWrite).mockResolvedValue(null);
+    vi.mocked(createClient).mockResolvedValue(
+      stubDoBanco(estado) as unknown as Awaited<ReturnType<typeof createClient>>,
+    );
+    autorizadoComoAdmin();
+  });
+
+  it("grava o padrão SEM apagar as outras chaves de settings", async () => {
+    const { PATCH } = await import("./route");
+    const res = await PATCH(requisicao({ provider: "openai", default_model: "gpt-5.4-mini" }));
+
+    expect(res.status).toBe(200);
+
+    const settings = (estado.atualizacao?.settings ?? {}) as Record<string, unknown>;
+    // O que mudou:
+    expect(settings.llm).toEqual({ provider: "openai", default_model: "gpt-5.4-mini" });
+    // O que NÃO podia ser tocado:
+    expect(settings.branding).toEqual(SETTINGS_EXISTENTES.branding);
+    expect(settings.security).toEqual(SETTINGS_EXISTENTES.security);
+  });
+
+  it("recusa provedor que esta instalação não suporta", async () => {
+    const { PATCH } = await import("./route");
+    const res = await PATCH(requisicao({ provider: "foobar", default_model: "qualquer" }));
+
+    expect(res.status).toBe(422);
+    expect(estado.atualizacao).toBeNull();
+  });
+
+  it("recusa modelo que não está no catálogo do provedor", async () => {
+    estado.modeloExiste = false;
+    const { PATCH } = await import("./route");
+    const res = await PATCH(requisicao({ provider: "openai", default_model: "modelo-que-nao-existe" }));
+
+    expect(res.status).toBe(404);
+    expect(estado.atualizacao).toBeNull();
+  });
+
+  it("exige papel admin — a troca do padrão muda todo ponto herdado", async () => {
+    const { PATCH } = await import("./route");
+    await PATCH(requisicao({ provider: "openai", default_model: "gpt-5.4-mini" }));
+
+    expect(vi.mocked(requireRole)).toHaveBeenCalledWith(
+      "admin",
+      expect.objectContaining({ resource: "ai_providers" }),
+    );
+  });
+});

--- a/app/api/v1/ai/providers/route.ts
+++ b/app/api/v1/ai/providers/route.ts
@@ -187,6 +187,11 @@ export async function GET(): Promise<Response> {
   return ok({
     papeis: PAPEIS,
     pontos,
+    // O padrão decide o modelo de TODO ponto sem binding explícito — numa
+    // instalação nova, 24 dos 25. Ele já era usado aqui para resolver cada
+    // ponto; o que faltava era CHEGAR À TELA, e sem isso não havia como
+    // mostrá-lo nem trocá-lo (invariante 6: toda configuração tem superfície).
+    padrao: padraoDaOrganizacao,
     provedores: PROVEDORES,
     credenciais: credsRes.data ?? [],
     modelos,
@@ -335,4 +340,100 @@ export async function PUT(req: NextRequest): Promise<Response> {
   });
 
   return ok({ binding: gravado, avisos: validacao.avisos });
+}
+
+
+const corpoDoPatch = z.object({
+  provider: z
+    .string()
+    .min(1)
+    .refine(ehProvedorSuportado, {
+      message:
+        "provedor não suportado por esta instalação — escolha um da lista em Agente de IA → Provedores",
+    }),
+  default_model: z.string().min(1),
+});
+
+/**
+ * Troca o PADRÃO da organização — o modelo que vale em todo ponto sem binding
+ * explícito.
+ *
+ * Uma escrita aqui muda o comportamento de dezenas de pontos de uma vez, e é
+ * por isso que exige `admin` como o PUT: quem pode mudar um ponto pode mudar
+ * todos, mas quem não pode mudar nenhum não muda o padrão pela porta dos fundos.
+ */
+export async function PATCH(req: NextRequest): Promise<Response> {
+  const supportDenied = await requireSupportWrite();
+  if (supportDenied) return supportDenied;
+
+  const authz = await requireRole("admin", { resource: "ai_providers" });
+  if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
+  const { user, org } = authz;
+
+  const parsed = corpoDoPatch.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) {
+    return fail("invalid_body", t("corpo inválido"), 422, { details: parsed.error.issues });
+  }
+  const corpo = parsed.data;
+
+  const db = await createClient();
+
+  // O modelo tem de existir no catálogo DAQUELE provedor. Sem esta conferência,
+  // um erro de digitação vira padrão da organização e derruba todo ponto
+  // herdado — o mesmo modo de falha que o `PUT` já evita ponto a ponto.
+  const { data: modelo } = await db
+    .from("ai_models")
+    .select("model_id")
+    .eq("provider", corpo.provider)
+    .eq("model_id", corpo.default_model)
+    .maybeSingle();
+  if (!modelo) {
+    return fail(
+      "modelo_desconhecido",
+      t(`"${corpo.default_model}" não está no catálogo de ${corpo.provider}`),
+      404,
+    );
+  }
+
+  // MERGE, nunca sobrescrita. `organizations.settings` é um jsonb compartilhado
+  // — `branding` (a marca da instalação) e `security` (a política de MFA) moram
+  // nele. Um `update({ settings: { llm } })` ingênuo apaga os dois em silêncio, e
+  // o sintoma aparece dias depois, longe daqui.
+  const { data: orgAtual } = await db
+    .from("organizations")
+    .select("settings")
+    .eq("id", org.orgId)
+    .maybeSingle();
+
+  const settingsAtuais = ((orgAtual?.settings ?? {}) as Record<string, unknown>) || {};
+  const settings = {
+    ...settingsAtuais,
+    llm: { provider: corpo.provider, default_model: corpo.default_model },
+  };
+
+  const { data: gravado, error } = await db
+    .from("organizations")
+    .update({ settings })
+    .eq("id", org.orgId)
+    .select("settings")
+    .maybeSingle();
+
+  if (error) return fail("save_failed", error.message, 500);
+  if (!gravado) {
+    // Mesma armadilha do PUT: no PostgREST, update que casa zero linhas volta
+    // como sucesso, e a tela diria "salvo" sem nada ter sido gravado.
+    return fail("save_failed", t("nada foi gravado — verifique as permissões da organização"), 500);
+  }
+
+  void audit({
+    action: "ai.org_default_updated",
+    organizationId: org.orgId,
+    actorUserId: user.id,
+    resourceType: "organization",
+    resourceId: org.orgId,
+    metadata: { provider: corpo.provider, default_model: corpo.default_model },
+  });
+
+  return ok({ padrao: { provider: corpo.provider, defaultModel: corpo.default_model } });
 }

--- a/app/app/ai/providers/_components/PainelDeProvedores.tsx
+++ b/app/app/ai/providers/_components/PainelDeProvedores.tsx
@@ -93,6 +93,7 @@ interface Dados {
   provedores: Provedor[];
   credenciais: Credencial[];
   modelos: Modelo[];
+  padrao: { provider: string; defaultModel: string | null };
   podeEditar: boolean;
 }
 
@@ -197,6 +198,8 @@ export function PainelDeProvedores() {
         </Card>
       )}
 
+      <CartaoDoPadrao dados={dados} aoSalvar={carregar} />
+
       <div className="space-y-8">
         {porPapel.map(({ papel, info, pontos }) => (
           <section key={papel} data-testid={`papel-${papel}`}>
@@ -239,6 +242,125 @@ export function PainelDeProvedores() {
 }
 
 /** O que o grupo usa hoje, sem obrigar a abrir ponto a ponto. */
+function CartaoDoPadrao({ dados, aoSalvar }: { dados: Dados; aoSalvar: () => Promise<void> }) {
+  const t = useT();
+  const [provider, setProvider] = useState(dados.padrao.provider);
+  const [modelId, setModelId] = useState(dados.padrao.defaultModel ?? "");
+  const [salvando, setSalvando] = useState(false);
+
+  const modelosDoProvedor = useMemo(
+    () => dados.modelos.filter((m) => m.provider === provider),
+    [dados.modelos, provider],
+  );
+
+  // Quantos pontos herdam HOJE. É o número que explica por que esta caixa
+  // importa: numa instalação nova são 24 de 25, e trocar aqui muda os 24.
+  const herdam = dados.pontos.filter((p) => p.efetivo.origem === "padrao_da_organizacao");
+
+  // Os que o padrão NÃO resolve sozinho: embedding precisa de modelo de
+  // embedding (com a dimensão certa) e áudio precisa de transcritor. Dizer
+  // isto aqui é mais barato que deixar a busca degradar em silêncio depois —
+  // que é o modo de falha que `avisosDeLeitura` no resolver já descreve.
+  const especialistas = dados.pontos.filter(
+    (p) => p.exige.embeddingDims !== undefined || p.exige.audio === true,
+  );
+
+  const mudou = provider !== dados.padrao.provider || modelId !== (dados.padrao.defaultModel ?? "");
+
+  async function salvar() {
+    setSalvando(true);
+    try {
+      const res = await fetch("/api/v1/ai/providers", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ provider, default_model: modelId }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        toast.error(json?.error?.message ? t(json.error.message) : t("não consegui salvar"));
+        return;
+      }
+      toast.success(`${t("O padrão agora é")} ${modelId}`);
+      await aoSalvar();
+    } finally {
+      setSalvando(false);
+    }
+  }
+
+  return (
+    <Card className="mb-6 p-4" data-testid="cartao-do-padrao">
+      <h2 className="text-base font-semibold">{t("Modelo padrão")}</h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {t("Vale em todo ponto que você não configurou individualmente — hoje,")} {herdam.length}{" "}
+        {t("de")} {dados.pontos.length}. {t("Trocar aqui muda todos eles de uma vez.")}
+      </p>
+
+      <div className="mt-4 flex flex-wrap items-end gap-3">
+        <div className="min-w-48">
+          <Label className="text-xs">{t("Provedor")}</Label>
+          <Select
+            value={provider}
+            onValueChange={(v) => {
+              setProvider(v);
+              // Modelo de outro provedor não vale nada aqui: a rota confere o
+              // par (provider, model_id) no catálogo e devolveria 404.
+              setModelId("");
+            }}
+          >
+            <SelectTrigger data-testid="padrao-provider">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {dados.provedores.map((p) => (
+                <SelectItem key={p.id} value={p.id}>
+                  {t(p.rotulo)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="min-w-64">
+          <Label className="text-xs">{t("Modelo")}</Label>
+          <Select value={modelId} onValueChange={setModelId}>
+            <SelectTrigger data-testid="padrao-modelo">
+              <SelectValue placeholder={t("escolha")} />
+            </SelectTrigger>
+            <SelectContent>
+              {modelosDoProvedor.map((m) => (
+                <SelectItem key={m.model_id} value={m.model_id}>
+                  {m.display_name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {dados.podeEditar && (
+          <Button
+            size="sm"
+            disabled={salvando || !mudou || modelId === ""}
+            onClick={() => void salvar()}
+            data-testid="salvar-padrao"
+          >
+            {salvando ? t("Salvando…") : t("Salvar padrão")}
+          </Button>
+        )}
+      </div>
+
+      {especialistas.length > 0 && (
+        <p className="mt-3 text-xs text-muted-foreground" data-testid="padrao-especialistas">
+          {especialistas.length}{" "}
+          {t(
+            "pontos precisam de um modelo especialista (embedding ou áudio) e não seguem este padrão — configure cada um abaixo:",
+          )}{" "}
+          {especialistas.map((p) => t(p.rotulo)).join(", ")}.
+        </p>
+      )}
+    </Card>
+  );
+}
+
 function ResumoDoGrupo({ pontos }: { pontos: Ponto[] }) {
   const t = useT();
   const modelos = [...new Set(pontos.map((p) => p.efetivo.modelId ?? t("não definido")))];

--- a/lib/audit/actions.ts
+++ b/lib/audit/actions.ts
@@ -177,6 +177,7 @@ export const AUDIT_ACTIONS = [
   "ai.org_memory_entry_updated",
   /** Provedor/modelo de um ponto do sistema que usa IA foi trocado no painel. */
   "ai.purpose_binding_updated",
+  "ai.org_default_updated",
   // Ligar/desligar uma das duas verificações que consultam modelo. Auditável
   // porque muda o que o sistema confere antes de falar com o cliente — e porque
   // custa dinheiro por mensagem.

--- a/lib/i18n/dicionario.ts
+++ b/lib/i18n/dicionario.ts
@@ -928,6 +928,18 @@ export const DICIONARIO: Traducoes = {
   Custa: { es: "Cuesta" },
   ". O modelo usado se escolhe em": { es: ". El modelo usado se elige en" },
   "Provedores de IA": { es: "Proveedores de IA" },
+  "Modelo padrão": { es: "Modelo predeterminado" },
+  "Vale em todo ponto que você não configurou individualmente — hoje,": {
+    es: "Vale en todo punto que no configuraste individualmente — hoy,",
+  },
+  "Trocar aqui muda todos eles de uma vez.": {
+    es: "Cambiar aquí los cambia todos de una vez.",
+  },
+  "Salvar padrão": { es: "Guardar predeterminado" },
+  "O padrão agora é": { es: "El predeterminado ahora es" },
+  "pontos precisam de um modelo especialista (embedding ou áudio) e não seguem este padrão — configure cada um abaixo:": {
+    es: "puntos necesitan un modelo especialista (embedding o audio) y no siguen este predeterminado — configurá cada uno abajo:",
+  },
   "Antes de cada mensagem sair": { es: "Antes de que cada mensaje salga" },
   "O assistente escreve, e o sistema confere. São": {
     es: "El asistente escribe, y el sistema revisa. Son",


### PR DESCRIPTION
# O que este PR faz

O **padrão da organização** (`organizations.settings.llm`) decide o modelo de todo ponto de IA sem binding explícito — numa instalação nova, **24 dos 25**. Ele já era lido pelo `GET /api/v1/ai/providers` para resolver cada ponto, mas **nunca chegava ao cliente**, e o único lugar que o escrevia era a primeira publicação de um agente (`lib/ai/agents/first-publication.ts`).

Resultado: o que governa quase toda a IA da organização só era mudável por dentro do banco.

Agora a tela **Provedores de IA** ganha um cartão "Modelo padrão": mostra qual é, quantos pontos herdam dele hoje, quais exigem modelo especialista (embedding, áudio) e não seguem o padrão — e deixa trocar.

## Por que

Isso contraria o invariante 6 do Sistema Vivo, que o `docs/doctrine/sistema-vivo.md` enuncia assim:

> nenhum mecanismo de backend pode depender de estado configurável que não tenha **tela para ver, tela para mudar, e caminho visível de falha**

Achado instalando o CRM numa VPS: a tela mostrava 24 pontos em `claude-sonnet-5` e o banco tinha **um** binding. Os outros 24 eram o padrão — invisível como conceito, e sem porta.

## Como

- o `GET` passa a devolver `padrao` no payload (ele já o calculava);
- **novo `PATCH`** grava `settings.llm` com papel `admin`, `requireSupportWrite()`, validação do par (provedor, modelo) contra `ai_models` e auditoria (`ai.org_default_updated`, ação nova em `lib/audit/actions.ts`);
- a tela ganha `CartaoDoPadrao`, com o contador de pontos herdando e o aviso dos que exigem especialista.

Sem migration. Só adição: **+224 linhas em 4 arquivos**, mais o teste.

### O caso que o teste existe para vigiar

`organizations.settings` é um jsonb **compartilhado** — `branding` (a marca da instalação) e `security` (a política de MFA) moram nele. Um `update({ settings: { llm } })` ingênuo apagaria os dois em silêncio, e o sintoma apareceria dias depois, longe da causa. O `PATCH` faz merge, e é o primeiro caso de `route.test.ts`:

```ts
expect(settings.llm).toEqual({ provider: "openai", ... });  // o que mudou
expect(settings.branding).toEqual(...);                      // não podia ser tocado
expect(settings.security).toEqual(...);                      // idem
```

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Teste novo: `app/api/v1/ai/providers/route.test.ts`, 4 casos, verdes
- [x] `pnpm test:unit` — **delta zero** contra a `main`: as 4 falhas que restam já falham sem este PR (são de separador de caminho no Windows; no CI passam)
- [x] RBAC: `admin`, o mesmo do `PUT` que muda um ponto — quem pode mudar um pode mudar todos
- [x] Audit emitido (`ai.org_default_updated`)
- [x] Zod validando o input
- [x] i18n: as 6 strings novas entraram em `lib/i18n/dicionario.ts` (o gate `i18n-espanhol-cobre-a-tela` pegou a falta e está verde)
- [x] Sem `console.log`
- [x] Sem env var nova, sem mudança de schema

## O que eu **não** fiz

- **Não provei pela tela.** Rodei os testes; não dirigi o browser. O template diz que a prova E2E fica com o mantenedor, então deixo declarado em vez de afirmar o que não medi.
- **Sem fragmento em `.changes/`** — o template diz que é trabalho de vocês. Se preferirem que eu escreva, digam e eu escrevo.

## Nota lateral, se for útil

Rodando `pnpm test:unit` no Windows, 4 arquivos falham sem nenhuma alteração no código: `lgpd-pdf-meet`, `lgpd-pdf-replies`, `rascunho-superado-nao-e-regravado` e `suporte-cobertura-de-efeitos`. A causa é separador de caminho — `join()` produz `\` e as regexes dos testes esperam `/`, e o `pdfjs-dist` recusa caminho com barra invertida. No CI (Linux) passam. Quem contribui do Windows vê 6 falhas que não existem e não tem como saber que são do ambiente. Posso abrir issue separada se acharem que vale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)