### PR TITLE
fix(agenda): a letra sobre o accent não pintava — `text-accent-fg` não é um utilitário

### DIFF
--- a/.changes/letra-legivel-sobre-o-accent-da-agenda.md
+++ b/.changes/letra-legivel-sobre-o-accent-da-agenda.md
@@ -1,0 +1,7 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A letra volta a aparecer sobre o destaque colorido da agenda
+---
+
+Na agenda, o que estava selecionado — a aba do histórico, o dia de hoje na grade, o horário escolhido na marcação — pintava o fundo com a cor da marca e deixava a letra na cor do texto da página. Em instalação com marca escura, isso era escuro sobre escuro. A letra agora recebe a cor de contraste que a marca calcula, nos dois temas.

--- a/app/app/agenda/_client.tsx
+++ b/app/app/agenda/_client.tsx
@@ -417,7 +417,7 @@ export function AgendaClient({
                   "rounded-sm px-2.5 py-1 text-xs transition-colors duration-fast ease-out",
                   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500",
                   visao === v.id
-                    ? "bg-accent font-semibold text-accent-fg"
+                    ? "bg-accent font-semibold text-accent-foreground"
                     : "text-text-muted hover:bg-surface-elevated hover:text-text",
                 )}
               >

--- a/app/vitrine-agenda/_client.tsx
+++ b/app/vitrine-agenda/_client.tsx
@@ -152,7 +152,7 @@ export function VitrineDaAgenda() {
                     "rounded-sm px-2.5 py-1 text-xs transition-colors duration-fast ease-out",
                     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500",
                     visao === v.id
-                      ? "bg-accent font-semibold text-accent-fg"
+                      ? "bg-accent font-semibold text-accent-foreground"
                       : "text-text-muted hover:bg-surface-elevated hover:text-text",
                   )}
                 >

--- a/components/agenda/GradeDaAgenda.tsx
+++ b/components/agenda/GradeDaAgenda.tsx
@@ -565,7 +565,7 @@ function ColunaDeDia({
         <span
           className={cn(
             "flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-[11px] tabular-nums",
-            ehHoje ? "bg-accent text-accent-fg font-semibold" : "text-text",
+            ehHoje ? "bg-accent text-accent-foreground font-semibold" : "text-text",
           )}
         >
           {format(dia, "d")}
@@ -677,7 +677,7 @@ function VisaoDeMes({
                   className={cn(
                     "flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-[11px] tabular-nums",
                     isSameDay(d, agora)
-                      ? "bg-accent font-semibold text-accent-fg"
+                      ? "bg-accent font-semibold text-accent-foreground"
                       : doMes
                         ? "text-text"
                         : "text-text-subtle",

--- a/components/agenda/HistoricoDaAgenda.tsx
+++ b/components/agenda/HistoricoDaAgenda.tsx
@@ -135,7 +135,7 @@ export function HistoricoDaAgenda({
                 "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors duration-fast ease-out",
                 "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500",
                 aba === a.id
-                  ? "bg-accent font-semibold text-accent-fg"
+                  ? "bg-accent font-semibold text-accent-foreground"
                   : "text-text-muted hover:bg-surface-elevated hover:text-text",
               )}
             >
@@ -147,7 +147,7 @@ export function HistoricoDaAgenda({
                 data-testid={`contador-${a.id}`}
                 className={cn(
                   "rounded-full px-1.5 text-[10px] tabular-nums",
-                  aba === a.id ? "bg-accent-fg/20" : "bg-surface-elevated text-text-subtle",
+                  aba === a.id ? "bg-accent-foreground/20" : "bg-surface-elevated text-text-subtle",
                 )}
               >
                 {n}

--- a/components/agenda/PainelDeMarcacao.tsx
+++ b/components/agenda/PainelDeMarcacao.tsx
@@ -556,8 +556,8 @@ export function PainelDeMarcacao({
                   "flex h-9 items-center justify-center rounded-sm text-sm tabular-nums transition-colors duration-fast ease-out",
                   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500",
                   !isSameMonth(d, mes) && "text-text-subtle",
-                  disponivel && !escolhido && "bg-accent-soft text-text hover:bg-accent hover:text-accent-fg",
-                  escolhido && "bg-accent font-semibold text-accent-fg",
+                  disponivel && !escolhido && "bg-accent-soft text-text hover:bg-accent hover:text-accent-foreground",
+                  escolhido && "bg-accent font-semibold text-accent-foreground",
                   !disponivel && "cursor-default text-text-subtle",
                   isSameDay(d, agora) && !escolhido && "ring-1 ring-inset ring-border-strong",
                 )}
@@ -671,7 +671,7 @@ export function PainelDeMarcacao({
                   "h-11 shrink-0 rounded-sm border text-sm tabular-nums transition-colors duration-fast ease-out",
                   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500",
                   horario?.instante === h.instante
-                    ? "border-accent bg-accent font-semibold text-accent-fg"
+                    ? "border-accent bg-accent font-semibold text-accent-foreground"
                     : "border-border bg-surface text-text hover:border-accent hover:bg-accent-soft",
                 )}
               >

--- a/docs/testing/user-journey-map.md
+++ b/docs/testing/user-journey-map.md
@@ -1670,6 +1670,32 @@ alimentado com 7 classes, emitiu **4** — nenhuma das 3 com barra.
 | Telas internas (`/app`, kanban, inbox, contatos) | — | **NÃO COBERTO.** Numa instalação fresca todas redirecionam para `/onboarding/welcome`; alcançá-las pede concluir o onboarding, o que pede WAHA e chave de IA. A sonda registra o redirecionamento em vez de fingir cobertura |
 | O efeito visual das 252 revividas foi *revisto por um designer* | — | **NÃO MEDIDO.** A migração provou que passaram a pintar; não provou que cada uma pinta o que a tela precisa. Onde a intenção original estava errada, o erro agora está visível |
 
+### O que a linha "NÃO COBERTO" acima custou: `text-accent-fg` (2026-09-10)
+
+A tabela acima declara, desde 2026-08-26, que as telas internas de `/app` não
+foram medidas — porque numa instalação fresca elas redirecionam para o
+onboarding, e alcançá-las pede WAHA e chave de IA. **Um defeito morou exatamente
+ali por duas semanas, e quem o encontrou foi uma clínica em produção.**
+
+A classe `text-accent-fg` **nunca existiu**. O `@theme inline` faz a ponte com o
+nome `--color-accent-foreground`; `--color-accent-fg` é o token do `:root`, e
+token do `:root` não vira utilitário sozinho. Escrever `text-accent-fg` não é
+erro — é NADA: a regra não é emitida, o elemento não recebe `color`, e o texto
+herda a cor da página. Como a mesma `className` trazia `bg-accent`, que existe, o
+resultado era fundo da marca com letra da página.
+
+Medido no CSS que o dev server servia: `bg-accent` 24 vezes, `text-accent-fg`
+**zero**. Numa instalação com marca escura (`#062b46`, cliente real) isso deu
+escuro sobre escuro em 9 lugares de 6 arquivos — aba do histórico, dia de hoje na
+grade, dia e horário escolhidos na marcação. Com a paleta Sage padrão o defeito
+existia igual, só menos gritante, e por isso ninguém viu.
+
+| caso | prioridade | estado |
+|---|---|---|
+| Toda classe de cor usada em componente corresponde a chave do `@theme inline` | `[P0]` | **PASS**, congelado em `tests/unit/tailwind-tokens.test.ts`. A guarda deriva a lista de proibidos do próprio CSS (token do `:root` sem ponte), não de lista digitada — no nascimento o conjunto era exatamente um: `accent-fg`. Sabotagem provada nas duas direções |
+| A letra sobre `bg-accent` passa no contraste, nos dois temas, com marca de cliente | `[P0]` | **PASS** por medição de token: `#062b46` dá 14.57 no claro e 6.97 no escuro; a auditoria completa da marca deu **0 reprovas** em 18 + 26 pares |
+| As telas internas de `/app` medidas na tela, em instalação com marca | `[P0]` | **CONTINUA NÃO COBERTO.** Este defeito foi achado por leitura de CSS e por print de usuário, não por sonda. A lacuna que o produziu segue aberta |
+
 ### O defeito que só o antes/depois encontrou: o rótulo colado no campo
 
 O `space-*` inverteu o lado da margem — e isso não é cosmético:

--- a/tests/unit/tailwind-tokens.test.ts
+++ b/tests/unit/tailwind-tokens.test.ts
@@ -98,6 +98,59 @@ describe("Tailwind 4 — a ponte token → utilitário", () => {
     expect(orfaos, `tokens referenciados no @theme mas ausentes do :root`).toEqual([]);
   });
 
+  it("nenhum componente usa, como utilitário, token do `:root` que o `@theme` não faz ponte", () => {
+    // A MÃO INVERSA do teste acima, e o defeito que ela pega é pior, porque é
+    // invisível: o teste anterior olha do `@theme` para o `:root` e pega o token
+    // que não existe; este olha do COMPONENTE para o `@theme` e pega a classe
+    // que não existe.
+    //
+    // A armadilha é o nome. Quem lê `--color-accent-fg` no `:root` conclui que
+    // `text-accent-fg` é o utilitário — mas o Tailwind gera utilitário a partir
+    // das CHAVES do `@theme inline`, e lá a chave é `--color-accent-foreground`.
+    // O resultado de `text-accent-fg` não é erro: é NADA. A classe não é
+    // emitida, o elemento não recebe `color`, e o texto herda a cor da página.
+    //
+    // Medido no CSS que o dev server servia quando esta guarda nasceu:
+    // `bg-accent` aparecia 24 vezes e `text-accent-fg`, ZERO. Os dois vinham na
+    // mesma `className` — então o fundo pintava com o accent da marca e a letra
+    // ficava na cor do texto da página. Numa instalação com marca escura
+    // (`#062b46`, medida em cliente real) isso é escuro sobre escuro: a aba
+    // ativa da agenda ficou ilegível em 6 arquivos, com build, lint e a suíte
+    // inteira verdes.
+    //
+    // Por que a guarda é esta e não "proibir `-fg`": porque o produto tem
+    // `--color-success-fg` e irmãs, que TÊM ponte e são utilitários legítimos.
+    // O que define o defeito não é o sufixo, é a ausência de ponte — então a
+    // guarda deriva a lista de proibidos do próprio CSS, e não de uma lista
+    // digitada aqui, que envelheceria na primeira ponte nova.
+    const doTema = new Set(propsDe(bloco("@theme inline")));
+    const semPonte = [...new Set(propsDe(bloco(":root")))]
+      .filter((p) => p.startsWith("--color-") && !doTema.has(p))
+      .map((p) => p.replace("--color-", ""));
+
+    // Se um dia TODO token do `:root` ganhar ponte, esta guarda fica sem alvo e
+    // passa por vacuidade. Isso é sucesso, não buraco — mas registre-se que o
+    // conjunto medido no nascimento era exatamente um: `accent-fg`.
+    const culpados = semPonte.flatMap((nome) =>
+      ocorrencias(
+        listarFontes(["app", "components", "lib", "hooks"]),
+        // Os prefixos são os que consomem `--color-*`. A variante (`hover:`,
+        // `dark:`, `data-[…]:`) entra pelo lookbehind, igual às guardas de
+        // `rounded`/`shadow` — sem ela, `hover:text-accent-fg` passaria verde
+        // enquanto pinta errado sob o cursor, que é o modo mais difícil de ver.
+        new RegExp(
+          `(?<=[\\s"'\`:])(?:text|bg|border|ring|outline|fill|stroke|from|via|to|divide|accent|caret|shadow)-${nome}(?=[\\s"'\`/!]|$)`,
+          "g",
+        ),
+      ).map((onde) => `${onde}  (${nome})`),
+    );
+
+    expect(
+      culpados,
+      "classe montada com nome de token que o `@theme inline` não faz ponte — ela não gera CSS nenhum",
+    ).toEqual([]);
+  });
+
   it("o `@source` cobre toda pasta que realmente escreve className", () => {
     // `source(none)` desliga a descoberta automática. O preço é este: pasta de
     // UI nova fora da lista perde TODAS as classes, sem erro de build — a tela


### PR DESCRIPTION
## O defeito

`text-accent-fg` **nunca existiu como classe**. A ponte do Tailwind 4 (`@theme inline`, em `app/globals.css`) registra a chave `--color-accent-foreground`:

```css
--color-accent-foreground: var(--color-accent-fg);   /* ← a chave é esta */
```

`--color-accent-fg` é o token do `:root`, e token do `:root` não vira utilitário sozinho. Escrever `text-accent-fg` não produz erro — produz **nada**: a regra não é emitida, o elemento não recebe `color`, e o texto herda a cor da página.

Como a mesma `className` trazia `bg-accent`, que existe, o resultado era **fundo com a cor da marca e letra com a cor do texto da página**.

## A medição

No CSS que o dev server servia, antes do conserto:

| classe | ocorrências no CSS compilado |
|---|---|
| `bg-accent` | 24 — existe |
| `text-accent-fg` | **0** |
| `bg-accent-fg` | **0** |
| `text-accent-foreground` | 2 — o nome correto |

Numa instalação com marca escura (`#062b46`, cliente real) isso é escuro sobre escuro. Atinge 9 lugares em 6 arquivos: a aba ativa do histórico e seu contador, o dia de hoje na grade, o dia de hoje na visão de mês, o dia e o horário escolhidos na marcação, e as abas de visão da agenda e da vitrine pública.

Com a paleta Sage padrão o defeito é o mesmo, só menos gritante — que é por que ele atravessou a migração do Tailwind 4 sem ninguém ver. O mapa de jornadas já declarava a lacuna: *"Telas internas (`/app`, kanban, inbox, contatos) — **NÃO COBERTO**"*.

## O que NÃO era o defeito

A derivação de cor da marca está correta e não foi tocada. Para `#062b46` ela entrega:

- claro: `accent #062b46` + `accentFg #ffffff` → contraste **14.57**
- escuro: `accent #7b98b1` + `accentFg #000000` → contraste **6.97**

E a auditoria completa (`medirPares` sobre a régua do produto) dá **0 reprovas** em 18 + 26 pares. O sistema calculava a cor certa; a classe é que não chegava a pedi-la.

## A guarda

A nova guarda em `tests/unit/tailwind-tokens.test.ts` é a **mão inversa** da que já existia. A antiga olha do `@theme` para o `:root` e pega token ausente. Esta olha do **componente** para o `@theme` e pega **classe** ausente.

Ela deriva a lista de proibidos do próprio CSS — todo `--color-*` declarado no `:root` que o `@theme inline` não faz ponte —, e não de uma lista digitada que envelheceria na primeira ponte nova. No nascimento o conjunto medido era exatamente um: `accent-fg`. O lookbehind cobre variante (`hover:`, `dark:`, `data-[…]:`), pelo mesmo motivo já pago pelas guardas de `rounded` e `shadow` neste arquivo.

Sabotagem provada nas duas direções: com o conserto, verde; revertendo o conserto e mantendo a guarda, vermelho apontando as 9 linhas exatas.

## Verificação

- `pnpm typecheck` — zerado
- `pnpm lint` — 0 erros
- `pnpm test:unit` — `Tests 15 failed | 7949 passed`. As 15 são **pré-existentes**: `leads-import-route` (11), `agenda-google-connect-route` (2), `agenda-google-config` (1), `namespace-das-imagens` (1). Conferido rodando os mesmos 4 arquivos na `main` limpa com as mudanças em stash — mesmas 15 falhas, mesmos arquivos.
- `pnpm release:conferir` — fragmento reconhecido

🤖 Generated with [Claude Code](https://claude.com/claude-code)
