### PR TITLE
fix(agenda): o botão "Reativar" tipo de agendamento passa a funcionar

### DIFF
--- a/.changes/reativar-tipo-de-agendamento.md
+++ b/.changes/reativar-tipo-de-agendamento.md
@@ -1,0 +1,24 @@
+---
+impacto: capacidade_nova
+secao: corrigido
+titulo: O botão "Reativar" de tipo de agendamento passa a funcionar
+---
+
+Em Configurações › Agenda, um tipo de agendamento desativado mostra o botão
+"Reativar" — e ele **nunca funcionou**, desde que a tela existe. Clicar devolvia
+sempre o mesmo erro: "Nenhum campo para alterar." Quem tinha desativado um tipo
+por engano ficava sem saída pela tela: só criando outro com nome diferente, já
+que o nome original continuava ocupado pelo tipo desligado.
+
+A causa era um campo que o servidor descartava em silêncio. A tela pedia para
+ligar o tipo de volta usando a mesma porta que altera nome, duração e
+responsável — e essa porta não conhece o campo "ativo", então recebia um pedido
+que, do lado dela, não mudava nada.
+
+Agora reativar tem porta própria no servidor, com a mesma exigência de papel do
+desativar (gerente ou administrador), e fica registrado na trilha de auditoria
+como "tipo reativado" — separado de uma alteração comum de campo, para que um
+tipo religado não se confunda com um tipo que teve a duração mudada.
+
+Você não precisa fazer nada para adotar. Desativar continua igual, e nenhum
+compromisso já marcado é afetado.

--- a/app/api/v1/agenda/tipos/reativar/route.ts
+++ b/app/api/v1/agenda/tipos/reativar/route.ts
@@ -1,0 +1,91 @@
+import { requireSupportWrite } from "@/lib/impersonate/support";
+/**
+ * REATIVAR UM TIPO DE AGENDAMENTO — o outro lado do `DELETE` da rota irmã.
+ *
+ * ─── O defeito que esta rota fecha ────────────────────────────────────────
+ *
+ * A tela de Configurações › Agenda sempre teve o botão "Reativar", e ele
+ * **nunca funcionou**. Ele mandava `PATCH /api/v1/agenda/tipos` com
+ * `{ id, is_active: true }`, e o `alterarSchema` daquela rota é
+ * `criarSchema.partial()` — `is_active` não está entre os doze campos de
+ * `camposDoTipo`. Zod descarta chave desconhecida **em silêncio**, então o
+ * corpo chegava vazio ao `update` e a rota respondia 422 "Nenhum campo para
+ * alterar." — uma recusa que não nomeia o que aconteceu, numa tela em que o
+ * usuário só vê "não deu".
+ *
+ * Quem escondeu o defeito do compilador foi um `as never` na chamada (o único
+ * do arquivo da tela). Ele saiu junto com este conserto.
+ *
+ * ─── Por que uma ROTA, e não `is_active` no schema do PATCH ───────────────
+ *
+ * O caminho curto seria acrescentar `is_active` a `camposDoTipo`. Ele custa uma
+ * linha e cobra duas coisas:
+ *
+ * 1. O MESMO pedido que muda duração passaria a poder **desligar** um tipo. E
+ *    desligar já tem porta própria (o `DELETE`), com a guarda e a decisão de
+ *    "desativar, nunca apagar" escritas lá.
+ * 2. A trilha perderia a distinção. Reativar cairia em `api_audit_log` como
+ *    `agenda.tipo_alterado { campos: ["is_active"] }` — indistinguível, para
+ *    quem audita depois, de "mudaram a duração". Ligar de volta um tipo que
+ *    alguém desligou é ato de gestão e merece verbo próprio na trilha:
+ *    `agenda.tipo_reativado`.
+ *
+ * Sub-rota de ação é a forma que esta casa já usa para o ato que não é um campo
+ * — `agenda/google/desconectar`, `contacts/merge`, `lgpd/anonymize`.
+ *
+ * ─── Simetria com o `DELETE` ──────────────────────────────────────────────
+ *
+ * Mesmo papel (`manager`), mesma guarda de suporte, mesmo filtro explícito de
+ * `organization_id` no client de service role, mesmo 404 quando não há linha.
+ * Dizer "reativei" sobre o que não existe é a mesma família de mentira que o
+ * `DELETE` recusa do outro lado.
+ */
+import { type NextRequest } from "next/server";
+import { z } from "zod";
+
+import { fail, ok } from "@/lib/api/wrappers";
+import { audit } from "@/lib/audit";
+import { requireRole } from "@/lib/auth/require-role";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { traduzir } from "@/lib/i18n/dicionario";
+
+export const dynamic = "force-dynamic";
+
+const corpo = z.object({ id: z.string().uuid() });
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const supportDenied = await requireSupportWrite();
+  if (supportDenied) return supportDenied;
+
+  const requestId = req.headers.get("x-request-id") ?? undefined;
+  const autorizado = await requireRole("manager", { requestId, resource: "calendar_event_types" });
+  if (!autorizado.ok) return autorizado.response;
+  const t = (texto: string) => traduzir(texto, autorizado.user.idioma);
+
+  const lido = corpo.safeParse(await req.json().catch(() => ({})));
+  if (!lido.success) return fail("validation_failed", t("corpo inválido"), 422, { requestId });
+
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("calendar_event_types")
+    .update({ is_active: true })
+    .eq("id", lido.data.id)
+    // O tenant vem da SESSÃO, nunca do corpo — o corpo carrega só o `id` do
+    // tipo, e sem este filtro a service role reativaria tipo de outra casa.
+    .eq("organization_id", autorizado.org.orgId)
+    .select("id")
+    .maybeSingle();
+
+  if (error) return fail("internal_error", error.message, 500, { requestId });
+  if (!data) return fail("not_found", t("Tipo de agendamento não encontrado."), 404, { requestId });
+
+  await audit({
+    actorUserId: autorizado.user.id,
+    action: "agenda.tipo_reativado",
+    organizationId: autorizado.org.orgId,
+    resourceType: "calendar_event_types",
+    resourceId: lido.data.id,
+    metadata: {},
+  });
+  return ok(data, { requestId });
+}

--- a/app/api/v1/agenda/tipos/route.ts
+++ b/app/api/v1/agenda/tipos/route.ts
@@ -18,6 +18,20 @@ import { requireSupportWrite } from "@/lib/impersonate/support";
  * DELETE aqui grava `is_active = false`: some da tela de marcar e continua
  * respondendo pelo passado. É o mesmo raciocínio do anti-pattern 7 da doutrina
  * (cascade fantasma).
+ *
+ * ─── E a volta mora AO LADO, não aqui ────────────────────────────────────
+ *
+ * Reativar é `POST /api/v1/agenda/tipos/reativar`. `is_active` está fora de
+ * `camposDoTipo` DE PROPÓSITO: aceitá-lo no PATCH deixaria o mesmo pedido que
+ * muda a duração poder desligar o tipo, e a trilha registraria a religada como
+ * `agenda.tipo_alterado { campos: ["is_active"] }` — indistinguível de uma
+ * alteração de campo qualquer.
+ *
+ * ⚠️ Essa exclusão é silenciosa e já custou: Zod DESCARTA chave desconhecida sem
+ * dizer nada, então o botão "Reativar" da tela mandou `is_active` para cá
+ * durante toda a vida dele e recebeu 422 "Nenhum campo para alterar." — uma
+ * recusa que não nomeia o que foi descartado. Quem vigia a travessia hoje é
+ * `tests/unit/agenda-reativar-tipo.test.ts`.
  */
 import { type NextRequest } from "next/server";
 import { z } from "zod";

--- a/app/app/settings/tenant/agenda/_client.tsx
+++ b/app/app/settings/tenant/agenda/_client.tsx
@@ -412,7 +412,15 @@ export function TiposDeAgendamentoClient({
                       disabled={salvando}
                       onClick={() =>
                         void comErro(
-                          () => apiClient.patch("/api/v1/agenda/tipos", { id: tipo.id, is_active: true } as never),
+                          // Rota PRÓPRIA, e o `as never` que estava aqui saiu.
+                          //
+                          // Este botão nunca funcionou: mandava `is_active` num
+                          // PATCH cujo schema é `criarSchema.partial()`, onde
+                          // esse campo não existe. Zod descarta chave
+                          // desconhecida em silêncio, o corpo chegava vazio e a
+                          // resposta era 422 "Nenhum campo para alterar.". O
+                          // cast era o que impedia o typecheck de acusar.
+                          () => apiClient.post("/api/v1/agenda/tipos/reativar", { id: tipo.id }),
                           "Tipo reativado.",
                         )
                       }

--- a/lib/audit/actions.ts
+++ b/lib/audit/actions.ts
@@ -427,6 +427,10 @@ export const AUDIT_ACTIONS = [
   "agenda.tipo_criado",
   "agenda.tipo_alterado",
   "agenda.tipo_desativado",
+  // Ligar de volta um tipo que alguém desligou é ato de gestão e tem verbo
+  // próprio: como `agenda.tipo_alterado { campos: ["is_active"] }` ele seria,
+  // na trilha, indistinguível de "mudaram a duração".
+  "agenda.tipo_reativado",
   // A rodada que AVISOU alguém do próprio compromisso. Mensagem que saiu para o
   // telefone de um cliente é efeito, e efeito audita — mas só a rodada que
   // enviou: a que varreu e não achou ninguém a avisar não é mutação.

--- a/tests/e2e/agenda-tipos-de-agendamento.spec.ts
+++ b/tests/e2e/agenda-tipos-de-agendamento.spec.ts
@@ -238,7 +238,21 @@ test("o tipo NASCE com responsável — e quem escolhe 'Definir depois' recebe a
   await page.screenshot({ path: "evidence/calendario/d6-tipo-com-responsavel.png", fullPage: true });
 });
 
-test("desativar tira o tipo da tela de marcar, sem apagar a história", async ({ page }) => {
+test("desativar tira o tipo da tela de marcar, e reativar o traz de volta", async ({ page }) => {
+  /**
+   * ⚠️ ESTE CASO JÁ EXISTIA E CONFERIA O BOTÃO "Reativar" SÓ COM `toBeVisible`.
+   *
+   * Foi exatamente assim que ele sobreviveu morto. O botão mandava
+   * `PATCH /api/v1/agenda/tipos` com `{ id, is_active: true }`; o
+   * `alterarSchema` daquela rota é `criarSchema.partial()`, onde `is_active` não
+   * existe, e Zod descarta chave desconhecida em silêncio — o corpo chegava
+   * vazio e a resposta era 422 "Nenhum campo para alterar.". Nunca funcionou uma
+   * vez, desde que a tela nasceu.
+   *
+   * Ver que o controle está DESENHADO não é ver que ele ABRE. O caso agora
+   * clica, e cobra o efeito nos dois lugares: o rótulo "desativado" sai da lista
+   * e o tipo volta a ser oferecido em /app/agenda.
+   */
   const creds = lerCreds();
   await entrar(page, creds);
   await page.goto("/app/settings/tenant/agenda");
@@ -274,6 +288,33 @@ test("desativar tira o tipo da tela de marcar, sem apagar a história", async ({
     page.getByRole("button", { name: new RegExp(`^${nome}`) }),
     "tipo desativado continua oferecido para marcar",
   ).toHaveCount(0);
+
+  // ─── A VOLTA ────────────────────────────────────────────────────────────
+  //
+  // Sem esta metade, desativar é uma porta que só abre para um lado: o nome
+  // continua ocupado pelo tipo desligado (o slug é único), então quem errou o
+  // clique não consegue nem recriar com o mesmo nome.
+  await page.goto("/app/settings/tenant/agenda");
+  await expect(page.getByTestId("tipos-de-agendamento-config")).toBeVisible({ timeout: 20_000 });
+  await linha.getByRole("button", { name: "Reativar" }).click();
+
+  await expect(
+    linha.getByText("desativado"),
+    "cliquei em Reativar e o tipo continua marcado como desativado",
+  ).toHaveCount(0, { timeout: 20_000 });
+  await expect(
+    linha.getByRole("button", { name: "Desativar" }),
+    "o tipo voltou mas a lista não oferece desligar de novo",
+  ).toBeVisible();
+
+  // E volta a aparecer onde importa — o mesmo lugar de onde saiu.
+  await page.goto("/app/agenda");
+  await page.getByRole("button", { name: /novo agendamento/i }).click();
+  await expect(page.getByTestId("tipos-de-agendamento")).toBeVisible({ timeout: 15_000 });
+  await expect(
+    page.getByRole("button", { name: new RegExp(`^${nome}`) }),
+    "reativei o tipo e ele não voltou para a tela de marcar",
+  ).toHaveCount(1);
 });
 
 test("ligo o aviso do compromisso pela tela, e ele fica ligado", async ({ page }) => {

--- a/tests/unit/agenda-reativar-tipo.test.ts
+++ b/tests/unit/agenda-reativar-tipo.test.ts
@@ -1,0 +1,384 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import ts from "typescript";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { audit } from "@/lib/audit";
+import { requireRole } from "@/lib/auth/require-role";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/**
+ * REATIVAR TIPO DE AGENDAMENTO — e a travessia tela → rota que deixou o botão
+ * nascer morto.
+ *
+ * ─── O defeito, medido ──────────────────────────────────────────────────────
+ *
+ * O botão "Reativar" de Configurações › Agenda existe desde que a tela existe e
+ * **nunca funcionou uma vez**. Ele mandava `PATCH /api/v1/agenda/tipos` com
+ * `{ id, is_active: true }`; o `alterarSchema` daquela rota é
+ * `criarSchema.partial().extend({ id })`, e `is_active` não está entre os doze
+ * campos de `camposDoTipo`. Zod **descarta chave desconhecida em silêncio**,
+ * então `campos` chegava `{}` e a rota respondia 422 "Nenhum campo para
+ * alterar." — para um usuário que não pediu para alterar campo nenhum.
+ *
+ * O compilador teria acusado. Não acusou porque a chamada terminava em
+ * `as never`, o único cast do arquivo da tela, exatamente em cima da travessia.
+ *
+ * ─── Por que este arquivo tem DUAS partes ───────────────────────────────────
+ *
+ * A parte de COMPORTAMENTO prova que a rota nova faz o que diz: grava
+ * `is_active: true`, filtra o tenant pela sessão, audita com verbo próprio e
+ * recusa o que não existe. Ela não alcança o defeito original — a rota antiga
+ * também "funcionava", só que sobre um corpo vazio.
+ *
+ * Quem alcança o defeito é a TRAVESSIA. Ela mede as duas pontas no fonte: as
+ * chaves que a tela manda no corpo e os campos que o schema da rota aceita. No
+ * estado anterior a este commit ela reprova sozinha, nomeando `is_active`. E
+ * ela vale para o campo que ainda não existe: qualquer chave futura que a tela
+ * mande e a rota não conheça fica vermelha aqui, em vez de virar um 422 mudo na
+ * mão de quem clicou.
+ *
+ * Ancorado no AST e não em regex de propósito — a prosa deste repositório cita
+ * `is_active` e `apiClient.patch(` em comentário o tempo todo, e uma varredura
+ * de texto acusaria o arquivo por ele falar de si mesmo.
+ *
+ * ─── Medir ──────────────────────────────────────────────────────────────────
+ *
+ *   npx vitest run tests/unit/agenda-reativar-tipo.test.ts
+ *
+ * Para ver a travessia morder, devolva `is_active: true` ao corpo do
+ * `apiClient.patch("/api/v1/agenda/tipos", …)` da tela. Para ver o
+ * comportamento morder, troque `is_active: true` por `false` na rota nova.
+ */
+
+vi.mock("@/lib/audit", () => ({
+  audit: vi.fn(async () => undefined),
+  isServiceRoleConfigured: vi.fn(() => true),
+}));
+vi.mock("@/lib/auth/require-role", () => ({ requireRole: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
+
+// Este teste isola o handler; autoridade de suporte é exercitada na suíte própria.
+vi.mock("@/lib/impersonate/support", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/impersonate/support")>()),
+  requireSupportWrite: vi.fn(async () => null),
+  authenticatedSessionId: vi.fn(async () => "f2200000-0000-4000-8000-000000000099"),
+}));
+
+const RAIZ = join(__dirname, "..", "..");
+const ROTA_TIPOS = join(RAIZ, "app", "api", "v1", "agenda", "tipos", "route.ts");
+const ROTA_REATIVAR = join(RAIZ, "app", "api", "v1", "agenda", "tipos", "reativar", "route.ts");
+const TELA = join(RAIZ, "app", "app", "settings", "tenant", "agenda", "_client.tsx");
+
+const ORG = "22222222-2222-4222-8222-222222222222";
+const ANA = "11111111-1111-4111-8111-111111111111";
+const TIPO = "33333333-3333-4333-8333-333333333333";
+const OUTRA_ORG_TIPO = "44444444-4444-4444-8444-444444444444";
+
+/** O que a rota gravou, em que tabela, e sob quais filtros. */
+let tabelaAlvo: string | null = null;
+let atualizacao: Record<string, unknown> | null = null;
+let filtros: Record<string, unknown> = {};
+/** A linha que o banco devolve — `null` simula tipo inexistente nesta organização. */
+let linha: { id: string } | null = null;
+
+function pedido(corpo?: unknown): NextRequest {
+  return new NextRequest("https://crm.exemplo/api/v1/agenda/tipos/reativar", {
+    method: "POST",
+    ...(corpo === undefined ? {} : { body: JSON.stringify(corpo) }),
+  });
+}
+
+beforeEach(() => {
+  // `clearAllMocks` ANTES de configurar: os casos de recusa aserem que `audit`
+  // NÃO foi chamado, e sem isto eles herdam as chamadas dos casos anteriores e
+  // falham por vazamento de fixture, não por defeito da rota.
+  vi.clearAllMocks();
+  tabelaAlvo = null;
+  atualizacao = null;
+  filtros = {};
+  linha = { id: TIPO };
+  vi.mocked(requireRole).mockResolvedValue({
+    ok: true,
+    user: { id: ANA } as never,
+    org: { orgId: ORG } as never,
+  });
+  vi.mocked(createAdminClient).mockReturnValue({
+    from: (tabela: string) => ({
+      update: (valores: Record<string, unknown>) => {
+        tabelaAlvo = tabela;
+        atualizacao = valores;
+        const cadeia = {
+          eq: (coluna: string, valor: unknown) => {
+            filtros[coluna] = valor;
+            return cadeia;
+          },
+          select: () => cadeia,
+          maybeSingle: async () => ({ data: linha, error: null }),
+        };
+        return cadeia;
+      },
+    }),
+  } as never);
+});
+
+describe("POST /api/v1/agenda/tipos/reativar — comportamento", () => {
+  it("liga o tipo de volta, na tabela certa", async () => {
+    const { POST } = await import("@/app/api/v1/agenda/tipos/reativar/route");
+    const r = await POST(pedido({ id: TIPO }));
+    expect(r.status).toBe(200);
+    expect(tabelaAlvo).toBe("calendar_event_types");
+    expect(
+      atualizacao,
+      "a rota respondeu 200 sem gravar nada — que é exatamente o que o botão " +
+        "antigo fazia, só que com 422 em vez de 200",
+    ).toEqual({ is_active: true });
+  });
+
+  it("o tenant vem da SESSÃO — sem isto a service role reativa tipo de outra casa", async () => {
+    const { POST } = await import("@/app/api/v1/agenda/tipos/reativar/route");
+    await POST(pedido({ id: OUTRA_ORG_TIPO }));
+    expect(filtros.organization_id).toBe(ORG);
+    expect(filtros.id).toBe(OUTRA_ORG_TIPO);
+  });
+
+  it("audita com verbo PRÓPRIO, e não como uma alteração de campo qualquer", async () => {
+    const { POST } = await import("@/app/api/v1/agenda/tipos/reativar/route");
+    await POST(pedido({ id: TIPO }));
+    expect(audit).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(audit).mock.calls[0]?.[0]).toMatchObject({
+      action: "agenda.tipo_reativado",
+      organizationId: ORG,
+      resourceType: "calendar_event_types",
+      resourceId: TIPO,
+      actorUserId: ANA,
+    });
+  });
+
+  it("não diz que reativou o que não existe", async () => {
+    // 404 e não 200: dizer "reativei" sobre o que não há é a mesma família de
+    // mentira que o `DELETE` da rota irmã recusa do outro lado.
+    linha = null;
+    const { POST } = await import("@/app/api/v1/agenda/tipos/reativar/route");
+    const r = await POST(pedido({ id: TIPO }));
+    expect(r.status).toBe(404);
+    expect(audit).not.toHaveBeenCalled();
+  });
+
+  it("corpo sem `id` é recusado ANTES de qualquer escrita", async () => {
+    const { POST } = await import("@/app/api/v1/agenda/tipos/reativar/route");
+    const r = await POST(pedido({}));
+    expect(r.status).toBe(422);
+    expect(atualizacao, "a validação falhou e a rota gravou mesmo assim").toBeNull();
+    expect(audit).not.toHaveBeenCalled();
+  });
+
+  it("reativar exige `manager` — e a recusa de papel para antes da escrita", async () => {
+    vi.mocked(requireRole).mockResolvedValue({
+      ok: false,
+      response: new Response(null, { status: 403 }) as never,
+    } as never);
+    const { POST } = await import("@/app/api/v1/agenda/tipos/reativar/route");
+    const r = await POST(pedido({ id: TIPO }));
+    expect(r.status).toBe(403);
+    expect(atualizacao).toBeNull();
+  });
+
+  it("CONTROLE: o dublê só registra quando a rota escreve", () => {
+    // Sem esta asserção, um `update` que o dublê não interceptasse deixaria
+    // `atualizacao` sempre `null` — e os dois casos de recusa acima passariam
+    // por instrumento cego em vez de por comportamento.
+    expect(atualizacao).toBeNull();
+    expect(filtros).toEqual({});
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TRAVESSIA TELA → ROTA
+// ─────────────────────────────────────────────────────────────────────────────
+
+function ast(caminho: string): ts.SourceFile {
+  const fonte = readFileSync(caminho, "utf8");
+  return ts.createSourceFile(
+    caminho,
+    fonte,
+    ts.ScriptTarget.Latest,
+    true,
+    caminho.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+}
+
+function percorre(no: ts.Node, visita: (n: ts.Node) => void): void {
+  visita(no);
+  no.forEachChild((filho) => percorre(filho, visita));
+}
+
+/** Os nomes declarados em `const <nome> = { … }` no arquivo dado. */
+function chavesDaConstante(arquivo: ts.SourceFile, nome: string): string[] {
+  let achadas: string[] | null = null;
+  percorre(arquivo, (no) => {
+    if (
+      ts.isVariableDeclaration(no) &&
+      ts.isIdentifier(no.name) &&
+      no.name.text === nome &&
+      no.initializer &&
+      ts.isObjectLiteralExpression(no.initializer)
+    ) {
+      achadas = no.initializer.properties.flatMap((p) =>
+        p.name && (ts.isIdentifier(p.name) || ts.isStringLiteral(p.name)) ? [p.name.text] : [],
+      );
+    }
+  });
+  if (achadas === null) throw new Error(`não achei \`const ${nome} = { … }\` — a rota mudou de forma`);
+  return achadas;
+}
+
+/**
+ * Tira as cascas que não mudam o valor em runtime: `as T`, `<T>x`, `satisfies T`
+ * e parênteses.
+ *
+ * ⚠️ Sem isto a trava não morde o defeito que ela existe para pegar. O corpo
+ * infrator era `{ id, is_active: true } as never` — um `AsExpression`, não um
+ * `ObjectLiteralExpression` —, então a primeira versão desta varredura
+ * ATRAVESSAVA o corpo sem ver chave nenhuma e o caso passava verde. Medido: com
+ * a tela sabotada de volta ao estado antigo, 10 casos passaram e o principal
+ * foi um deles. O cast escondeu o campo do compilador E do guarda que existe
+ * para vigiar o compilador.
+ */
+function desembrulha(no: ts.Expression): ts.Expression {
+  let atual = no;
+  for (;;) {
+    if (ts.isAsExpression(atual) || ts.isSatisfiesExpression(atual) || ts.isTypeAssertionExpression(atual)) {
+      atual = atual.expression;
+      continue;
+    }
+    if (ts.isParenthesizedExpression(atual)) {
+      atual = atual.expression;
+      continue;
+    }
+    return atual;
+  }
+}
+
+/**
+ * As chaves de todo corpo que a tela manda em `apiClient.<metodo>("<caminho>", { … })`.
+ *
+ * Espalhamento condicional (`...(x ? { campo: y } : {})`) conta: a chave chega
+ * ao servidor nas mesmas condições que as outras.
+ */
+function chavesEnviadas(arquivo: ts.SourceFile, metodo: string, caminho: string): string[] {
+  const chaves = new Set<string>();
+  let achouChamada = false;
+
+  const colhe = (obj: ts.ObjectLiteralExpression): void => {
+    for (const prop of obj.properties) {
+      if (ts.isSpreadAssignment(prop)) {
+        percorre(prop.expression, (n) => {
+          if (ts.isObjectLiteralExpression(n)) colhe(n);
+        });
+        continue;
+      }
+      if (prop.name && (ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name))) {
+        chaves.add(prop.name.text);
+      }
+    }
+  };
+
+  percorre(arquivo, (no) => {
+    if (!ts.isCallExpression(no)) return;
+    const alvo = no.expression;
+    if (!ts.isPropertyAccessExpression(alvo)) return;
+    if (!ts.isIdentifier(alvo.expression) || alvo.expression.text !== "apiClient") return;
+    if (alvo.name.text !== metodo) return;
+    const primeiro = no.arguments[0];
+    if (!primeiro || !ts.isStringLiteral(primeiro) || primeiro.text !== caminho) return;
+    achouChamada = true;
+    const corpo = no.arguments[1];
+    if (!corpo) return;
+    const nu = desembrulha(corpo);
+    if (ts.isObjectLiteralExpression(nu)) colhe(nu);
+  });
+
+  if (!achouChamada) {
+    throw new Error(`não achei \`apiClient.${metodo}("${caminho}", …)\` na tela — a chamada mudou de forma`);
+  }
+  return [...chaves];
+}
+
+describe("travessia tela → rota: a tela não manda campo que a rota descarta", () => {
+  const rota = ast(ROTA_TIPOS);
+  const tela = ast(TELA);
+  const camposDoTipo = chavesDaConstante(rota, "camposDoTipo");
+
+  it("CONTROLE: as duas pontas foram realmente lidas", () => {
+    // Sem isto, um `camposDoTipo` que o leitor não achasse viraria lista vazia e
+    // TODA chave da tela apareceria como infratora — ou, na direção contrária,
+    // um `chavesEnviadas` vazio faria os casos abaixo passarem sobre nada.
+    expect(camposDoTipo.length, "camposDoTipo veio vazio — o leitor de AST cegou").toBeGreaterThan(5);
+    expect(camposDoTipo).toContain("duration_minutes");
+    expect(
+      camposDoTipo,
+      "`is_active` entrou em camposDoTipo — então o PATCH voltou a poder DESLIGAR " +
+        "um tipo, e a trilha perdeu a distinção entre alterar e desativar",
+    ).not.toContain("is_active");
+  });
+
+  it("PATCH: toda chave enviada é aceita pelo `alterarSchema`", () => {
+    // `alterarSchema` é `criarSchema.partial().extend({ id })`.
+    const aceitas = new Set([...camposDoTipo, "id"]);
+    const enviadas = chavesEnviadas(tela, "patch", "/api/v1/agenda/tipos");
+    expect(enviadas.length).toBeGreaterThan(1);
+    expect(
+      enviadas.filter((c) => !aceitas.has(c)),
+      "Zod descarta chave desconhecida em SILÊNCIO: o campo some do corpo, o " +
+        "`update` chega vazio e quem clicou recebe 422 sem saber por quê. Foi " +
+        "assim que o botão Reativar passou a vida inteira sem funcionar.",
+    ).toEqual([]);
+  });
+
+  it("POST: toda chave enviada na criação é aceita pelo `criarSchema`", () => {
+    const aceitas = new Set(camposDoTipo);
+    const enviadas = chavesEnviadas(tela, "post", "/api/v1/agenda/tipos");
+    expect(enviadas.length).toBeGreaterThan(1);
+    expect(enviadas.filter((c) => !aceitas.has(c))).toEqual([]);
+  });
+
+  it("o botão Reativar aponta para uma rota que EXISTE", () => {
+    // O defeito original não foi rota errada, foi campo descartado — mas o
+    // conserto trocou o endereço, e endereço sem arquivo é 404: o mesmo botão
+    // morto, com outra causa.
+    const enviadas = chavesEnviadas(tela, "post", "/api/v1/agenda/tipos/reativar");
+    expect(enviadas).toEqual(["id"]);
+    expect(existsSync(ROTA_REATIVAR), `sem arquivo em ${ROTA_REATIVAR}`).toBe(true);
+    expect(readFileSync(ROTA_REATIVAR, "utf8")).toMatch(/export async function POST/);
+  });
+
+  it("nenhuma chamada da tela apaga o compilador com `as never`", () => {
+    // Era o único cast do arquivo, e estava exatamente em cima desta travessia:
+    // sem ele o `pnpm typecheck` teria acusado `is_active` no dia em que o botão
+    // foi escrito. Um cast aqui desliga o tsc no lugar onde ele é a última
+    // defesa — a própria trava acima só alcança chave literal.
+    //
+    // Pelo AST, e não por regex: a primeira versão deste caso procurava o texto
+    // e reprovou o arquivo por causa do COMENTÁRIO que explica o cast, três
+    // linhas acima da chamada. Varredura de texto acusa o repositório por ele
+    // falar de si mesmo — é o mesmo motivo que ancora o resto deste arquivo.
+    const infratoras: string[] = [];
+    percorre(tela, (no) => {
+      if (!ts.isCallExpression(no)) return;
+      const alvo = no.expression;
+      if (!ts.isPropertyAccessExpression(alvo)) return;
+      if (!ts.isIdentifier(alvo.expression) || alvo.expression.text !== "apiClient") return;
+      for (const arg of no.arguments) {
+        percorre(arg, (n) => {
+          if (ts.isAsExpression(n) && n.type.kind === ts.SyntaxKind.NeverKeyword) {
+            infratoras.push(`apiClient.${alvo.name.text} — ${n.expression.getText().slice(0, 60)}`);
+          }
+        });
+      }
+    });
+    expect(infratoras).toEqual([]);
+  });
+});


### PR DESCRIPTION
O botão "Reativar" de Configurações › Tipos de agendamento existe desde que a tela existe e **nunca funcionou uma vez**. Clicar devolve sempre `422 "Nenhum campo para alterar."` — para quem não pediu para alterar campo nenhum.

Quem desativa um tipo por engano fica sem saída pela tela: o nome segue ocupado pelo tipo desligado, porque o slug é único.

## A causa

`app/app/settings/tenant/agenda/_client.tsx` manda `PATCH /api/v1/agenda/tipos` com `{ id, is_active: true }`. O `alterarSchema` daquela rota é `criarSchema.partial().extend({ id })`, e `is_active` não está entre os doze campos de `camposDoTipo`. **Zod descarta chave desconhecida em silêncio**: o corpo chega vazio ao `update` e a rota cai na recusa de "nenhum campo".

O compilador teria acusado. Não acusou porque a chamada terminava em `as never` — o único cast do arquivo, exatamente em cima da travessia.

## O conserto

Espelha o `DELETE` em vez de tornar `is_active` editável. Aceitá-lo no PATCH deixaria o mesmo pedido que muda duração poder **desligar** um tipo, e a trilha registraria a religada como `agenda.tipo_alterado { campos: ["is_active"] }` — indistinguível de uma alteração de campo qualquer. Sub-rota de ação é a forma que a casa já usa (`agenda/google/desconectar`, `contacts/merge`, `lgpd/anonymize`).

- `POST /api/v1/agenda/tipos/reativar` — mesma guarda do desativar (`manager` + `requireSupportWrite`), filtro explícito de `organization_id`, 404 quando não há linha
- `agenda.tipo_reativado` em `AUDIT_ACTIONS`
- o `as never` sai da tela

## O que medi

**`tests/unit/agenda-reativar-tipo.test.ts`** (12 casos), em duas camadas:

- comportamento da rota nova: grava `is_active: true`, filtra o tenant pela sessão, audita com verbo próprio, recusa o que não existe, e os dois caminhos de recusa não escrevem
- **travessia tela → rota**: toda chave que a tela manda tem de ser aceita pelo schema, medida nas duas pontas pelo AST. Sabotado de volta ao estado anterior, o caso reprova **nomeando `is_active`**

⚠️ Custo pago no próprio teste, e vale para quem escrever guarda parecida: a primeira versão da travessia **passou verde com a tela sabotada**. O corpo era `{…} as never` — um `AsExpression`, não um `ObjectLiteralExpression` —, então a varredura atravessava sem ver chave nenhuma. O cast escondia o campo do compilador **e** do guarda escrito para vigiar o compilador. O leitor agora desembrulha `as`/`satisfies` antes de ler o corpo.

**O caso e2e já existia e conferia o botão só com `toBeVisible`** — foi assim que ele sobreviveu morto. Ver que o controle está desenhado não é ver que ele abre. Reescrito: agora clica e cobra o efeito nos dois lugares (o rótulo "desativado" sai da lista, e o tipo volta a ser oferecido em `/app/agenda`).

Gates na prévia do merge: `typecheck` 0, testes da área 26/26.

**Provado em tela**, numa VPS real rodando a mudança: desativar → reativar → o aviso "Tipo reativado." e a linha volta ao normal.

## O que NÃO medi

- `pnpm test:unit` inteiro nesta branch (rodei na branch de origem da mudança: 5 arquivos vermelhos, os 4 conhecidos de Windows + 1 meu, já corrigido)
- a corrida do `pnpm test:e2e` — precisa de Supabase local e app buildado; a spec alterada roda no CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)