### PR TITLE
feat(inbox): o balão mostra de onde saiu a mensagem — e o rótulo para de afirmar o que o dado não sustenta (@lucasa15, do #631)

### DIFF
--- a/.changes/inbox-rotulo-origem-mensagem.md
+++ b/.changes/inbox-rotulo-origem-mensagem.md
@@ -1,0 +1,14 @@
+---
+impacto: capacidade_nova
+secao: adicionado
+titulo: O balão do atendimento mostra de onde saiu cada mensagem
+---
+
+O balão de uma mensagem enviada agora identifica a origem dela: **Celular** para
+a resposta dada pelo WhatsApp do telefone (fora do CRM), **Automação** para o que
+saiu de uma regra, **Você** para o que foi digitado no CRM e **IA** para o agente.
+
+Antes, só a IA era identificada. A resposta dada pelo celular chegava à conversa
+sem rótulo e parecia ter sido digitada no CRM — enquanto o painel de atividade já
+contava esse atendimento como feito por fora. Agora a conversa mostra o que o
+painel sempre soube.

--- a/.changes/inbox-rotulo-origem-mensagem.md
+++ b/.changes/inbox-rotulo-origem-mensagem.md
@@ -5,8 +5,9 @@ titulo: O balão do atendimento mostra de onde saiu cada mensagem
 ---
 
 O balão de uma mensagem enviada agora identifica a origem dela: **Celular** para
-a resposta dada pelo WhatsApp do telefone (fora do CRM), **Automação** para o que
-saiu de uma regra, **Você** para o que foi digitado no CRM e **IA** para o agente.
+a resposta dada pelo WhatsApp do telefone (fora do CRM), **IA** para o agente,
+**Você** para o que você mesmo digitou no CRM e **Atendente** para o que outra
+pessoa da equipe digitou.
 
 Antes, só a IA era identificada. A resposta dada pelo celular chegava à conversa
 sem rótulo e parecia ter sido digitada no CRM — enquanto o painel de atividade já

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -589,6 +589,7 @@ jobs:
         marca-logo.spec.ts
         historico-de-captacao.spec.ts
         inbox-quem-manda.spec.ts
+        inbox-rotulo-de-origem.spec.ts
         troca-de-organizacao-tem-volta.spec.ts
         organizacoes-criacao-convite-e-cache.spec.ts
         suporte-temporario.spec.ts

--- a/app/admin/(protected)/inbox/_components/AdminThread.tsx
+++ b/app/admin/(protected)/inbox/_components/AdminThread.tsx
@@ -90,6 +90,10 @@ export function AdminThreadClient({ conversationId }: Props) {
               {t("Sem mensagens nesta conversa.")}
             </p>
           ) : (
+            // Sem `viewerUserId` de propósito: quem lê aqui é o super-admin da
+            // plataforma, olhando a conversa de OUTRA organização. Nenhuma
+            // mensagem é dele, então "Você" seria falso em todas — sem o id, o
+            // balão rotula "Atendente", que é o que o dado sustenta.
             messages.map((msg) => <MessageBubble key={msg.id} message={msg} />)
           )}
         </div>

--- a/components/inbox/ChatThread.tsx
+++ b/components/inbox/ChatThread.tsx
@@ -247,6 +247,10 @@ export function ChatThread({ conversationId, onResponder }: Props) {
                   // citada é antiga demais e ficou fora da página, o fio some —
                   // que é melhor que segurar a conversa esperando.
                   citada={porId.get(item.data.reply_to_message_id ?? "") ?? null}
+                  // Sem isto o balão diz "Você" em toda mensagem digitada no
+                  // CRM — inclusive nas do colega, porque `sent_via='user'` só
+                  // registra que um humano digitou, nunca qual.
+                  viewerUserId={currentUser.id}
                 />
               ),
             )}

--- a/components/inbox/MessageBubble.test.tsx
+++ b/components/inbox/MessageBubble.test.tsx
@@ -3,8 +3,18 @@
  *
  * `external_device` é a resposta dada pelo WhatsApp do CELULAR (fora do CRM) —
  * antes ela chegava à bolha sem rótulo, indistinguível do que foi digitado no
- * CRM. Este teste prende os seis valores de `sent_via` ao rótulo certo, mais o
- * caso que NÃO leva rótulo (mensagem recebida).
+ * CRM. Este teste prende cada valor de `sent_via` ao rótulo certo, mais o caso
+ * que NÃO leva rótulo (mensagem recebida).
+ *
+ * `sent_via='user'` não diz QUAL humano digitou — só que um humano digitou. Por
+ * isso "Você" depende de duas pontas: `viewerUserId` (quem lê) e
+ * `sent_by_user_id` (quem enviou). Faltando qualquer uma, o rótulo é
+ * "Atendente"; os casos abaixo prendem as três combinações (sou eu, é o colega,
+ * não se sabe).
+ *
+ * Não há caso para `'automation'`: nenhum emissor grava esse valor, e o
+ * componente deixou de nomeá-lo. Quem guarda essa propriedade — nas duas
+ * direções — é tests/unit/rotulo-de-origem-tem-emissor.test.ts.
  *
  * Sem provider de idioma o `t()` degrada para a chave (pt-BR), então o texto
  * esperado é o português — o espanhol é coberto por i18n-espanhol-cobre-a-tela.
@@ -54,18 +64,47 @@ describe("MessageBubble — rótulo de origem", () => {
     expect(screen.getByText("Celular")).toBeInTheDocument();
   });
 
-  it("automação mostra 'Automação'", () => {
+  it("automação não inventa rótulo — ninguém grava esse valor", () => {
     render(<MessageBubble message={msg({ sent_via: "automation" })} />);
-    expect(screen.getByText("Automação")).toBeInTheDocument();
+    expect(screen.queryByText("Automação")).not.toBeInTheDocument();
   });
 
-  it("digitada no CRM (user) mostra 'Você'", () => {
-    render(<MessageBubble message={msg({ sent_via: "user" })} />);
+  it("digitada no CRM por QUEM ESTÁ LENDO mostra 'Você'", () => {
+    render(
+      <MessageBubble
+        message={msg({ sent_via: "user", sent_by_user_id: "u-eu" })}
+        viewerUserId="u-eu"
+      />,
+    );
     expect(screen.getByText("Você")).toBeInTheDocument();
   });
 
-  it("crm também mostra 'Você'", () => {
-    render(<MessageBubble message={msg({ sent_via: "crm" })} />);
+  it("digitada no CRM pelo COLEGA mostra 'Atendente', nunca 'Você'", () => {
+    render(
+      <MessageBubble
+        message={msg({ sent_via: "user", sent_by_user_id: "u-colega" })}
+        viewerUserId="u-eu"
+      />,
+    );
+    expect(screen.getByText("Atendente")).toBeInTheDocument();
+    expect(screen.queryByText("Você")).not.toBeInTheDocument();
+  });
+
+  it("sem emissor gravado (sent_by_user_id nulo) mostra 'Atendente'", () => {
+    // Os dois nulos se equivalem em `===`. Sem a guarda de `viewerUserId != null`
+    // este caso voltaria a dizer "Você" para uma mensagem de dono desconhecido.
+    render(<MessageBubble message={msg({ sent_via: "user", sent_by_user_id: null })} />);
+    expect(screen.getByText("Atendente")).toBeInTheDocument();
+    expect(screen.queryByText("Você")).not.toBeInTheDocument();
+  });
+
+  it("crm (o DEFAULT da coluna) segue a mesma regra de 'user'", () => {
+    render(
+      <MessageBubble
+        message={msg({ sent_via: "crm", sent_by_user_id: "u-eu" })}
+        viewerUserId="u-eu"
+      />,
+    );
     expect(screen.getByText("Você")).toBeInTheDocument();
   });
 
@@ -83,7 +122,7 @@ describe("MessageBubble — rótulo de origem", () => {
 
   it("system não inventa rótulo", () => {
     render(<MessageBubble message={msg({ sent_via: "system" })} />);
-    for (const rotulo of ["Celular", "Automação", "Você", "IA"]) {
+    for (const rotulo of ["Celular", "Automação", "Você", "Atendente", "IA"]) {
       expect(screen.queryByText(rotulo)).not.toBeInTheDocument();
     }
   });

--- a/components/inbox/MessageBubble.test.tsx
+++ b/components/inbox/MessageBubble.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * O balão diz de quem saiu a mensagem.
+ *
+ * `external_device` é a resposta dada pelo WhatsApp do CELULAR (fora do CRM) —
+ * antes ela chegava à bolha sem rótulo, indistinguível do que foi digitado no
+ * CRM. Este teste prende os seis valores de `sent_via` ao rótulo certo, mais o
+ * caso que NÃO leva rótulo (mensagem recebida).
+ *
+ * Sem provider de idioma o `t()` degrada para a chave (pt-BR), então o texto
+ * esperado é o português — o espanhol é coberto por i18n-espanhol-cobre-a-tela.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { MessageBubble } from "./MessageBubble";
+import type { Message } from "@/lib/types/messaging";
+
+function msg(over: Partial<Message> = {}): Message {
+  return {
+    id: "m1",
+    organization_id: "org1",
+    conversation_id: "c1",
+    channel_session_id: "s1",
+    contact_id: "ct1",
+    external_id: null,
+    type: "text",
+    direction: "outbound",
+    status: "sent",
+    ack: null,
+    error_code: null,
+    error_message: null,
+    body: "corpo da mensagem",
+    media_url: null,
+    media_mime: null,
+    media_size_bytes: null,
+    media_storage_path: null,
+    sent_via: "user",
+    sent_by_user_id: null,
+    sent_at: "2026-09-08T12:00:00.000Z",
+    delivered_at: null,
+    read_at: null,
+    metadata: {},
+    edited_at: null,
+    revoked_at: null,
+    reply_to_message_id: null,
+    created_at: "2026-09-08T12:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("MessageBubble — rótulo de origem", () => {
+  it("resposta pelo celular (external_device) mostra 'Celular'", () => {
+    render(<MessageBubble message={msg({ sent_via: "external_device" })} />);
+    expect(screen.getByText("Celular")).toBeInTheDocument();
+  });
+
+  it("automação mostra 'Automação'", () => {
+    render(<MessageBubble message={msg({ sent_via: "automation" })} />);
+    expect(screen.getByText("Automação")).toBeInTheDocument();
+  });
+
+  it("digitada no CRM (user) mostra 'Você'", () => {
+    render(<MessageBubble message={msg({ sent_via: "user" })} />);
+    expect(screen.getByText("Você")).toBeInTheDocument();
+  });
+
+  it("crm também mostra 'Você'", () => {
+    render(<MessageBubble message={msg({ sent_via: "crm" })} />);
+    expect(screen.getByText("Você")).toBeInTheDocument();
+  });
+
+  it("IA continua mostrando 'IA' (comportamento preservado)", () => {
+    render(<MessageBubble message={msg({ sent_via: "ai" })} />);
+    expect(screen.getByText("IA")).toBeInTheDocument();
+  });
+
+  it("mensagem recebida (inbound) não leva rótulo de origem", () => {
+    render(
+      <MessageBubble message={msg({ sent_via: "external_device", direction: "inbound" })} />,
+    );
+    expect(screen.queryByText("Celular")).not.toBeInTheDocument();
+  });
+
+  it("system não inventa rótulo", () => {
+    render(<MessageBubble message={msg({ sent_via: "system" })} />);
+    for (const rotulo of ["Celular", "Automação", "Você", "IA"]) {
+      expect(screen.queryByText(rotulo)).not.toBeInTheDocument();
+    }
+  });
+});

--- a/components/inbox/MessageBubble.tsx
+++ b/components/inbox/MessageBubble.tsx
@@ -57,9 +57,18 @@ export function MessageBubble({ message, debugCitations, onResponder, citada }: 
   const citations = extractCitations(message.metadata);
   const showCitationButton =
     isOutbound && aiGenerated && (debugCitations ?? false);
+  // De quem saiu esta linha. `external_device` é a resposta pelo CELULAR — o
+  // operador atendeu pelo WhatsApp do telefone, fora do CRM, e o ingest carimba
+  // aqui. Antes isto voltava null para tudo que não fosse IA, e a bolha ficava
+  // sem nome: o dono lia a conversa como se tudo tivesse sido digitado no CRM.
+  // Os rótulos passam por t() no render (ver dicionario.ts para o espanhol).
   const senderLabel = (() => {
     if (!isOutbound) return null;
     if (message.sent_via === "ai") return "IA";
+    if (message.sent_via === "external_device") return "Celular";
+    if (message.sent_via === "automation") return "Automação";
+    if (message.sent_via === "user") return "Você";
+    if (message.sent_via === "crm") return "Você";
     return null;
   })();
 

--- a/components/inbox/MessageBubble.tsx
+++ b/components/inbox/MessageBubble.tsx
@@ -22,6 +22,17 @@ interface Props {
   onResponder?: (m: Message) => void;
   /** A mensagem citada por ESTA, quando houver — desenha o fio. */
   citada?: Message | null;
+  /**
+   * QUEM está lendo a conversa. É o que separa "Você" de "Atendente": a coluna
+   * `sent_via='user'` só diz *"um humano digitou no CRM"*, nunca QUAL humano.
+   *
+   * Sem este id, uma organização com dois atendentes mostrava "Você" nas
+   * mensagens do colega — cada um lia o atendimento do outro como se fosse o
+   * seu. Por isso a ausência do id NÃO cai em "Você": quem não sabe quem está
+   * lendo (a leitura do super-admin em `AdminThread`, por exemplo) rotula
+   * "Atendente", que é verdadeiro para todo mundo.
+   */
+  viewerUserId?: string | null;
 }
 
 function AckIndicator({ status, t }: { status: string; t: (texto: string) => string }) {
@@ -37,7 +48,13 @@ function AckIndicator({ status, t }: { status: string; t: (texto: string) => str
   return null;
 }
 
-export function MessageBubble({ message, debugCitations, onResponder, citada }: Props) {
+export function MessageBubble({
+  message,
+  debugCitations,
+  onResponder,
+  citada,
+  viewerUserId,
+}: Props) {
   const localeDaData = useLocaleDeData();
   const t = useT();
   const isOutbound = message.direction === "outbound";
@@ -62,13 +79,30 @@ export function MessageBubble({ message, debugCitations, onResponder, citada }: 
   // aqui. Antes isto voltava null para tudo que não fosse IA, e a bolha ficava
   // sem nome: o dono lia a conversa como se tudo tivesse sido digitado no CRM.
   // Os rótulos passam por t() no render (ver dicionario.ts para o espanhol).
+  //
+  // NÃO HÁ RAMO PARA `'automation'`. O CHECK do banco aceita o valor e o union
+  // de `Message` o declara, mas nenhuma linha de app/, lib/ ou workers/ o
+  // grava: as ações de automação chamam `sendMessageHandler` com
+  // `actor.type === "webhook_source"`, e `_handler.ts` carimba `'ai'` em tudo
+  // que não é `"user"`. Um ramo aqui seria controle decorativo — a tela
+  // prometendo uma distinção que o motor não faz. Carimbar `'automation'` na
+  // origem é decisão de produto com efeito colateral medido (o dedup de eco da
+  // ingestão de canal filtra `sent_via in ('ai','user')`, e o valor novo
+  // duplicaria a mensagem na conversa), então fica para uma issue própria.
+  // Vigiado nas duas direções por tests/unit/rotulo-de-origem-tem-emissor.
   const senderLabel = (() => {
     if (!isOutbound) return null;
     if (message.sent_via === "ai") return "IA";
     if (message.sent_via === "external_device") return "Celular";
-    if (message.sent_via === "automation") return "Automação";
-    if (message.sent_via === "user") return "Você";
-    if (message.sent_via === "crm") return "Você";
+    if (message.sent_via === "user" || message.sent_via === "crm") {
+      // "Você" exige as DUAS pontas: saber quem lê e saber quem enviou. Falta
+      // qualquer uma, o rótulo cai para "Atendente" — que continua dizendo o
+      // que `sent_via` de fato garante (um humano, pelo CRM) sem afirmar uma
+      // identidade que o dado não sustenta.
+      return viewerUserId != null && message.sent_by_user_id === viewerUserId
+        ? "Você"
+        : "Atendente";
+    }
     return null;
   })();
 

--- a/lib/types/messaging.ts
+++ b/lib/types/messaging.ts
@@ -71,7 +71,11 @@ export interface Message {
   media_mime: string | null;
   media_size_bytes: number | null;
   media_storage_path: string | null;
-  sent_via: "user" | "ai" | "system";
+  // Espelha o CHECK do banco (messages_sent_via_check): 'crm', 'external_device',
+  // 'automation', 'ai', 'user', 'system'. O tipo listava só três e o TypeScript
+  // aceitava os demais só porque o dado vem do Supabase sem cast — a tela então
+  // não conseguia nem NOMEAR o valor para exibi-lo (ver MessageBubble).
+  sent_via: "user" | "ai" | "system" | "external_device" | "automation" | "crm";
   sent_by_user_id: string | null;
   sent_at: string;
   delivered_at: string | null;

--- a/tests/e2e/inbox-rotulo-de-origem.spec.ts
+++ b/tests/e2e/inbox-rotulo-de-origem.spec.ts
@@ -1,0 +1,244 @@
+/**
+ * DE ONDE SAIU CADA MENSAGEM — provado pela tela, como o dono lê a conversa.
+ *
+ * ## Por que pela tela, e não pelo teste de componente
+ *
+ * O PR #631 trouxe `components/inbox/MessageBubble.test.tsx`, que monta o
+ * objeto `Message` à mão e confere o rótulo. Isso prova que o RENDER sabe
+ * desenhar — e nada mais. Não prova que:
+ *
+ *   1. a coluna `sent_via` sobrevive à rota (`listMessagesHandler` → `MSG_COLS`)
+ *      e chega ao componente. Um `select` sem a coluna devolve `undefined`, o
+ *      componente cai no `return null` final, e **todos os rótulos somem em
+ *      silêncio** — sem erro, sem vermelho, sem nada na tela;
+ *   2. o rótulo aparece de fato no balão certo, e não atrás de outro elemento.
+ *
+ * As duas são exatamente a classe que a doutrina de QA Visual manda provar pelo
+ * frontend: `curl` valida o backend, não o que o dono VÊ.
+ *
+ * ## O que este spec NÃO afirma, de propósito
+ *
+ * Não há caso para `sent_via='automation'`. Nenhuma linha do produto grava esse
+ * valor (medido: `grep -rn 'sent_via:' app lib workers` devolve só `ai`,
+ * `user` e `external_device`, mais o DEFAULT `crm`), então um caso aqui teria
+ * de inserir à mão um estado que a aplicação não produz — provaria o render de
+ * novo, com um banco no meio para disfarçar. Quem guarda essa propriedade é
+ * `tests/unit/rotulo-de-origem-tem-emissor.test.ts`, que casa as duas pontas.
+ *
+ * E não há caso afirmando "o que a automação envia mostra IA", que é a verdade
+ * de hoje: prender o SINTOMA faria o teste ficar vermelho no dia em que alguém
+ * consertar o carimbo, empurrando quem vier depois a desfazer o conserto.
+ *
+ * Pré-requisitos (banco local, app buildada):
+ *   pnpm exec tsx scripts/seed-e2e-credentials.ts
+ *   pnpm e2e:env && pnpm e2e:build
+ *   E2E_PORT=3021 pnpm exec playwright test tests/e2e/inbox-rotulo-de-origem.spec.ts
+ */
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { expect, test, type Page } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+
+import { carregarEnvLocal } from "../../scripts/lib/env-de-teste";
+
+const CREDS_PATH = path.join(process.cwd(), ".e2e-creds.json");
+const EVIDENCIA = path.join(process.cwd(), ".superpowers/evidence/inbox-rotulo-de-origem");
+
+interface Creds {
+  password: string;
+  org_id: string;
+  users: Record<string, { id: string; email: string; role: string }>;
+}
+
+const env = carregarEnvLocal();
+const admin = createClient(env.NEXT_PUBLIC_SUPABASE_URL!, env.SUPABASE_SERVICE_ROLE_KEY!, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+/**
+ * Prefixo do nome do contato: a limpeza apaga por ele, não pelos ids desta
+ * execução. O Playwright reinicia o worker depois de um teste vermelho e o
+ * módulo é reavaliado — limpar só o que esta rodada criou deixa a fixture da
+ * rodada anterior no banco, e a segunda execução mede duas conversas.
+ */
+const PREFIXO = "Rotulo de Origem E2E";
+const NOME_DO_CONTATO = `${PREFIXO} ${Date.now()}`;
+
+let creds: Creds;
+let conversaId = "";
+
+async function login(page: Page, email: string, senha: string): Promise<void> {
+  await page.goto("/login");
+  await page.locator("#email").fill(email);
+  await page.locator("#password").fill(senha);
+  await page.getByRole("button", { name: /entrar/i }).click();
+  await page.waitForURL(/\/app/, { timeout: 60_000 });
+}
+
+async function captura(page: Page, nome: string): Promise<void> {
+  fs.mkdirSync(EVIDENCIA, { recursive: true });
+  await page.screenshot({ path: path.join(EVIDENCIA, `${nome}.png`), fullPage: true });
+}
+
+/** Apaga TODA fixture deste spec, por prefixo — ver o comentário de PREFIXO. */
+async function limpar(): Promise<void> {
+  const { data } = await admin
+    .from("contacts")
+    .select("id")
+    .eq("organization_id", creds.org_id)
+    .like("display_name", `${PREFIXO}%`);
+  const ids = ((data as Array<{ id: string }> | null) ?? []).map((c) => c.id);
+  if (ids.length === 0) return;
+  await admin.from("messages").delete().in("contact_id", ids);
+  await admin.from("conversations").delete().in("contact_id", ids);
+  await admin.from("contacts").delete().in("id", ids);
+}
+
+test.describe("Inbox — o balão diz de onde saiu a mensagem", () => {
+  test.describe.configure({ timeout: 180_000 });
+
+  test.beforeAll(async () => {
+    if (!fs.existsSync(CREDS_PATH)) {
+      execFileSync("npx", ["tsx", "scripts/seed-e2e-credentials.ts"], { stdio: "inherit" });
+    }
+    creds = JSON.parse(fs.readFileSync(CREDS_PATH, "utf8")) as Creds;
+    await limpar();
+
+    const { data: sessaoExistente } = await admin
+      .from("channel_sessions")
+      .select("id")
+      .eq("organization_id", creds.org_id)
+      .limit(1)
+      .maybeSingle();
+    let sessaoId = (sessaoExistente as { id: string } | null)?.id ?? null;
+    if (!sessaoId) {
+      const { data, error } = await admin
+        .from("channel_sessions")
+        .insert({
+          organization_id: creds.org_id,
+          waha_session_name: `e2e-rotulo-origem-${Date.now()}`,
+          webhook_secret_encrypted: "e2e",
+        })
+        .select("id")
+        .single();
+      if (error) throw new Error(`channel_sessions: ${error.message}`);
+      sessaoId = (data as { id: string }).id;
+    }
+
+    const { data: contato, error: erroContato } = await admin
+      .from("contacts")
+      .insert({
+        organization_id: creds.org_id,
+        display_name: NOME_DO_CONTATO,
+        // E.164 com o `+`: `contacts_phone_e164_format` exige `^\+\d{8,15}$`.
+        phone_number: `+55119${String(Date.now()).slice(-8)}`,
+      })
+      .select("id")
+      .single();
+    if (erroContato) throw new Error(`contacts: ${erroContato.message}`);
+    const contatoId = (contato as { id: string }).id;
+
+    const { data: conversa, error: erroConversa } = await admin
+      .from("conversations")
+      .insert({
+        organization_id: creds.org_id,
+        contact_id: contatoId,
+        channel_session_id: sessaoId,
+        status: "open",
+        last_message_at: new Date().toISOString(),
+        last_inbound_at: new Date().toISOString(),
+      })
+      .select("id")
+      .single();
+    if (erroConversa) throw new Error(`conversations: ${erroConversa.message}`);
+    conversaId = (conversa as { id: string }).id;
+
+    // As QUATRO linhas, uma por origem ALCANÇÁVEL, com os valores que os
+    // emissores reais gravam:
+    //   inbound          — o cliente escreveu (lib/waha/ingest.ts)
+    //   external_device  — o atendente respondeu pelo CELULAR, fora do CRM
+    //                      (lib/waha/ingest.ts:622,850)
+    //   ai               — o agente respondeu (workers/ai-response-worker.ts:1068)
+    //   user             — alguém digitou no CRM (app/api/v1/messages/_handler.ts:529)
+    //
+    // O corpo de cada uma é único e sem acento: ele é a ÂNCORA que amarra o
+    // rótulo ao balão certo. Sem isso, `getByText("Celular")` casaria com o
+    // rótulo de qualquer bolha da conversa e o teste passaria com os rótulos
+    // trocados entre si.
+    const base = {
+      organization_id: creds.org_id,
+      conversation_id: conversaId,
+      channel_session_id: sessaoId,
+      contact_id: contatoId,
+      type: "text" as const,
+    };
+    const t0 = Date.now();
+    const linhas = [
+      { ...base, direction: "inbound", status: "delivered", body: "PERGUNTA DO CLIENTE", sent_at: new Date(t0).toISOString() },
+      { ...base, direction: "outbound", status: "sent", sent_via: "external_device", body: "RESPOSTA PELO CELULAR", sent_at: new Date(t0 + 1000).toISOString() },
+      { ...base, direction: "outbound", status: "sent", sent_via: "ai", body: "RESPOSTA DO AGENTE", sent_at: new Date(t0 + 2000).toISOString() },
+      { ...base, direction: "outbound", status: "sent", sent_via: "user", body: "RESPOSTA DIGITADA NO CRM", sent_at: new Date(t0 + 3000).toISOString() },
+    ];
+    const { error: erroMsg } = await admin.from("messages").insert(linhas);
+    if (erroMsg) throw new Error(`messages: ${erroMsg.message}`);
+  });
+
+  test.afterAll(async () => {
+    await limpar();
+  });
+
+  test("cada balão enviado leva o nome da sua origem, e o recebido não leva nenhum", async ({
+    page,
+  }) => {
+    await login(page, creds.users.agent!.email, creds.password);
+    await page.goto(`/app/inbox/${conversaId}`);
+
+    // A PRECONDIÇÃO: a conversa carregou de verdade. Sem isto, uma tela vazia
+    // faria todo `not.toBeVisible()` abaixo passar por vacuidade — que é o
+    // modo de falha exato desta feature (coluna ausente no select → nenhum
+    // rótulo, e um teste só de ausência ficaria verde).
+    const doCliente = page.locator("text=PERGUNTA DO CLIENTE").first();
+    await expect(doCliente).toBeVisible({ timeout: 60_000 });
+
+    /**
+     * O balão que CONTÉM aquele corpo. Subir do texto para o container é o que
+     * amarra o rótulo à mensagem certa — a asserção solta `getByText("IA")`
+     * ficaria verde com os três rótulos na bolha errada.
+     */
+    const balaoCom = (corpo: string) =>
+      page.locator("div").filter({ hasText: new RegExp(`^${corpo}`) }).last();
+
+    const esperado: Array<[string, string]> = [
+      ["RESPOSTA PELO CELULAR", "Celular"],
+      ["RESPOSTA DO AGENTE", "IA"],
+      ["RESPOSTA DIGITADA NO CRM", "Você"],
+    ];
+
+    for (const [corpo, rotulo] of esperado) {
+      const bolha = balaoCom(corpo);
+      await expect(bolha, `a mensagem "${corpo}" não apareceu na conversa`).toBeVisible({
+        timeout: 30_000,
+      });
+      await expect(
+        bolha,
+        `o balão de "${corpo}" devia dizer "${rotulo}" — é o que messages.sent_via gravou`,
+      ).toContainText(rotulo);
+    }
+
+    // O CONTROLE NEGATIVO, e ele é o que separa "rotula certo" de "rotula
+    // tudo": a mensagem RECEBIDA não leva rótulo de origem nenhum. Sem ele,
+    // um componente que carimbasse "Celular" em toda bolha passaria nos três
+    // casos acima.
+    const bolhaDoCliente = balaoCom("PERGUNTA DO CLIENTE");
+    for (const rotulo of ["Celular", "IA", "Você"]) {
+      await expect(
+        bolhaDoCliente,
+        `a mensagem do cliente não pode levar o rótulo "${rotulo}"`,
+      ).not.toContainText(rotulo);
+    }
+
+    await captura(page, "conversa-com-rotulos-de-origem");
+  });
+});

--- a/tests/e2e/inbox-rotulo-de-origem.spec.ts
+++ b/tests/e2e/inbox-rotulo-de-origem.spec.ts
@@ -155,13 +155,22 @@ test.describe("Inbox — o balão diz de onde saiu a mensagem", () => {
     if (erroConversa) throw new Error(`conversations: ${erroConversa.message}`);
     conversaId = (conversa as { id: string }).id;
 
-    // As QUATRO linhas, uma por origem ALCANÇÁVEL, com os valores que os
-    // emissores reais gravam:
-    //   inbound          — o cliente escreveu (lib/waha/ingest.ts)
-    //   external_device  — o atendente respondeu pelo CELULAR, fora do CRM
-    //                      (lib/waha/ingest.ts:622,850)
-    //   ai               — o agente respondeu (workers/ai-response-worker.ts:1068)
-    //   user             — alguém digitou no CRM (app/api/v1/messages/_handler.ts:529)
+    // As QUATRO linhas, com os valores que os emissores REAIS gravam — cada um
+    // com o arquivo que o carimba, para ninguém precisar acreditar nesta lista:
+    //
+    //   inbound  + external_device — o CLIENTE escreveu (lib/waha/ingest.ts:622)
+    //   outbound + external_device — o atendente respondeu pelo CELULAR, fora
+    //                                do CRM (lib/waha/ingest.ts:850)
+    //   outbound + ai              — o agente respondeu
+    //                                (workers/ai-response-worker.ts:1068)
+    //   outbound + user            — alguém digitou no CRM
+    //                                (app/api/v1/messages/_handler.ts:529)
+    //
+    // ⚠️ A PRIMEIRA E A SEGUNDA TÊM O MESMO `sent_via`. Isso não é descuido do
+    // fixture: a ingestão carimba `external_device` nos dois sentidos, e quem
+    // separa o cliente do atendente é a DIREÇÃO. Por isso o controle negativo
+    // lá embaixo é forte — se o componente parasse de olhar `direction`, toda
+    // mensagem recebida passaria a dizer "Celular" para o dono.
     //
     // O corpo de cada uma é único e sem acento: ele é a ÂNCORA que amarra o
     // rótulo ao balão certo. Sem isso, `getByText("Celular")` casaria com o
@@ -176,13 +185,21 @@ test.describe("Inbox — o balão diz de onde saiu a mensagem", () => {
     };
     const t0 = Date.now();
     const linhas = [
-      { ...base, direction: "inbound", status: "delivered", body: "PERGUNTA DO CLIENTE", sent_at: new Date(t0).toISOString() },
+      { ...base, direction: "inbound", status: "delivered", sent_via: "external_device", body: "PERGUNTA DO CLIENTE", sent_at: new Date(t0).toISOString() },
       { ...base, direction: "outbound", status: "sent", sent_via: "external_device", body: "RESPOSTA PELO CELULAR", sent_at: new Date(t0 + 1000).toISOString() },
       { ...base, direction: "outbound", status: "sent", sent_via: "ai", body: "RESPOSTA DO AGENTE", sent_at: new Date(t0 + 2000).toISOString() },
       { ...base, direction: "outbound", status: "sent", sent_via: "user", body: "RESPOSTA DIGITADA NO CRM", sent_at: new Date(t0 + 3000).toISOString() },
     ];
-    const { error: erroMsg } = await admin.from("messages").insert(linhas);
-    if (erroMsg) throw new Error(`messages: ${erroMsg.message}`);
+    // Uma a uma, e não em lote: no insert em LOTE o PostgREST une as chaves de
+    // todas as linhas e manda NULL onde a linha não a tem — então uma linha que
+    // omitisse `sent_via` bateria no NOT NULL em vez de cair no DEFAULT da
+    // coluna. Medido aqui: `null value in column "sent_via" ... violates
+    // not-null constraint`. Linha a linha, o fixture grava o que a aplicação
+    // grava.
+    for (const linha of linhas) {
+      const { error: erroMsg } = await admin.from("messages").insert(linha);
+      if (erroMsg) throw new Error(`messages (${linha.body}): ${erroMsg.message}`);
+    }
   });
 
   test.afterAll(async () => {
@@ -206,9 +223,21 @@ test.describe("Inbox — o balão diz de onde saiu a mensagem", () => {
      * O balão que CONTÉM aquele corpo. Subir do texto para o container é o que
      * amarra o rótulo à mensagem certa — a asserção solta `getByText("IA")`
      * ficaria verde com os três rótulos na bolha errada.
+     *
+     * O caminho é `<p>` do corpo → PAI. Em `MessageBubble` o rótulo e o corpo
+     * são IRMÃOS dentro da bolha (`<div class="mb-0.5 …">{t(senderLabel)}</div>`
+     * e `<p class="whitespace-pre-wrap …">{message.body}</p>`), então o pai do
+     * `<p>` é o menor elemento que contém os dois.
+     *
+     * A primeira versão era `locator("div").filter({hasText: /^corpo/})`, e ela
+     * não achava nada: o `^` exige que o texto do div COMECE pelo corpo, e o da
+     * bolha começa pelo rótulo. O sintoma ("element(s) not found") lê como "a
+     * mensagem não renderizou" — e a captura da falha mostrava as quatro
+     * bolhas certas na tela. Locator quebrado e feature quebrada dão o MESMO
+     * vermelho; foi a captura que separou os dois.
      */
     const balaoCom = (corpo: string) =>
-      page.locator("div").filter({ hasText: new RegExp(`^${corpo}`) }).last();
+      page.getByText(corpo, { exact: true }).locator("xpath=..");
 
     const esperado: Array<[string, string]> = [
       ["RESPOSTA PELO CELULAR", "Celular"],

--- a/tests/e2e/inbox-rotulo-de-origem.spec.ts
+++ b/tests/e2e/inbox-rotulo-de-origem.spec.ts
@@ -11,7 +11,11 @@
  *      e chega ao componente. Um `select` sem a coluna devolve `undefined`, o
  *      componente cai no `return null` final, e **todos os rótulos somem em
  *      silêncio** — sem erro, sem vermelho, sem nada na tela;
- *   2. o rótulo aparece de fato no balão certo, e não atrás de outro elemento.
+ *   2. o rótulo aparece de fato no balão certo, e não atrás de outro elemento;
+ *   3. o "Você" é do usuário LOGADO. `sent_via='user'` registra que um humano
+ *      digitou no CRM, nunca qual — a distinção depende de `sent_by_user_id`
+ *      chegar à tela junto com o id da sessão. Um teste de componente pode
+ *      passar o par à mão; só a tela prova que a rota entrega os dois.
  *
  * As duas são exatamente a classe que a doutrina de QA Visual manda provar pelo
  * frontend: `curl` valida o backend, não o que o dono VÊ.
@@ -155,7 +159,7 @@ test.describe("Inbox — o balão diz de onde saiu a mensagem", () => {
     if (erroConversa) throw new Error(`conversations: ${erroConversa.message}`);
     conversaId = (conversa as { id: string }).id;
 
-    // As QUATRO linhas, com os valores que os emissores REAIS gravam — cada um
+    // As CINCO linhas, com os valores que os emissores REAIS gravam — cada um
     // com o arquivo que o carimba, para ninguém precisar acreditar nesta lista:
     //
     //   inbound  + external_device — o CLIENTE escreveu (lib/waha/ingest.ts:622)
@@ -163,8 +167,18 @@ test.describe("Inbox — o balão diz de onde saiu a mensagem", () => {
     //                                do CRM (lib/waha/ingest.ts:850)
     //   outbound + ai              — o agente respondeu
     //                                (workers/ai-response-worker.ts:1068)
-    //   outbound + user            — alguém digitou no CRM
-    //                                (app/api/v1/messages/_handler.ts:529)
+    //   outbound + user (eu)       — o agente que faz o login digitou no CRM
+    //                                (app/api/v1/messages/_handler.ts:529, que
+    //                                grava `sent_by_user_id` junto)
+    //   outbound + user (colega)   — OUTRA pessoa da mesma organização digitou
+    //                                no CRM
+    //
+    // ⚠️ AS DUAS ÚLTIMAS TÊM O MESMO `sent_via`. Também não é descuido: a
+    // coluna registra que *um humano digitou no CRM*, nunca QUAL — quem separa
+    // é `sent_by_user_id` contra o id de quem está lendo. Sem a quinta linha,
+    // um componente que dissesse "Você" em toda mensagem de `sent_via='user'`
+    // passaria neste spec, e numa org com dois atendentes cada um leria o
+    // atendimento do outro como seu.
     //
     // ⚠️ A PRIMEIRA E A SEGUNDA TÊM O MESMO `sent_via`. Isso não é descuido do
     // fixture: a ingestão carimba `external_device` nos dois sentidos, e quem
@@ -188,7 +202,8 @@ test.describe("Inbox — o balão diz de onde saiu a mensagem", () => {
       { ...base, direction: "inbound", status: "delivered", sent_via: "external_device", body: "PERGUNTA DO CLIENTE", sent_at: new Date(t0).toISOString() },
       { ...base, direction: "outbound", status: "sent", sent_via: "external_device", body: "RESPOSTA PELO CELULAR", sent_at: new Date(t0 + 1000).toISOString() },
       { ...base, direction: "outbound", status: "sent", sent_via: "ai", body: "RESPOSTA DO AGENTE", sent_at: new Date(t0 + 2000).toISOString() },
-      { ...base, direction: "outbound", status: "sent", sent_via: "user", body: "RESPOSTA DIGITADA NO CRM", sent_at: new Date(t0 + 3000).toISOString() },
+      { ...base, direction: "outbound", status: "sent", sent_via: "user", sent_by_user_id: creds.users.agent!.id, body: "RESPOSTA DIGITADA POR MIM", sent_at: new Date(t0 + 3000).toISOString() },
+      { ...base, direction: "outbound", status: "sent", sent_via: "user", sent_by_user_id: creds.users.manager!.id, body: "RESPOSTA DIGITADA PELO COLEGA", sent_at: new Date(t0 + 4000).toISOString() },
     ];
     // Uma a uma, e não em lote: no insert em LOTE o PostgREST une as chaves de
     // todas as linhas e manda NULL onde a linha não a tem — então uma linha que
@@ -242,7 +257,8 @@ test.describe("Inbox — o balão diz de onde saiu a mensagem", () => {
     const esperado: Array<[string, string]> = [
       ["RESPOSTA PELO CELULAR", "Celular"],
       ["RESPOSTA DO AGENTE", "IA"],
-      ["RESPOSTA DIGITADA NO CRM", "Você"],
+      ["RESPOSTA DIGITADA POR MIM", "Você"],
+      ["RESPOSTA DIGITADA PELO COLEGA", "Atendente"],
     ];
 
     for (const [corpo, rotulo] of esperado) {
@@ -256,12 +272,24 @@ test.describe("Inbox — o balão diz de onde saiu a mensagem", () => {
       ).toContainText(rotulo);
     }
 
+    // "VOCÊ" NÃO PODE APARECER NA MENSAGEM DE OUTRA PESSOA.
+    //
+    // A asserção positiva acima não fecha sozinha: "Atendente" e "Você" são
+    // textos distintos, mas um componente que desenhasse os DOIS rótulos na
+    // mesma bolha passaria no `toContainText("Atendente")`. Esta é a asserção
+    // que o dono da conta sente — ler o atendimento do colega como se fosse
+    // seu é a mentira, e ela não some por acrescentar um rótulo certo ao lado.
+    await expect(
+      balaoCom("RESPOSTA DIGITADA PELO COLEGA"),
+      "o balão do colega não pode dizer 'Você' — sent_via='user' não diz QUAL humano digitou",
+    ).not.toContainText("Você");
+
     // O CONTROLE NEGATIVO, e ele é o que separa "rotula certo" de "rotula
     // tudo": a mensagem RECEBIDA não leva rótulo de origem nenhum. Sem ele,
-    // um componente que carimbasse "Celular" em toda bolha passaria nos três
+    // um componente que carimbasse "Celular" em toda bolha passaria nos
     // casos acima.
     const bolhaDoCliente = balaoCom("PERGUNTA DO CLIENTE");
-    for (const rotulo of ["Celular", "IA", "Você"]) {
+    for (const rotulo of ["Celular", "IA", "Você", "Atendente"]) {
       await expect(
         bolhaDoCliente,
         `a mensagem do cliente não pode levar o rótulo "${rotulo}"`,

--- a/tests/unit/rotulo-de-origem-tem-emissor.test.ts
+++ b/tests/unit/rotulo-de-origem-tem-emissor.test.ts
@@ -1,0 +1,217 @@
+/**
+ * O BALÃO NÃO OFERECE RÓTULO QUE O SISTEMA NUNCA PRODUZ — NEM CALA UM QUE PRODUZ.
+ *
+ * ## O defeito, medido no PR #631 (2026-09-08)
+ *
+ * `MessageBubble` passou a nomear a origem de cada mensagem enviada a partir de
+ * `messages.sent_via`. Quatro dos cinco rótulos casam com um valor que alguém
+ * de fato grava. Um não:
+ *
+ *   grep -rn 'sent_via:' --include='*.ts' app lib workers | grep -v '\.test\.'
+ *     app/api/v1/messages/_handler.ts:529  → 'ai' | 'user'
+ *     lib/waha/ingest.ts:622, :850         → 'external_device'
+ *     lib/channels/zernio/ingest.ts:480    → 'external_device'
+ *     workers/ai-response-worker.ts:1068   → 'ai'
+ *     (mais o DEFAULT 'crm' da coluna, em supabase/baseline.sql)
+ *
+ * **Ninguém grava `'automation'`.** O CHECK do banco aceita o valor, o tipo em
+ * `lib/types/messaging.ts` o declara, o componente tem um ramo para ele — e
+ * nenhuma linha de `messages` pode chegar nele. O rótulo "Automação" é
+ * inalcançável.
+ *
+ * E a consequência não é só código morto. As ações de automação
+ * (`lib/automation/actions/send-whatsapp.ts`, `send-ai-message.ts`) chamam
+ * `sendMessageHandler` com `actor: { type: "webhook_source" }`, e a linha 529 é
+ * `ctx.actor.type !== "user" ? "ai" : "user"` — então o que a automação envia é
+ * carimbado `'ai'` e o balão mostra **"IA"**. Um template fixo de uma regra
+ * aparece para o dono como se o agente de IA o tivesse escrito.
+ *
+ * ## Por que um guarda, e não uma conferida no diff
+ *
+ * É a classe do "controle decorativo": a tela OFERECE o que o motor nunca
+ * produz. Ela não deixa vermelho em lugar nenhum — nem tipo, nem lint, nem
+ * teste de componente, porque o teste de componente **constrói o objeto à mão**
+ * e pode passar qualquer valor do union. O teste que o PR trouxe faz
+ * exatamente isso (`msg({ sent_via: "automation" })`) e fica verde: ele prova
+ * que o RENDER sabe desenhar o rótulo, nunca que algum dado chega nele.
+ *
+ * A propriedade só é decidível olhando as DUAS pontas ao mesmo tempo — quem
+ * escreve a coluna e quem a lê —, e as duas são enumeráveis a partir do
+ * repositório. É a mesma régua de `cron-audita-so-quando-ha-efeito`: varre a
+ * fonte em vez de manter lista, então alcança emissor que ainda não existe.
+ *
+ * ## As duas direções, e por que as duas precisam existir
+ *
+ * Só "todo rótulo tem emissor" seria satisfeito pelo conserto degenerado
+ * *apagar todos os rótulos* — que é o defeito de volta, na direção de que
+ * ninguém reclama. Por isso o irmão: "todo valor emitido tem rótulo".
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const RAIZ = process.cwd();
+
+/** Onde o rótulo é decidido. */
+const COMPONENTE = path.join(RAIZ, "components", "inbox", "MessageBubble.tsx");
+
+/**
+ * Onde a coluna pode ser ESCRITA. `tests/` fora de propósito: um fixture pode
+ * inventar qualquer valor do union sem que o produto o produza — foi
+ * exatamente essa a confusão que este guarda existe para desfazer.
+ */
+const AREAS_DE_ESCRITA = ["app", "lib", "workers"];
+
+const BASELINE = path.join(RAIZ, "supabase", "baseline.sql");
+
+/**
+ * Valores que o produto NÃO emite hoje e que, mesmo assim, podem ser rotulados.
+ *
+ * Lista que só encolhe. Entrada nova precisa do argumento de por que a linha
+ * existe no banco sem ninguém a escrever pelo código — legado, dado importado,
+ * default de coluna. "Vai ser usado um dia" não serve: é justamente a forma do
+ * defeito que originou este arquivo.
+ */
+const ROTULO_SEM_EMISSOR_DE_PROPOSITO: Record<string, string> = {};
+
+/**
+ * Valores emitidos que NÃO levam rótulo, com o motivo.
+ *
+ * `system` não está aqui porque ninguém o emite — se algum dia alguém emitir,
+ * o teste da segunda direção cobra o rótulo, e é isso que se quer.
+ */
+const EMISSOR_SEM_ROTULO_DE_PROPOSITO: Record<string, string> = {};
+
+function lerArquivos(dir: string): string[] {
+  const saida: string[] = [];
+  const pilha = [dir];
+  while (pilha.length > 0) {
+    const atual = pilha.pop()!;
+    for (const entrada of readdirSync(atual)) {
+      if (entrada === "node_modules" || entrada === ".next") continue;
+      const p = path.join(atual, entrada);
+      if (statSync(p).isDirectory()) {
+        pilha.push(p);
+        continue;
+      }
+      if (!/\.(ts|tsx)$/.test(entrada)) continue;
+      if (/\.test\.(ts|tsx)$/.test(entrada)) continue;
+      saida.push(p);
+    }
+  }
+  return saida;
+}
+
+/** Os valores que o componente sabe NOMEAR: `message.sent_via === "X"`. */
+function rotulosOferecidos(): Set<string> {
+  const src = readFileSync(COMPONENTE, "utf8");
+  const re = /sent_via\s*===\s*"([a-z_]+)"/g;
+  const s = new Set<string>();
+  for (const m of src.matchAll(re)) s.add(m[1]!);
+  return s;
+}
+
+/** Os valores que alguma linha de produção ESCREVE: `sent_via: "X"`. */
+function valoresEmitidos(): Map<string, string[]> {
+  const mapa = new Map<string, string[]>();
+  for (const area of AREAS_DE_ESCRITA) {
+    for (const arquivo of lerArquivos(path.join(RAIZ, area))) {
+      const src = readFileSync(arquivo, "utf8");
+      for (const m of src.matchAll(/sent_via:\s*"([a-z_]+)"/g)) {
+        const v = m[1]!;
+        mapa.set(v, [...(mapa.get(v) ?? []), path.relative(RAIZ, arquivo)]);
+      }
+      // A forma ternária de `_handler.ts`: `sent_via: cond ? ("ai" as const) : ("user" as const)`
+      for (const m of src.matchAll(/sent_via:[^\n]*?\?\s*\("([a-z_]+)"[^\n]*?:\s*\("([a-z_]+)"/g)) {
+        for (const v of [m[1]!, m[2]!]) {
+          mapa.set(v, [...(mapa.get(v) ?? []), path.relative(RAIZ, arquivo)]);
+        }
+      }
+    }
+  }
+  return mapa;
+}
+
+/** O DEFAULT da coluna é um emissor: toda linha que omite `sent_via` cai nele. */
+function defaultDaColuna(): string | null {
+  const sql = readFileSync(BASELINE, "utf8");
+  const m = /"sent_via"\s+"text"\s+DEFAULT\s+'([a-z_]+)'/.exec(sql);
+  return m?.[1] ?? null;
+}
+
+/** O vocabulário que o banco ACEITA — o CHECK. */
+function vocabularioDoBanco(): Set<string> {
+  const sql = readFileSync(BASELINE, "utf8");
+  const m = /CONSTRAINT "messages_sent_via_check" CHECK \(\("sent_via" = ANY \(ARRAY\[([^\]]+)\]/.exec(sql);
+  if (m === null) return new Set();
+  return new Set([...m[1]!.matchAll(/'([a-z_]+)'/g)].map((x) => x[1]!));
+}
+
+const oferecidos = rotulosOferecidos();
+const emitidos = valoresEmitidos();
+const padrao = defaultDaColuna();
+const vocabulario = vocabularioDoBanco();
+const produzidos = new Set<string>([...emitidos.keys(), ...(padrao ? [padrao] : [])]);
+
+describe("o rótulo de origem do balão", () => {
+  it("os quatro extratores estão vivos — controle positivo antes de concluir", () => {
+    // Sem isto, um regex que parou de casar devolve conjunto vazio e as duas
+    // asserções abaixo passam por VACUIDADE. É o modo de falha 7 da triagem:
+    // grep vazio é indistinguível de instrumento morto.
+    expect(oferecidos.size, `nenhum \`sent_via === "…"\` em ${COMPONENTE}`).toBeGreaterThan(0);
+    expect(emitidos.size, "nenhum `sent_via: \"…\"` em app/, lib/ ou workers/").toBeGreaterThan(0);
+    expect(padrao, "DEFAULT de messages.sent_via não encontrado no baseline").not.toBeNull();
+    expect(vocabulario.size, "CHECK messages_sent_via_check não encontrado").toBeGreaterThan(0);
+
+    // E as âncoras concretas: se a fonte mudar de forma, isto estoura em vez de
+    // devolver silêncio. O piso é bem abaixo do medido em 2026-09-08 (5 rótulos
+    // oferecidos, 3 valores emitidos, 6 no vocabulário) para não reprovar o
+    // próximo PR que mova um arquivo de lugar.
+    expect(oferecidos.has("ai"), "o rótulo da IA sumiu do componente").toBe(true);
+    expect(emitidos.has("external_device"), "ninguém mais grava external_device?").toBe(true);
+  });
+
+  it("todo rótulo que a tela oferece corresponde a um valor que alguém GRAVA", () => {
+    const orfaos = [...oferecidos]
+      .filter((v) => !produzidos.has(v))
+      .filter((v) => !(v in ROTULO_SEM_EMISSOR_DE_PROPOSITO));
+
+    expect(
+      orfaos,
+      `MessageBubble nomeia ${JSON.stringify(orfaos)}, mas nenhuma linha de ` +
+        `app/, lib/ ou workers/ grava esse valor em messages.sent_via, e ele não ` +
+        `é o DEFAULT da coluna ('${padrao}'). Um rótulo que o dado nunca produz é ` +
+        `controle decorativo: a tela promete uma distinção que o motor não faz. ` +
+        `Emissores achados: ${JSON.stringify([...produzidos].sort())}.`,
+    ).toEqual([]);
+  });
+
+  it("todo valor que alguém grava tem rótulo — senão a distinção morre calada", () => {
+    // O irmão da asserção acima. Sem ele, "apagar todos os rótulos" satisfaria
+    // o teste e devolveria o defeito original: a bolha sem nome, com o dono
+    // lendo tudo como se tivesse sido digitado no CRM.
+    const mudos = [...produzidos]
+      .filter((v) => !oferecidos.has(v))
+      .filter((v) => !(v in EMISSOR_SEM_ROTULO_DE_PROPOSITO));
+
+    expect(
+      mudos,
+      `estes valores chegam a messages.sent_via e o balão não os nomeia: ` +
+        `${JSON.stringify(mudos)}. Emitidos por: ` +
+        JSON.stringify(Object.fromEntries([...emitidos].map(([k, v]) => [k, [...new Set(v)]]))),
+    ).toEqual([]);
+  });
+
+  it("todo rótulo oferecido é um valor que o BANCO aceita", () => {
+    // Um ramo para um valor fora do CHECK é inalcançável por construção, e a
+    // leitura do componente não denuncia — o union do TypeScript e o CHECK do
+    // Postgres são dois vocabulários que ninguém casa.
+    const foraDoCheck = [...oferecidos].filter((v) => !vocabulario.has(v));
+    expect(
+      foraDoCheck,
+      `o componente nomeia ${JSON.stringify(foraDoCheck)}, que o CHECK ` +
+        `messages_sent_via_check recusa (${JSON.stringify([...vocabulario].sort())}).`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Reconciliação do **PR #631** (@lucasa15). O commit dele está aqui **com a autoria dele**, e o head vira ancestral — o PR fecha como **`MERGED`**.

Ele abriu depois o **#656**, uma versão mais enxuta da mesma ideia. Os dois consertos abaixo valem para as duas versões, e esta branch já os traz.

## O que o PR faz, e por que estava certo na origem

`messages.sent_via` **é coluna real** (`baseline.sql:1654,1664`), `NOT NULL DEFAULT 'crm'`, com CHECK de 6 valores — o PR **não infere nada**, lê o que está gravado. E ele achou à mão uma divergência que nenhum gate nosso via: o banco aceitava **6** valores e o TypeScript declarava **3** (issue **#650**).

## Bloqueador 1 — "Você" mentia sobre a mensagem do colega

`sent_via='user'` diz *"um humano digitou no CRM"*, nunca **qual** humano — quem diz isso é `sent_by_user_id`, que o componente lia **zero** vezes.

Numa organização com dois atendentes, **cada um lia o atendimento do outro como se fosse o seu**. Antes do PR não havia rótulo (ambíguo); depois havia uma afirmação **falsa** de autoria, que é pior.

**Preservamos a intenção dele em vez de rebaixá-la.** Entra a prop `viewerUserId` — o `ChatThread` já tinha `currentUser` em mãos e não a passava. "Você" quando o id casa; "Atendente" quando é o colega. E a **ausência** do id não cai em "Você": a leitura do super-admin em `AdminThread` rotula "Atendente", verdadeiro para todo mundo.

## Bloqueador 2 — "Automação" que ninguém grava

O CHECK aceita o valor e o union o declara, mas **nenhuma linha** de `app/`, `lib/` ou `workers/` o escreve:

```console
$ grep -rn 'sent_via:' --include='*.ts' app lib workers | grep -v '\.test\.'
lib/messaging/_handler.ts:529        → 'ai' | 'user'
lib/waha/ingest.ts:622,850           → 'external_device'
lib/channels/adapters/zernio/ingest.ts:480 → 'external_device'
workers/.../ai-response-worker.ts:1068 → 'ai'
# controle positivo: 'external_device' aparece 7×
```

As ações de automação chamam o handler com `actor.type === "webhook_source"`, e ele carimba `'ai'` em tudo que não é `"user"` — **inclusive o template fixo**, que não tem IA nenhuma. O ramo era controle decorativo, e o fragmento levava essa promessa para a tela de atualização da VPS.

**Não carimbamos `'automation'` na origem, e a razão está medida:** `lib/waha/ingest.ts:79` filtra o dedup de eco em `sent_via in ('ai','user')`. Com o valor novo, o eco que volta do WhatsApp deixa de casar e entra como linha nova — **toda mensagem de automação apareceria duas vezes na conversa**, a segunda rotulada "Celular". Mais `fn_atrito_metrics` mudando de significado. É decisão de produto → issue **#652**.

## Testes e sabotagem

`tests/unit/rotulo-de-origem-tem-emissor.test.ts` (guarda a classe "rótulo sem emissor", com controle nas duas direções) e `tests/e2e/inbox-rotulo-de-origem.spec.ts`, registrada em `SPECS_PARTE_3`. A prova de tela **rodou de verdade** na triagem: `1 passed (8.2s)` contra Supabase local + baseline + build de produção, mostrando *Celular / IA / Você* nos balões enviados e nenhum rótulo no recebido.

| sabotagem | previsto | observado |
|---|---|---|
| ignorar `viewerUserId` na comparação | 2 casos | **2** (`Tests 2 failed \| 7 passed`) |
| emissor novo sem rótulo (`sent_via:'system'`) | 1 caso, e **zero** nos pré-existentes | **igual** — o zero é a prova de que o buraco era real |
| `sent_via` fora do `MSG_COLS` | 1 caso no e2e, e **7/7 verde** nos unitários | **igual** |

## Três guardas nossas que estavam cegas

Nenhuma cobrável dele — por isso o texto é "a nossa rede não enxergava":

- **#650** — `messages.sent_via` nunca entrou na lista do invariante de vocabulário banco × TypeScript, que existe **exatamente** para isso.
- **#651** — o guarda de espanhol é cego a `t(<variável>)`. Provado com a mesma string: literal → 1 vermelho nomeando "Celular"; variável → 5 verdes.
- **#652** — a automação se apresenta como IA.

## Gates

```
pnpm typecheck   exit 0
vitest (balão + guarda da classe)   exit 0   Tests 13 passed (13)
```

**NÃO MEDIDO:** a suíte inteira e o `test:db` não foram rodados nesta ponta — quem prova é o CI, e os cinco checks são obrigatórios. Não abrimos a tela em espanhol para conferir layout (hoje "Celular" em espanhol é a mesma palavra, então o dano visível é zero).

@lucasa15 — o **#656** é a mesma ideia mais enxuta e você pode fechá-lo, ou eu fecho apontando para cá; o crédito é o mesmo nos dois casos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)