### PR TITLE
fix(test): o gate de cobertura de efeitos volta a rodar no Windows

### DIFF
--- a/tests/unit/helpers/caminho.ts
+++ b/tests/unit/helpers/caminho.ts
@@ -21,6 +21,20 @@ import path from "node:path";
  * `varrer-codigo.ts` vive lá: quatro cópias desta linha é a garantia de que
  * uma delas vai divergir.
  */
+/**
+ * O MESMO tratamento para quem já tem o caminho na mão — relativo, ou vindo de
+ * um `join` que não passou por `path.relative`.
+ *
+ * Existe porque `relativoEmBarraNormal` só cobre metade dos chamadores: um
+ * `readdirSync` recursivo monta `app\api\v1\...` a partir de um diretório
+ * RELATIVO, e ali não há raiz para subtrair. Sem esta porta, quem tem esse
+ * caminho escreve o `.split(path.sep).join("/")` à mão — que é a cópia que
+ * este arquivo existe para não ter.
+ */
+export function emBarraNormal(caminho: string): string {
+  return caminho.split(path.sep).join("/");
+}
+
 export function relativoEmBarraNormal(raiz: string, absoluto: string): string {
-  return path.relative(raiz, absoluto).split(path.sep).join("/");
+  return emBarraNormal(path.relative(raiz, absoluto));
 }

--- a/tests/unit/suporte-cobertura-de-efeitos.test.ts
+++ b/tests/unit/suporte-cobertura-de-efeitos.test.ts
@@ -2,7 +2,25 @@ import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import ts from "typescript";
 import { expect, it } from "vitest";
-function files(dir:string):string[]{return readdirSync(dir,{withFileTypes:true}).flatMap(item=>item.isDirectory()?files(join(dir,item.name)):[join(dir,item.name)]);}
+
+import { emBarraNormal } from "./helpers/caminho";
+// A varredura devolve SEMPRE barra normal. Sem isto, no Windows ela devolvia
+// `app\api\v1\...` e os dois `it` abaixo erravam em direções opostas: o
+// `endsWith("/route.ts")` do primeiro casava ZERO arquivos (253 rotas passavam
+// sem inspeção, e o gate ficava verde sem ter olhado nada), e o
+// `p.split("/").at(-1)` do segundo devolvia o caminho inteiro, então as três
+// exceções declaradas no `Set` de `exceptions` nunca casavam e os três arquivos
+// justificados viravam acusação. No CI (Linux) passava, que é o que manteve o
+// defeito vivo até aqui.
+function files(dir:string):string[]{return readdirSync(dir,{withFileTypes:true}).flatMap(item=>item.isDirectory()?files(join(dir,item.name)):[join(dir,item.name)]).map(emBarraNormal);}
+
+// Controle positivo: sem ele, uma varredura quebrada devolve zero arquivos e
+// zero é indistinguível de "está tudo em ordem" — foi assim que o separador de
+// caminho passou despercebido. Mesma doutrina de `helpers/varrer-codigo.ts`.
+it("a varredura enxerga os handlers e as actions que ela diz cobrir",()=>{
+ expect(files("app/api/v1").filter(p=>p.endsWith("/route.ts")).length).toBeGreaterThan(100);
+ expect(files("app/actions").filter(p=>!p.endsWith(".test.ts")).length).toBeGreaterThan(10);
+});
 it("todo handler mutante do app declara guarda de suporte ou é infraestrutura identificada",()=>{
  const uncovered:string[]=[];
  for(const path of files("app/api/v1").filter(p=>p.endsWith("/route.ts"))){


### PR DESCRIPTION
# O que este PR faz

O gate de `tests/unit/suporte-cobertura-de-efeitos.test.ts` não roda no Windows — e num dos dois casos ele passa **verde sem ter olhado nada**. Não é um teste vermelho: é um gate que existe, aparece no `pnpm test:unit`, e não cobre o que diz cobrir.

Achado auditando os arquivos rastreados na base `620b3eae`. Não é do #690 nem vizinho dele.

---

## O defeito

A varredura monta caminho com `join` e os dois `it` comparam contra literais com `/`. No Windows isso erra nas duas direções ao mesmo tempo:

**1. O gate dos 157 handlers fica vazio.** `files("app/api/v1").filter(p => p.endsWith("/route.ts"))` — em `app\api\v1\admin\audit\route.ts` o `endsWith("/route.ts")` é **falso**. Medido nesta árvore: **302** arquivos sob `app/api/v1`, **253** casam depois de normalizar, **0** casavam antes. O laço não executava uma vez sequer, `uncovered` ficava `[]`, e `expect(uncovered).toEqual([])` passava. Zero arquivos é indistinguível de "está tudo em ordem" — é a armadilha que o cabeçalho de `helpers/varrer-codigo.ts` descreve, e este arquivo não tinha o controle positivo que aquela doutrina exige.

**2. As três exceções viram acusação.** `p.split("/").at(-1)` devolve o caminho inteiro em vez do nome do arquivo, então o `Set` de exceções nunca casava: `updateProfile.ts`, `trocarIdioma.ts` e `recoverOrganization.ts` eram acusados de não declarar efeito **sendo exatamente os três que a linha declara como justificados**. Respeitadas 0 vezes antes, 3 depois.

No CI (Linux) os dois passavam. É o mesmo defeito que os PRs #135 e #433 já consertaram em outros gates, e pela mesma razão o `helpers/caminho.ts` existe — com um docstring que descreve este caso quase linha a linha.

## O conserto

`emBarraNormal` é a metade que faltava de `relativoEmBarraNormal`. A varredura monta caminho a partir de um diretório RELATIVO (`files("app/api/v1")`), e ali não há raiz para subtrair — então `relativoEmBarraNormal` não serve. Sem essa porta, quem tem esse caminho escreve o `.split(path.sep).join("/")` à mão, que é a cópia que aquele arquivo existe para não ter. `relativoEmBarraNormal` passou a ser `emBarraNormal(path.relative(...))`: continua uma cópia só da linha.

Vem junto o controle positivo que faltava — ele afirma que a varredura ENCONTROU handlers e actions conhecidos antes de qualquer conclusão de ausência.

## Prova

- **Antes**: `suporte-cobertura-de-efeitos` vermelho, com as 3 exceções acusadas.
- **Depois**: 3 casos verdes, e os dois gates rodando de verdade no Windows (253 rotas inspecionadas, 3 exceções respeitadas).
- **Sabotagem**: removendo a normalização, o controle positivo reprova com `expected 0 to be greater than 100` e o segundo caso volta a acusar os três — e o gate dos handlers **continua verde**, que é o defeito inteiro em uma linha de saída.
- `pnpm typecheck` zerado, `pnpm lint` zerado nos arquivos tocados.
- Os três outros consumidores de `relativoEmBarraNormal` (`marca-sem-divergencia-de-hidratacao`, `telas-filtram-a-organizacao-ativa`, `telas-sem-dado-de-mentira`) seguem verdes: 18 casos.

## Sem fragmento em `.changes/`

Mudança só de teste, sem efeito para quem opera uma VPS — mesmo critério do #691, que também não trouxe fragmento. Se preferirem um, eu escrevo.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam
- [ ] RLS — não toca tabela
- [ ] Audit log — não há mutação
- [ ] Zod — nenhum input externo
- [x] Sem `console.log` esquecido
- [ ] Migration — não há schema
- [x] Doc — o docstring de `helpers/caminho.ts` cobre a nova porta

## Duplicata

Procurei em issues e PRs, todos os estados: "separador de caminho", "barra normal", "Windows", "path.sep", "relativoEmBarraNormal", o nome do arquivo, `supportWriteError`, `resolveActiveOrg`. Os PRs #135 e #433 consertaram a mesma classe **em outros gates** e estão fechados; este arquivo nasceu depois, no #613, com o defeito de volta. Nenhuma issue ou PR aberto cobre este.
