### PR TITLE
fix(EPIC-03): persistir mídia recebida pela API oficial

### DIFF
--- a/lib/channels/adapters/meta-cloud.ts
+++ b/lib/channels/adapters/meta-cloud.ts
@@ -185,6 +185,63 @@ export const metaCloudAdapter: ChannelAdapter = {
     unknownError: "meta_unknown",
   },
 
+  async fetchInboundMedia(input): Promise<{ buffer: Buffer; mime: string }> {
+    const creds = await resolveMetaCreds(createAdminClient(), {
+      organizationId: input.organizationId,
+      phoneNumberId: input.sessionRef,
+    });
+    if (!creds) {
+      throw new Error("meta_not_configured: sem credencial para baixar a mídia.");
+    }
+
+    const prefix = "meta-media:";
+    if (!input.url.startsWith(prefix)) {
+      throw new Error("meta_media_invalid_ref: ponte não reconhecido.");
+    }
+    const mediaId = input.url.slice(prefix.length);
+    if (!/^[A-Za-z0-9._~-]+$/.test(mediaId)) {
+      throw new Error("meta_media_invalid_ref: media_id inválido.");
+    }
+
+    const headers = { Authorization: `Bearer ${creds.token}` };
+    const lookup = await fetch(
+      `https://graph.facebook.com/${creds.graphVersion}/${encodeURIComponent(mediaId)}`,
+      { headers, signal: AbortSignal.timeout(15_000) },
+    );
+    const metadata = (await lookup.json().catch(() => ({}))) as {
+      url?: string;
+      mime_type?: string;
+      error?: { code?: number; message?: string };
+    };
+    if (!lookup.ok || metadata.error || !metadata.url) {
+      const detalhe = metadata.error?.message ?? lookup.statusText ?? "sem URL";
+      throw new Error(
+        `meta_media_lookup_failed: ${metadata.error?.code ?? lookup.status} ${detalhe}`.trim(),
+      );
+    }
+
+    const mediaUrl = new URL(metadata.url);
+    if (mediaUrl.protocol !== "https:" || mediaUrl.hostname !== "lookaside.fbsbx.com") {
+      throw new Error("meta_media_lookup_failed: host de mídia inesperado.");
+    }
+
+    const download = await fetch(mediaUrl.toString(), {
+      headers,
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!download.ok) {
+      throw new Error(`meta_media_download_failed: ${download.status} ${download.statusText}`.trim());
+    }
+
+    const buffer = Buffer.from(await download.arrayBuffer());
+    const mime =
+      download.headers.get("content-type")?.split(";")[0]?.trim() ||
+      metadata.mime_type ||
+      input.hintMime ||
+      "application/octet-stream";
+    return { buffer, mime };
+  },
+
   async send(envelope: OutboundEnvelope): Promise<{ externalId: string | null }> {
     // Sessão primeiro, env como fallback. O `sessionRef` do canal oficial É o
     // `phone_number_id` (ver `resolveSessionRef`), então ele é a chave da busca.

--- a/lib/channels/meta/ingest.ts
+++ b/lib/channels/meta/ingest.ts
@@ -180,6 +180,10 @@ export async function ingestMetaInbound(
       type: e.type === "text" ? "text" : e.type,
       body: e.type === "contact" ? (e.sharedContact?.name ?? e.text) : e.text,
       external_id: e.externalId,
+      // O webhook oficial entrega o media_id, não um arquivo que o browser
+      // consiga abrir. Mantemos um ponteiro opaco para o adapter resolver pela
+      // Graph API; sem ele a bolha nem é renderizada e o worker pula a mídia.
+      media_url: e.media ? `meta-media:${e.media.id}` : null,
       media_mime: e.media?.mime ?? null,
       sent_at: e.sentAt.toISOString(),
       metadata: {
@@ -208,6 +212,22 @@ export async function ingestMetaInbound(
   } as never);
 
   const messageId = (inserida as { id: string } | null)?.id ?? "";
+  if (e.media && messageId) {
+    const { error: erroPersistencia } = await admin.rpc("emit_event" as never, {
+      p_event_type: "media.persist_requested",
+      p_entity_kind: "message",
+      p_entity_id: messageId,
+      p_payload: { message_id: messageId, conversation_id: conversationId as string },
+      p_metadata: { source: "meta_webhook" },
+      p_organization_id: orgId,
+    } as never);
+    if (erroPersistencia) {
+      console.error(
+        "[meta.ingest] emit media.persist_requested failed",
+        erroPersistencia.message,
+      );
+    }
+  }
   await aplicarEfeitosPosEntrada(admin, {
     organizationId: orgId,
     contactId: contactId as string,

--- a/tests/unit/channel-adapter-meta.test.ts
+++ b/tests/unit/channel-adapter-meta.test.ts
@@ -218,6 +218,53 @@ describe("adapter meta_cloud — envio", () => {
   });
 });
 
+describe("adapter meta_cloud — mídia recebida", () => {
+  it("resolve o media_id na Graph e baixa os bytes com a credencial da sessão", async () => {
+    configurar();
+    sessaoNoBanco.token = "token-da-sessao";
+    const bytes = new Uint8Array([79, 103, 103, 83]);
+    const spy = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({
+          id: "987654321",
+          url: "https://lookaside.fbsbx.com/whatsapp_business/attachments/?mid=987654321",
+          mime_type: "audio/ogg; codecs=opus",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers({ "content-type": "audio/ogg" }),
+        arrayBuffer: async () => bytes.buffer,
+      });
+    vi.stubGlobal("fetch", spy);
+
+    const media = await a().fetchInboundMedia!({
+      organizationId: ORG,
+      sessionRef: "sessao-pn",
+      url: "meta-media:987654321",
+      hintMime: "audio/ogg; codecs=opus",
+    });
+
+    expect([...media.buffer]).toEqual([79, 103, 103, 83]);
+    expect(media.mime).toBe("audio/ogg");
+    expect(spy.mock.calls.map(([url]) => url)).toEqual([
+      "https://graph.facebook.com/v22.0/987654321",
+      "https://lookaside.fbsbx.com/whatsapp_business/attachments/?mid=987654321",
+    ]);
+    for (const [, init] of spy.mock.calls) {
+      expect((init.headers as Record<string, string>).Authorization).toBe(
+        "Bearer token-da-sessao",
+      );
+    }
+  });
+});
+
 describe("credencial por sessão — o que destrava multi-tenant", () => {
   it("com token na SESSÃO, o env deixa de valer", async () => {
     // Ordem sessão-primeiro: um env esquecido não pode silenciar o que foi

--- a/tests/unit/meta-ingest-media.test.ts
+++ b/tests/unit/meta-ingest-media.test.ts
@@ -1,0 +1,113 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ingestMetaInbound } from "@/lib/channels/meta/ingest";
+import type { InboundMessageEvent } from "@/lib/channels/meta/webhook";
+
+const estado = vi.hoisted(() => ({
+  insert: null as Record<string, unknown> | null,
+  rpcs: [] as Array<{ name: string; args: Record<string, unknown> }>,
+}));
+
+vi.mock("@/lib/channels/contato-por-telefone", () => ({
+  encontrarContatoPorTelefone: async () => null,
+}));
+
+vi.mock("@/lib/channels/pos-entrada", () => ({
+  aplicarEfeitosPosEntrada: async () => undefined,
+}));
+
+function adminFalso(): SupabaseClient {
+  const from = (table: string) => {
+    if (table === "channel_sessions") {
+      const chain: Record<string, unknown> = {
+        select: () => chain,
+        eq: () => chain,
+        is: () => chain,
+        maybeSingle: async () => ({
+          data: { id: "session-1", organization_id: "org-1" },
+          error: null,
+        }),
+      };
+      return chain;
+    }
+
+    if (table === "messages") {
+      const terminal = {
+        maybeSingle: async () => ({ data: { id: "message-1" }, error: null }),
+      };
+      return {
+        insert: (payload: Record<string, unknown>) => {
+          estado.insert = payload;
+          return { select: () => terminal };
+        },
+      };
+    }
+
+    throw new Error(`tabela inesperada: ${table}`);
+  };
+
+  const rpc = async (name: string, args: Record<string, unknown>) => {
+    estado.rpcs.push({ name, args });
+    if (name === "fn_upsert_wa_contact") return { data: "contact-1", error: null };
+    if (name === "fn_upsert_wa_conversation") {
+      return { data: "conversation-1", error: null };
+    }
+    return { data: null, error: null };
+  };
+
+  return { from, rpc } as unknown as SupabaseClient;
+}
+
+const EVENTO_COM_MIDIA: InboundMessageEvent = {
+  kind: "inbound_message",
+  wabaId: "waba-1",
+  phoneNumberId: "phone-1",
+  externalId: "wamid.MEDIA",
+  from: "5519999999999",
+  profileName: "Cliente",
+  sentAt: new Date("2026-09-11T12:00:00.000Z"),
+  type: "image",
+  text: null,
+  media: {
+    id: "987654321",
+    url: null,
+    mime: "image/jpeg",
+    voice: false,
+  },
+};
+
+beforeEach(() => {
+  estado.insert = null;
+  estado.rpcs = [];
+});
+
+describe("ingestão oficial de mídia", () => {
+  it("guarda um ponteiro recuperável e solicita a persistência dos bytes", async () => {
+    const outcome = await ingestMetaInbound(adminFalso(), EVENTO_COM_MIDIA, {
+      organizationId: "org-1",
+    });
+
+    expect(outcome).toEqual({
+      status: "ingested",
+      messageId: "message-1",
+      conversationId: "conversation-1",
+    });
+    expect(estado.insert).toMatchObject({
+      type: "image",
+      media_url: "meta-media:987654321",
+      media_mime: "image/jpeg",
+    });
+    expect(estado.rpcs).toContainEqual({
+      name: "emit_event",
+      args: {
+        p_event_type: "media.persist_requested",
+        p_entity_kind: "message",
+        p_entity_id: "message-1",
+        p_payload: { message_id: "message-1", conversation_id: "conversation-1" },
+        p_metadata: { source: "meta_webhook" },
+        p_organization_id: "org-1",
+      },
+    });
+  });
+});


### PR DESCRIPTION
# O que este PR faz

Corrige o recebimento de áudio, documento, imagem e vídeo em canais `meta_cloud`.

Antes, o webhook oficial gravava a mensagem sem uma referência recuperável para o arquivo e não solicitava sua persistência. A conversa recebia o registro, mas a mídia não chegava ao armazenamento nem aparecia na interface.

Agora, a ingestão guarda o `media_id` como ponteiro opaco, emite `media.persist_requested` e o adapter da Meta resolve e baixa os bytes pela Graph API usando a credencial da própria sessão. O download aceita somente URLs HTTPS do host de mídia da Meta.

Não há mudança de schema.

## Validação

- `pnpm exec vitest run tests/unit/channel-adapter-meta.test.ts tests/unit/meta-ingest-media.test.ts`: 17 testes aprovados.
- Suíte relacionada a mídia e worker: 59 testes aprovados em 8 arquivos.
- `pnpm typecheck`: aprovado.
- `pnpm lint`: aprovado com zero erros.
- `pnpm lint:channels`: aprovado.
- `pnpm build`: aprovado.
- A suíte completa no Windows terminou com 8.099 testes aprovados e 32 falhas em 11 arquivos. Os mesmos arquivos falharam novamente com a alteração removida, no `main` limpo, por dependências do ambiente e verificações já existentes.

---

### 📌 Contribuindo de um fork? Você está no lugar certo.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam (`pnpm test:unit`)
- [x] RLS testada, se toca tabela tenant-aware — não se aplica; não há alteração de tabela ou policy
- [x] Audit log emitido, se há mutação relevante — o fluxo emite `media.persist_requested` pelo mecanismo de eventos existente
- [x] Zod valida todo input externo novo — não há contrato externo novo; o `media_id` é validado antes da chamada à Graph API
- [x] Sem `console.log` esquecido
- [x] Mudança de schema saiu como migration versionada + apêndice no `baseline.sql` + linha no MANIFEST — não se aplica; não há mudança de schema
- [x] Doc atualizada se mudou contrato (PRD/spec) — não se aplica; o contrato público não mudou

Convenções completas em [`CLAUDE.md`](../CLAUDE.md) · fluxo em [`CONTRIBUTING.md`](../CONTRIBUTING.md).
