### PR TITLE
feat(ia): o modelo padrão da organização ganha tela (@paulolimajr77, do #671)

### DIFF
--- a/.changes/modelo-padrao-da-organizacao-ganha-tela.md
+++ b/.changes/modelo-padrao-da-organizacao-ganha-tela.md
@@ -4,10 +4,11 @@ secao: adicionado
 titulo: O modelo de IA padrão da organização passa a ter tela
 ---
 
-O padrão de IA da organização — o modelo que vale em **todo ponto que não tem
-escolha própria**, o que numa instalação nova são 24 dos 25 — existia no banco e
-já era usado para decidir cada ponto, mas não aparecia em lugar nenhum. Não dava
-para ver qual era, e muito menos trocar sem mexer no banco à mão.
+O padrão de IA da organização decide o modelo de **todo ponto que não tem escolha própria** — numa instalação nova, 24 dos 25.
+
+Ele existia no banco e já era usado para decidir cada ponto, mas não aparecia em
+lugar nenhum: não dava para ver qual era, e muito menos trocar sem mexer no
+banco à mão.
 
 Agora ele aparece em **Agente de IA › Provedores**, junto com os pontos, e pode
 ser trocado ali. A troca confere se o modelo existe no catálogo daquele provedor

--- a/.changes/modelo-padrao-da-organizacao-ganha-tela.md
+++ b/.changes/modelo-padrao-da-organizacao-ganha-tela.md
@@ -1,0 +1,22 @@
+---
+impacto: capacidade_nova
+secao: adicionado
+titulo: O modelo de IA padrão da organização passa a ter tela
+---
+
+O padrão de IA da organização — o modelo que vale em **todo ponto que não tem
+escolha própria**, o que numa instalação nova são 24 dos 25 — existia no banco e
+já era usado para decidir cada ponto, mas não aparecia em lugar nenhum. Não dava
+para ver qual era, e muito menos trocar sem mexer no banco à mão.
+
+Agora ele aparece em **Agente de IA › Provedores**, junto com os pontos, e pode
+ser trocado ali. A troca confere se o modelo existe no catálogo daquele provedor
+antes de gravar — um erro de digitação viraria o padrão da organização e
+derrubaria todos os pontos que herdam dele de uma vez.
+
+A escrita preserva o resto das configurações da organização (a marca e a
+política de verificação em duas etapas moram no mesmo lugar) e fica registrada
+no histórico de auditoria.
+
+Você não precisa fazer nada para adotar. Quem nunca mexeu continua no padrão de
+sempre; o que muda é que agora dá para ver e escolher.

--- a/app/api/v1/ai/providers/route.test.ts
+++ b/app/api/v1/ai/providers/route.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { requireRole } from "@/lib/auth/require-role";
+import { requireSupportWrite } from "@/lib/impersonate/support";
+import { createClient } from "@/lib/supabase/server";
+import type { AuthUser } from "@/lib/auth/types";
+
+/**
+ * PATCH /api/v1/ai/providers — o padrão da organização ganha superfície.
+ *
+ * O padrão (`organizations.settings.llm`) decide o modelo de TODO ponto que não
+ * tem binding explícito — numa instalação recém-criada, 24 dos 25. Até aqui ele
+ * só era escrito de raspão, pela primeira publicação de um agente
+ * (`lib/ai/agents/first-publication.ts`), e não tinha tela nenhuma: violava o
+ * invariante 6 do Sistema Vivo ("toda configuração tem superfície").
+ *
+ * O caso que este arquivo existe para vigiar é o segundo: `settings` é um jsonb
+ * COMPARTILHADO — `branding`, `security` e o que mais vier moram nele. Escrever
+ * `{ llm: ... }` por cima apaga a marca da instalação e a política de MFA em
+ * silêncio, e o sintoma aparece dias depois, longe daqui.
+ */
+
+vi.mock("@/lib/auth/require-role", () => ({ requireRole: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("@/lib/audit", () => ({ audit: vi.fn(async () => undefined) }));
+vi.mock("@/lib/impersonate/support", () => ({ requireSupportWrite: vi.fn(async () => null) }));
+
+const ORG_ID = "22222222-2222-4222-8222-222222222222";
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+
+/** O que já vive em `settings` e não pode sumir quando o padrão é gravado. */
+const SETTINGS_EXISTENTES = {
+  branding: { app_name: "THOTH CRM", accent_hex: "#506d48" },
+  security: { mfa_required: false },
+  llm: { provider: "anthropic", default_model: "claude-sonnet-5" },
+};
+
+interface EstadoDoBanco {
+  atualizacao: Record<string, unknown> | null;
+  modeloExiste: boolean;
+}
+
+function stubDoBanco(estado: EstadoDoBanco) {
+  return {
+    from(tabela: string) {
+      if (tabela === "organizations") {
+        return {
+          select() {
+            return this;
+          },
+          eq() {
+            return this;
+          },
+          update(payload: Record<string, unknown>) {
+            estado.atualizacao = payload;
+            return this;
+          },
+          maybeSingle() {
+            return Promise.resolve({
+              data: estado.atualizacao
+                ? { settings: estado.atualizacao.settings }
+                : { settings: SETTINGS_EXISTENTES },
+              error: null,
+            });
+          },
+        };
+      }
+      if (tabela === "ai_models") {
+        return {
+          select() {
+            return this;
+          },
+          eq() {
+            return this;
+          },
+          maybeSingle() {
+            return Promise.resolve({
+              data: estado.modeloExiste ? { model_id: "gpt-5.4-mini" } : null,
+              error: null,
+            });
+          },
+        };
+      }
+      throw new Error(`tabela inesperada: ${tabela}`);
+    },
+  };
+}
+
+function autorizadoComoAdmin() {
+  const user: AuthUser = {
+    id: USER_ID,
+    email: "dono@example.com",
+    full_name: null,
+    avatar_url: null,
+    is_platform_admin: false,
+    idioma: "pt-BR" as const,
+  } as AuthUser;
+  vi.mocked(requireRole).mockResolvedValue({
+    ok: true,
+    user,
+    org: { orgId: ORG_ID, role: "admin" },
+  } as unknown as Awaited<ReturnType<typeof requireRole>>);
+}
+
+function requisicao(corpo: unknown) {
+  return new NextRequest("http://localhost/api/v1/ai/providers", {
+    method: "PATCH",
+    body: JSON.stringify(corpo),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("PATCH /api/v1/ai/providers — padrão da organização", () => {
+  let estado: EstadoDoBanco;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    estado = { atualizacao: null, modeloExiste: true };
+    vi.mocked(requireSupportWrite).mockResolvedValue(null);
+    vi.mocked(createClient).mockResolvedValue(
+      stubDoBanco(estado) as unknown as Awaited<ReturnType<typeof createClient>>,
+    );
+    autorizadoComoAdmin();
+  });
+
+  it("grava o padrão SEM apagar as outras chaves de settings", async () => {
+    const { PATCH } = await import("./route");
+    const res = await PATCH(requisicao({ provider: "openai", default_model: "gpt-5.4-mini" }));
+
+    expect(res.status).toBe(200);
+
+    const settings = (estado.atualizacao?.settings ?? {}) as Record<string, unknown>;
+    // O que mudou:
+    expect(settings.llm).toEqual({ provider: "openai", default_model: "gpt-5.4-mini" });
+    // O que NÃO podia ser tocado:
+    expect(settings.branding).toEqual(SETTINGS_EXISTENTES.branding);
+    expect(settings.security).toEqual(SETTINGS_EXISTENTES.security);
+  });
+
+  it("recusa provedor que esta instalação não suporta", async () => {
+    const { PATCH } = await import("./route");
+    const res = await PATCH(requisicao({ provider: "foobar", default_model: "qualquer" }));
+
+    expect(res.status).toBe(422);
+    expect(estado.atualizacao).toBeNull();
+  });
+
+  it("recusa modelo que não está no catálogo do provedor", async () => {
+    estado.modeloExiste = false;
+    const { PATCH } = await import("./route");
+    const res = await PATCH(requisicao({ provider: "openai", default_model: "modelo-que-nao-existe" }));
+
+    expect(res.status).toBe(404);
+    expect(estado.atualizacao).toBeNull();
+  });
+
+  it("exige papel admin — a troca do padrão muda todo ponto herdado", async () => {
+    const { PATCH } = await import("./route");
+    await PATCH(requisicao({ provider: "openai", default_model: "gpt-5.4-mini" }));
+
+    expect(vi.mocked(requireRole)).toHaveBeenCalledWith(
+      "admin",
+      expect.objectContaining({ resource: "ai_providers" }),
+    );
+  });
+});

--- a/app/api/v1/ai/providers/route.test.ts
+++ b/app/api/v1/ai/providers/route.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from "next/server";
 
 import { requireRole } from "@/lib/auth/require-role";
 import { requireSupportWrite } from "@/lib/impersonate/support";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
 import type { AuthUser } from "@/lib/auth/types";
 
@@ -19,10 +20,24 @@ import type { AuthUser } from "@/lib/auth/types";
  * COMPARTILHADO — `branding`, `security` e o que mais vier moram nele. Escrever
  * `{ llm: ... }` por cima apaga a marca da instalação e a política de MFA em
  * silêncio, e o sintoma aparece dias depois, longe daqui.
+ *
+ * ═══ E O TERCEIRO CASO, QUE UM TESTE DE UNIDADE NÃO PODE VER SOZINHO ═══
+ *
+ * A RLS de `organizations` só deixa ESCREVER platform admin. Com o cliente de
+ * sessão, o `update` casa ZERO linhas para o `admin` do próprio tenant — e o
+ * PostgREST devolve **sucesso**, sem erro: a tela diria "salvo" e nada teria
+ * sido gravado. Medido: `admin` da org → 0 linhas; cliente admin → 1.
+ *
+ * Nenhum mock enxerga isso, porque o stub abaixo sempre dá certo. Por isso o
+ * `createClient` e o `createAdminClient` são dublês DIFERENTES aqui, e há um
+ * caso que afirma qual dos dois escreveu — trocar de volta reprova, mesmo com
+ * o comportamento visível idêntico. A varredura por classe vive em
+ * `tests/unit/escrita-em-organizations-usa-cliente-admin.test.ts`.
  */
 
 vi.mock("@/lib/auth/require-role", () => ({ requireRole: vi.fn() }));
 vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
 vi.mock("@/lib/audit", () => ({ audit: vi.fn(async () => undefined) }));
 vi.mock("@/lib/impersonate/support", () => ({ requireSupportWrite: vi.fn(async () => null) }));
 
@@ -113,13 +128,20 @@ function requisicao(corpo: unknown) {
 
 describe("PATCH /api/v1/ai/providers — padrão da organização", () => {
   let estado: EstadoDoBanco;
+  let estadoDeSessao: EstadoDoBanco;
 
   beforeEach(() => {
     vi.clearAllMocks();
     estado = { atualizacao: null, modeloExiste: true };
+    estadoDeSessao = { atualizacao: null, modeloExiste: true };
     vi.mocked(requireSupportWrite).mockResolvedValue(null);
     vi.mocked(createClient).mockResolvedValue(
-      stubDoBanco(estado) as unknown as Awaited<ReturnType<typeof createClient>>,
+      stubDoBanco(estadoDeSessao) as unknown as Awaited<ReturnType<typeof createClient>>,
+    );
+    // Dublê SEPARADO de propósito: é `estado` (o do admin) que as asserções
+    // leem, então uma escrita pelo cliente de sessão aparece como ausência.
+    vi.mocked(createAdminClient).mockReturnValue(
+      stubDoBanco(estado) as unknown as ReturnType<typeof createAdminClient>,
     );
     autorizadoComoAdmin();
   });
@@ -138,6 +160,20 @@ describe("PATCH /api/v1/ai/providers — padrão da organização", () => {
     expect(settings.security).toEqual(SETTINGS_EXISTENTES.security);
   });
 
+  it("escreve pelo CLIENTE ADMIN, não pelo de sessão", async () => {
+    // A RLS de `organizations` só deixa escrever platform admin: pelo cliente
+    // de sessão isto casaria zero linhas e o PostgREST devolveria sucesso.
+    const { PATCH } = await import("./route");
+    await PATCH(requisicao({ provider: "openai", default_model: "gpt-5.4-mini" }));
+
+    expect(estado.atualizacao, "o cliente admin não gravou").not.toBeNull();
+    expect(
+      estadoDeSessao.atualizacao,
+      "o cliente de SESSÃO gravou — com a RLS real isto casaria zero linhas e " +
+        "voltaria como sucesso, com a tela dizendo 'salvo'",
+    ).toBeNull();
+  });
+
   it("recusa provedor que esta instalação não suporta", async () => {
     const { PATCH } = await import("./route");
     const res = await PATCH(requisicao({ provider: "foobar", default_model: "qualquer" }));
@@ -147,7 +183,10 @@ describe("PATCH /api/v1/ai/providers — padrão da organização", () => {
   });
 
   it("recusa modelo que não está no catálogo do provedor", async () => {
-    estado.modeloExiste = false;
+    // `ai_models` é catálogo global e é lido pelo cliente de SESSÃO — só a
+    // escrita em `organizations` precisa do admin. Por isso a bandeira vai no
+    // dublê de sessão, e não no do admin.
+    estadoDeSessao.modeloExiste = false;
     const { PATCH } = await import("./route");
     const res = await PATCH(requisicao({ provider: "openai", default_model: "modelo-que-nao-existe" }));
 

--- a/app/api/v1/ai/providers/route.ts
+++ b/app/api/v1/ai/providers/route.ts
@@ -30,6 +30,7 @@ import {
 import { PAPEIS, PONTOS_DE_IA, PONTO_POR_ID } from "@/lib/ai/pontos/registro";
 import { PROVEDORES, ehProvedorSuportado } from "@/lib/ai/pontos/provedores";
 import { validarBinding } from "@/lib/ai/pontos/validar-binding";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
 import { traduzir } from "@/lib/i18n/dicionario";
 
@@ -396,11 +397,30 @@ export async function PATCH(req: NextRequest): Promise<Response> {
     );
   }
 
+  // ⚠️ CLIENTE ADMIN, E NÃO É ATALHO: a RLS de `organizations` só deixa
+  // ESCREVER quem é platform admin. Com o cliente de sessão, o `update` abaixo
+  // casa ZERO linhas para o `admin` do próprio tenant — e o PostgREST devolve
+  // SUCESSO, sem erro. Medido: `admin` da org → 0 linhas afetadas; mesmo
+  // comando com o cliente admin → 1. É a pior forma de falhar, porque a tela
+  // diria "salvo".
+  //
+  // Como o `install.sh` cria o dono da instalação COMO platform admin, o
+  // caminho funcionaria na máquina de quem testa e quebraria para o segundo
+  // administrador do time — o tipo de defeito que só aparece no cliente.
+  //
+  // É o que fazem os oito escritores de `organizations` deste repo, com o
+  // gêmeo exato em `app/actions/auth/politicaDeMfa.ts:62`, que escreve o MESMO
+  // jsonb. O `.eq("id", org.orgId)` abaixo é obrigatório e não decorativo: o
+  // service role passa por cima da RLS, então o filtro de tenant vira
+  // responsabilidade deste arquivo. `org.orgId` vem do `requireRole` (cookie/
+  // JWT), nunca do corpo.
+  const admin = createAdminClient();
+
   // MERGE, nunca sobrescrita. `organizations.settings` é um jsonb compartilhado
   // — `branding` (a marca da instalação) e `security` (a política de MFA) moram
   // nele. Um `update({ settings: { llm } })` ingênuo apaga os dois em silêncio, e
   // o sintoma aparece dias depois, longe daqui.
-  const { data: orgAtual } = await db
+  const { data: orgAtual } = await admin
     .from("organizations")
     .select("settings")
     .eq("id", org.orgId)
@@ -412,7 +432,7 @@ export async function PATCH(req: NextRequest): Promise<Response> {
     llm: { provider: corpo.provider, default_model: corpo.default_model },
   };
 
-  const { data: gravado, error } = await db
+  const { data: gravado, error } = await admin
     .from("organizations")
     .update({ settings })
     .eq("id", org.orgId)

--- a/app/api/v1/ai/providers/route.ts
+++ b/app/api/v1/ai/providers/route.ts
@@ -187,6 +187,11 @@ export async function GET(): Promise<Response> {
   return ok({
     papeis: PAPEIS,
     pontos,
+    // O padrão decide o modelo de TODO ponto sem binding explícito — numa
+    // instalação nova, 24 dos 25. Ele já era usado aqui para resolver cada
+    // ponto; o que faltava era CHEGAR À TELA, e sem isso não havia como
+    // mostrá-lo nem trocá-lo (invariante 6: toda configuração tem superfície).
+    padrao: padraoDaOrganizacao,
     provedores: PROVEDORES,
     credenciais: credsRes.data ?? [],
     modelos,
@@ -335,4 +340,100 @@ export async function PUT(req: NextRequest): Promise<Response> {
   });
 
   return ok({ binding: gravado, avisos: validacao.avisos });
+}
+
+
+const corpoDoPatch = z.object({
+  provider: z
+    .string()
+    .min(1)
+    .refine(ehProvedorSuportado, {
+      message:
+        "provedor não suportado por esta instalação — escolha um da lista em Agente de IA → Provedores",
+    }),
+  default_model: z.string().min(1),
+});
+
+/**
+ * Troca o PADRÃO da organização — o modelo que vale em todo ponto sem binding
+ * explícito.
+ *
+ * Uma escrita aqui muda o comportamento de dezenas de pontos de uma vez, e é
+ * por isso que exige `admin` como o PUT: quem pode mudar um ponto pode mudar
+ * todos, mas quem não pode mudar nenhum não muda o padrão pela porta dos fundos.
+ */
+export async function PATCH(req: NextRequest): Promise<Response> {
+  const supportDenied = await requireSupportWrite();
+  if (supportDenied) return supportDenied;
+
+  const authz = await requireRole("admin", { resource: "ai_providers" });
+  if (!authz.ok) return authz.response;
+  const t = (texto: string) => traduzir(texto, authz.user.idioma);
+  const { user, org } = authz;
+
+  const parsed = corpoDoPatch.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) {
+    return fail("invalid_body", t("corpo inválido"), 422, { details: parsed.error.issues });
+  }
+  const corpo = parsed.data;
+
+  const db = await createClient();
+
+  // O modelo tem de existir no catálogo DAQUELE provedor. Sem esta conferência,
+  // um erro de digitação vira padrão da organização e derruba todo ponto
+  // herdado — o mesmo modo de falha que o `PUT` já evita ponto a ponto.
+  const { data: modelo } = await db
+    .from("ai_models")
+    .select("model_id")
+    .eq("provider", corpo.provider)
+    .eq("model_id", corpo.default_model)
+    .maybeSingle();
+  if (!modelo) {
+    return fail(
+      "modelo_desconhecido",
+      t(`"${corpo.default_model}" não está no catálogo de ${corpo.provider}`),
+      404,
+    );
+  }
+
+  // MERGE, nunca sobrescrita. `organizations.settings` é um jsonb compartilhado
+  // — `branding` (a marca da instalação) e `security` (a política de MFA) moram
+  // nele. Um `update({ settings: { llm } })` ingênuo apaga os dois em silêncio, e
+  // o sintoma aparece dias depois, longe daqui.
+  const { data: orgAtual } = await db
+    .from("organizations")
+    .select("settings")
+    .eq("id", org.orgId)
+    .maybeSingle();
+
+  const settingsAtuais = ((orgAtual?.settings ?? {}) as Record<string, unknown>) || {};
+  const settings = {
+    ...settingsAtuais,
+    llm: { provider: corpo.provider, default_model: corpo.default_model },
+  };
+
+  const { data: gravado, error } = await db
+    .from("organizations")
+    .update({ settings })
+    .eq("id", org.orgId)
+    .select("settings")
+    .maybeSingle();
+
+  if (error) return fail("save_failed", error.message, 500);
+  if (!gravado) {
+    // Mesma armadilha do PUT: no PostgREST, update que casa zero linhas volta
+    // como sucesso, e a tela diria "salvo" sem nada ter sido gravado.
+    return fail("save_failed", t("nada foi gravado — verifique as permissões da organização"), 500);
+  }
+
+  void audit({
+    action: "ai.org_default_updated",
+    organizationId: org.orgId,
+    actorUserId: user.id,
+    resourceType: "organization",
+    resourceId: org.orgId,
+    metadata: { provider: corpo.provider, default_model: corpo.default_model },
+  });
+
+  return ok({ padrao: { provider: corpo.provider, defaultModel: corpo.default_model } });
 }

--- a/app/app/ai/providers/_components/PainelDeProvedores.tsx
+++ b/app/app/ai/providers/_components/PainelDeProvedores.tsx
@@ -93,6 +93,7 @@ interface Dados {
   provedores: Provedor[];
   credenciais: Credencial[];
   modelos: Modelo[];
+  padrao: { provider: string; defaultModel: string | null };
   podeEditar: boolean;
 }
 
@@ -197,6 +198,8 @@ export function PainelDeProvedores() {
         </Card>
       )}
 
+      <CartaoDoPadrao dados={dados} aoSalvar={carregar} />
+
       <div className="space-y-8">
         {porPapel.map(({ papel, info, pontos }) => (
           <section key={papel} data-testid={`papel-${papel}`}>
@@ -239,6 +242,125 @@ export function PainelDeProvedores() {
 }
 
 /** O que o grupo usa hoje, sem obrigar a abrir ponto a ponto. */
+function CartaoDoPadrao({ dados, aoSalvar }: { dados: Dados; aoSalvar: () => Promise<void> }) {
+  const t = useT();
+  const [provider, setProvider] = useState(dados.padrao.provider);
+  const [modelId, setModelId] = useState(dados.padrao.defaultModel ?? "");
+  const [salvando, setSalvando] = useState(false);
+
+  const modelosDoProvedor = useMemo(
+    () => dados.modelos.filter((m) => m.provider === provider),
+    [dados.modelos, provider],
+  );
+
+  // Quantos pontos herdam HOJE. É o número que explica por que esta caixa
+  // importa: numa instalação nova são 24 de 25, e trocar aqui muda os 24.
+  const herdam = dados.pontos.filter((p) => p.efetivo.origem === "padrao_da_organizacao");
+
+  // Os que o padrão NÃO resolve sozinho: embedding precisa de modelo de
+  // embedding (com a dimensão certa) e áudio precisa de transcritor. Dizer
+  // isto aqui é mais barato que deixar a busca degradar em silêncio depois —
+  // que é o modo de falha que `avisosDeLeitura` no resolver já descreve.
+  const especialistas = dados.pontos.filter(
+    (p) => p.exige.embeddingDims !== undefined || p.exige.audio === true,
+  );
+
+  const mudou = provider !== dados.padrao.provider || modelId !== (dados.padrao.defaultModel ?? "");
+
+  async function salvar() {
+    setSalvando(true);
+    try {
+      const res = await fetch("/api/v1/ai/providers", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ provider, default_model: modelId }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        toast.error(json?.error?.message ? t(json.error.message) : t("não consegui salvar"));
+        return;
+      }
+      toast.success(`${t("O padrão agora é")} ${modelId}`);
+      await aoSalvar();
+    } finally {
+      setSalvando(false);
+    }
+  }
+
+  return (
+    <Card className="mb-6 p-4" data-testid="cartao-do-padrao">
+      <h2 className="text-base font-semibold">{t("Modelo padrão")}</h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {t("Vale em todo ponto que você não configurou individualmente — hoje,")} {herdam.length}{" "}
+        {t("de")} {dados.pontos.length}. {t("Trocar aqui muda todos eles de uma vez.")}
+      </p>
+
+      <div className="mt-4 flex flex-wrap items-end gap-3">
+        <div className="min-w-48">
+          <Label className="text-xs">{t("Provedor")}</Label>
+          <Select
+            value={provider}
+            onValueChange={(v) => {
+              setProvider(v);
+              // Modelo de outro provedor não vale nada aqui: a rota confere o
+              // par (provider, model_id) no catálogo e devolveria 404.
+              setModelId("");
+            }}
+          >
+            <SelectTrigger data-testid="padrao-provider">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {dados.provedores.map((p) => (
+                <SelectItem key={p.id} value={p.id}>
+                  {t(p.rotulo)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="min-w-64">
+          <Label className="text-xs">{t("Modelo")}</Label>
+          <Select value={modelId} onValueChange={setModelId}>
+            <SelectTrigger data-testid="padrao-modelo">
+              <SelectValue placeholder={t("escolha")} />
+            </SelectTrigger>
+            <SelectContent>
+              {modelosDoProvedor.map((m) => (
+                <SelectItem key={m.model_id} value={m.model_id}>
+                  {m.display_name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {dados.podeEditar && (
+          <Button
+            size="sm"
+            disabled={salvando || !mudou || modelId === ""}
+            onClick={() => void salvar()}
+            data-testid="salvar-padrao"
+          >
+            {salvando ? t("Salvando…") : t("Salvar padrão")}
+          </Button>
+        )}
+      </div>
+
+      {especialistas.length > 0 && (
+        <p className="mt-3 text-xs text-muted-foreground" data-testid="padrao-especialistas">
+          {especialistas.length}{" "}
+          {t(
+            "pontos precisam de um modelo especialista (embedding ou áudio) e não seguem este padrão — configure cada um abaixo:",
+          )}{" "}
+          {especialistas.map((p) => t(p.rotulo)).join(", ")}.
+        </p>
+      )}
+    </Card>
+  );
+}
+
 function ResumoDoGrupo({ pontos }: { pontos: Ponto[] }) {
   const t = useT();
   const modelos = [...new Set(pontos.map((p) => p.efetivo.modelId ?? t("não definido")))];

--- a/lib/audit/actions.ts
+++ b/lib/audit/actions.ts
@@ -177,6 +177,7 @@ export const AUDIT_ACTIONS = [
   "ai.org_memory_entry_updated",
   /** Provedor/modelo de um ponto do sistema que usa IA foi trocado no painel. */
   "ai.purpose_binding_updated",
+  "ai.org_default_updated",
   // Ligar/desligar uma das duas verificações que consultam modelo. Auditável
   // porque muda o que o sistema confere antes de falar com o cliente — e porque
   // custa dinheiro por mensagem.

--- a/lib/i18n/dicionario.ts
+++ b/lib/i18n/dicionario.ts
@@ -928,6 +928,18 @@ export const DICIONARIO: Traducoes = {
   Custa: { es: "Cuesta" },
   ". O modelo usado se escolhe em": { es: ". El modelo usado se elige en" },
   "Provedores de IA": { es: "Proveedores de IA" },
+  "Modelo padrão": { es: "Modelo predeterminado" },
+  "Vale em todo ponto que você não configurou individualmente — hoje,": {
+    es: "Vale en todo punto que no configuraste individualmente — hoy,",
+  },
+  "Trocar aqui muda todos eles de uma vez.": {
+    es: "Cambiar aquí los cambia todos de una vez.",
+  },
+  "Salvar padrão": { es: "Guardar predeterminado" },
+  "O padrão agora é": { es: "El predeterminado ahora es" },
+  "pontos precisam de um modelo especialista (embedding ou áudio) e não seguem este padrão — configure cada um abaixo:": {
+    es: "puntos necesitan un modelo especialista (embedding o audio) y no siguen este predeterminado — configurá cada uno abajo:",
+  },
   "Antes de cada mensagem sair": { es: "Antes de que cada mensaje salga" },
   "O assistente escreve, e o sistema confere. São": {
     es: "El asistente escribe, y el sistema revisa. Son",

--- a/tests/unit/escrita-em-organizations-usa-cliente-admin.test.ts
+++ b/tests/unit/escrita-em-organizations-usa-cliente-admin.test.ts
@@ -125,13 +125,18 @@ function escritasEmOrganizations(caminho: string): Achado[] {
       MUTACOES.has(no.expression.name.text)
     ) {
       const alvo = no.expression.expression;
+      // `arguments[0]` sai do índice como `Expression | undefined` sob
+      // `noUncheckedIndexedAccess`, e o `length === 1` do lado não estreita o
+      // tipo — daí o `const` antes do guard, em vez do índice repetido.
+      const argumentoDoFrom = ts.isCallExpression(alvo) ? alvo.arguments[0] : undefined;
       if (
         ts.isCallExpression(alvo) &&
         ts.isPropertyAccessExpression(alvo.expression) &&
         alvo.expression.name.text === "from" &&
         alvo.arguments.length === 1 &&
-        ts.isStringLiteral(alvo.arguments[0]) &&
-        alvo.arguments[0].text === "organizations"
+        argumentoDoFrom !== undefined &&
+        ts.isStringLiteral(argumentoDoFrom) &&
+        argumentoDoFrom.text === "organizations"
       ) {
         const raiz = raizDaCadeia(alvo.expression.expression);
         if (raiz !== null && !admins.has(raiz)) {

--- a/tests/unit/escrita-em-organizations-usa-cliente-admin.test.ts
+++ b/tests/unit/escrita-em-organizations-usa-cliente-admin.test.ts
@@ -1,0 +1,191 @@
+/**
+ * QUEM ESCREVE EM `organizations` PRECISA DO CLIENTE ADMIN — E O PORQUÊ É UMA FALHA SILENCIOSA.
+ *
+ * A RLS de `organizations` deixa o membro LER a própria organização e deixa
+ * ESCREVER só quem é platform admin. Com o cliente de sessão, um
+ * `update(...).eq("id", orgId)` feito pelo `admin` do próprio tenant casa ZERO
+ * linhas — e o PostgREST devolve **sucesso**, sem erro. A tela diz "salvo" e
+ * nada foi gravado.
+ *
+ * ═══ POR QUE ISTO PRECISA DE UM GATE, E NÃO DE UMA LINHA NA DOUTRINA ═══
+ *
+ * O modo de falha é invisível de três maneiras ao mesmo tempo:
+ *
+ * 1. **Não dá erro.** Nenhum `catch` acende, nenhum Sentry abre.
+ * 2. **Funciona na máquina de quem escreveu.** O `install.sh` cria o dono da
+ *    instalação COMO platform admin — então o autor testa, grava, e só o
+ *    SEGUNDO administrador do time descobre. Num produto self-host, isso
+ *    significa que o defeito viaja até o cliente.
+ * 3. **Os testes de rota não podem vê-lo.** Eles mockam `createClient` inteiro
+ *    com um stub que sempre dá certo; um teste de unidade não tem RLS.
+ *
+ * A regra não está no `CLAUDE.md` — ela vive só como padrão nos arquivos
+ * irmãos, e um contribuidor que siga o `createClient()` do resto do handler
+ * acerta tudo que os gates visíveis sabem cobrar e ainda assim entrega um
+ * controle decorativo. Aconteceu no PR #671, e é por isso que este arquivo
+ * existe: `lib/ai/pontos` não tinha como saber.
+ *
+ * ═══ O QUE ESTE GATE NÃO DIZ ═══
+ *
+ * Ele não afere que o `.eq("organization_id", …)` / `.eq("id", …)` está lá — o
+ * cliente admin passa por cima da RLS, e o filtro de tenant vira
+ * responsabilidade do arquivo (anti-pattern 10 do `CLAUDE.md`). Isso é matéria
+ * de revisão humana. Aqui a pergunta é só: a escrita tem chance de acontecer?
+ */
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { arquivosDeCodigo, caminhoRelativo } from "./helpers/varrer-codigo";
+
+const RAIZES = ["app", "lib", "workers"] as const;
+const MUTACOES = new Set(["update", "insert", "upsert", "delete"]);
+
+/**
+ * Arquivos liberados, com o motivo escrito. Esta lista só encolhe: quem
+ * acrescentar um nome aqui está dizendo que a escrita não passa pela RLS de
+ * `organizations` por um motivo que sobrevive à leitura de outra pessoa.
+ */
+const LIBERADOS = new Map<string, string>([
+  [
+    "lib/auth/provision.ts",
+    "cria a organização no provisionamento, antes de existir membro — não há " +
+      "sessão de tenant para a RLS avaliar, e o cliente já é o de serviço.",
+  ],
+]);
+
+interface Achado {
+  arquivo: string;
+  linha: number;
+  cliente: string;
+  metodo: string;
+}
+
+/** O identificador-raiz de uma cadeia `x.from(...).update(...)`. */
+function raizDaCadeia(no: ts.Expression): string | null {
+  let atual: ts.Node = no;
+  while (true) {
+    if (ts.isIdentifier(atual)) return atual.text;
+    if (ts.isCallExpression(atual)) {
+      atual = atual.expression;
+      continue;
+    }
+    if (ts.isPropertyAccessExpression(atual)) {
+      atual = atual.expression;
+      continue;
+    }
+    if (ts.isAwaitExpression(atual) || ts.isParenthesizedExpression(atual)) {
+      atual = atual.expression;
+      continue;
+    }
+    return null;
+  }
+}
+
+/**
+ * Os nomes que, NAQUELE arquivo, foram declarados a partir de
+ * `createAdminClient()`. Resolver o identificador é o ponto: procurar a string
+ * "createAdminClient" no arquivo inteiro daria verde para um handler que tem o
+ * cliente admin numa função e o de sessão na outra — que é exatamente a forma
+ * do PR #671.
+ */
+function nomesDoClienteAdmin(fonte: ts.SourceFile): Set<string> {
+  const nomes = new Set<string>();
+  const visitar = (no: ts.Node): void => {
+    if (ts.isVariableDeclaration(no) && no.initializer && ts.isIdentifier(no.name)) {
+      let init: ts.Node = no.initializer;
+      if (ts.isAwaitExpression(init)) init = init.expression;
+      if (
+        ts.isCallExpression(init) &&
+        ts.isIdentifier(init.expression) &&
+        init.expression.text === "createAdminClient"
+      ) {
+        nomes.add(no.name.text);
+      }
+    }
+    ts.forEachChild(no, visitar);
+  };
+  visitar(fonte);
+  return nomes;
+}
+
+function escritasEmOrganizations(caminho: string): Achado[] {
+  const texto = readFileSync(caminho, "utf8");
+  if (!texto.includes('from("organizations")')) return [];
+
+  const fonte = ts.createSourceFile(caminho, texto, ts.ScriptTarget.Latest, true);
+  const admins = nomesDoClienteAdmin(fonte);
+  const achados: Achado[] = [];
+
+  const visitar = (no: ts.Node): void => {
+    // `<cadeia>.<mutacao>(...)` onde a cadeia contém `.from("organizations")`.
+    if (
+      ts.isCallExpression(no) &&
+      ts.isPropertyAccessExpression(no.expression) &&
+      MUTACOES.has(no.expression.name.text)
+    ) {
+      const alvo = no.expression.expression;
+      if (
+        ts.isCallExpression(alvo) &&
+        ts.isPropertyAccessExpression(alvo.expression) &&
+        alvo.expression.name.text === "from" &&
+        alvo.arguments.length === 1 &&
+        ts.isStringLiteral(alvo.arguments[0]) &&
+        alvo.arguments[0].text === "organizations"
+      ) {
+        const raiz = raizDaCadeia(alvo.expression.expression);
+        if (raiz !== null && !admins.has(raiz)) {
+          achados.push({
+            arquivo: caminhoRelativo(caminho),
+            linha: fonte.getLineAndCharacterOfPosition(no.getStart()).line + 1,
+            cliente: raiz,
+            metodo: no.expression.name.text,
+          });
+        }
+      }
+    }
+    ts.forEachChild(no, visitar);
+  };
+  visitar(fonte);
+  return achados;
+}
+
+const ARQUIVOS = arquivosDeCodigo(RAIZES);
+
+describe("toda escrita em `organizations` passa pelo cliente admin", () => {
+  it("CONTROLE: a varredura enxerga os arquivos que tocam a tabela", () => {
+    expect(ARQUIVOS.length).toBeGreaterThan(500);
+    const tocam = ARQUIVOS.filter((a) => readFileSync(a, "utf8").includes('from("organizations")'));
+    expect(
+      tocam.length,
+      "zero arquivos tocando `organizations` é indistinguível de 'está tudo em ordem' — a sonda cegou",
+    ).toBeGreaterThan(20);
+  });
+
+  it("CONTROLE: o resolvedor de identificador reconhece o padrão em vigor", () => {
+    const gemeo = ARQUIVOS.find((a) => caminhoRelativo(a) === "app/actions/auth/politicaDeMfa.ts");
+    expect(gemeo, "o gêmeo que escreve o MESMO jsonb sumiu — a sonda perdeu a referência").toBeDefined();
+    expect(escritasEmOrganizations(gemeo as string)).toEqual([]);
+  });
+
+  it("nenhum arquivo escreve com o cliente de sessão", () => {
+    const achados = ARQUIVOS.flatMap(escritasEmOrganizations).filter(
+      (a) => !LIBERADOS.has(a.arquivo),
+    );
+    expect(
+      achados,
+      "Escrita em `organizations` com cliente de sessão. A RLS só deixa escrever " +
+        "platform admin, então isto casa ZERO linhas e o PostgREST devolve SUCESSO — " +
+        "a tela diz 'salvo' e nada foi gravado. Troque por `createAdminClient()` e " +
+        "mantenha o filtro de tenant explícito (`.eq(\"id\", org.orgId)`), que com o " +
+        "service role passa a ser responsabilidade deste arquivo.",
+    ).toEqual([]);
+  });
+
+  it("a lista de liberados não tem nome órfão", () => {
+    for (const arquivo of LIBERADOS.keys()) {
+      const existe = ARQUIVOS.some((a) => caminhoRelativo(a) === arquivo);
+      expect(existe, `\`${arquivo}\` está liberado e não existe mais — a lista só encolhe`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Reconciliação do **#671** de @paulolimajr77, com o merge preservando os commits e a autoria dele — o PR original fecha como **mergeado**.

## O bloqueador, e por que ele era nosso

O `PATCH` gravava com o cliente de sessão. A RLS de `organizations` deixa o membro **ler** a própria organização e deixa **escrever** só quem é platform admin — então o `update` casava **zero linhas** para o `admin` do próprio tenant, e o PostgREST devolve **sucesso**.

```
é admin da org?                        → admin
é platform admin?                      → 0
CONTROLE lê a org:                     → 1     ← a sonda enxerga
LINHAS AFETADAS pelo update do PATCH:  → 0     ← a medida
LINHAS AFETADAS com admin client:      → 1     ← o conserto
```

E o `GET` anuncia `podeEditar: roleAtLeast(org.role, "admin")` — a tela oferecia o controle exatamente a quem ia receber o 500 "nada foi gravado". Funcionava só para o dono da instalação, que o `install.sh` cria como platform admin.

**@paulolimajr77 não tinha como saber.** A regra não está no `CLAUDE.md` (vive só como padrão nos arquivos irmãos), e os gates são cegos para ela por construção: os testes de rota mockam `createClient` inteiro com um stub que sempre dá certo, e teste de unidade não tem RLS.

## O conserto, e o gate que ele obriga

Troquei por `createAdminClient()`, mantendo o `.eq("id", org.orgId)` — que agora é obrigatório e não decorativo, porque com o service role o filtro de tenant vira responsabilidade do arquivo.

E, por passe 11 (todo defeito que os gates deixaram passar vira gate novo): `tests/unit/escrita-em-organizations-usa-cliente-admin.test.ts` varre `app|lib|workers` pelo AST e reprova toda cadeia `<cliente>.from("organizations").update|insert|upsert|delete` cujo cliente não venha de `createAdminClient()`.

Ele **resolve o identificador** — procurar a string `createAdminClient` no arquivo daria verde para um handler que tem o cliente admin numa função e o de sessão na outra, que é exatamente a forma deste PR.

**Sabotagem** (devolvi `await db` no `update`; `git diff --numstat` = `1 1`): previsto 1 vermelho e qual; observado

```
Tests  1 failed | 3 passed (4)
  × nenhum arquivo escreve com o cliente de sessão
```

Restaurado, árvore limpa.

Dois controles positivos (a varredura enxerga >500 arquivos e >20 tocando a tabela; o gêmeo `politicaDeMfa.ts`, que escreve o MESMO jsonb, passa) e um quarto caso que reprova nome órfão na lista de liberados — que tem **um** nome, com o motivo escrito.

Contra a `main` sozinha o gate nasce verde: zero violações hoje.

## O fragmento

Faltava, e eu escrevi: `.changes/modelo-padrao-da-organizacao-ganha-tela.md`.

## O que o PR dele faz, e o que não mexer

Zod no corpo; RBAC `admin` + `requireSupportWrite`; modelo conferido contra o catálogo do provedor; **merge em vez de sobrescrita** (`branding` e `security` moram no mesmo jsonb); guarda de zero linhas; audit `ai.org_default_updated`. Nenhuma migration — então os números disputados por outros PRs não são tocados. E o padrão preserva quem já instalou: `organizations.settings.llm` já existia e já era lido pelo resolver; o PR só o traz à tela.

## NÃO MEDIDO

**A tela pelo browser (DoD 12).** Não rodei Playwright nesta prévia. É o buraco declarado deste PR.

Fecha #671.