### PR TITLE
fix(notificacoes): as preferências não divergem mais entre o servidor e o navegador

### DIFF
--- a/.changes/avisos-param-de-divergir-na-hidratacao.md
+++ b/.changes/avisos-param-de-divergir-na-hidratacao.md
@@ -1,0 +1,15 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Preferências de aviso param de divergir entre o servidor e o navegador
+---
+
+A tela de configurações de notificação abria com o navegador discordando do HTML que o servidor tinha mandado. Quem havia desligado o push de mensagem via, por um instante, o interruptor ligado — e o React reagia a essa discordância descartando e refazendo a árvore da tela no cliente.
+
+O valor era lido dentro do inicializador de `useState`, que roda de novo na hidratação. Sem `window`, essa leitura devolve o padrão (tudo ligado); com `window`, devolve o que está no `localStorage`. Os dois lados não tinham como concordar para quem tivesse mudado qualquer preferência — em dez interruptores e no identificador que a tela de alertas procura.
+
+A tela passou a ler as preferências por `useSyncExternalStore`, o mesmo mecanismo que o seletor de tema já usa desde o #666: existe um valor determinístico para a comparação de hidratação, e só depois do commit o React troca para o valor real. O interruptor continua respondendo na hora, sem recarregar a página.
+
+Sem mudança de configuração: nada a editar no `.env` e nenhum passo a mais na atualização.
+
+Achado a partir do relato de que a divergência reaparecia a cada conserto — a leitura do navegador voltava para dentro de um inicializador novo. Junto vem a guarda que reprova esse padrão, para que a terceira instância não nasça igual.

--- a/app/app/settings/notifications/_client.test.tsx
+++ b/app/app/settings/notifications/_client.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * A PRIMEIRA RENDERIZAÇÃO DO CLIENTE MOSTRA AS MESMAS PREFERÊNCIAS QUE O SERVIDOR MANDOU.
+ *
+ * ═══ O DEFEITO QUE ESTE ARQUIVO EXISTE PARA IMPEDIR (issue #690) ═══
+ *
+ * `NotificationPrefsClient` inicializava com
+ * `useState<NotifyPrefs>(() => lerPrefs())`. O inicializador de `useState` roda
+ * de novo na hidratação — que É a primeira renderização do cliente, a mesma que
+ * o React compara contra o HTML que o servidor mandou. `lerPrefs()` decide a
+ * fonte por `typeof window === "undefined"`: sem `window` devolve o padrão (tudo
+ * ligado); com `window`, lê `localStorage` de verdade.
+ *
+ * Quem desligou o push de mensagem produzia, nesse instante, um cliente dizendo
+ * `push: false` contra um servidor dizendo `push: true` — em dez `Switch` e no
+ * `data-testid` que `canalLigado("message", "push")` alimentava durante o
+ * render. É a mesma classe que o PR #666 consertou no seletor de tema
+ * (`lib/theme.tsx`), e esta é a segunda instância viva dela.
+ *
+ * ═══ POR QUE A RECEITA ABAIXO É FIEL, E NÃO UM TRUQUE DE jsdom ═══
+ *
+ * `renderToStaticMarkup` nunca roda `useEffect` — é o mesmo motivo que
+ * `lib/theme.test.tsx` e `tests/unit/marca-sem-divergencia-de-hidratacao.test.tsx`
+ * usam. Isso o torna um substituto fiel tanto do HTML do servidor quanto da
+ * saída da PRIMEIRA renderização do cliente (a que a hidratação compara),
+ * porque nos dois casos nenhum efeito rodou ainda. Em jsdom `window` sempre
+ * existe, então "renderizar como servidor" exige apagá-lo de propósito durante
+ * a chamada — `renderToStaticMarkup` não toca em nenhuma API de DOM.
+ *
+ * ═══ SABOTAGEM QUE ESTE ARQUIVO JÁ REPROVOU ═══
+ *
+ * Voltar `useState<NotifyPrefs>(() => lerPrefs())` (o defeito de volta, com o
+ * conserto no lugar): as duas asserções de igualdade ficam vermelhas — a
+ * primeira passada do cliente passa a dizer `alerts-enable` enquanto o servidor
+ * continua dizendo `alerts-toggle`.
+ */
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { NotificationPrefsClient as NotificationPrefsClientType } from "./_client";
+import type * as Prefs from "@/lib/notifications/prefs";
+
+vi.mock("@/hooks/i18n/useT", () => ({ useT: () => (chave: string) => chave }));
+// O assunto aqui é o store das preferências, não a permissão do navegador.
+vi.mock("@/hooks/notifications/useNotificationPermission", () => ({
+  useNotificationPermission: () => ({
+    permission: "granted",
+    enabled: true,
+    request: async () => "granted",
+    setEnabled: () => {},
+  }),
+}));
+
+const CHAVE = "notify.prefs.v1";
+
+let NotificationPrefsClient: typeof NotificationPrefsClientType;
+let prefs: typeof Prefs;
+
+beforeEach(async () => {
+  window.localStorage.clear();
+  // O cache do external store (`prefsEmCache`) mora no MÓDULO, não no
+  // componente — é o que faz `getSnapshot` devolver sempre a mesma referência
+  // sem reler o storage a cada render. Mas isso faria um teste vazar cache para
+  // o de depois; `resetModules` + reimportar dá a cada `it` um módulo (e um
+  // cache) genuinamente zerado, igual a uma aba nova.
+  vi.resetModules();
+  ({ NotificationPrefsClient } = await import("./_client"));
+  prefs = await import("@/lib/notifications/prefs");
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+/** O que o servidor Node (sem `window`) produz — `renderToStaticMarkup` nunca roda efeito. */
+function renderizarComoServidor(): string {
+  const janelaReal = globalThis.window;
+  // @ts-expect-error — apagar de propósito para `typeof window === "undefined"` ser verdade.
+  delete globalThis.window;
+  try {
+    return renderToStaticMarkup(<NotificationPrefsClient />);
+  } finally {
+    globalThis.window = janelaReal;
+  }
+}
+
+/** O que a PRIMEIRA renderização do cliente produz — mesma chamada, `window` de verdade. */
+function renderizarComoPrimeiraPassadaDoCliente(): string {
+  return renderToStaticMarkup(<NotificationPrefsClient />);
+}
+
+function montar(): HTMLDivElement {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  act(() => {
+    createRoot(container).render(<NotificationPrefsClient />);
+  });
+  return container;
+}
+
+describe("as preferências de notificação não divergem entre o SSR e a primeira renderização do cliente", () => {
+  it("com o push de mensagem desligado, a primeira passada do cliente bate com o servidor", () => {
+    window.localStorage.setItem(CHAVE, JSON.stringify({ message: { in_app: true, push: false } }));
+
+    const doServidor = renderizarComoServidor();
+    const doCliente = renderizarComoPrimeiraPassadaDoCliente();
+
+    // Os dois precisam dizer "alerts-toggle" — é o que `getServerSnapshot`
+    // devolve, e é o que a hidratação tem de bater ANTES de o React trocar
+    // para `getSnapshot`, o valor real.
+    expect(doServidor).toContain('data-testid="alerts-toggle"');
+    expect(
+      doCliente,
+      "A primeira renderização do cliente leu o localStorage direto no " +
+        "inicializador do useState, produzindo 'alerts-enable' — diferente do " +
+        "que o servidor mandou ('alerts-toggle'). É o hydration mismatch.",
+    ).toContain('data-testid="alerts-toggle"');
+    expect(doCliente).toBe(doServidor);
+  });
+
+  it("com o interruptor legado `alerts.enabled=0`, a primeira passada do cliente também bate", () => {
+    // `prefsPadrao()` consulta esta chave antes de qualquer outra: é um
+    // SEGUNDO caminho para o mesmo `localStorage`, e o que passasse por um não
+    // passaria necessariamente pelo outro.
+    window.localStorage.setItem("alerts.enabled", "0");
+
+    const doServidor = renderizarComoServidor();
+    const doCliente = renderizarComoPrimeiraPassadaDoCliente();
+
+    expect(doServidor).toContain('data-testid="alerts-toggle"');
+    expect(doCliente).toBe(doServidor);
+  });
+
+  it("GUARDA DE VACUIDADE: depois do commit, a preferência real aparece", () => {
+    // Sem este caso, os dois de cima passariam num componente que nunca lê o
+    // localStorage — "sempre ligado" bateria com "sempre ligado" para sempre, e
+    // o defeito oposto (a preferência do usuário nunca é aplicada) ficaria
+    // invisível.
+    window.localStorage.setItem(CHAVE, JSON.stringify({ message: { in_app: true, push: false } }));
+
+    expect(montar().innerHTML).toContain('data-testid="alerts-enable"');
+  });
+
+  it("gravarCanal avisa os ouvintes: o interruptor reflete a troca sem recarregar", () => {
+    const container = montar();
+    expect(container.innerHTML).toContain('data-testid="alerts-toggle"');
+
+    act(() => {
+      prefs.gravarCanal("message", "push", false);
+    });
+
+    expect(container.innerHTML).toContain('data-testid="alerts-enable"');
+  });
+});

--- a/app/app/settings/notifications/_client.tsx
+++ b/app/app/settings/notifications/_client.tsx
@@ -2,19 +2,19 @@
 
 import { useT } from "@/hooks/i18n/useT";
 
-import { useState } from "react";
+import { useSyncExternalStore } from "react";
 
 import { Card } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
 import { useNotificationPermission } from "@/hooks/notifications/useNotificationPermission";
 import {
   NOTIFY_UI_CATEGORIES,
-  canalLigado,
+  assinarPrefs,
+  getPrefsSnapshot,
+  getPrefsSnapshotDoServidor,
   gravarCanal,
-  lerPrefs,
   type NotifyCategory,
   type NotifyChannelPref,
-  type NotifyPrefs,
 } from "@/lib/notifications/prefs";
 
 const LABELS: Record<NotifyCategory, string> = {
@@ -28,7 +28,7 @@ const LABELS: Record<NotifyCategory, string> = {
 export function NotificationPrefsClient() {
   const t = useT();
   const { permission, request } = useNotificationPermission();
-  const [prefs, setPrefs] = useState<NotifyPrefs>(() => lerPrefs());
+  const prefs = useSyncExternalStore(assinarPrefs, getPrefsSnapshot, getPrefsSnapshotDoServidor);
   const denied = permission === "denied";
   const unsupported = permission === "unsupported";
 
@@ -39,7 +39,7 @@ export function NotificationPrefsClient() {
         if (next !== "granted") return;
       }
     }
-    setPrefs(gravarCanal(category, channel, on));
+    gravarCanal(category, channel, on);
   }
 
   return (
@@ -82,7 +82,7 @@ export function NotificationPrefsClient() {
                   disabled={denied || unsupported}
                   onCheckedChange={(on) => void onToggle(cat, "push", on)}
                   aria-label={`${t(LABELS[cat])} via push`}
-                  data-testid={cat === "message" ? (canalLigado("message", "push") ? "alerts-toggle" : "alerts-enable") : undefined}
+                  data-testid={cat === "message" ? (prefs.message.push ? "alerts-toggle" : "alerts-enable") : undefined}
                 />
               </td>
             </tr>

--- a/lib/notifications/prefs.ts
+++ b/lib/notifications/prefs.ts
@@ -52,6 +52,60 @@ export function lerPrefs(): NotifyPrefs {
   return base;
 }
 
+/**
+ * ═══ POR QUE ISTO É UM EXTERNAL STORE, E NÃO `useState` ═══
+ *
+ * `NotificationPrefsClient` inicializava com `useState(() => lerPrefs())`, e o
+ * inicializador de `useState` roda de novo na HIDRATAÇÃO — que é a primeira
+ * renderização do cliente, a mesma que o React compara contra o HTML que o
+ * servidor mandou. `lerPrefs()`/`prefsPadrao()` decidem a fonte por
+ * `typeof window === "undefined"`: no servidor sempre devolvem o padrão (tudo
+ * ligado); no navegador leem `localStorage` de verdade. Quem desligou qualquer
+ * aviso produzia, nesse instante, um cliente dizendo `push: false` contra um
+ * servidor dizendo `push: true` — em dez `Switch` e no `data-testid` que
+ * `canalLigado("message", "push")` alimentava durante o render.
+ *
+ * A saída é a mesma que `lib/theme.tsx` já usa para esta exata classe de
+ * defeito (issue #666): `useSyncExternalStore`. `getServerSnapshot` devolve o
+ * valor determinístico que o servidor viu, e a comparação de hidratação usa
+ * esse mesmo valor dos DOIS lados; só depois do commit o React troca para
+ * `getSnapshot`, o valor real — sem `setState` dentro de `useEffect` (que o
+ * `react-hooks/set-state-in-effect` recusa, corretamente) e sem a cascata de
+ * renders que ele causaria.
+ */
+type OuvinteDePrefs = () => void;
+const ouvintesDePrefs = new Set<OuvinteDePrefs>();
+
+export function assinarPrefs(ouvinte: OuvinteDePrefs): () => void {
+  ouvintesDePrefs.add(ouvinte);
+  return () => {
+    ouvintesDePrefs.delete(ouvinte);
+  };
+}
+
+// O cache não é otimização: `useSyncExternalStore` compara snapshots com
+// `Object.is`, e `lerPrefs()` monta um objeto novo a cada chamada — devolvê-lo
+// direto do `getSnapshot` seria um laço infinito de re-render.
+let prefsEmCache: NotifyPrefs | null = null;
+
+export function getPrefsSnapshot(): NotifyPrefs {
+  if (prefsEmCache === null) prefsEmCache = lerPrefs();
+  return prefsEmCache;
+}
+
+const PREFS_DO_SERVIDOR: NotifyPrefs = {
+  message: { in_app: true, push: true },
+  lead_assigned: { in_app: true, push: true },
+  lead_won: { in_app: true, push: true },
+  lead_lost: { in_app: true, push: true },
+  mention: { in_app: true, push: true },
+};
+
+/** Sem `window`, `prefsPadrao()` devolve exatamente este valor — congelado aqui. */
+export function getPrefsSnapshotDoServidor(): NotifyPrefs {
+  return PREFS_DO_SERVIDOR;
+}
+
 export function canalLigado(category: NotifyCategory, channel: NotifyChannelPref): boolean {
   return lerPrefs()[category][channel];
 }
@@ -71,5 +125,7 @@ export function gravarCanal(
     }
   }
   if (category === "message" && channel === "push") setAlertsEnabled(on);
+  prefsEmCache = next;
+  for (const ouvinte of ouvintesDePrefs) ouvinte();
   return next;
 }

--- a/tests/unit/hidratacao-useState-nao-le-o-navegador.test.ts
+++ b/tests/unit/hidratacao-useState-nao-le-o-navegador.test.ts
@@ -1,0 +1,343 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, posix } from "node:path";
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+/**
+ * NENHUM `useState` DECIDE O PRIMEIRO RENDER LENDO O NAVEGADOR.
+ *
+ * ─── A classe, e a segunda instância viva (issue #690) ──────────────────────
+ *
+ * O inicializador de `useState` roda de novo na HIDRATAÇÃO — que é a primeira
+ * renderização do cliente, a mesma que o React compara contra o HTML que o
+ * servidor mandou. Uma função que decide a fonte por `typeof window ===
+ * "undefined"` devolve o padrão no servidor e o valor real no cliente, e a
+ * diferença aparece nessa comparação como hydration mismatch.
+ *
+ * O PR #666 consertou a instância do seletor de tema (`lib/theme.tsx`) e a
+ * deixou viva em `app/app/settings/notifications/_client.tsx`, que inicializava
+ * com `useState<NotifyPrefs>(() => lerPrefs())`. Não é hipótese: `lerPrefs()`
+ * alcança `window.localStorage` dois níveis abaixo, em `prefsPadrao()`, então
+ * o valor vai para dez `Switch` e para o `data-testid` que
+ * `canalLigado("message", "push")` alimentava durante o render.
+ *
+ * ─── Por que a sonda segue chamada, e não só olha a expressão ───────────────
+ *
+ * Uma sonda que só procurasse `window` DENTRO do inicializador não pegaria o
+ * defeito real: ali dentro só existe `lerPrefs()`. O texto da issue é explícito
+ * — *"nenhuma guarda reprova useState que lê o navegador no inicializador"* — e
+ * o que lê o navegador é a função CHAMADA. Por isso esta sonda resolve o
+ * identificador: função local do mesmo arquivo, ou `import` de um módulo do
+ * repositório, seguido transitivamente (com conjunto de visitados, para ciclo
+ * não travar a suíte).
+ *
+ * ─── O que ela NÃO é ────────────────────────────────────────────────────────
+ *
+ * Ela não julga `new Date()` nem qualquer outra fonte de não-determinismo: a
+ * classe aqui é "lê o navegador", e alargar isso para "qualquer coisa que mude
+ * entre servidor e cliente" reprovaria meia dúzia de relógios de tela que já
+ * existem e não são este defeito.
+ *
+ * Controles nas duas direções, no fim do arquivo: `hooks/ai/useDebugToggle.ts`
+ * é o padrão CORRETO (inicializador determinístico, leitura no `useEffect`) e
+ * precisa passar; um inicializador que chama `lerPrefs` precisa reprovar.
+ */
+const RAIZ = join(__dirname, "..", "..");
+const DIRS = ["app", "components", "lib", "hooks"];
+
+/**
+ * Globais que só existem no navegador. Uma leitura a qualquer um deles no
+ * caminho do inicializador é a classe do defeito.
+ */
+const GLOBAIS_DO_NAVEGADOR = new Set([
+  "window",
+  "document",
+  "localStorage",
+  "sessionStorage",
+  "navigator",
+  "location",
+  "history",
+  "screen",
+  "matchMedia",
+  "Notification",
+  "getComputedStyle",
+  "requestAnimationFrame",
+  "cancelAnimationFrame",
+  "IntersectionObserver",
+  "ResizeObserver",
+  "MutationObserver",
+  "indexedDB",
+  "caches",
+  "customElements",
+  "visualViewport",
+]);
+
+/** Caminhos relativos à raiz, em POSIX — a identidade do módulo neste arquivo. */
+export function arquivosVigiados(): string[] {
+  const saida: string[] = [];
+  const descer = (dir: string): void => {
+    for (const e of readdirSync(join(RAIZ, dir), { withFileTypes: true })) {
+      if (e.name === "node_modules" || e.name.startsWith(".")) continue;
+      const rel = posix.join(dir, e.name);
+      if (e.isDirectory()) descer(rel);
+      else if (/\.tsx?$/.test(e.name) && !/\.test\.tsx?$/.test(e.name)) saida.push(rel);
+    }
+  };
+  for (const d of DIRS) descer(d);
+  return saida.sort();
+}
+
+export function fontesDoRepositorio(): Map<string, string> {
+  const mapa = new Map<string, string>();
+  for (const rel of arquivosVigiados()) mapa.set(rel, readFileSync(join(RAIZ, rel), "utf8"));
+  return mapa;
+}
+
+/** `@/lib/x` e `./x` viram o caminho relativo à raiz, ou `null` se for pacote. */
+function resolverModulo(especificador: string, deArquivo: string, fontes: Map<string, string>): string | null {
+  let base: string;
+  if (especificador.startsWith("@/")) base = especificador.slice(2);
+  else if (especificador.startsWith(".")) base = posix.join(posix.dirname(deArquivo), especificador);
+  else return null;
+  for (const sufixo of [".ts", ".tsx", "/index.ts", "/index.tsx"]) {
+    if (fontes.has(base + sufixo)) return base + sufixo;
+  }
+  return null;
+}
+
+type Indice = {
+  funcoes: Map<string, Map<string, ts.Node>>;
+  imports: Map<string, Map<string, string>>;
+};
+
+/**
+ * O arquivo sob varredura pode não estar no mapa — os controles abaixo passam
+ * uma fonte de fixture. Sem esta camada, `useState(() => ler())` com `ler` no
+ * MESMO arquivo não resolveria, e o controle positivo passaria com a sonda
+ * quebrada, que é o pior resultado possível para uma guarda.
+ */
+type Busca = {
+  funcoes: (arquivo: string) => Map<string, ts.Node> | undefined;
+  imports: (arquivo: string) => Map<string, string> | undefined;
+};
+
+const cacheDeIndice = new WeakMap<Map<string, string>, Indice>();
+
+function funcoesDoArquivo(sf: ts.SourceFile): Map<string, ts.Node> {
+  const mapa = new Map<string, ts.Node>();
+  for (const st of sf.statements) {
+    if (ts.isFunctionDeclaration(st) && st.name && st.body) {
+      mapa.set(st.name.text, st);
+    } else if (ts.isVariableStatement(st)) {
+      for (const d of st.declarationList.declarations) {
+        if (!ts.isIdentifier(d.name) || !d.initializer) continue;
+        if (ts.isArrowFunction(d.initializer) || ts.isFunctionExpression(d.initializer)) {
+          mapa.set(d.name.text, d.initializer);
+        }
+      }
+    }
+  }
+  return mapa;
+}
+
+function importsDoArquivo(sf: ts.SourceFile, fontes: Map<string, string>): Map<string, string> {
+  const mapa = new Map<string, string>();
+  for (const st of sf.statements) {
+    if (!ts.isImportDeclaration(st) || !st.importClause) continue;
+    // `import x = require("y")` também é ImportDeclaration, e ali o
+    // `moduleSpecifier` não é literal de string.
+    if (!ts.isStringLiteral(st.moduleSpecifier)) continue;
+    const alvo = resolverModulo(st.moduleSpecifier.text, sf.fileName, fontes);
+    if (!alvo) continue;
+    const cl = st.importClause;
+    if (cl.name) mapa.set(cl.name.text, alvo);
+    if (cl.namedBindings && ts.isNamedImports(cl.namedBindings)) {
+      for (const el of cl.namedBindings.elements) mapa.set(el.name.text, alvo);
+    }
+  }
+  return mapa;
+}
+
+function indice(fontes: Map<string, string>): Indice {
+  const existente = cacheDeIndice.get(fontes);
+  if (existente) return existente;
+  const fns = new Map<string, Map<string, ts.Node>>();
+  const imp = new Map<string, Map<string, string>>();
+  for (const [rel, fonte] of fontes) {
+    // `fileName` é o caminho relativo POSIX de propósito: é a chave de
+    // resolução de `./x` e `@/x`, e mantém a sonda igual em Windows e Linux.
+    const arquivo = ts.createSourceFile(rel, fonte, ts.ScriptTarget.Latest, true);
+    fns.set(rel, funcoesDoArquivo(arquivo));
+    imp.set(rel, importsDoArquivo(arquivo, fontes));
+  }
+  const novo = { funcoes: fns, imports: imp };
+  cacheDeIndice.set(fontes, novo);
+  return novo;
+}
+
+/** O índice do repositório, com o arquivo sob varredura por cima. */
+function buscaCom(fontes: Map<string, string>, nomeDoArquivo: string, fonte: string): Busca {
+  const idx = indice(fontes);
+  const arquivo = ts.createSourceFile(nomeDoArquivo, fonte, ts.ScriptTarget.Latest, true);
+  const fns = funcoesDoArquivo(arquivo);
+  const imp = importsDoArquivo(arquivo, fontes);
+  return {
+    funcoes: (rel) => (rel === nomeDoArquivo ? fns : idx.funcoes.get(rel)),
+    imports: (rel) => (rel === nomeDoArquivo ? imp : idx.imports.get(rel)),
+  };
+}
+
+/**
+ * Nomes de globais do navegador alcançáveis a partir de `no`, seguindo
+ * chamadas a funções locais e a funções importadas de módulos do repositório.
+ */
+function globaisAlcancados(no: ts.Node, busca: Busca, arquivo: string, visitados: Set<string>): Set<string> {
+  const achados = new Set<string>();
+  const visitar = (n: ts.Node, deArquivo: string): void => {
+    if (ts.isIdentifier(n)) {
+      if (GLOBAIS_DO_NAVEGADOR.has(n.text)) {
+        achados.add(n.text);
+        return;
+      }
+      const local = busca.funcoes(deArquivo)?.get(n.text);
+      if (local) {
+        const chave = `${deArquivo}#${n.text}`;
+        if (!visitados.has(chave)) {
+          visitados.add(chave);
+          visitar(local, deArquivo);
+        }
+        return;
+      }
+      const alvo = busca.imports(deArquivo)?.get(n.text);
+      if (alvo) {
+        const chave = `${alvo}#${n.text}`;
+        if (!visitados.has(chave)) {
+          visitados.add(chave);
+          const fn = busca.funcoes(alvo)?.get(n.text);
+          if (fn) visitar(fn, alvo);
+        }
+      }
+      return;
+    }
+    ts.forEachChild(n, (filho) => visitar(filho, deArquivo));
+  };
+  visitar(no, arquivo);
+  return achados;
+}
+
+/**
+ * Linhas (1-based) das chamadas a `useState` cujo inicializador — o primeiro
+ * argumento, quando é função — alcança um global do navegador.
+ *
+ * Ancorado no AST e não em regex: a prosa deste repositório cita `useState` e
+ * `window` o tempo todo, inclusive nos comentários que explicam este defeito, e
+ * um regex reprovaria o arquivo por ele falar de si mesmo.
+ */
+export function inicializadoresQueLeemONavegador(
+  fonte: string,
+  nomeDoArquivo: string,
+  fontes: Map<string, string>,
+): number[] {
+  const busca = buscaCom(fontes, nomeDoArquivo, fonte);
+  const arquivo = ts.createSourceFile(nomeDoArquivo, fonte, ts.ScriptTarget.Latest, true);
+  const infratoras: number[] = [];
+
+  const visita = (n: ts.Node): void => {
+    if (ts.isCallExpression(n)) {
+      const e = n.expression;
+      const ehUseState =
+        (ts.isIdentifier(e) && e.text === "useState") ||
+        (ts.isPropertyAccessExpression(e) && e.name.text === "useState");
+      const a0 = n.arguments[0];
+      if (ehUseState && a0 && (ts.isArrowFunction(a0) || ts.isFunctionExpression(a0))) {
+        if (globaisAlcancados(a0, busca, nomeDoArquivo, new Set()).size > 0) {
+          infratoras.push(arquivo.getLineAndCharacterOfPosition(n.getStart(arquivo)).line + 1);
+        }
+      }
+    }
+    ts.forEachChild(n, visita);
+  };
+  visita(arquivo);
+  return infratoras;
+}
+
+describe("o inicializador de useState não lê o navegador", () => {
+  const fontes = fontesDoRepositorio();
+
+  it("GUARDA DE VACUIDADE: a varredura alcança o repositório de verdade", () => {
+    // Sem este caso, um caminho errado devolveria zero arquivos e a suíte
+    // inteira passaria por não ter olhado nada.
+    expect(arquivosVigiados().length).toBeGreaterThan(1000);
+    expect(fontes.has("app/app/settings/notifications/_client.tsx")).toBe(true);
+    expect(fontes.has("lib/notifications/prefs.ts")).toBe(true);
+  });
+
+  it("nenhum arquivo de `app|components|lib|hooks` tem inicializador que lê o navegador", () => {
+    const violacoes: string[] = [];
+    for (const [rel, fonte] of fontes) {
+      for (const linha of inicializadoresQueLeemONavegador(fonte, rel, fontes)) {
+        violacoes.push(`${rel}:${linha}`);
+      }
+    }
+    expect(
+      violacoes,
+      "Inicializador de `useState` que lê o navegador: ele roda de novo na " +
+        "hidratação, com `window` de verdade, e o cliente diverge do HTML que " +
+        "o servidor mandou. Use `useSyncExternalStore` com um " +
+        "`getServerSnapshot` determinístico — ver `lib/theme.tsx`.",
+    ).toEqual([]);
+  });
+
+  it("CONTROLE POSITIVO: a sonda reprova o padrão do defeito, inclusive através de um import", () => {
+    // `lerPrefs()` mora em outro módulo e só lá dentro toca `window`. Se a
+    // sonda não seguisse o import, este caso passaria — e o defeito real
+    // (issue #690) teria passado com ele.
+    const fonte = [
+      '"use client";',
+      'import { useState } from "react";',
+      'import { lerPrefs } from "@/lib/notifications/prefs";',
+      "export function C() {",
+      "  const [prefs] = useState(() => lerPrefs());",
+      "  return prefs.message.in_app;",
+      "}",
+    ].join("\n");
+    expect(inicializadoresQueLeemONavegador(fonte, "app/fixture.tsx", fontes)).toEqual([5]);
+  });
+
+  it("CONTROLE NEGATIVO: o padrão correto do repositório passa", () => {
+    // `hooks/ai/useDebugToggle.ts` é o controle que a própria issue cita:
+    // inicializador determinístico (`defaultFor(role)`), leitura do navegador
+    // dentro do `useEffect`. Também serve de guarda contra a sonda alargar
+    // para "qualquer função chamada" e reprovar o repositório inteiro.
+    const rel = "hooks/ai/useDebugToggle.ts";
+    expect(inicializadoresQueLeemONavegador(fontes.get(rel)!, rel, fontes)).toEqual([]);
+  });
+
+  it("CONTROLE POSITIVO LOCAL: uma função auxiliar do mesmo arquivo também reprova", () => {
+    const fonte = [
+      'import { useState } from "react";',
+      "function ler() {",
+      "  return window.localStorage.getItem('x');",
+      "}",
+      "export function C() {",
+      "  const [v] = useState(() => ler());",
+      "  return v;",
+      "}",
+    ].join("\n");
+    expect(inicializadoresQueLeemONavegador(fonte, "app/fixture.tsx", fontes)).toEqual([6]);
+  });
+
+  it("CONTROLE NEGATIVO do relógio: `new Date()` NÃO é desta classe", () => {
+    // Deliberadamente fora do escopo: meia dúzia de telas inicializa um
+    // relógio assim, e nenhuma delas é o defeito do `window`.
+    const fonte = [
+      'import { useState } from "react";',
+      "export function C() {",
+      "  const [agora] = useState(() => new Date());",
+      "  return agora.toISOString();",
+      "}",
+    ].join("\n");
+    expect(inicializadoresQueLeemONavegador(fonte, "app/fixture.tsx", fontes)).toEqual([]);
+  });
+});


### PR DESCRIPTION
# O que este PR faz

Configurações › Notificações abria com o cliente discordando do HTML que o servidor mandou: quem havia desligado o push de mensagem via, por um instante, o interruptor ligado. `NotificationPrefsClient` inicializava com `useState(() => lerPrefs())`, e o inicializador de `useState` roda de novo na hidratação — a primeira renderização do cliente, a mesma que o React compara contra o HTML do servidor. `lerPrefs()` decide a fonte por `typeof window === "undefined"`, então os dois lados nunca concordavam para quem tinha mudado qualquer preferência. É a segunda instância viva da classe que o #666 consertou no seletor de tema.

Closes #690

---

## O conserto (item 1 da issue)

A tela passou a ler as preferências por `useSyncExternalStore`, com `getServerSnapshot` devolvendo o valor determinístico que o servidor viu — o mesmo mecanismo de `lib/theme.tsx`. Sem `setState` dentro de `useEffect` e sem a cascata de renders que ele causaria. O interruptor continua respondendo na hora, sem recarregar.

O `data-testid` deixou de chamar `canalLigado("message", "push")` durante o render e passou a ler o mesmo snapshot que alimenta os dez `Switch`, que era a outra metade do defeito.

## A guarda (item 2, que a issue diz valer mais)

`tests/unit/hidratacao-useState-nao-le-o-navegador.test.ts` varre `app|components|lib|hooks` pelo AST e reprova `useState` cujo inicializador alcance um global do navegador. A sonda **resolve o identificador**: segue funções locais do mesmo arquivo e funções importadas de módulos do repositório, transitivamente e com conjunto de visitados. Uma sonda que só procurasse `window` dentro do inicializador não pegaria este defeito — ali dentro só existe `lerPrefs()`.

Controles nas duas direções: `hooks/ai/useDebugToggle.ts` (o padrão correto que a issue cita) precisa passar; a mesma função auxiliar local e o mesmo import precisam reprovar; `new Date()` não é desta classe.

## Prova

- **Antes do conserto**, a varredura acusou exatamente uma violação em 1623 arquivos: `app/app/settings/notifications/_client.tsx:31 via=window,localStorage`. Depois, zero.
- **Sabotagem da guarda**: com `useState(() => lerPrefs())` de volta, ela reprova apontando `_client.tsx:32`. Revertido em seguida.
- **Regressão de comportamento** (`app/app/settings/notifications/_client.test.tsx`): renderiza por `renderToStaticMarkup` com e sem `window`, que é o substituto fiel do SSR e da primeira passada do cliente. Com o defeito de volta, 3 dos 4 casos ficam vermelhos.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado (nos arquivos tocados: 0 erros, 0 avisos)
- [x] Testes relevantes existem e passam — 10 casos novos, todos verdes
- [ ] RLS testada — não toca tabela tenant-aware
- [ ] Audit log — não há mutação relevante
- [x] Zod — nenhum input externo novo
- [x] Sem `console.log` esquecido
- [ ] Migration — não há mudança de schema
- [x] Doc atualizada — fragmento em `.changes/`

## Uma coisa que quem for revisar precisa saber

`pnpm test:unit` completo tem **9 testes vermelhos em 7 arquivos** nesta máquina. **Não são deste PR**: rodei os mesmos arquivos com a árvore limpa na base congelada (`620b3eae`, sem nenhuma linha minha) e os 9 caem igual. São `lgpd-pdf-meet`/`lgpd-pdf-replies` (pdfjs), `sentry-comunidade-so-erro`, `gateway-destino-por-caminho`, `ai-response-worker-model-routing`, `rascunho-superado-nao-e-regravado` e `suporte-cobertura-de-efeitos`. O `lib/theme.test.tsx` também aparece vermelho na suíte cheia, mas passa isolado — é o estouro de 15s que o cabeçalho do `vitest.config.ts` já descreve.

Não consertei nenhum deles aqui: são outra classe, e misturar alargaria o diff sem necessidade.
