### PR TITLE
feat(followup): falta sem retorno após a régua abre aviso na Central (@matheuspedro360, do #657)

### DIFF
--- a/.changes/aviso-no-show-recuperacao-esgotada.md
+++ b/.changes/aviso-no-show-recuperacao-esgotada.md
@@ -1,0 +1,19 @@
+---
+impacto: capacidade_nova
+secao: adicionado
+titulo: Falta sem retorno depois da régua de recuperação vira aviso na Central
+---
+
+Quando um cliente falta a um compromisso e a equipe confirma a falta, o sistema já matricula
+esse contato num fluxo de recuperação — as mensagens de reengajamento que tentam remarcar. Até
+agora, se a régua inteira era enviada e o cliente **nunca respondia**, o fluxo simplesmente
+terminava: o card ficava parado na mesma etapa e ninguém era avisado de que a recuperação tinha
+esgotado.
+
+Agora, quando isso acontece, abre um aviso na Central de avisos apontando para o compromisso —
+"Cliente faltou e não respondeu à recuperação" —, para alguém decidir o próximo passo e mover o
+card no funil. É um aviso por falta (o mesmo compromisso remarcado gera uma falta nova, e um
+aviso novo); reprocessar não duplica.
+
+O construtor de fluxo não move etapa por conta própria de propósito — faltar a uma visita não é
+o negócio esfriando, e quem decide isso continua sendo uma pessoa.

--- a/lib/followup/engine.ts
+++ b/lib/followup/engine.ts
@@ -41,6 +41,10 @@ import {
   type NodeResult,
 } from "./node-handlers";
 import { coletarEsperasAdaptativas, type EsperaAdaptativa, type TimingPlan } from "./timing-plan";
+import {
+  avisoDeRecuperacaoEsgotada,
+  type AvisoRecuperacaoEsgotada,
+} from "./no-show-recuperacao-esgotada";
 import { interpolarDestino, persistirRespostaFollowupSupabase } from "./persistir-resposta";
 
 const MAX_STEPS = 80;
@@ -125,6 +129,13 @@ export interface AdminClient {
   updateEnrollment(id: string, orgId: string, patch: EnrollmentPatch): Promise<void>;
   loadFlowPointerName(orgId: string, pointerId: string): Promise<string | null>;
   insertDeadInboxItem(item: { organization_id: string; title: string; body: string; ref_id: string }): Promise<void>;
+  /**
+   * Régua de recuperação de falta esgotada sem resposta — abre um item na
+   * Central referenciando o COMPROMISSO. Opcional: só a produção precisa; os
+   * adaptadores de teste que não exercitam no-show podem omitir. Ver
+   * `no-show-recuperacao-esgotada.ts`.
+   */
+  abrirAvisoRecuperacaoEsgotada?(item: AvisoRecuperacaoEsgotada): Promise<void>;
   persistirRespostaFollowup(input: {
     organization_id: string;
     contact_id: string;
@@ -447,6 +458,16 @@ async function applyResult(
       patch.outcome = result.outcome;
       if (result.cancel_reason) patch.cancel_reason = result.cancel_reason;
       break;
+  }
+
+  // Aviso ANTES do `status='completed'`, mesma ordem (e mesma razão) de
+  // `markDead`: se cair entre as duas escritas, o enrollment continua
+  // claimable e um tick futuro re-executa `complete` → re-tenta o aviso (o
+  // índice único da 0224 torna a repetição um no-op). A ordem inversa
+  // arriscaria o aviso NUNCA sair.
+  const avisoEsgotada = avisoDeRecuperacaoEsgotada(enrollment, result, isReplay);
+  if (avisoEsgotada) {
+    await db.abrirAvisoRecuperacaoEsgotada?.(avisoEsgotada);
   }
 
   await db.updateEnrollment(enrollment.id, enrollment.organization_id, patch);
@@ -827,6 +848,27 @@ export function createSupabaseAdminClient(admin: SupabaseClient): AdminClient {
         ref_id: item.ref_id,
       });
       if (error) throw new Error(error.message);
+    },
+    async abrirAvisoRecuperacaoEsgotada(item) {
+      const { error } = await admin.from("agent_inbox_items").insert({
+        organization_id: item.organization_id,
+        // Reusa o kind da 0224 (mesma família: "a recuperação desta falta
+        // precisa de olhar humano") — evita migration só para um rótulo, e a
+        // Central já sabe renderizar `ref_kind='appointment'`.
+        kind: "appointment_recovery_review",
+        severity: "warn",
+        title: "Cliente faltou e não respondeu à recuperação",
+        body:
+          "As mensagens de reengajamento pós-falta foram enviadas e o cliente não respondeu. " +
+          "Decida o próximo passo e mova o card no funil.",
+        ref_kind: "appointment",
+        ref_id: item.appointment_id,
+        appointment_revision: item.appointment_revision,
+      });
+      // 23505 = já há aviso para esta (compromisso, revisão): o índice único
+      // `inbox_appointment_revision_unique` (0224) garante um por revisão,
+      // inclusive depois de resolvido. Repetição é no-op, não erro.
+      if (error && error.code !== "23505") throw new Error(error.message);
     },
     async persistirRespostaFollowup(input) {
       await persistirRespostaFollowupSupabase(admin, input);

--- a/lib/followup/no-show-recuperacao-esgotada.test.ts
+++ b/lib/followup/no-show-recuperacao-esgotada.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import type { EnrollmentRow, NodeResult } from "./node-handlers";
+import { avisoDeRecuperacaoEsgotada } from "./no-show-recuperacao-esgotada";
+
+const enrollmentBase: EnrollmentRow = {
+  id: "enr-1",
+  organization_id: "org-1",
+  pointer_id: "ptr-1",
+  version_id: "ver-1",
+  contact_id: "contact-1",
+  conversation_id: "conv-1",
+  current_node_id: "r3",
+  status: "waiting_reply",
+  next_eval_at: null,
+  claimed_until: null,
+  attempts: 0,
+  max_attempts: 3,
+  last_error: null,
+  steps_taken: 6,
+  outcome: null,
+  cancel_reason: null,
+  started_at: "2026-09-09T12:00:00.000Z",
+  completed_at: null,
+  updated_at: "2026-09-09T12:00:00.000Z",
+  appointment_id: "appt-1",
+  appointment_revision: 2,
+};
+
+const esgotou: NodeResult = { kind: "complete", outcome: "exhausted" };
+
+describe("avisoDeRecuperacaoEsgotada", () => {
+  it("abre aviso quando a régua de no-show esgota sem resposta", () => {
+    expect(avisoDeRecuperacaoEsgotada(enrollmentBase, esgotou, false)).toEqual({
+      organization_id: "org-1",
+      appointment_id: "appt-1",
+      appointment_revision: 2,
+      ref_enrollment_id: "enr-1",
+    });
+  });
+
+  it("carrega revisão null quando o enrollment não tem (compat)", () => {
+    const semRev = { ...enrollmentBase, appointment_revision: null };
+    expect(avisoDeRecuperacaoEsgotada(semRev, esgotou, false)?.appointment_revision).toBeNull();
+  });
+
+  it("não avisa em replay — o reprocesso não reabre o aviso", () => {
+    expect(avisoDeRecuperacaoEsgotada(enrollmentBase, esgotou, true)).toBeNull();
+  });
+
+  it("não avisa quando o cliente respondeu (outcome replied) nem no ramo fora do alvo (outcome null)", () => {
+    expect(
+      avisoDeRecuperacaoEsgotada(enrollmentBase, { kind: "complete", outcome: "replied" }, false),
+    ).toBeNull();
+    expect(
+      avisoDeRecuperacaoEsgotada(
+        enrollmentBase,
+        { kind: "complete", outcome: null, cancel_reason: "fora do alvo" },
+        false,
+      ),
+    ).toBeNull();
+  });
+
+  it("não avisa quando o fluxo só avançou (não concluiu)", () => {
+    const avanco: NodeResult = {
+      kind: "advance",
+      next_node_id: "m3",
+      next_eval_at: new Date("2026-09-09T15:00:00.000Z"),
+    };
+    expect(avisoDeRecuperacaoEsgotada(enrollmentBase, avanco, false)).toBeNull();
+  });
+
+  it("não avisa quando o enrollment não veio de uma falta (sem appointment_id)", () => {
+    const semAppt = { ...enrollmentBase, appointment_id: null };
+    expect(avisoDeRecuperacaoEsgotada(semAppt, esgotou, false)).toBeNull();
+  });
+});

--- a/lib/followup/no-show-recuperacao-esgotada.ts
+++ b/lib/followup/no-show-recuperacao-esgotada.ts
@@ -1,0 +1,58 @@
+/**
+ * O laço de retorno do no-show quando a recuperação NÃO deu certo.
+ *
+ * `fn_appointment_recover` (migration 0224) matricula o contato num fluxo de
+ * `appointment_no_show` com o `appointment_id` fixado no enrollment. Se a régua
+ * chega ao fim e o cliente nunca respondeu, o enrollment conclui com outcome
+ * `exhausted` — e aí o card fica exatamente onde estava: o construtor de fluxo
+ * não move etapa, e não há turno do agente ao fim de uma régua de texto fixo
+ * para chamar `crm_move_lead_stage`.
+ *
+ * Sem sinal nenhum, isso é uma demanda que morreu em silêncio (invariante 4 do
+ * Sistema Vivo: nenhuma demanda sem próximo passo). O sinal é um item na Central
+ * de avisos, com o COMPROMISSO como referência — quem opera decide o próximo
+ * passo e move o card à mão. É a decisão registrada em relatório: "Aviso na
+ * Central + mover manual", em vez de uma feature de mover-etapa no construtor.
+ *
+ * Esta função é a REGRA (pura, testável sem banco); quem grava o item é o
+ * adaptador em `engine.ts` (`abrirAvisoRecuperacaoEsgotada`), no mesmo lugar e
+ * pelo mesmo motivo que `insertDeadInboxItem`.
+ */
+import type { EnrollmentRow, NodeResult } from "./node-handlers";
+
+export interface AvisoRecuperacaoEsgotada {
+  organization_id: string;
+  appointment_id: string;
+  /** A revisão do compromisso no momento da matrícula — o índice único da 0224
+   *  é por (compromisso, revisão, tipo), então remarcar gera uma falta nova e
+   *  um aviso novo, e reprocessar a mesma não duplica. */
+  appointment_revision: number | null;
+  /** Só para o log/correlação — o `ref_id` do item é o compromisso, não isto. */
+  ref_enrollment_id: string;
+}
+
+/**
+ * Deve abrir aviso? Só quando TODAS valem:
+ *  - o passo não é replay (senão um reprocesso abre o aviso de novo — o 23505 do
+ *    índice único cobre, mas nem chega lá);
+ *  - o enrollment terminou de verdade (`complete`) com outcome `exhausted` —
+ *    `replied` (cliente voltou, normalmente via `cancel_on_reply`) e o `custom`
+ *    do ramo "fora do alvo" (outcome `null`) não avisam;
+ *  - o enrollment carrega `appointment_id` — é o que distingue uma régua de
+ *    recuperação de falta de qualquer outro fluxo esgotado.
+ */
+export function avisoDeRecuperacaoEsgotada(
+  enrollment: EnrollmentRow,
+  result: NodeResult,
+  isReplay: boolean,
+): AvisoRecuperacaoEsgotada | null {
+  if (isReplay) return null;
+  if (result.kind !== "complete" || result.outcome !== "exhausted") return null;
+  if (!enrollment.appointment_id) return null;
+  return {
+    organization_id: enrollment.organization_id,
+    appointment_id: enrollment.appointment_id,
+    appointment_revision: enrollment.appointment_revision ?? null,
+    ref_enrollment_id: enrollment.id,
+  };
+}

--- a/lib/followup/turn-bridge.ts
+++ b/lib/followup/turn-bridge.ts
@@ -361,15 +361,42 @@ export function createPgAdminClient(pool: pg.Pool): TurnBridgeAdminClient {
       );
     },
     async abrirAvisoRecuperacaoEsgotada(item) {
+      // ⚠️ `insert ... select`, e NÃO `insert ... values`. A diferença é a
+      // guarda de LGPD, e ela precisa estar DENTRO da escrita.
+      //
+      // Esta é a QUARTA porta para `appointment_recovery_review`, e as outras
+      // três já guardam anonimização — `fn_appointment_recover` recusa contato
+      // anonimizado, `fn_meet_redact_contact` resolve os abertos, e há um bloco
+      // de cura no baseline. Esta nascia sem, e a consequência é concreta:
+      //
+      //   a cascata de LGPD NÃO cancela `followup_enrollments` (medido, com
+      //   controle positivo). Um contato anonimizado com régua em curso chega
+      //   ao fim dela DEPOIS da redação — e reabriria, aqui, um aviso
+      //   apontando para o compromisso que a anonimização tinha desligado.
+      //
+      // Um `if` em TypeScript antes do insert resolveria o caso e deixaria a
+      // guarda a um refactor de distância de sumir. No `select` ela é parte da
+      // escrita: quem mudar a consulta tem de apagar a linha de propósito.
+      //
+      // O contato vem do COMPROMISSO, não do enrollment: é o vínculo que a
+      // anonimização de fato percorre.
+      //
       // `on conflict do nothing` casa o índice parcial da 0224
       // (inbox_appointment_revision_unique): repetir num reprocesso é no-op.
       await pool.query(
         `insert into agent_inbox_items
            (organization_id, kind, severity, title, body, ref_kind, ref_id, appointment_revision)
-         values ($1, 'appointment_recovery_review', 'warn',
-                 'Cliente faltou e não respondeu à recuperação',
-                 'As mensagens de reengajamento pós-falta foram enviadas e o cliente não respondeu. Decida o próximo passo e mova o card no funil.',
-                 'appointment', $2, $3)
+         select $1, 'appointment_recovery_review', 'warn',
+                'Cliente faltou e não respondeu à recuperação',
+                'As mensagens de reengajamento pós-falta foram enviadas e o cliente não respondeu. Decida o próximo passo e mova o card no funil.',
+                'appointment', a.id, $3
+           from calendar_appointments a
+           join contacts c
+             on c.organization_id = a.organization_id
+            and c.id = a.contact_id
+          where a.organization_id = $1
+            and a.id = $2
+            and not c.is_anonymized
          on conflict (organization_id, ref_id, appointment_revision, kind)
            where ref_kind = 'appointment' and appointment_revision is not null
            do nothing`,

--- a/lib/followup/turn-bridge.ts
+++ b/lib/followup/turn-bridge.ts
@@ -360,6 +360,22 @@ export function createPgAdminClient(pool: pg.Pool): TurnBridgeAdminClient {
         [item.organization_id, item.title, item.body, item.ref_id],
       );
     },
+    async abrirAvisoRecuperacaoEsgotada(item) {
+      // `on conflict do nothing` casa o índice parcial da 0224
+      // (inbox_appointment_revision_unique): repetir num reprocesso é no-op.
+      await pool.query(
+        `insert into agent_inbox_items
+           (organization_id, kind, severity, title, body, ref_kind, ref_id, appointment_revision)
+         values ($1, 'appointment_recovery_review', 'warn',
+                 'Cliente faltou e não respondeu à recuperação',
+                 'As mensagens de reengajamento pós-falta foram enviadas e o cliente não respondeu. Decida o próximo passo e mova o card no funil.',
+                 'appointment', $2, $3)
+         on conflict (organization_id, ref_id, appointment_revision, kind)
+           where ref_kind = 'appointment' and appointment_revision is not null
+           do nothing`,
+        [item.organization_id, item.appointment_id, item.appointment_revision],
+      );
+    },
     async persistirRespostaFollowup(input) {
       await persistirRespostaFollowupPg((sql, params) => pool.query(sql, params), input);
     },

--- a/tests/invariants/agenda-presenca-recuperacao.test.ts
+++ b/tests/invariants/agenda-presenca-recuperacao.test.ts
@@ -359,10 +359,33 @@ describe("presença e recuperação transacionais", () => {
       [rec.enrollment_id],
     );
 
-    await runFollowupTick(
-      { db: createPgAdminClient(pool), clock: () => new Date(), enqueueJob: async () => {} },
-      { limit: 10 },
-    );
+    // ⚠️ DOIS TICKS, e não é folga: o motor avança UM nó por rodada.
+    //
+    // O primeiro tick tira o enrollment do gatilho e o deixa PARADO no nó
+    // `end` (`current_node_id='end'`, ainda `status='active'`); é o SEGUNDO que
+    // EXECUTA o `end` e conclui com `outcome='exhausted'`, que é o que dispara
+    // o aviso. Em produção o cron roda a cada minuto e isso é invisível.
+    //
+    // Medido, porque a primeira versão deste teste tinha um tick só e o
+    // diagnóstico foi para o lugar errado — a suspeita (minha e do autor) era
+    // de que `fn_claim_due_followup_enrollments` estivesse falhando, já que
+    // `claimed: 0` é indistinguível de "nada vencido". Sondei a função direto:
+    //
+    //   SONDA-CLAIM-OK  {"n":1}
+    //   SONDA-TICK      {"claimed":1,"advanced":1,"scheduled":0,"failed":0}
+    //   SONDA-POS       {"status":"active","current_node_id":"end"}
+    //
+    // O claim funcionava o tempo todo. Faltava uma rodada.
+    for (let rodada = 0; rodada < 2; rodada += 1) {
+      await pool.query(
+        "update followup_enrollments set next_eval_at = now() - interval '1 second' where id = $1 and status = 'active'",
+        [rec.enrollment_id],
+      );
+      await runFollowupTick(
+        { db: createPgAdminClient(pool), clock: () => new Date(), enqueueJob: async () => {} },
+        { limit: 10 },
+      );
+    }
 
     const enr = (
       await pool.query("select status, outcome from followup_enrollments where id = $1", [rec.enrollment_id])
@@ -724,5 +747,99 @@ describe("presença e recuperação transacionais", () => {
       outcome_message_id: null,
       outcome_user_id: GOV_AGENT_A,
     });
+  });
+  it("contato ANONIMIZADO não ganha aviso — a régua termina calada", async () => {
+    // ═══ POR QUE ESTE CASO EXISTE ═══
+    //
+    // A cascata de LGPD **não cancela** `followup_enrollments`. Então um contato
+    // anonimizado com régua em curso chega ao fim dela DEPOIS da redação, e a
+    // porta do aviso reabriria um item apontando para o compromisso que a
+    // anonimização tinha desligado.
+    //
+    // As outras três portas para `appointment_recovery_review` já guardam isso
+    // (`fn_appointment_recover` recusa contato anonimizado,
+    // `fn_meet_redact_contact` resolve os abertos, e há um bloco de cura no
+    // baseline). Esta era a quarta e nascia sem — e nenhum invariante cobrava a
+    // guarda de quem escreve o `kind` pelo TypeScript. Por isso ela mora DENTRO
+    // do `insert ... select` em `turn-bridge.ts`, e não num `if` antes dele:
+    // no `select`, quem mudar a consulta tem de apagar a linha de propósito.
+    await stopFlows();
+    const v = (
+      await pool.query(
+        "insert into followup_flow_versions(organization_id,graph) values($1,$2) returning id",
+        [
+          GOV_ORG,
+          {
+            nodes: [
+              { id: "t", type: "trigger", label: "Falta", position: { x: 0, y: 0 }, config: {} },
+              { id: "end", type: "end", label: "Fim", position: { x: 0, y: 1 }, config: { outcome: "exhausted" } },
+            ],
+            edges: [{ id: "e", source: "t", target: "end", priority: 0, condition: { type: "always" } }],
+          },
+        ],
+      )
+    ).rows[0].id;
+    const ponteiro = (
+      await pool.query(
+        "insert into followup_flow_pointers(organization_id,name,status,active_version_id,trigger_config) values($1,'Recuperação anonimizada '||gen_random_uuid(),'active',$2,$3) returning id",
+        [GOV_ORG, v, { kind: "appointment_no_show", cancel_on_reply: false }],
+      )
+    ).rows[0].id;
+    const agent = (
+      await pool.query(
+        "insert into ai_agents(organization_id,name,system_prompt) values($1,'Recuperação anonimizada '||gen_random_uuid(),'Prompt') returning id",
+        [GOV_ORG],
+      )
+    ).rows[0].id;
+    await pool.query(
+      "insert into ai_agent_versions(organization_id,agent_id,version_number,system_prompt,provider,model,channel_session_id,status,followup) values($1,$2,1,'Prompt','anthropic','claude-sonnet-4-6',$3,'published',$4)",
+      [GOV_ORG, agent, GOV_SESSION, { enabled: true, flow_pointer_ids: [ponteiro] }],
+    );
+
+    const a = await fixture();
+    await change(a.id);
+    const rec = await recover(a.id);
+    expect(rec.result).toBe("started");
+
+    // A redação acontece DEPOIS da matrícula — é exatamente a ordem que cria o
+    // problema, e a que a cascata de LGPD produz hoje.
+    await pool.query(
+      "update contacts set is_anonymized = true, anonymized_at = now(), display_name = 'Cliente Anonimizado #1' where id = $1",
+      [a.contact],
+    );
+
+    // CONTROLE POSITIVO: o enrollment continua vivo depois da anonimização.
+    // Sem isto, "nenhum aviso" poderia ser porque a régua já tinha morrido — e
+    // o teste passaria sem medir a guarda.
+    expect(
+      (await pool.query("select status from followup_enrollments where id = $1", [rec.enrollment_id])).rows[0].status,
+      "a cascata de LGPD passou a cancelar o enrollment — se isso mudou de propósito, este caso perdeu o objeto",
+    ).toBe("active");
+
+    for (let rodada = 0; rodada < 2; rodada += 1) {
+      await pool.query(
+        "update followup_enrollments set next_eval_at = now() - interval '1 second' where id = $1 and status = 'active'",
+        [rec.enrollment_id],
+      );
+      await runFollowupTick(
+        { db: createPgAdminClient(pool), clock: () => new Date(), enqueueJob: async () => {} },
+        { limit: 10 },
+      );
+    }
+
+    // CONTROLE: a régua CHEGOU AO FIM — senão "nenhum aviso" seria trivial.
+    expect(
+      (await pool.query("select status, outcome from followup_enrollments where id = $1", [rec.enrollment_id])).rows[0],
+    ).toMatchObject({ status: "completed", outcome: "exhausted" });
+
+    expect(
+      (
+        await pool.query(
+          "select count(*)::int n from agent_inbox_items where organization_id=$1 and ref_id=$2 and kind='appointment_recovery_review'",
+          [GOV_ORG, a.id],
+        )
+      ).rows[0].n,
+      "abriu aviso para um contato anonimizado — o item aponta para um compromisso que a redação desligou",
+    ).toBe(0);
   });
 });

--- a/tests/invariants/agenda-presenca-recuperacao.test.ts
+++ b/tests/invariants/agenda-presenca-recuperacao.test.ts
@@ -1,4 +1,5 @@
 import { completeTurnForEnrollment, createPgAdminClient } from "@/lib/followup/turn-bridge";
+import { runFollowupTick } from "@/lib/followup/engine";
 import { randomUUID } from "node:crypto";
 import pg from "pg";
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
@@ -306,6 +307,87 @@ describe("presença e recuperação transacionais", () => {
         await pool.query(
           "select count(*)::int n from agent_inbox_items where ref_id=$1 and kind='appointment_recovery_review'",
           [a.id],
+        )
+      ).rows[0].n,
+    ).toBe(1);
+  });
+  it("régua de recuperação esgotada sem resposta abre aviso na Central referenciando o compromisso", async () => {
+    await stopFlows();
+    // Fluxo mínimo que chega direto ao fim com outcome `exhausted` — o motor
+    // conclui num tick só e o hook de `no-show-recuperacao-esgotada` dispara.
+    const v = (
+      await pool.query(
+        "insert into followup_flow_versions(organization_id,graph) values($1,$2) returning id",
+        [
+          GOV_ORG,
+          {
+            nodes: [
+              { id: "t", type: "trigger", label: "Falta", position: { x: 0, y: 0 }, config: {} },
+              { id: "end", type: "end", label: "Fim", position: { x: 0, y: 1 }, config: { outcome: "exhausted" } },
+            ],
+            edges: [{ id: "e", source: "t", target: "end", priority: 0, condition: { type: "always" } }],
+          },
+        ],
+      )
+    ).rows[0].id;
+    const p = (
+      await pool.query(
+        "insert into followup_flow_pointers(organization_id,name,status,active_version_id,trigger_config) values($1,'Recuperação esgotável '||gen_random_uuid(),'active',$2,$3) returning id",
+        [GOV_ORG, v, { kind: "appointment_no_show", cancel_on_reply: false }],
+      )
+    ).rows[0].id;
+    const agent = (
+      await pool.query(
+        "insert into ai_agents(organization_id,name,system_prompt) values($1,'Recuperação esgotável '||gen_random_uuid(),'Prompt') returning id",
+        [GOV_ORG],
+      )
+    ).rows[0].id;
+    await pool.query(
+      "insert into ai_agent_versions(organization_id,agent_id,version_number,system_prompt,provider,model,channel_session_id,status,followup) values($1,$2,1,'Prompt','anthropic','claude-sonnet-4-6',$3,'published',$4)",
+      [GOV_ORG, agent, GOV_SESSION, { enabled: true, flow_pointer_ids: [p] }],
+    );
+
+    const a = await fixture();
+    await change(a.id);
+    const rec = await recover(a.id);
+    expect(rec.result).toBe("started");
+
+    // O enrollment recém-criado pode estar a alguns ms no futuro para o Postgres
+    // (ver followup-relogio.ts) — força-o a devido antes do tick.
+    await pool.query(
+      "update followup_enrollments set next_eval_at = now() - interval '1 second' where id = $1",
+      [rec.enrollment_id],
+    );
+
+    await runFollowupTick(
+      { db: createPgAdminClient(pool), clock: () => new Date(), enqueueJob: async () => {} },
+      { limit: 10 },
+    );
+
+    const enr = (
+      await pool.query("select status, outcome from followup_enrollments where id = $1", [rec.enrollment_id])
+    ).rows[0];
+    expect(enr).toMatchObject({ status: "completed", outcome: "exhausted" });
+
+    const aviso = (
+      await pool.query(
+        "select severity, ref_kind, appointment_revision::int rev from agent_inbox_items where organization_id=$1 and ref_id=$2 and kind='appointment_recovery_review'",
+        [GOV_ORG, a.id],
+      )
+    ).rows;
+    expect(aviso).toHaveLength(1);
+    expect(aviso[0]).toMatchObject({ severity: "warn", ref_kind: "appointment", rev: 2 });
+
+    // Idempotente: reprocessar o mesmo passo não abre um segundo aviso.
+    await runFollowupTick(
+      { db: createPgAdminClient(pool), clock: () => new Date(), enqueueJob: async () => {} },
+      { limit: 10 },
+    );
+    expect(
+      (
+        await pool.query(
+          "select count(*)::int n from agent_inbox_items where organization_id=$1 and ref_id=$2 and kind='appointment_recovery_review'",
+          [GOV_ORG, a.id],
         )
       ).rows[0].n,
     ).toBe(1);


### PR DESCRIPTION
Reconciliação do **#657** de @matheuspedro360, com o merge preservando os commits e a autoria dele — o PR original fecha como **mergeado**.

## O vermelho não era o que nós dois suspeitávamos

O invariante reprovava com o enrollment parado em `status: active`. A hipótese — minha e dele — era que `fn_claim_due_followup_enrollments` estivesse falhando. Era plausível: o `engine.ts` **engole falha de claim**, e o comentário dele diz com todas as letras que `claimed: 0` é indistinguível de "nada vencido".

Sondei a função direto, num Postgres de verdade:

```
SONDA-ESTADO {"status":"active","vencido":true,"claimed_until":null,
              "appointment_revision":"2","ap_status":"no_show","recibos":"1"}
SONDA-CLAIM-OK  {"n":1}
SONDA-TICK      {"claimed":1,"advanced":1,"scheduled":0,"failed":0}
SONDA-POS       {"status":"active","current_node_id":"end"}
```

**O claim funcionava o tempo todo.** O motor avança **um nó por rodada**: o primeiro tick tira o enrollment do gatilho e o deixa **parado** no nó `end`; é o segundo que **executa** o `end` e conclui com `exhausted`. O teste tinha um tick só.

Em produção o cron roda a cada minuto e isso é invisível — não é defeito de produto. O laço agora roda duas rodadas, com o motivo e a medição escritos ali, para a próxima pessoa não repetir o caminho.

## O bloqueador que era nosso, e eu consertei

`abrirAvisoRecuperacaoEsgotada` é a **quarta porta** para `appointment_recovery_review`, e as outras três já guardam anonimização: `fn_appointment_recover` recusa contato anonimizado, `fn_meet_redact_contact` resolve os abertos com `ref_id=null`, e há um bloco de cura no baseline. Esta nascia **sem** — e nenhum invariante cobrava a guarda de quem escreve o `kind` pelo TypeScript.

A consequência é concreta: **a cascata de LGPD não cancela `followup_enrollments`.** Um contato anonimizado com régua em curso chega ao fim dela *depois* da redação, e esta porta reabriria um aviso apontando para o compromisso que a anonimização tinha desligado.

A guarda foi para **dentro** da escrita — `insert ... select` com join em `contacts` e `not c.is_anonymized` —, e não num `if` antes do insert. Num `if` ela fica a um refactor de distância de sumir; no `select`, quem mudar a consulta tem de apagar a linha de propósito. O contato vem do **compromisso**, que é o vínculo que a anonimização de fato percorre.

## O que eu medi

```
pnpm test:db tests/invariants/agenda-presenca-recuperacao.test.ts
Tests  19 passed (19)
```

**Sabotagem** (tirei `and not c.is_anonymized`; `git diff --numstat` = `0 1`): previsto 1 vermelho e qual; observado

```
× contato ANONIMIZADO não ganha aviso — a régua termina calada
Tests  1 failed | 18 passed (19)
```

Restaurado, árvore limpa. `pnpm typecheck` exit 0.

O invariante novo tem **dois** controles positivos, porque "nenhum aviso" é fácil de obter por acidente: um afirma que o enrollment continua vivo depois da anonimização (senão a régua teria morrido antes), e outro que ela **chegou ao fim** (senão não haveria o que avisar).

## O que ele acertou, e é bastante

- **A porta já existia, e ele reusou a certa.** Não criou `kind` nem migration: usou `appointment_recovery_review`, que já vive na `main` em 6 arquivos de produto. É o oposto do erro comum aqui, que é criar aviso novo sem porta.
- **Dedup e resolvedor certos**: o índice `inbox_appointment_revision_unique` é precisamente o `on conflict` dele, e o `23505` tolerado no `engine.ts` fecha o laço.
- **Sem colisão com os inseridores existentes**: os dois da `main` só disparam com `result <> 'started'`, e o dele só com enrollment iniciado e esgotado — mutuamente exclusivos. Verifiquei.
- A regra é **pura e testável sem banco**, e quem grava é o adaptador — mesmo desenho de `insertDeadInboxItem`.

## NÃO MEDIDO

A suíte completa e o `e2e` nesta prévia — o CI deste PR roda os dois. E se o cenário de LGPD já ocorreu em alguma instalação real: não há como saber daqui.

Fecha #657.