### PR TITLE
fix(test): o gate de cobertura de efeitos volta a rodar no Windows (@dajiaohuang, do #696)

### DIFF
--- a/tests/unit/helpers/caminho.ts
+++ b/tests/unit/helpers/caminho.ts
@@ -1,6 +1,20 @@
 import path from "node:path";
 
 /**
+ * O MESMO tratamento para quem já tem o caminho na mão — relativo, ou vindo de
+ * um `join` que não passou por `path.relative`.
+ *
+ * Existe porque `relativoEmBarraNormal` só cobre metade dos chamadores: um
+ * `readdirSync` recursivo monta `app\api\v1\...` a partir de um diretório
+ * RELATIVO, e ali não há raiz para subtrair. Sem esta porta, quem tem esse
+ * caminho escreve o `.split(path.sep).join("/")` à mão — que é a cópia que
+ * este arquivo existe para não ter.
+ */
+export function emBarraNormal(caminho: string): string {
+  return caminho.split(path.sep).join("/");
+}
+
+/**
  * Caminho relativo à raiz, SEMPRE em barra normal — nunca a do sistema de
  * arquivos.
  *
@@ -21,20 +35,6 @@ import path from "node:path";
  * `varrer-codigo.ts` vive lá: quatro cópias desta linha é a garantia de que
  * uma delas vai divergir.
  */
-/**
- * O MESMO tratamento para quem já tem o caminho na mão — relativo, ou vindo de
- * um `join` que não passou por `path.relative`.
- *
- * Existe porque `relativoEmBarraNormal` só cobre metade dos chamadores: um
- * `readdirSync` recursivo monta `app\api\v1\...` a partir de um diretório
- * RELATIVO, e ali não há raiz para subtrair. Sem esta porta, quem tem esse
- * caminho escreve o `.split(path.sep).join("/")` à mão — que é a cópia que
- * este arquivo existe para não ter.
- */
-export function emBarraNormal(caminho: string): string {
-  return caminho.split(path.sep).join("/");
-}
-
 export function relativoEmBarraNormal(raiz: string, absoluto: string): string {
   return emBarraNormal(path.relative(raiz, absoluto));
 }

--- a/tests/unit/helpers/caminho.ts
+++ b/tests/unit/helpers/caminho.ts
@@ -21,6 +21,20 @@ import path from "node:path";
  * `varrer-codigo.ts` vive lá: quatro cópias desta linha é a garantia de que
  * uma delas vai divergir.
  */
+/**
+ * O MESMO tratamento para quem já tem o caminho na mão — relativo, ou vindo de
+ * um `join` que não passou por `path.relative`.
+ *
+ * Existe porque `relativoEmBarraNormal` só cobre metade dos chamadores: um
+ * `readdirSync` recursivo monta `app\api\v1\...` a partir de um diretório
+ * RELATIVO, e ali não há raiz para subtrair. Sem esta porta, quem tem esse
+ * caminho escreve o `.split(path.sep).join("/")` à mão — que é a cópia que
+ * este arquivo existe para não ter.
+ */
+export function emBarraNormal(caminho: string): string {
+  return caminho.split(path.sep).join("/");
+}
+
 export function relativoEmBarraNormal(raiz: string, absoluto: string): string {
-  return path.relative(raiz, absoluto).split(path.sep).join("/");
+  return emBarraNormal(path.relative(raiz, absoluto));
 }

--- a/tests/unit/suporte-cobertura-de-efeitos.test.ts
+++ b/tests/unit/suporte-cobertura-de-efeitos.test.ts
@@ -2,7 +2,25 @@ import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import ts from "typescript";
 import { expect, it } from "vitest";
-function files(dir:string):string[]{return readdirSync(dir,{withFileTypes:true}).flatMap(item=>item.isDirectory()?files(join(dir,item.name)):[join(dir,item.name)]);}
+
+import { emBarraNormal } from "./helpers/caminho";
+// A varredura devolve SEMPRE barra normal. Sem isto, no Windows ela devolvia
+// `app\api\v1\...` e os dois `it` abaixo erravam em direções opostas: o
+// `endsWith("/route.ts")` do primeiro casava ZERO arquivos (253 rotas passavam
+// sem inspeção, e o gate ficava verde sem ter olhado nada), e o
+// `p.split("/").at(-1)` do segundo devolvia o caminho inteiro, então as três
+// exceções declaradas no `Set` de `exceptions` nunca casavam e os três arquivos
+// justificados viravam acusação. No CI (Linux) passava, que é o que manteve o
+// defeito vivo até aqui.
+function files(dir:string):string[]{return readdirSync(dir,{withFileTypes:true}).flatMap(item=>item.isDirectory()?files(join(dir,item.name)):[join(dir,item.name)]).map(emBarraNormal);}
+
+// Controle positivo: sem ele, uma varredura quebrada devolve zero arquivos e
+// zero é indistinguível de "está tudo em ordem" — foi assim que o separador de
+// caminho passou despercebido. Mesma doutrina de `helpers/varrer-codigo.ts`.
+it("a varredura enxerga os handlers e as actions que ela diz cobrir",()=>{
+ expect(files("app/api/v1").filter(p=>p.endsWith("/route.ts")).length).toBeGreaterThan(100);
+ expect(files("app/actions").filter(p=>!p.endsWith(".test.ts")).length).toBeGreaterThan(10);
+});
 it("todo handler mutante do app declara guarda de suporte ou é infraestrutura identificada",()=>{
  const uncovered:string[]=[];
  for(const path of files("app/api/v1").filter(p=>p.endsWith("/route.ts"))){


### PR DESCRIPTION
Reconciliação do **#696** de @dajiaohuang, com o merge preservando os commits e a autoria dele — o PR original fecha como **mergeado**.

## O que o PR dele faz

`tests/unit/suporte-cobertura-de-efeitos.test.ts` monta caminho com `join` e compara contra literais com `/`. No Windows isso erra nas duas direções ao mesmo tempo: o `endsWith("/route.ts")` casa **zero** arquivos (253 rotas passam sem inspeção e o gate fica **verde sem ter olhado nada**), e o `p.split("/").at(-1)` devolve o caminho inteiro, então as três exceções declaradas viram acusação.

## O que eu medi

Prévia do merge contra `origin/main@78e97e18`.

**A cegueira reproduzida** (sabotei a varredura para devolver zero arquivos, que é o que o Windows produzia):

```
Tests  1 failed | 2 passed (3)
  × a varredura enxerga os handlers e as actions que ela diz cobrir
```

Os **dois gates reais continuaram verdes**. É o defeito inteiro numa linha de saída: sem o controle positivo que este PR acrescenta, uma varredura cega é indistinguível de "está tudo em ordem".

**Os quatro consumidores do helper:** `Tests 18 passed (18)` — `suporte-cobertura-de-efeitos`, `marca-sem-divergencia-de-hidratacao`, `telas-filtram-a-organizacao-ativa`, `telas-sem-dado-de-mentira`. Bate com o que ele reportou.

**`emBarraNormal` com separador do Windows:** `app\api\v1\x` → `app/api/v1/x`.

## O que eu acrescentei

Um commit só, de acabamento: a porta nova entrou **acima** de `relativoEmBarraNormal` e os dois blocos de docstring ficaram empilhados antes dela — o editor passava a mostrar, sobre `emBarraNormal`, o texto que explica a outra função, e `relativoEmBarraNormal` ficou sem docstring. Só reordenação; nenhuma linha de texto ou de código mudou.

## NÃO MEDIDO

Não rodei em Windows de verdade — não tenho a máquina. O que medi foi a **consequência** do separador errado (varredura devolvendo zero) e a normalização em si, não o sistema de arquivos.

## Sem fragmento em `.changes/`

Mudança só de teste, sem efeito para quem opera uma VPS — mesmo critério do #691.

Fecha #696.