### PR TITLE
fix(worker): o laço rápido do drain volta a montar o admin client (@ragaspaleilao, do #643)

### DIFF
--- a/.changes/worker-drain-hyphenate-esm-cjs.md
+++ b/.changes/worker-drain-hyphenate-esm-cjs.md
@@ -1,0 +1,9 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O laço rápido do worker volta a montar o admin client
+---
+
+`@react-pdf/hyphenate` é ESM puro e não expunha a condição `require` no seu `exports`. Como o worker roda via `tsx` (CommonJS), qualquer import de `@react-pdf/renderer` (usado pela exportação de dados LGPD) derrubava `carregarDeps()` do drain loop com `ERR_PACKAGE_PATH_NOT_EXPORTED` — e como `register-handlers.ts` registra os 12 handlers do `event_log` num só import chain, isso tirava o laço rápido de TODOS eles, não só do LGPD, caindo pro cron de 1×/min como única rede de segurança.
+
+Patch (`patches/@react-pdf__hyphenate.patch`) acrescenta a condição `require` ao exports map — Node 22.12+/24 já sabe carregar ESM via `require()` quando o mapa permite. Provado no worker real: o warning "event-log drain OFF" some do log de boot.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM node:22-alpine AS deps
 WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@9.15.9 --activate
 COPY package.json pnpm-lock.yaml ./
+COPY patches ./patches
 RUN pnpm install --frozen-lockfile
 
 # ---- build: gera .next/standalone ----

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -16,6 +16,7 @@ ENV APP_VERSION=$APP_VERSION
 RUN corepack enable && corepack prepare pnpm@9.15.9 --activate
 
 COPY package.json pnpm-lock.yaml ./
+COPY patches ./patches
 RUN pnpm install --frozen-lockfile
 
 COPY . .

--- a/package.json
+++ b/package.json
@@ -134,6 +134,9 @@
       "fast-uri": "^3.1.7",
       "qs": "^6.16.0",
       "browserslist": "^4.28.8"
+    },
+    "patchedDependencies": {
+      "@react-pdf/hyphenate": "patches/@react-pdf__hyphenate.patch"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -134,9 +134,6 @@
       "fast-uri": "^3.1.7",
       "qs": "^6.16.0",
       "browserslist": "^4.28.8"
-    },
-    "patchedDependencies": {
-      "@react-pdf/hyphenate": "patches/@react-pdf__hyphenate.patch"
     }
   }
 }

--- a/patches/@react-pdf__hyphenate.patch
+++ b/patches/@react-pdf__hyphenate.patch
@@ -1,0 +1,20 @@
+diff --git a/package.json b/package.json
+index 477fe06e7938a695df193bb1af1d70880078ffad..eec05990630d10c1c22ae33c420dbc9199c093ca 100644
+--- a/package.json
++++ b/package.json
+@@ -11,11 +11,13 @@
+   "exports": {
+     ".": {
+       "types": "./lib/index.d.ts",
+-      "import": "./lib/index.js"
++      "import": "./lib/index.js",
++      "require": "./lib/index.js"
+     },
+     "./*": {
+       "types": "./lib/*.d.ts",
+-      "import": "./lib/*.js"
++      "import": "./lib/*.js",
++      "require": "./lib/*.js"
+     }
+   },
+   "typesVersions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,11 @@ overrides:
   qs: ^6.16.0
   browserslist: ^4.28.8
 
+patchedDependencies:
+  '@react-pdf/hyphenate':
+    hash: 7zbg3hcwdkwwiwo2qqqwdmolwi
+    path: patches/@react-pdf__hyphenate.patch
+
 importers:
 
   .:
@@ -6791,7 +6796,7 @@ snapshots:
       is-url: 1.2.4
       pdfkit: 0.20.1
 
-  '@react-pdf/hyphenate@0.1.0':
+  '@react-pdf/hyphenate@0.1.0(patch_hash=7zbg3hcwdkwwiwo2qqqwdmolwi)':
     dependencies:
       hyphen: 1.6.6
 
@@ -6870,7 +6875,7 @@ snapshots:
   '@react-pdf/textkit@7.0.1':
     dependencies:
       '@react-pdf/fns': 3.1.3
-      '@react-pdf/hyphenate': 0.1.0
+      '@react-pdf/hyphenate': 0.1.0(patch_hash=7zbg3hcwdkwwiwo2qqqwdmolwi)
       bidi-js: 1.0.3
       unicode-properties: 1.4.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,6 @@ overrides:
   qs: ^6.16.0
   browserslist: ^4.28.8
 
-patchedDependencies:
-  '@react-pdf/hyphenate':
-    hash: 7zbg3hcwdkwwiwo2qqqwdmolwi
-    path: patches/@react-pdf__hyphenate.patch
-
 importers:
 
   .:
@@ -6796,7 +6791,7 @@ snapshots:
       is-url: 1.2.4
       pdfkit: 0.20.1
 
-  '@react-pdf/hyphenate@0.1.0(patch_hash=7zbg3hcwdkwwiwo2qqqwdmolwi)':
+  '@react-pdf/hyphenate@0.1.0':
     dependencies:
       hyphen: 1.6.6
 
@@ -6875,7 +6870,7 @@ snapshots:
   '@react-pdf/textkit@7.0.1':
     dependencies:
       '@react-pdf/fns': 3.1.3
-      '@react-pdf/hyphenate': 0.1.0(patch_hash=7zbg3hcwdkwwiwo2qqqwdmolwi)
+      '@react-pdf/hyphenate': 0.1.0
       bidi-js: 1.0.3
       unicode-properties: 1.4.1
 

--- a/tests/unit/drain-loop-carrega-deps-sob-tsx.test.ts
+++ b/tests/unit/drain-loop-carrega-deps-sob-tsx.test.ts
@@ -30,6 +30,18 @@ const MODULOS = [
   "@/lib/event-log/register-handlers",
 ] as const;
 
+/**
+ * O gerador de PDF saiu do caminho do laço (virou `await import` dentro da
+ * função, em `workers/lgpd-export-worker.ts`), e por isso os três acima
+ * resolveriam mesmo SEM o patch em `patches/@react-pdf__hyphenate.patch`.
+ *
+ * Mas o patch continua sendo o que faz a exportação de LGPD funcionar de
+ * verdade: sem ele, `renderLgpdPdf` falha na HORA DA CHAMADA, com o titular
+ * esperando o arquivo. Este módulo está aqui para que tirar o patch fique
+ * vermelho em algum lugar — e no lugar certo, separado do laço.
+ */
+const MODULO_TARDIO = "@/lib/lgpd/pdf-renderer";
+
 function importaSobTsx(modulo: string): { ok: boolean; saida: string } {
   const script = `import(${JSON.stringify(modulo)}).then(()=>process.exit(0)).catch(e=>{console.error(String(e&&e.message||e));process.exit(1)})`;
   try {
@@ -57,4 +69,9 @@ describe("o laço rápido do event_log carrega as dependências sob tsx", () => 
       expect(r.ok, `não resolveu sob tsx:\n${r.saida}`).toBe(true);
     });
   }
+
+  it(`${MODULO_TARDIO} resolve sob tsx (o import tardio do worker de LGPD)`, () => {
+    const r = importaSobTsx(MODULO_TARDIO);
+    expect(r.ok, `não resolveu sob tsx:\n${r.saida}`).toBe(true);
+  });
 });

--- a/tests/unit/drain-loop-carrega-deps-sob-tsx.test.ts
+++ b/tests/unit/drain-loop-carrega-deps-sob-tsx.test.ts
@@ -1,0 +1,60 @@
+/**
+ * O laço rápido do `event_log` carrega três módulos por `await import`, e o que
+ * decide se ele vive é a resolução deles **sob `tsx`** — não sob o vitest.
+ *
+ * ⚠️ POR QUE ESTE ARQUIVO ABRE UM PROCESSO FILHO
+ *
+ * O vitest resolve `node_modules` pelo Vite, que honra a condição `import` do
+ * `exports`. O worker de produção roda sob `tsx`, que **não** honra. Foi
+ * exatamente essa diferença que deixou `@react-pdf/hyphenate@0.1.0` quebrar o
+ * laço em produção por 10 dias e três releases, com
+ * `tests/unit/event-log-drain-loop.test.ts` **6/6 verde o tempo todo**.
+ *
+ * Então este teste não pode importar os módulos: ele precisa PEDIR ao `tsx` que
+ * os importe, e olhar o exit code. E prende o CAMINHO (`register-handlers`, que
+ * é quem de fato falhava), não o pacote — o teste do autor prendia
+ * `require("@react-pdf/renderer")`, e o defeito era no subpath `./en-us`.
+ *
+ * Trabalho original de @ragaspaleilao no PR #643.
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const TSX = "node_modules/tsx/dist/cli.mjs";
+
+/** Os três que `carregarDeps()` importa, na ordem em que ela os pede. */
+const MODULOS = [
+  "@/lib/event-log/drain-loop",
+  "@/lib/agent-engine/edge/crm/drain",
+  "@/lib/event-log/register-handlers",
+] as const;
+
+function importaSobTsx(modulo: string): { ok: boolean; saida: string } {
+  const script = `import(${JSON.stringify(modulo)}).then(()=>process.exit(0)).catch(e=>{console.error(String(e&&e.message||e));process.exit(1)})`;
+  try {
+    execFileSync("node", [TSX, "--eval", script], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 60_000,
+      env: { ...process.env, NODE_NO_WARNINGS: "1" },
+    });
+    return { ok: true, saida: "" };
+  } catch (e) {
+    const err = e as { stderr?: string; stdout?: string };
+    return { ok: false, saida: String(err.stderr ?? err.stdout ?? e) };
+  }
+}
+
+describe("o laço rápido do event_log carrega as dependências sob tsx", () => {
+  it("CONTROLE: o tsx está no disco — sem isto, os casos abaixo passariam por não medir nada", () => {
+    expect(existsSync(TSX)).toBe(true);
+  });
+
+  for (const modulo of MODULOS) {
+    it(`${modulo} resolve sob tsx`, () => {
+      const r = importaSobTsx(modulo);
+      expect(r.ok, `não resolveu sob tsx:\n${r.saida}`).toBe(true);
+    });
+  }
+});

--- a/tests/unit/react-pdf-resolve-sob-tsx.test.ts
+++ b/tests/unit/react-pdf-resolve-sob-tsx.test.ts
@@ -1,0 +1,74 @@
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * `@react-pdf/hyphenate@0.1.0` é ESM puro (`"type":"module"`) e seu `exports`
+ * map só definia a condição `import`. Este repo não declara `"type":"module"`
+ * no `package.json` (CommonJS por padrão), e o worker roda via `tsx`
+ * (`Dockerfile.worker`), que resolve `node_modules` com `require()` nativo do
+ * Node — a mesma resolução que `register-handlers.ts` atravessa pra montar o
+ * admin client do drain loop (`lib/event-log/drain-loop.ts`). Sem a condição
+ * `require`, QUALQUER import estático de `@react-pdf/renderer` (usado pelo
+ * PDF de exportação LGPD, `lib/lgpd/pdf-renderer.tsx`) derrubava
+ * `carregarDeps()` com `ERR_PACKAGE_PATH_NOT_EXPORTED` — e como
+ * `register-handlers.ts` registra os 12 handlers num só import chain, UM
+ * pacote quebrado tirava o laço rápido de TODOS, não só do LGPD (medido em
+ * VPS, 2026-09-08: warn "event-log drain OFF" a cada boot do worker,
+ * handlers caindo pro cron de 1×/min).
+ *
+ * O conserto é `patches/@react-pdf__hyphenate.patch`
+ * (`pnpm.patchedDependencies` no `package.json`), que acrescenta a condição
+ * `require` ao `exports` do hyphenate — Node 22.12+/24 já sabe carregar ESM
+ * via `require()` quando o mapa permite (o pacote não usa top-level await).
+ * Confirmado nos dois sentidos: sem o patch este teste falha com o erro
+ * acima; com ele, passa.
+ *
+ * Mesma técnica de `import-puro-sem-env.test.ts` (processo FILHO com `tsx`
+ * de verdade), mas com uma virada que É o ponto do teste: `import()` DINÂMICO
+ * não serve aqui — ele entrega pro loader ESM nativo do Node, que sempre
+ * honra a condição `import` do exports map (nunca quebrou, patch ou não). O
+ * `tsx` intercepta `require()` GLOBALMENTE (o hook em `register-*.cjs`),
+ * inclusive dentro do código-fonte ESM de dependências que ELE PRÓPRIO já
+ * carregou — é assim que a resolução profunda de `@react-pdf/textkit`
+ * atravessa o hook do `tsx` e bate no exports map do hyphenate. Confirmado
+ * manualmente: `import()` no `--eval` passa sempre (falso-negativo); só
+ * `require()` reproduz o defeito e prova o patch.
+ */
+
+const RAIZ = join(__dirname, "..", "..");
+const TSX_CLI = join(RAIZ, "node_modules", "tsx", "dist", "cli.mjs");
+
+function requireNoTsx(modulo: string): { ok: boolean; erro: string } {
+  const script = `try{require(${JSON.stringify(modulo)});console.log("OK")}catch(e){console.log("ERRO:"+String(e&&e.message).split("\\n")[0])}`;
+  try {
+    const saida = execFileSync(process.execPath, [TSX_CLI, "--eval", script], {
+      cwd: RAIZ,
+      encoding: "utf8",
+      timeout: 60_000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { ok: saida.includes("OK"), erro: saida.trim() };
+  } catch (e) {
+    const bruto =
+      typeof e === "object" && e !== null && "stdout" in e
+        ? String((e as { stdout?: unknown }).stdout ?? "")
+        : "";
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, erro: `${bruto} ${msg}`.trim().slice(0, 400) };
+  }
+}
+
+describe("@react-pdf/renderer resolve sob tsx (CommonJS)", () => {
+  it("importa sem ERR_PACKAGE_PATH_NOT_EXPORTED", { timeout: 60_000 }, () => {
+    const r = requireNoTsx("@react-pdf/renderer");
+    expect(
+      r.ok,
+      `@react-pdf/renderer não importou sob tsx — provável regressão do patch ` +
+        `de @react-pdf/hyphenate (a condição "require" do exports map em ` +
+        `patches/@react-pdf__hyphenate.patch). Isto derruba carregarDeps() do ` +
+        `drain loop do worker E a exportação de dados LGPD. Saída: ${r.erro}`,
+    ).toBe(true);
+  });
+});

--- a/workers/lgpd-export-worker.ts
+++ b/workers/lgpd-export-worker.ts
@@ -29,7 +29,23 @@ import { env } from "@/lib/env";
 import { logger } from "@/lib/logger";
 import { collectExportData } from "@/lib/lgpd/export-collector";
 import { findLgpdRequest } from "@/lib/lgpd/repository";
-import { renderLgpdPdf } from "@/lib/lgpd/pdf-renderer";
+// IMPORT TARDIO, e a razão é o laço rápido do `event_log`.
+//
+// `lib/event-log/register-handlers.ts` — cujo próprio comentário pede "keep it
+// lightweight" — importa o handler da LGPD no topo, e ele importava este
+// arquivo, que importava o gerador de PDF, que arrasta `@react-pdf/renderer`
+// inteiro. Resultado: TODA montagem do laço carregava a pilha de PDF só para
+// registrar um handler que, na esmagadora maioria das rodadas, não roda.
+//
+// Isso deixou de ser só desperdício em 29/08, quando `@react-pdf/hyphenate`
+// passou a declarar `exports` sem a condição `require`: sob `tsx` (que é como o
+// worker roda, e diferente do vitest, que resolve pelo Vite) o import falhava,
+// `carregarDeps()` caía no catch, e o laço rápido MORRIA — 10 dias e três
+// releases, com a guarda 6/6 verde.
+//
+// O patch em `patches/` conserta a dependência e continua valendo. Este import
+// tardio conserta a CAUSA: o laço deixa de depender de PDF para existir. Um
+// depende de o pnpm aplicar o patch em todo ambiente; o outro, não.
 import { signPdfPades, isPadesConfigured } from "@/lib/lgpd/pades-signer";
 import {
   EmailNotConfigured,
@@ -151,6 +167,7 @@ export async function processLgpdExport(event: EventRow): Promise<HandlerResult>
 
     // 4. Render PDF (with warning banner when unsigned).
     const padesConfigured = isPadesConfigured();
+    const { renderLgpdPdf } = await import("@/lib/lgpd/pdf-renderer");
     const pdfBuffer = await renderLgpdPdf(data, { unsignedWarning: !padesConfigured });
 
     // 5. Sign (stubbed when key missing).


### PR DESCRIPTION
Reconciliação do **PR #643** (@ragaspaleilao). O commit dele está aqui com a autoria dele — o PR fecha como **`MERGED`**.

O `e2e` dele estava vermelho por um defeito **nosso**, já consertado no #640: abrir conversa por link direto esperava a lista carregar duas vezes. Trazer a `main` para dentro resolve, e ele não precisou fazer nada.

## O defeito que ele achou

`@react-pdf/hyphenate@0.1.0` é `"type":"module"` e o `exports` só tinha a condição `import`. Sob `tsx`, `lib/event-log/register-handlers` deixava de resolver e `carregarDeps()` caía no `catch`: **o laço rápido do `event_log` morre e os 14 handlers caem para o cron de 1×/min.**

Vivo desde `08371da4` (29/ago) e **em três releases** — v1.16.0, v1.16.1 e v1.17.0.

## Por que atravessou os cinco checks obrigatórios

Duas cegueiras somadas:

1. **O vitest resolve `node_modules` pelo Vite**, que honra a condição `import`. O worker roda sob `tsx`, que não honra. Por isso `tests/unit/event-log-drain-loop.test.ts` ficava **6/6 verde com o laço morto em produção**.
2. **Nenhum job inicia a imagem do worker** — só a do app (`imagem-do-app-sobe`). É a issue **#648**.

## O teste — acrescentei um que prende o caminho

O dele prende `require("@react-pdf/renderer")`: o **pacote**. O defeito era no subpath `./en-us`, e quem falhava era `register-handlers`, dois `await import` adiante.

`tests/unit/drain-loop-carrega-deps-sob-tsx.test.ts` abre um processo `tsx` e pede a ele que importe os **três** módulos que `carregarDeps()` importa. Tem controle positivo: se o `tsx` não estiver no disco, o primeiro caso reprova — senão os outros passariam por não medir nada.

**Sabotagem** (revertendo `package.json`/`pnpm-lock.yaml` para os da `main`, ou seja, tirando o patch):

| | previsto | observado |
|---|---|---|
| teste novo (caminho) | 1 vermelho, no `register-handlers` | **`Tests 1 failed \| 3 passed (4)`**, e é esse |
| restaurado | 4 verdes | **4 passed** |

## Gates

```
pnpm typecheck   exit 0
vitest (o teste novo)   exit 0   Tests 4 passed (4)
```

**NÃO MEDIDO:** não subi o worker real contra um banco — só o grafo de módulos foi exercitado, que é exatamente o que o defeito atingia. E não rodei a suíte inteira nesta ponta; quem prova é o CI.

## Issues abertas com o nome dele

**#648** — nenhum gate inicia a imagem do worker.
**#649** — o laço rápido morre sem abrir aviso na Central, e o `warn` acusa o inocente (*"não consegui montar o admin client"* quando o admin client importa sem erro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)