### PR TITLE
test(e2e): a espera que faltava na moeda, e três comentários que citavam linha vencida (@IanCouto, do #660)

### DIFF
--- a/tests/e2e/agenda-kit-visual.spec.ts
+++ b/tests/e2e/agenda-kit-visual.spec.ts
@@ -683,15 +683,17 @@ test.describe("kit visual da Agenda", () => {
     await expect(page.getByTestId("grade-da-agenda")).toBeVisible({ timeout: ESPERA });
     await page.screenshot({ path: "evidence/calendario/kit-visual-celular.png", fullPage: true });
 
-    // A página NUNCA rola na horizontal: `html, body` têm `overflow-x: hidden`,
+    // A página NUNCA rola na horizontal: `html, body` têm `overflow-x: clip`,
     // então uma grade larga demais não ganharia barra — sumiria pela direita.
     const estouro = await page.evaluate(
       // ⚠️ `body.scrollWidth`, NÃO `documentElement`. `app/globals.css` põe
-      // `overflow-x: hidden` em `html` E em `body` (linhas 422 e 440), e sob isso
-      // o `scrollWidth` do `documentElement` é GRAMPEADO no `clientWidth`: a
-      // conta dá zero mesmo com um filho de 3000px dentro. Medido com o chromium
-      // do repo, viewport 390x844, filho de 3000px — `visible` → 2610,
-      // `hidden` → 0, e `body.scrollWidth` = 3000 nos DOIS casos.
+      // `overflow-x: clip` em `html` E em `body` (com `hidden` ANTES, como reserva
+      // para motor sem `clip` — Safari < 16). Sob `hidden` puro, que quebra
+      // o sticky da barra), o `scrollWidth` do `documentElement` era GRAMPEADO
+      // no `clientWidth`: a conta dava zero mesmo com um filho de 3000px.
+      // Medido com o chromium do repo, viewport 390x844, filho de 3000px —
+      // `visible` → 2610, `hidden` → 0, e `body.scrollWidth` = 3000 nos DOIS
+      // casos. A medida fica no `body` para não voltar a ser incapaz de falhar.
       //
       // A asserção existia e era incapaz de falhar. Trocar a medida é o conserto;
       // o caso de sabotagem ao lado é o que prova que a nova consegue.

--- a/tests/e2e/agenda-tela-do-produto.spec.ts
+++ b/tests/e2e/agenda-tela-do-produto.spec.ts
@@ -227,11 +227,13 @@ test.describe("a Agenda como o dono do produto a usa", () => {
 
     const estouro = await page.evaluate(
       // ⚠️ `body.scrollWidth`, NÃO `documentElement`. `app/globals.css` põe
-      // `overflow-x: hidden` em `html` E em `body` (linhas 422 e 440), e sob isso
-      // o `scrollWidth` do `documentElement` é GRAMPEADO no `clientWidth`: a
-      // conta dá zero mesmo com um filho de 3000px dentro. Medido com o chromium
-      // do repo, viewport 390x844, filho de 3000px — `visible` → 2610,
-      // `hidden` → 0, e `body.scrollWidth` = 3000 nos DOIS casos.
+      // `overflow-x: clip` em `html` E em `body` (com `hidden` ANTES, como reserva
+      // para motor sem `clip` — Safari < 16). Sob `hidden` puro, que quebra
+      // o sticky da barra), o `scrollWidth` do `documentElement` era GRAMPEADO
+      // no `clientWidth`: a conta dava zero mesmo com um filho de 3000px.
+      // Medido com o chromium do repo, viewport 390x844, filho de 3000px —
+      // `visible` → 2610, `hidden` → 0, e `body.scrollWidth` = 3000 nos DOIS
+      // casos. A medida fica no `body` para não voltar a ser incapaz de falhar.
       //
       // A asserção existia e era incapaz de falhar. Trocar a medida é o conserto;
       // o caso de sabotagem ao lado é o que prova que a nova consegue.

--- a/tests/e2e/moeda-da-organizacao.spec.ts
+++ b/tests/e2e/moeda-da-organizacao.spec.ts
@@ -43,6 +43,14 @@ async function loginAdmin(page: Page): Promise<void> {
 /** Código único por execução — reruns num banco compartilhado ficam verdes. */
 const SUFIXO = Date.now().toString(36);
 
+// Dois casos, cada um com `loginComoAdmin`. O helper espera a janela TOTP
+// virar quando o código da suíte já foi usado — e essa espera sozinha come os
+// 30 s do teto global. Medido no CI: o primeiro caso passou em 7,9 s; o segundo
+// estourou 30 s esperando a linha do produto, enquanto o `afterEach` já tinha
+// navegado de volta para Configurações. Mesmo padrão de `navegacao.spec.ts` e
+// `prova-painel-provedores.spec.ts`.
+test.describe.configure({ timeout: 90_000 });
+
 test.describe("moeda da organização", () => {
   test.afterEach(async ({ page }) => {
     // Devolve o padrão para não vazar estado a outros specs do mesmo banco.
@@ -95,16 +103,19 @@ test.describe("moeda da organização", () => {
     await expect(page.getByText(/organiza..o atualizada/i)).toBeVisible({ timeout: 10_000 });
 
     await page.goto("/app/products");
+    await expect(page.getByTestId("tela-produtos")).toBeVisible();
     await page.getByTestId("novo-produto").click();
+    await expect(page.getByTestId("form-produto")).toBeVisible();
 
     const codigo = `E2E-MXN-${SUFIXO}`;
     await page.getByTestId("produto-codigo").fill(codigo);
     await page.getByLabel(/^Nome$/).fill("Producto de prueba MXN");
     await page.getByTestId("produto-preco").fill("249,90");
     await page.getByTestId("salvar-produto").click();
+    await expect(page.getByText(/produto cadastrado/i)).toBeVisible({ timeout: 15_000 });
 
     const linha = page.getByTestId(`produto-${codigo}`);
-    await expect(linha).toBeVisible({ timeout: 10_000 });
+    await expect(linha).toBeVisible({ timeout: 15_000 });
 
     // ⚠️ A ASSERÇÃO É O NÚMERO, não a presença da linha. `comoMoeda()` (o
     // ajudante que este PR removeu) mostraria "MXN 249,90" aqui — os mesmos

--- a/tests/e2e/navegacao.spec.ts
+++ b/tests/e2e/navegacao.spec.ts
@@ -54,11 +54,13 @@ const sidebar = (page: Page) => page.getByRole("navigation", { name: "Navegaçã
 async function expectSemOverflowHorizontal(page: Page, contexto: string): Promise<void> {
   const m = await page.evaluate(() => ({
     // ⚠️ `body.scrollWidth`, NÃO `documentElement`. `app/globals.css` põe
-    // `overflow-x: hidden` em `html` E em `body` (linhas 422 e 440), e sob isso
-    // o `scrollWidth` do `documentElement` é GRAMPEADO no `clientWidth`: a
-    // conta dá zero mesmo com um filho de 3000px dentro. Medido com o chromium
-    // do repo, viewport 390x844, filho de 3000px — `visible` → 2610,
-    // `hidden` → 0, e `body.scrollWidth` = 3000 nos DOIS casos.
+    // `overflow-x: clip` em `html` E em `body` (é `clip` e não `hidden` porque
+    // `hidden` derruba o sticky da barra — ver barra-lateral-nao-flutua).
+    // Com `hidden`, o `scrollWidth` do `documentElement` era GRAMPEADO no
+    // `clientWidth`: a conta dava zero mesmo com um filho de 3000px dentro.
+    // Medido com o chromium do repo, viewport 390x844, filho de 3000px —
+    // `visible` → 2610, `hidden` → 0, e `body.scrollWidth` = 3000 nos DOIS
+    // casos. A medida fica no `body` para não voltar a ser incapaz de falhar.
     //
     // A asserção existia e era incapaz de falhar. Trocar a medida é o conserto;
     // o caso de sabotagem ao lado é o que prova que a nova consegue.


### PR DESCRIPTION
Resgate de duas peças do **PR #660** (@IanCouto), fechado porque o conserto principal já tinha entrado pelo #635 — **convergência independente**: ele e @rafaeskytrabalho acharam o mesmo defeito, diagnosticaram a mesma causa e escreveram a mesma correção, no mesmo dia, sem ver o trabalho um do outro.

Estas duas peças a `main` **não tinha**, e elas são só dele.

## 1. A espera que faltava

`tests/e2e/moeda-da-organizacao.spec.ts` ganha `test.describe.configure({ timeout: 90_000 })` e três esperas explícitas.

A `main` estava com **zero** `describe.configure` nesse arquivo (conferido com controle positivo). Ele mediu a instabilidade no CI: *"o primeiro caso passou em 7,9 s; o segundo estourou 30 s"*.

**Não reproduzi a instabilidade** — a medição é dele, e está creditada como dele.

## 2. Três comentários citando linha vencida

`agenda-kit-visual:690`, `agenda-tela-do-produto:230` e `navegacao:57` diziam `overflow-x: hidden` e citavam *"linhas 422 e 440"* — que hoje são **674** e **697**. Prosa de estado vencida, do tipo que faz a próxima pessoa medir contra a régua errada.

## Uma afirmação dele foi corrigida ANTES de entrar

Os comentários chamavam `hidden` de **"proibido"**.

Na `main` ele existe **de propósito**, antes do `clip`, como reserva para motor que não conhece `clip` (Safari < 16) — está escrito em `app/globals.css:671-673`:

```css
/* A linha `hidden` fica como reserva para motor que não conhece `clip`
   (Safari < 16): lá o comportamento segue exatamente o de hoje —
   protegido, sem sticky. */
overflow-x: hidden;
overflow-x: clip;
```

Trazer o texto como estava importaria uma afirmação **falsa** para dentro de três arquivos. E prosa errada é pior que prosa ausente: ela faz a próxima pessoa parar de olhar, porque o argumento parece fechado. Reescrito para descrever o que o código faz.

## Gates

```
pnpm typecheck                             exit 0
vitest e2e-cobertura-completa.test.ts      exit 0   Tests 4 passed (4)
```

**NÃO MEDIDO:** não rodei as specs e2e em si — quem as roda é o job `e2e`, obrigatório. E não reproduzi a instabilidade que a peça 1 conserta; a medição dela é do autor.

Só testes e comentários — nenhum comportamento de produto muda, nenhum fragmento devido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)