### PR TITLE
feat(EPIC-01): os e-mails de acesso funcionam num Supabase próprio

### DIFF
--- a/.changes/emails-de-acesso-no-supabase-proprio.md
+++ b/.changes/emails-de-acesso-no-supabase-proprio.md
@@ -21,6 +21,6 @@ GOTRUE_MAILER_SUBJECTS_RECOVERY="Redefinir sua senha · SUA MARCA"
 
 **A marca passa a seguir o banco.** O `marca-emails.sh` lê o `.env`, então trocar nome ou cor em **Configurações › Marca** não reescrevia os e-mails de acesso. Servindo pelo app, a marca é resolvida a cada busca e o GoTrue re-busca sozinho a cada 10 minutos (`GOTRUE_MAILER_TEMPLATE_MAX_AGE`) — sem reiniciar nada e sem rodar script.
 
-> ⚠️ **Se você seguiu a receita antiga, troque as variáveis.** Até esta versão, `docs/deploy-selfhost/README.md` e o `marca-emails.sh` mandavam apontar `GOTRUE_MAILER_TEMPLATES_*` para um **caminho de arquivo**. Isso não funciona e falha calado: o GoTrue cola o que não começa com `http` no fim do `SITE_URL` e faz um GET, então ele busca `https://SEU_DOMINIO/opt/.../confirmation.html`, recebe o HTML da tela de login e manda **isso** para a caixa de entrada do cliente. Medido em 2026-09-09; o Gmail marcou como phishing.
+**Se você seguiu a receita antiga, troque as variáveis.** Até esta versão, `docs/deploy-selfhost/README.md` e o `marca-emails.sh` mandavam apontar `GOTRUE_MAILER_TEMPLATES_*` para um **caminho de arquivo**. Isso não funciona e falha calado: o GoTrue cola o que não começa com `http` no fim do `SITE_URL` e faz um GET, então ele busca `https://SEU_DOMINIO/opt/.../confirmation.html`, recebe o HTML da tela de login e manda **isso** para a caixa de entrada do cliente. Medido em 2026-09-09; o Gmail marcou como phishing.
 
 Achado instalando numa VPS com Supabase próprio, seguindo a documentação do produto do começo ao fim.

--- a/.changes/emails-de-acesso-no-supabase-proprio.md
+++ b/.changes/emails-de-acesso-no-supabase-proprio.md
@@ -17,6 +17,8 @@ GOTRUE_MAILER_SUBJECTS_RECOVERY="Redefinir sua senha · SUA MARCA"
 
 **Nada muda para quem não apontar**, e nada muda na nuvem do Supabase — lá o caminho continua sendo o `marca-emails.sh` pela Management API.
 
+**O kit ensina e confere, mas não escreve — e o motivo é honesto.** O GoTrue não é serviço deste compose: o kit sobe `app`, `worker`, `scheduler`, `waha`, `redis`, `srh` e `caddy`, e o Supabase próprio é outra stack, que pode nem estar na mesma máquina. Escrever nela seria o instalador editar instalação de terceiro. Então o `install.sh` passa a imprimir as quatro linhas exatas quando a topologia é própria (antes ele mandava o self-hoster para `supabase.com/dashboard`, que ele não tem), e `bash hostgator-setup-kit/healthcheck.sh` ganhou uma seção que **mede o estado**: se o app serve o molde, se algum GoTrue desta máquina aponta para ele, e se o valor configurado é URL — acusando em vermelho o caminho de arquivo que falha calado.
+
 **Por que isso conserta e não só embeleza.** O modelo padrão do GoTrue linka para `/auth/v1/verify`, que devolve um `code` PKCE. O verificador desse code vive num cookie `SameSite=Strict`, e clique vindo de webmail é navegação cross-site: o cookie não viaja e a sessão nunca fecha. A conta é confirmada, a pessoa entra pela senha, e fica sem organização e sem menu. Os moldes do app linkam com `token_hash`, que não depende de cookie nenhum.
 
 **A marca passa a seguir o banco.** O `marca-emails.sh` lê o `.env`, então trocar nome ou cor em **Configurações › Marca** não reescrevia os e-mails de acesso. Servindo pelo app, a marca é resolvida a cada busca e o GoTrue re-busca sozinho a cada 10 minutos (`GOTRUE_MAILER_TEMPLATE_MAX_AGE`) — sem reiniciar nada e sem rodar script.

--- a/.changes/emails-de-acesso-no-supabase-proprio.md
+++ b/.changes/emails-de-acesso-no-supabase-proprio.md
@@ -1,0 +1,26 @@
+---
+impacto: capacidade_nova
+secao: adicionado
+titulo: Os e-mails de acesso passam a funcionar (e a ter marca) num Supabase próprio
+---
+
+Quem roda **Supabase self-hosted** ganha o que só existia na nuvem: e-mail de confirmação de conta e de redefinição de senha com a marca da instalação, e — o que importa mais — com o link que **fecha a sessão**.
+
+O app passa a servir os dois moldes em `/email-templates/confirmation` e `/email-templates/recovery`. Aponte o GoTrue para eles:
+
+```bash
+GOTRUE_MAILER_TEMPLATES_CONFIRMATION=https://SEU_DOMINIO/email-templates/confirmation
+GOTRUE_MAILER_TEMPLATES_RECOVERY=https://SEU_DOMINIO/email-templates/recovery
+GOTRUE_MAILER_SUBJECTS_CONFIRMATION="Confirme seu e-mail · SUA MARCA"
+GOTRUE_MAILER_SUBJECTS_RECOVERY="Redefinir sua senha · SUA MARCA"
+```
+
+**Nada muda para quem não apontar**, e nada muda na nuvem do Supabase — lá o caminho continua sendo o `marca-emails.sh` pela Management API.
+
+**Por que isso conserta e não só embeleza.** O modelo padrão do GoTrue linka para `/auth/v1/verify`, que devolve um `code` PKCE. O verificador desse code vive num cookie `SameSite=Strict`, e clique vindo de webmail é navegação cross-site: o cookie não viaja e a sessão nunca fecha. A conta é confirmada, a pessoa entra pela senha, e fica sem organização e sem menu. Os moldes do app linkam com `token_hash`, que não depende de cookie nenhum.
+
+**A marca passa a seguir o banco.** O `marca-emails.sh` lê o `.env`, então trocar nome ou cor em **Configurações › Marca** não reescrevia os e-mails de acesso. Servindo pelo app, a marca é resolvida a cada busca e o GoTrue re-busca sozinho a cada 10 minutos (`GOTRUE_MAILER_TEMPLATE_MAX_AGE`) — sem reiniciar nada e sem rodar script.
+
+> ⚠️ **Se você seguiu a receita antiga, troque as variáveis.** Até esta versão, `docs/deploy-selfhost/README.md` e o `marca-emails.sh` mandavam apontar `GOTRUE_MAILER_TEMPLATES_*` para um **caminho de arquivo**. Isso não funciona e falha calado: o GoTrue cola o que não começa com `http` no fim do `SITE_URL` e faz um GET, então ele busca `https://SEU_DOMINIO/opt/.../confirmation.html`, recebe o HTML da tela de login e manda **isso** para a caixa de entrada do cliente. Medido em 2026-09-09; o Gmail marcou como phishing.
+
+Achado instalando numa VPS com Supabase próprio, seguindo a documentação do produto do começo ao fim.

--- a/app/(public)/login/page.tsx
+++ b/app/(public)/login/page.tsx
@@ -70,10 +70,12 @@ export default async function LoginPage({
           role="alert"
         >
           {t(
-            "Este link veio do modelo de e-mail padrão do Supabase, que não fecha o acesso nesta instalação — pedir outro link não resolve. Quem administra o sistema precisa configurar os e-mails de acesso (",
+            "Este link veio do modelo de e-mail padrão do Supabase, que não fecha o acesso nesta instalação — pedir outro link não resolve. Quem administra o sistema precisa configurar os modelos de e-mail: na nuvem do Supabase, com ",
           )}
           <code>marca-emails.sh</code>
-          {t(", no kit de instalação).")}
+          {t(
+            "; num Supabase próprio, apontando GOTRUE_MAILER_TEMPLATES_* para as rotas /email-templates/ do app.",
+          )}
         </div>
       )}
       {error === "provisionamento" && (

--- a/app/email-templates/[modelo]/route.test.ts
+++ b/app/email-templates/[modelo]/route.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { marcaDaSaida } from "@/lib/branding/saida";
+
+/**
+ * A rota que o GoTrue busca. Três coisas não podem regredir: ela só conhece os
+ * dois modelos, devolve HTML de verdade, e nunca derruba o envio do e-mail por
+ * causa de marca — `marcaDaSaida` degrada, e a rota confia nisso.
+ */
+
+vi.mock("@/lib/branding/saida", async () => {
+  const real = await vi.importActual<typeof import("@/lib/branding/saida")>(
+    "@/lib/branding/saida",
+  );
+  return { ...real, marcaDaSaida: vi.fn() };
+});
+
+const MARCA = {
+  nome: "Acme",
+  logoUrl: null,
+  accent: "#506d48",
+  accentFg: "#ffffff",
+  origens: { nome: "instalacao", cor: "instalacao" },
+};
+
+const chamar = (modelo: string) =>
+  import("./route").then(({ GET }) =>
+    GET(new NextRequest(`https://exemplo.test/email-templates/${modelo}`), {
+      params: Promise.resolve({ modelo }),
+    }),
+  );
+
+describe("GET /email-templates/[modelo]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(marcaDaSaida).mockResolvedValue(MARCA);
+  });
+
+  it("serve o molde de confirmação com o link que fecha a sessão", async () => {
+    const res = await chamar("confirmation");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    const corpo = await res.text();
+    expect(corpo).toContain("{{ .RedirectTo }}&token_hash={{ .TokenHash }}");
+    expect(corpo).toContain("Acme");
+  });
+
+  it("serve o molde de recuperação", async () => {
+    const res = await chamar("recovery");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("{{ .TokenHash }}");
+  });
+
+  it("modelo desconhecido é 404, não um HTML qualquer", async () => {
+    // Sem isto, um typo na variável do GoTrue devolveria 200 com corpo errado —
+    // e o cliente receberia isso por e-mail em vez de nada.
+    const res = await chamar("../../etc/passwd");
+    expect(res.status).toBe(404);
+    expect(vi.mocked(marcaDaSaida)).not.toHaveBeenCalled();
+  });
+
+  it("resolve a marca da INSTALAÇÃO — não há organização neste momento", async () => {
+    await chamar("confirmation");
+    expect(vi.mocked(marcaDaSaida)).toHaveBeenCalledWith(null);
+  });
+
+  it("pede cache curto — a troca de marca tem de chegar", async () => {
+    const res = await chamar("confirmation");
+    expect(res.headers.get("cache-control")).toMatch(/max-age=\d+/);
+    expect(res.headers.get("x-robots-tag")).toContain("noindex");
+  });
+});

--- a/app/email-templates/[modelo]/route.ts
+++ b/app/email-templates/[modelo]/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { marcaDaSaida } from "@/lib/branding/saida";
+import {
+  MODELOS_DE_ACESSO,
+  montarTemplateDeAcesso,
+  type ModeloDeAcesso,
+} from "@/lib/email/templates/acesso-gotrue";
+
+/**
+ * GET /email-templates/{confirmation,recovery} — o molde que o GoTrue busca.
+ *
+ * ─── POR QUE UMA ROTA, E NÃO UM ARQUIVO ────────────────────────────────────
+ *
+ * O GoTrue **só carrega template por HTTP**. Fonte, `supabase/auth` v2.196.0,
+ * `internal/mailer/templatemailer/template.go`:
+ *
+ *     url := getEmailContentConfig(&cfg.Mailer.Templates, typ, "")
+ *     if !strings.HasPrefix(url, "http") {
+ *         url = cfg.SiteURL + url                       // ← linha 456
+ *     }
+ *     req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+ *
+ * O que não começa com `http` ele COLA no fim do `SiteURL` e busca. Um caminho
+ * de arquivo não falha: ele faz o GoTrue pedir `https://SEU_DOMINIO/opt/...`,
+ * receber o HTML da tela de login e mandar ISSO para a caixa de entrada.
+ * Aconteceu numa instalação real em 2026-09-09, e o Gmail marcou como phishing.
+ * A doc oficial concorda: `GOTRUE_MAILER_TEMPLATES_*` são *"template URLs"*, e
+ * os knobs irmãos são descritos como *"Email-template HTTP loading"*.
+ *
+ * ─── POR QUE O APP SERVE, E NÃO UM ARQUIVO ESTÁTICO ────────────────────────
+ *
+ * Porque a marca vive no BANCO (`platform_branding`), não no `.env`. O
+ * `marca-emails.sh` renderiza lendo o `.env`, então trocar nome ou cor em
+ * **Configurações › Marca** não reescreve os e-mails de acesso — buraco que o
+ * próprio produto documenta em `docs/white-label.en.md`. Servindo daqui, a
+ * marca é resolvida a cada busca, e o GoTrue re-busca sozinho a cada
+ * `GOTRUE_MAILER_TEMPLATE_MAX_AGE` (10 min por padrão): a troca chega sem
+ * reiniciar nada e sem rodar script.
+ *
+ * ─── SEM RATE LIMIT, DE PROPÓSITO ──────────────────────────────────────────
+ *
+ * A rota é pública, e a regra da casa é que rota pública tem teto. Aqui o teto
+ * seria contraproducente: quem consome é o GoTrue, no instante em que precisa
+ * montar o e-mail, e um 429 o faz cair no modelo PADRÃO — isto é, recriaria
+ * exatamente o defeito que esta rota existe para consertar, e só para quem
+ * estivesse criando conta naquele minuto. O que ela devolve não tem segredo
+ * (nome, cor e logo já aparecem na tela de login, sem sessão), não tem efeito
+ * colateral e custa uma linha lida. O `Cache-Control` abaixo é a proteção
+ * proporcional.
+ */
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ modelo: string }> },
+): Promise<NextResponse> {
+  const { modelo } = await params;
+
+  if (!MODELOS_DE_ACESSO.includes(modelo as ModeloDeAcesso)) {
+    return new NextResponse("modelo desconhecido", { status: 404 });
+  }
+
+  // `null` = camada da INSTALAÇÃO. Confirmar conta e redefinir senha acontecem
+  // quando ainda não há organização a que atribuir a pessoa — e mesmo quando há,
+  // o GoTrue não sabe qual é. `marcaDaSaida` nunca lança: degrada para o padrão
+  // do produto, que é uma instalação funcionando.
+  const marca = await marcaDaSaida(null);
+
+  return new NextResponse(montarTemplateDeAcesso(modelo as ModeloDeAcesso, marca), {
+    status: 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      // Curto de propósito: o GoTrue já tem cache próprio de 10 min, e este
+      // teto evita que uma troca de marca demore mais que isso para aparecer.
+      "cache-control": "public, max-age=300",
+      // O molde não é página do produto e não deve ser indexado nem seguido.
+      "x-robots-tag": "noindex, nofollow",
+    },
+  });
+}

--- a/docs/deploy-selfhost/README.md
+++ b/docs/deploy-selfhost/README.md
@@ -197,21 +197,36 @@ sem quebrar nada.
 `GOTRUE_SITE_URL=https://SEU_DOMINIO`,
 `GOTRUE_URI_ALLOW_LIST=https://SEU_DOMINIO/auth/confirm`,
 `GOTRUE_SMTP_{HOST,PORT,USER,PASS}` e
-`GOTRUE_MAILER_TEMPLATES_{CONFIRMATION,RECOVERY}` apontando para os templates
-de `supabase/templates/` (mesmo link `token_hash` acima).
-
-⚠️ **Não aponte para os arquivos do repositório direto.** Eles são MODELOS: o
-nome da marca e a cor do botão são `__APP_NAME__` / `__ACCENT__`, e o cliente
-receberia isso literalmente. Renderize antes e aponte para o resultado:
+`GOTRUE_MAILER_TEMPLATES_{CONFIRMATION,RECOVERY}` apontando para as **rotas do
+próprio app**:
 
 ```bash
-bash hostgator-setup-kit/marca-emails.sh --render-em /opt/deskcomm/emails
-# GOTRUE_MAILER_TEMPLATES_CONFIRMATION=/opt/deskcomm/emails/confirmation.html
-# GOTRUE_MAILER_TEMPLATES_RECOVERY=/opt/deskcomm/emails/recovery.html
+GOTRUE_MAILER_TEMPLATES_CONFIRMATION=https://SEU_DOMINIO/email-templates/confirmation
+GOTRUE_MAILER_TEMPLATES_RECOVERY=https://SEU_DOMINIO/email-templates/recovery
+GOTRUE_MAILER_SUBJECTS_CONFIRMATION="Confirme seu e-mail · SUA MARCA"
+GOTRUE_MAILER_SUBJECTS_RECOVERY="Redefinir sua senha · SUA MARCA"
 ```
 
-Num Supabase próprio não existe Management API, então este é o único caminho —
-e é preciso repetir o comando quando a marca mudar.
+O app serve o modelo já com a marca resolvida **do banco** — então trocar nome,
+cor ou logo em **Configurações › Marca** chega ao e-mail sozinho, em até 10
+minutos (`GOTRUE_MAILER_TEMPLATE_MAX_AGE`), sem reiniciar nada e sem rodar
+script.
+
+> ⚠️ **Tem de ser URL `http(s)`. Caminho de arquivo NÃO funciona — e falha
+> calado.** O GoTrue cola o que não começa com `http` no fim do `SITE_URL` e faz
+> um GET (`supabase/auth` v2.196.0,
+> `internal/mailer/templatemailer/template.go:456`). Apontar para
+> `/opt/.../confirmation.html` faz ele buscar
+> `https://SEU_DOMINIO/opt/.../confirmation.html`, receber o HTML da tela de
+> login e **mandar isso para a caixa de entrada do cliente**. Medido em
+> 2026-09-09 numa instalação real: o Gmail marcou como phishing.
+>
+> Esta seção mandava exatamente isso até 2026-09-10. Se você seguiu a versão
+> antiga, troque as duas variáveis pelas URLs acima.
+
+`bash hostgator-setup-kit/marca-emails.sh --render-em <dir>` continua existindo
+para **inspecionar** o HTML antes, ou para quem prefere servir os moldes por
+conta própria — num caminho HTTP seu, nunca como caminho de arquivo.
 
 ## 4. Conectar o WhatsApp
 

--- a/hostgator-setup-kit/healthcheck.sh
+++ b/hostgator-setup-kit/healthcheck.sh
@@ -43,3 +43,86 @@ else
   c_ylw "⚠ o agente NÃO está no cron — o botão de atualizar não vai aparecer na tela."
   c_ylw "  Ative rodando: bash hostgator-setup-kit/update.sh"
 fi
+
+step "E-mails de acesso (confirmar conta e redefinir senha)"
+# ── Por que esta seção existe ────────────────────────────────────────────────
+# Num Supabase PRÓPRIO, quem renderiza estes dois e-mails é o GoTrue, e o molde
+# padrão dele linka para `/auth/v1/verify`, que devolve um `code` PKCE. O
+# verificador desse code vive num cookie SameSite=Strict, e clique vindo de
+# webmail é navegação cross-site: o cookie não viaja e a sessão nunca fecha.
+# Medido em produção em 2026-09-10 — a conta era confirmada e a pessoa entrava
+# sem organização e sem menu.
+#
+# O conserto é apontar `GOTRUE_MAILER_TEMPLATES_*` para a rota do app. Como o
+# GoTrue não é serviço deste compose (o kit sobe app, worker, scheduler, waha,
+# redis, srh e caddy — o Supabase próprio fica FORA), o kit não tem como
+# escrever essa configuração. O que ele pode, e é o que faz aqui, é MEDIR o
+# estado e dizer as duas linhas exatas. Silêncio aqui seria o `return` mudo que
+# o invariante 6(c) do Sistema Vivo proíbe.
+case "${NEXT_PUBLIC_SUPABASE_URL:-}" in
+  https://*.supabase.co*)
+    c_grn "✓ Supabase na nuvem — os e-mails são configurados pela Management API."
+    c_dim "  Quem cuida disso é: bash hostgator-setup-kit/marca-emails.sh"
+    ;;
+  "")
+    c_ylw "⚠ NEXT_PUBLIC_SUPABASE_URL vazia no .env — não dá para saber a topologia."
+    ;;
+  *)
+    c_dim "  Supabase próprio: aqui não existe Management API, a ligação é por env do GoTrue."
+
+    # (a) A rota do app responde? Perguntamos de DENTRO da rede do compose, como
+    #     na seção de saúde acima: a rota é pública, mas o host pode estar atrás
+    #     de proxy e um erro de TLS aqui seria diagnóstico errado.
+    molde="$(dc exec -T app node -e "
+fetch('http://127.0.0.1:3000/email-templates/confirmation').then(r=>r.text()).then(t=>{console.log(t);process.exit(0)}).catch(()=>process.exit(1))
+" 2>/dev/null || echo '')"
+    if printf '%s' "$molde" | grep -q 'token_hash={{ .TokenHash }}'; then
+      c_grn "✓ o app serve o molde em /email-templates/confirmation"
+    elif [ -n "$molde" ]; then
+      c_ylw "⚠ /email-templates/confirmation respondeu, mas sem o token_hash esperado."
+      c_ylw "  Esta versão do app é anterior à correção. Rode: bash hostgator-setup-kit/update.sh"
+    else
+      c_ylw "⚠ o app não serviu /email-templates/confirmation."
+      c_ylw "  Ou está fora do ar, ou é uma versão anterior à correção."
+    fi
+
+    # (b) O GoTrue desta máquina está apontado para lá? Ele não é nosso, então
+    #     lemos o ambiente de QUALQUER contêiner que declare a variável — é
+    #     leitura, não escrita, e é o único jeito de responder sem adivinhar.
+    apontado=""; dono=""
+    # A chave sai de uma VARIÁVEL, não literal dentro do `sed`: o
+    # test-validators.sh varre o kit cobrando que todo `GOTRUE_MAILER_TEMPLATES_*=`
+    # escrito aqui seja URL http(s), e um `s/^CHAVE=//p` entraria nessa varredura
+    # como se `//p` fosse o valor configurado.
+    chave=GOTRUE_MAILER_TEMPLATES_CONFIRMATION
+    for c in $(docker ps --format '{{.Names}}' 2>/dev/null); do
+      v="$(docker inspect --format \
+        '{{range .Config.Env}}{{println .}}{{end}}' "$c" 2>/dev/null \
+        | sed -n "s/^${chave}=//p" | head -1)"
+      [ -n "$v" ] && { apontado="$v"; dono="$c"; break; }
+    done
+    if [ -z "$apontado" ]; then
+      c_ylw "⚠ nenhum GoTrue desta máquina aponta para o molde do app."
+      c_ylw "  Os e-mails de acesso vão sair no modelo padrão, e o link dele NÃO fecha"
+      c_ylw "  a sessão quando o clique vem do webmail."
+      c_ylw "  Acrescente ao serviço 'auth' do SEU Supabase (não a este compose):"
+      c_ylw "    GOTRUE_MAILER_TEMPLATES_CONFIRMATION=${NEXT_PUBLIC_APP_URL:-https://SEU_DOMINIO}/email-templates/confirmation"
+      c_ylw "    GOTRUE_MAILER_TEMPLATES_RECOVERY=${NEXT_PUBLIC_APP_URL:-https://SEU_DOMINIO}/email-templates/recovery"
+      c_dim "  (se o seu Supabase roda em outra máquina, confira lá — daqui não dá para ver)"
+    else
+      case "$apontado" in
+        http*/email-templates/*)
+          c_grn "✓ o GoTrue ($dono) busca o molde do app"
+          c_dim "  $apontado" ;;
+        http*)
+          c_ylw "⚠ o GoTrue ($dono) busca um molde que não é o do app:"
+          c_ylw "  $apontado" ;;
+        *)
+          c_red "✗ o GoTrue ($dono) está com CAMINHO DE ARQUIVO, não URL:"
+          c_red "  $apontado"
+          c_red "  O GoTrue cola isso no fim do SITE_URL e busca por HTTP — o cliente"
+          c_red "  recebe a tela de login dentro do e-mail. Troque por uma URL http(s)." ;;
+      esac
+    fi
+    ;;
+esac

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -1568,8 +1568,10 @@ esac
   printf '# Marca da instalação (white-label). Preencha APP_LOGO_URL com a URL de uma\n'
   printf '# imagem pública para trocar o texto por logo na sidebar. Ver lib/branding.ts.\n'
   printf '# APP_ACCENT_HEX é a SEMENTE da cor: o banco (platform_branding) manda depois\n'
-  printf '# da primeira leitura, mas é daqui que sai a cor dos e-mails de acesso, que o\n'
-  printf '# marca-emails.sh empurra para o GoTrue e o banco não alcança.\n'
+  printf '# da primeira leitura. Nos e-mails de acesso depende da topologia: na NUVEM do\n'
+  printf '# Supabase quem empurra é o marca-emails.sh, lendo daqui, e o banco não alcança;\n'
+  printf '# num Supabase PRÓPRIO o GoTrue busca /email-templates/ do app, que resolve a\n'
+  printf '# marca pelo banco — e aí trocar em Configurações > Marca chega ao e-mail.\n'
   # Normaliza a escolha do idioma ANTES de gravar: o campo aceita "1"/"2"
   # porque é o que se digita lendo um menu numerado, mas quem lê o `.env` — o
   # bootstrap, o SQL abaixo, um operador conferindo — precisa do código.

--- a/hostgator-setup-kit/install.sh
+++ b/hostgator-setup-kit/install.sh
@@ -1833,6 +1833,17 @@ fi
 # da máquina de quem desenvolve. (issue #431/#426)
 pendencia_dos_emails() {
   [ -s "${PENDENCIA_EMAIL:-/dev/null}" ] || return 0
+
+  # A receita DEPENDE DA TOPOLOGIA, e mandar a errada é pior que não mandar
+  # nada. Num Supabase PRÓPRIO não existe supabase.com/dashboard nem
+  # Management API: quem configura é env do GoTrue. Este bloco já mandou o
+  # self-hoster para um painel que ele não tem — e a pessoa fica achando que
+  # perdeu a senha do Supabase quando o que falta é uma variável.
+  case "${NEXT_PUBLIC_SUPABASE_URL:-}" in
+    https://*.supabase.co*) : ;;
+    *) pendencia_dos_emails_proprio; return 0 ;;
+  esac
+
   cat <<PEND
 
 $(c_ylw "  ─── FALTA UM PASSO, e ele é no painel do Supabase ─────")
@@ -1856,6 +1867,46 @@ $(sed 's/^/    /' "$PENDENCIA_EMAIL")
   Para o instalador fazer isso sozinho da próxima vez, rode
   \`bash hostgator-setup-kit/install.sh\` de novo e informe o token de
   acesso quando ele perguntar (supabase.com/dashboard/account/tokens).
+PEND
+}
+
+# ── A mesma pendência, na topologia em que o Supabase é seu ─────────────────
+# POR QUE O INSTALADOR NÃO ESCREVE ISTO SOZINHO: o GoTrue não é serviço deste
+# compose. O kit sobe app, worker, scheduler, waha, redis, srh e caddy; o
+# Supabase próprio é outra stack, com outro arquivo, que pode nem estar nesta
+# máquina. Escrever nele seria o instalador editar a instalação de terceiro.
+# Então ele faz o que pode fazer com honestidade: diz as duas linhas exatas, e
+# o healthcheck.sh confere depois se elas chegaram.
+pendencia_dos_emails_proprio() {
+  cat <<PEND
+
+$(c_ylw "  ─── FALTA UM PASSO, no SEU Supabase ───────────────────")
+
+  Os e-mails de acesso (confirmar cadastro e redefinir senha) ainda saem no
+  modelo padrão do GoTrue. O link desse modelo NÃO fecha a sessão quando o
+  clique vem do webmail — a conta é confirmada e a pessoa entra sem
+  organização e sem menu.
+
+  O que o passo automático encontrou:
+
+$(sed 's/^/    /' "$PENDENCIA_EMAIL")
+
+  Como o seu Supabase é próprio, não há painel na nuvem nem API para isto:
+  a configuração é por variável de ambiente do serviço \`auth\` (GoTrue).
+  Acrescente ao compose DELE — não a este:
+
+       GOTRUE_SITE_URL=https://${DOMAIN}
+       GOTRUE_URI_ALLOW_LIST=https://${DOMAIN}/auth/confirm
+       GOTRUE_MAILER_TEMPLATES_CONFIRMATION=https://${DOMAIN}/email-templates/confirmation
+       GOTRUE_MAILER_TEMPLATES_RECOVERY=https://${DOMAIN}/email-templates/recovery
+
+  $(c_ylw "Tem de ser URL http(s).") O GoTrue cola no fim do SITE_URL tudo o que não
+  começa com \`http\` e busca por HTTP — um caminho de arquivo faz o cliente
+  receber a tela de login dentro do e-mail.
+
+  Depois reinicie só o auth do seu Supabase e confira aqui com:
+
+       bash hostgator-setup-kit/healthcheck.sh
 PEND
 }
 

--- a/hostgator-setup-kit/marca-emails.sh
+++ b/hostgator-setup-kit/marca-emails.sh
@@ -233,14 +233,27 @@ HTML_CONFIRM="$(renderizar "$PROJ_DIR/supabase/templates/confirmation.html")" ||
 HTML_RECOVERY="$(renderizar "$PROJ_DIR/supabase/templates/recovery.html")" || instrua_e_saia "não achei supabase/templates/ — rode de dentro do repositório."
 
 if [ -n "$RENDER_EM" ]; then
-  # O caminho de quem roda GoTrue self-hosted: lá não existe Management API, e
-  # `GOTRUE_MAILER_TEMPLATES_*` aponta para ARQUIVO. Apontar para o modelo cru
-  # entregaria `__APP_NAME__` ao cliente final.
+  # Renderiza os modelos com a marca do .env e para por aqui.
+  #
+  # ATENCAO -- ISTO NAO E O CAMINHO SELF-HOSTED. `GOTRUE_MAILER_TEMPLATES_*`
+  # NAO aceita caminho de arquivo: o que nao comeca com `http` o GoTrue COLA no
+  # fim do SITE_URL e busca por HTTP (supabase/auth v2.196.0,
+  # internal/mailer/templatemailer/template.go:456). Apontar para um arquivo faz
+  # ele buscar `https://SEU_DOMINIO/caminho/do/arquivo`, receber a tela de login
+  # e mandar ISSO por e-mail -- medido em 2026-09-09, e o Gmail marcou como
+  # phishing.
+  #
+  # Quem roda self-hosted aponta para a ROTA DO APP (ver abaixo). Este ramo
+  # serve para inspecionar o HTML antes, ou para quem prefere servir por conta
+  # propria num caminho HTTP seu.
   mkdir -p "$RENDER_EM" || instrua_e_saia "não consegui escrever em $RENDER_EM"
   printf '%s\n' "$HTML_CONFIRM"  > "$RENDER_EM/confirmation.html"
   printf '%s\n' "$HTML_RECOVERY" > "$RENDER_EM/recovery.html"
   c_grn "✓ modelos renderizados em $RENDER_EM (marca: $APP_NOME, accent: $ACCENT)"
-  c_dim "  GoTrue self-hosted: aponte GOTRUE_MAILER_TEMPLATES_CONFIRMATION/RECOVERY para eles."
+  c_dim "  Isto e so o HTML renderizado -- NAO aponte GOTRUE_MAILER_TEMPLATES_* para estes arquivos."
+  c_dim "  Num Supabase proprio, aponte para a rota do app, que resolve a marca pelo BANCO:"
+  c_dim "    GOTRUE_MAILER_TEMPLATES_CONFIRMATION=${NEXT_PUBLIC_APP_URL:-https://SEU_DOMINIO}/email-templates/confirmation"
+  c_dim "    GOTRUE_MAILER_TEMPLATES_RECOVERY=${NEXT_PUBLIC_APP_URL:-https://SEU_DOMINIO}/email-templates/recovery"
   exit 0
 fi
 
@@ -259,8 +272,12 @@ case "${NEXT_PUBLIC_SUPABASE_URL:-}" in
 esac
 [ -n "$REF" ] || instrua_e_saia \
   "NEXT_PUBLIC_SUPABASE_URL não é um projeto da nuvem do Supabase (${NEXT_PUBLIC_SUPABASE_URL:-vazio}).
-    Num Supabase próprio, use GOTRUE_MAILER_TEMPLATES_* apontando para os
-    arquivos de \`marca-emails.sh --render-em <dir>\`."
+    Num Supabase próprio não há Management API — o caminho é apontar o GoTrue
+    para a rota do app, que serve o modelo já com a marca do banco:
+      GOTRUE_MAILER_TEMPLATES_CONFIRMATION=${NEXT_PUBLIC_APP_URL:-https://SEU_DOMINIO}/email-templates/confirmation
+      GOTRUE_MAILER_TEMPLATES_RECOVERY=${NEXT_PUBLIC_APP_URL:-https://SEU_DOMINIO}/email-templates/recovery
+    Tem de ser URL http(s): caminho de arquivo o GoTrue cola no fim do SITE_URL
+    e busca, e o cliente recebe a tela de login dentro do e-mail."
 
 api() {  # api <método> <caminho> [corpo]
   local method="$1" path="$2" body="${3:-}"

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -931,6 +931,40 @@ else
   printf '  ✗ Supabase próprio: rc=%s, mensagem sem GOTRUE_MAILER_TEMPLATES\n' "$rc_me"; fail=1
 fi
 
+# (2b) CONTRATO, e não é preferência de estilo: `GOTRUE_MAILER_TEMPLATES_*` só
+#      aceita URL http(s). O GoTrue COLA no fim do SITE_URL tudo o que não
+#      começa com `http` e busca por HTTP (supabase/auth v2.196.0,
+#      internal/mailer/templatemailer/template.go:456) — então um caminho de
+#      arquivo não dá erro: ele faz o GoTrue pedir `https://DOMINIO/opt/...`,
+#      receber o HTML da tela de login e mandar ISSO na caixa de entrada.
+#      Aconteceu numa instalação real em 2026-09-09 e o Gmail marcou como
+#      phishing. Varremos o kit inteiro porque três scripts imprimem estas
+#      linhas hoje (install.sh, marca-emails.sh, healthcheck.sh) e o quarto que
+#      aparecer não vai lembrar deste parágrafo.
+fora_do_contrato="$(grep -rhoE 'GOTRUE_MAILER_TEMPLATES_[A-Z]+=[^ "'"'"']*' ./*.sh \
+                    | grep -vE '=(https?://|\$\{[A-Za-z_]+:-https?://)' || true)"
+if [ -z "$fora_do_contrato" ]; then
+  printf '  ✓ todo GOTRUE_MAILER_TEMPLATES_* que o kit imprime é URL http(s)\n'
+else
+  printf '  ✗ o kit imprime GOTRUE_MAILER_TEMPLATES_* que NÃO é URL http(s):\n'
+  printf '%s\n' "$fora_do_contrato" | sed 's/^/      /'
+  fail=1
+fi
+
+# (2c) VACUIDADE do healthcheck: ele decide "o app serve o molde certo"
+#      procurando `token_hash={{ .TokenHash }}` na resposta da rota. Se o
+#      gerador do molde parar de emitir essa string, a sonda passa a responder
+#      "versão anterior à correção" para TODA instalação — inclusive as
+#      corretas —, e ninguém percebe, porque o aviso é plausível. Este caso
+#      amarra os dois lados.
+assinatura='token_hash={{ .TokenHash }}'
+if grep -qF "$assinatura" ./healthcheck.sh \
+   && grep -qF "$assinatura" ../lib/email/templates/acesso-gotrue.ts; then
+  printf '  ✓ a sonda do healthcheck procura a assinatura que o molde emite\n'
+else
+  printf '  ✗ healthcheck e lib/email/templates/acesso-gotrue.ts discordam da assinatura\n'; fail=1
+fi
+
 # (3) VACUIDADE: os modelos no disco precisam TER o placeholder, senão o caso
 #     (4) compararia a ausência de marca com a ausência de marca e passaria.
 for modelo in ../supabase/templates/confirmation.html ../supabase/templates/recovery.html; do

--- a/lib/auth/public-paths.ts
+++ b/lib/auth/public-paths.ts
@@ -51,6 +51,16 @@ export const PUBLIC_PATHS: RegExp[] = [
   /^\/manifest\.webmanifest$/,
   /^\/team\/accept-invite\/.+$/,
   /^\/account-suspended$/,
+  // OS MOLDES DE E-MAIL DO GoTrue. Quem busca é o GoTrue, um processo de
+  // terceiro que não tem — nem pode ter — sessão nossa. O conteúdo é HTML com
+  // placeholders Go (`{{ .TokenHash }}`) mais nome, cor e logo da instalação,
+  // que já aparecem na tela de login sem sessão. Sem esta linha o `proxy`
+  // devolve 307 para `/login` e o GoTrue manda a TELA DE LOGIN dentro do
+  // e-mail — o modo de falha exato que esta rota existe para acabar.
+  //
+  // Âncorado nos dois nomes: `/^\/email-templates\//` deixaria qualquer
+  // sub-path futuro nascer público de carona.
+  /^\/email-templates\/(confirmation|recovery)$/,
   // Documentos legais. O checkbox obrigatório de `/onboarding/welcome` linka os
   // dois, e o aceite acontece antes de a pessoa ter qualquer coisa no sistema —
   // exigir sessão para LER o que se está aceitando inverte a ordem. Âncorado nos

--- a/lib/email/templates/acesso-gotrue.test.ts
+++ b/lib/email/templates/acesso-gotrue.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { PUBLIC_PATHS } from "@/lib/auth/public-paths";
+import type { MarcaDeSaida } from "@/lib/branding/saida";
+import {
+  MODELOS_DE_ACESSO,
+  assuntoDoModelo,
+  montarTemplateDeAcesso,
+} from "@/lib/email/templates/acesso-gotrue";
+
+/**
+ * O CONTRATO DOS MOLDES DE E-MAIL DO GoTrue.
+ *
+ * Cada caso aqui prende um modo de falha que já aconteceu numa instalação real
+ * — nenhum é zelo preventivo.
+ */
+
+const MARCA: MarcaDeSaida = {
+  nome: 'Acme "Test" & Cia',
+  logoUrl: "https://exemplo.test/logo.png",
+  accent: "#506d48",
+  accentFg: "#ffffff",
+  origens: { nome: "instalacao", cor: "instalacao" },
+};
+
+describe("moldes de acesso do GoTrue", () => {
+  for (const modelo of MODELOS_DE_ACESSO) {
+    describe(modelo, () => {
+      const html = montarTemplateDeAcesso(modelo, MARCA);
+
+      it("linka com token_hash — o formato que NÃO depende de cookie", () => {
+        // O modelo padrão do GoTrue usa `{{ .ConfirmationURL }}`, que leva ao
+        // `/auth/v1/verify` e devolve um `code` PKCE. O verificador vive num
+        // cookie SameSite=Strict, que não viaja num clique vindo de webmail —
+        // a conta confirma e a sessão nunca fecha.
+        expect(html).toContain("{{ .TokenHash }}");
+        expect(html).not.toContain("{{ .ConfirmationURL }}");
+      });
+
+      it("usa `&`, nunca `?` — `.RedirectTo` já traz `?type=`", () => {
+        // Com `?` o separador duplica (`...?type=signup?token_hash=...`) e o
+        // parser de URL do browser para de reconhecer `token_hash`.
+        expect(html).toContain("{{ .RedirectTo }}&token_hash={{ .TokenHash }}");
+        expect(html).not.toContain("{{ .RedirectTo }}?token_hash");
+      });
+
+      it("não sobrou placeholder de renderização por script", () => {
+        // `__APP_NAME__` e `__ACCENT__` são do caminho do `marca-emails.sh`.
+        // Aqui a marca já vem resolvida; um `__` sobrando iria literal para a
+        // caixa de entrada do cliente.
+        expect(html).not.toMatch(/__[A-Z_]+__/);
+      });
+
+      it("escapa a marca — ela vem de texto livre no banco", () => {
+        expect(html).toContain("Acme &quot;Test&quot; &amp; Cia");
+        expect(html).not.toContain('Acme "Test" & Cia');
+      });
+
+      it("o assunto leva a marca — senão chega em inglês, do padrão do GoTrue", () => {
+        expect(assuntoDoModelo(modelo, MARCA)).toContain(MARCA.nome);
+      });
+    });
+  }
+
+  it("sem logo configurado, nada é desenhado no lugar", () => {
+    const html = montarTemplateDeAcesso("confirmation", { ...MARCA, logoUrl: null });
+    expect(html).not.toContain("<img");
+  });
+
+  it("a rota dos moldes é PÚBLICA — senão o GoTrue recebe a tela de login", () => {
+    // Este é o caso mais caro do arquivo. Quem busca é o GoTrue, que não tem
+    // sessão nossa: sem entrada em PUBLIC_PATHS o proxy responde 307 para
+    // `/login`, o GoTrue segue o redirect, recebe o HTML da tela de login e
+    // manda ISSO para a caixa de entrada. Medido em 2026-09-09 com um caminho
+    // de arquivo; o Gmail marcou como phishing.
+    const publico = (p: string) => PUBLIC_PATHS.some((re) => re.test(p));
+    for (const modelo of MODELOS_DE_ACESSO) {
+      expect(publico(`/email-templates/${modelo}`)).toBe(true);
+    }
+    // E não abre a porta para sub-path futuro nascer público de carona.
+    expect(publico("/email-templates/qualquer-outra")).toBe(false);
+    expect(publico("/email-templates/confirmation/x")).toBe(false);
+  });
+});

--- a/lib/email/templates/acesso-gotrue.ts
+++ b/lib/email/templates/acesso-gotrue.ts
@@ -1,0 +1,119 @@
+import { NEUTROS_DE_SAIDA, type MarcaDeSaida } from "@/lib/branding/saida";
+
+/**
+ * Os dois e-mails de ACESSO — confirmar conta e redefinir senha — no formato
+ * que o GoTrue renderiza.
+ *
+ * ─── POR QUE ISTO É DIFERENTE DE `invite.ts` ────────────────────────────────
+ *
+ * O convite de time é montado e ENVIADO por nós. Estes dois não: quem os
+ * renderiza e envia é o GoTrue, um processo de terceiro. Nós só entregamos o
+ * MOLDE, e ele preenche `{{ .RedirectTo }}` e `{{ .TokenHash }}` na hora do
+ * envio. Por isso a saída aqui é uma string de template Go, não um e-mail
+ * pronto — e por isso as chaves duplas NÃO passam por escape: elas são sintaxe
+ * do renderizador, não dado.
+ *
+ * ─── POR QUE `token_hash` E NÃO `{{ .ConfirmationURL }}` ────────────────────
+ *
+ * O modelo PADRÃO do GoTrue linka para `/auth/v1/verify`, que devolve um `code`
+ * PKCE. O verificador desse code vive num cookie `SameSite=Strict`
+ * (`lib/supabase/server.ts`), e clique vindo de webmail é navegação
+ * cross-site: o cookie não viaja, `exchangeCodeForSession` falha, e a conta é
+ * confirmada sem que a sessão feche. `token_hash` não depende de cookie nenhum.
+ *
+ * Medido numa instalação self-hosted em 2026-09-10: com o modelo padrão, o
+ * `api_audit_log` registrava `auth.email_link_rejected` com
+ * `"PKCE code verifier not found in storage"`; com estes moldes, o mesmo fluxo
+ * fecha a sessão.
+ *
+ * ─── `&`, NUNCA `?` ────────────────────────────────────────────────────────
+ *
+ * `.RedirectTo` já chega com `?type=` embutido — `signUp.ts` e
+ * `requestPasswordReset.ts` o anexam de propósito, porque é o único jeito de o
+ * `type` sobreviver ao hop pelo GoTrue no outro formato. Um `?` aqui duplicaria
+ * o separador e o parser de URL do browser pararia de reconhecer `token_hash`.
+ */
+
+export type ModeloDeAcesso = "confirmation" | "recovery";
+
+export const MODELOS_DE_ACESSO: readonly ModeloDeAcesso[] = ["confirmation", "recovery"];
+
+/** O texto de cada modelo. Assunto entra no `GOTRUE_MAILER_SUBJECTS_*`. */
+const COPIA: Record<ModeloDeAcesso, { assunto: (marca: string) => string; titulo: string; corpo: (marca: string) => string; botao: string; rodape: string }> = {
+  confirmation: {
+    assunto: (marca) => `Confirme seu e-mail · ${marca}`,
+    titulo: "Confirme seu e-mail",
+    corpo: (marca) =>
+      `Sua conta no ${marca} está quase pronta. Clique no botão abaixo para confirmar seu e-mail e ativar sua conta.`,
+    botao: "Confirmar e-mail",
+    rodape: "Se você não criou esta conta, ignore este e-mail.",
+  },
+  recovery: {
+    assunto: (marca) => `Redefinir sua senha · ${marca}`,
+    titulo: "Redefinir sua senha",
+    corpo: (marca) =>
+      `Recebemos um pedido para redefinir a senha da sua conta no ${marca}. Clique no botão abaixo para escolher uma nova.`,
+    botao: "Definir nova senha",
+    rodape:
+      "Se não foi você quem pediu, ignore este e-mail — sua senha continua a mesma.",
+  },
+};
+
+export function assuntoDoModelo(modelo: ModeloDeAcesso, marca: MarcaDeSaida): string {
+  return COPIA[modelo].assunto(marca.nome);
+}
+
+/**
+ * O molde, com a marca da INSTALAÇÃO já aplicada.
+ *
+ * Estilo inline apenas e zero asset externo além do logo, pelas mesmas razões
+ * de `invite.ts` — inclusive a dimensão no atributo, que o Outlook desktop
+ * exige porque descarta `height` de style em imagem.
+ */
+export function montarTemplateDeAcesso(modelo: ModeloDeAcesso, marca: MarcaDeSaida): string {
+  const t = COPIA[modelo];
+  const nome = escapeHtml(marca.nome);
+
+  const logo = marca.logoUrl
+    ? `<p style="margin:0 0 24px"><img src="${escapeHtml(marca.logoUrl)}" alt="${nome}" height="40" style="height:40px;width:auto;max-width:200px;border:0;display:block"></p>`
+    : "";
+
+  // As chaves duplas ficam CRUAS de propósito: o GoTrue as substitui.
+  const destino = "{{ .RedirectTo }}&token_hash={{ .TokenHash }}";
+
+  return `<!doctype html>
+<html lang="pt-BR">
+<body style="margin:0;padding:0;background:${NEUTROS_DE_SAIDA.fundo};font-family:system-ui,-apple-system,Segoe UI,sans-serif;color:${NEUTROS_DE_SAIDA.texto}">
+  <div style="max-width:560px;margin:0 auto;padding:32px 24px">
+    ${logo}
+    <h1 style="font-size:22px;line-height:1.3;margin:0 0 16px;color:${NEUTROS_DE_SAIDA.texto}">
+      ${escapeHtml(t.titulo)}
+    </h1>
+    <p style="margin:0 0 16px;font-size:15px;line-height:1.5">
+      ${escapeHtml(t.corpo(marca.nome))}
+    </p>
+    <p style="margin:24px 0">
+      <a href="${destino}" style="display:inline-block;padding:12px 24px;background:${marca.accent};color:${marca.accentFg};border-radius:6px;text-decoration:none;font-weight:600">
+        ${escapeHtml(t.botao)}
+      </a>
+    </p>
+    <p style="margin:0 0 8px;font-size:13px;color:${NEUTROS_DE_SAIDA.suave}">
+      Ou copie e cole este link no navegador:<br>
+      <span style="word-break:break-all;color:${marca.accent}">${destino}</span>
+    </p>
+    <p style="margin:24px 0 0;font-size:13px;color:${NEUTROS_DE_SAIDA.suave}">
+      ${escapeHtml(t.rodape)}
+    </p>
+  </div>
+</body>
+</html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/lib/i18n/dicionario.ts
+++ b/lib/i18n/dicionario.ts
@@ -5411,6 +5411,17 @@ export const DICIONARIO: Traducoes = {
   },
   "503 — Em manutenção": { es: "503 — En mantenimiento" },
   "Voltamos em alguns minutos.": { es: "Volvemos en unos minutos." },
+  // A recusa por modelo padrão passou a nomear as DUAS topologias: na nuvem o
+  // conserto é o script; num Supabase próprio ele não tem Management API para
+  // usar, e o caminho são as rotas do app.
+  "Este link veio do modelo de e-mail padrão do Supabase, que não fecha o acesso nesta instalação — pedir outro link não resolve. Quem administra o sistema precisa configurar os modelos de e-mail: na nuvem do Supabase, com ":
+    {
+      es: "Este enlace vino de la plantilla de correo predeterminada de Supabase, que no cierra el acceso en esta instalación — pedir otro enlace no lo resuelve. Quien administra el sistema necesita configurar las plantillas de correo: en la nube de Supabase, con ",
+    },
+  "; num Supabase próprio, apontando GOTRUE_MAILER_TEMPLATES_* para as rotas /email-templates/ do app.":
+    {
+      es: "; en un Supabase propio, apuntando GOTRUE_MAILER_TEMPLATES_* a las rutas /email-templates/ de la app.",
+    },
   "Conta suspensa": { es: "Cuenta suspendida" },
   "Sua conta está suspensa. Entre em contato com": {
     es: "Tu cuenta está suspendida. Contacta a",
@@ -5887,9 +5898,6 @@ export const DICIONARIO: Traducoes = {
   },
   "Sua conta foi confirmada, mas o convite não vale mais — ele expirou ou foi emitido para outro e-mail. Peça um novo a quem te convidou. Não criamos uma empresa nova para você, porque não era isso que você estava fazendo.": {
     es: "Tu cuenta fue confirmada, pero la invitación ya no vale — venció o fue emitida para otro correo. Pide una nueva a quien te invitó. No creamos una empresa nueva para ti, porque no era eso lo que estabas haciendo.",
-  },
-  "Este link veio do modelo de e-mail padrão do Supabase, que não fecha o acesso nesta instalação — pedir outro link não resolve. Quem administra o sistema precisa configurar os e-mails de acesso (": {
-    es: "Este enlace vino de la plantilla de correo predeterminada de Supabase, que no cierra el acceso en esta instalación — pedir otro enlace no resuelve. Quien administra el sistema necesita configurar los correos de acceso (",
   },
   ", no kit de instalação).": { es: ", en el kit de instalación)." },
   "Sua conta foi confirmada, mas houve um erro ao preparar seu ambiente. Tente entrar novamente em instantes.": {


### PR DESCRIPTION
Epic de origem: **EPIC-01 — Auth & App Shell**.

Numa instalação com **Supabase self-hosted** não existe caminho suportado para
configurar os e-mails de acesso — e a consequência não é estética: o convite não
fecha. Achado instalando numa VPS e seguindo esta documentação do começo ao fim.

## O buraco: um ambiente que nenhum dos dois caminhos cobre

| Ambiente | Como o molde chega ao GoTrue | Estado |
|---|---|---|
| Dev local | `supabase/config.toml` → `content_path` (a CLI resolve) | funciona |
| Supabase Cloud | `marca-emails.sh` → `PATCH` na Management API | funciona |
| **Self-hosted em docker** | **nenhum dos dois existe** | **quebrado** |

É por isso que passou despercebido: no dev local passa, na nuvem passa.

## Por que quebra o acesso, e não só a marca

O modelo **padrão** do GoTrue linka para `/auth/v1/verify`, que devolve um
`code` PKCE. O verificador desse code vive num cookie `SameSite=Strict`
(`lib/supabase/server.ts`), e clique vindo de webmail é navegação cross-site: o
cookie não viaja, `exchangeCodeForSession` falha, e a conta é confirmada **sem
que a sessão feche**. A pessoa entra pela senha e fica sem organização e sem
menu.

Na instalação medida:

```
12:20:49  email_confirmed_at gravado          ← o GoTrue confirmou
12:20:50  auth.email_link_rejected            "PKCE code verifier not found in storage"
12:21:36  auth.login_success                  entra, sem organização, sem menu
```

## E a documentação levava para a receita que não funciona

`GOTRUE_MAILER_TEMPLATES_*` **só aceita URL http(s)**. `supabase/auth` v2.196.0,
`internal/mailer/templatemailer/template.go`:

```go
url := getEmailContentConfig(&cfg.Mailer.Templates, typ, "")
if !strings.HasPrefix(url, "http") {
    url = cfg.SiteURL + url          // ← linha 456
}
req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
```

Um caminho de arquivo **não falha** — ele é colado no fim do `SiteURL` e
buscado. Seguindo `docs/deploy-selfhost/README.md` ao pé da letra, o GoTrue
buscou `https://crm.exemplo/opt/deskcomm/emails/confirmation.html`, recebeu o
HTML da tela de login e **mandou isso para a caixa de entrada**. O Gmail marcou
como phishing.

A doc oficial concorda: `GOTRUE_MAILER_TEMPLATES_*` são *"template URLs"*, e os
knobs irmãos aparecem como *"Email-template **HTTP** loading"*.

Três lugares orientavam o caminho errado, todos corrigidos aqui:

```
docs/deploy-selfhost/README.md          a receita inteira
hostgator-setup-kit/marca-emails.sh     dois comentários e a mensagem do --render-em
hostgator-setup-kit/install.sh          a afirmação de que "o banco não alcança" a cor
```

## O conserto: o app serve o molde

`GET /email-templates/{confirmation,recovery}` devolve o molde com a marca
resolvida **do banco**. Aponte o GoTrue para lá:

```bash
GOTRUE_MAILER_TEMPLATES_CONFIRMATION=https://SEU_DOMINIO/email-templates/confirmation
GOTRUE_MAILER_TEMPLATES_RECOVERY=https://SEU_DOMINIO/email-templates/recovery
```

Dois ganhos numa peça só:

1. **O link passa a usar `token_hash`**, que não depende de cookie nenhum.
2. **A marca passa a seguir o banco.** O `marca-emails.sh` lê o `.env`, então
   trocar nome ou cor em **Configurações › Marca** não reescrevia os e-mails de
   acesso — buraco que `docs/white-label.en.md` já documentava. Servindo daqui, o
   GoTrue re-busca sozinho a cada `GOTRUE_MAILER_TEMPLATE_MAX_AGE` (10 min): a
   troca chega sem reiniciar nada e sem rodar script.

**Nada muda para quem não apontar**, e nada muda na nuvem — lá o caminho continua
sendo a Management API.

### Duas decisões que merecem revisão

**A rota é pública.** Quem a busca é o GoTrue, que não tem — nem pode ter —
sessão nossa. Sem entrada em `PUBLIC_PATHS` o proxy responde 307 para `/login` e
o GoTrue manda a tela de login dentro do e-mail: o modo de falha exato que a
rota existe para acabar. O conteúdo é HTML com placeholders Go mais nome, cor e
logo — que já aparecem no `/login` sem sessão. Ancorada nos dois nomes, para
sub-path futuro não nascer público de carona (há teste).

**Sem rate limit, de propósito.** A regra da casa é que rota pública tem teto;
aqui ele seria contraproducente. Quem consome é o GoTrue, no instante em que
monta o e-mail, e um 429 o faz cair no modelo padrão — recriando o defeito, e só
para quem estivesse criando conta naquele minuto. Sem segredo, sem efeito
colateral, uma linha lida. O `Cache-Control` é a proteção proporcional.

## O que eu deixei de fora, e por quê

O invariante 6(c) pede que falta de configuração vire **item de inbox**, não
falha muda. Fui implementar e medi: `app/api/v1/ai/inbox/route.ts` filtra
`.eq("organization_id", org.orgId)`, e `/auth/confirm` não tem organização para
atribuir — um item com `organization_id` nulo **nunca apareceria**. Construir
assim criaria a falha muda que este PR combate. Fica como trabalho separado.

O que dá para fazer sem isso, e foi feito: a recusa do `/login` nomeava só o
`marca-emails.sh` — que num Supabase próprio não tem Management API para usar.
Ela mandava a pessoa pedir ao administrador algo que o administrador não
consegue fazer. Agora nomeia as duas topologias.

## Evidências

```
pnpm typecheck        limpo
pnpm lint             0 erros (346 avisos pré-existentes)
pnpm test:unit        Test Files 4 failed | 744 passed (748)
                      Tests      6 failed | 8004 passed | 1 expected fail
pnpm test:db          Test Files 185 passed (185)
                      Tests      1470 passed | 1 expected fail | 1 skipped
pnpm test:shell       1 falha
pnpm build            passou · /email-templates/[modelo] compilada
```

**Os vermelhos não são deste PR** — provados rodando em `origin/main` sem
nenhuma mudança:

```
$ git checkout --detach origin/main
$ npx vitest run tests/unit/lgpd-pdf-{meet,replies}.test.ts \
    tests/unit/rascunho-superado-nao-e-regravado.test.ts \
    tests/unit/suporte-cobertura-de-efeitos.test.ts
 Test Files  4 failed (4) · Tests 6 failed | 9 passed

$ pnpm test:shell
  ✗ .env continua 600 (só o dono lê)   →  FALHOU — 1 prova(s)
```

Separador de caminho e permissão de arquivo no Windows; no CI, Linux, passam.

**Testes novos (17):** o contrato dos moldes — `token_hash` e nunca
`{{ .ConfirmationURL }}`, `&` e nunca `?` (com `?` o separador duplica e o
parser de URL para de reconhecer o parâmetro), nenhum `__PLACEHOLDER__`
sobrando, marca escapada — e a rota, incluindo o caso que mais importa: que
`/email-templates/<modelo>` **está** em `PUBLIC_PATHS` e que
`/email-templates/qualquer-outra` **não** está.

**`pnpm test:e2e` não rodou** (contribuição de fora, conforme o
`CONTRIBUTING.md`). O que foi provado pela tela numa instalação real: com os
moldes servidos por HTTP, o e-mail de recuperação chega com a marca, o clique
**vindo do Gmail** fecha a sessão, e o `api_audit_log` passa de
`auth.email_link_rejected` para `auth.password_reset_completed` em 26 segundos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
