### PR TITLE
fix(atualizacao): a tela conta em que pé está, nas duas pontas do silêncio

### DIFF
--- a/.changes/a-tela-de-atualizacao-conta-em-que-pe-esta.md
+++ b/.changes/a-tela-de-atualizacao-conta-em-que-pe-esta.md
@@ -1,0 +1,26 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A tela de atualização passa a dizer em que pé está, do começo ao fim
+---
+
+Ao clicar em "Atualizar agora", a tela mostrava a lista dos quatro passos com
+todos eles vazios e o título "Atualizando para a versão X" — e ficava assim,
+sem mexer nada, por vários minutos. Não era travamento: o clique só registra o
+pedido, e o servidor confere se há algo a fazer de poucos em poucos minutos. Mas
+não havia como saber disso olhando, e a tela afirmava um trabalho que ainda nem
+tinha começado.
+
+Agora a espera tem nome próprio ("Pedido enviado — esperando o servidor pegar"),
+diz por que demora, avisa que ficar parada nesse tempo é normal e mostra um
+relógio contando desde o pedido. A lista de passos só aparece quando existe um
+passo de verdade. Você pode fechar a página: o pedido não se perde.
+
+Do outro lado acontecia o inverso, e era pior. Terminada a atualização, o
+sistema voltava e a tela oferecia de novo o botão "Atualizar agora" para a
+versão que **acabava de ser instalada** — quem clicava refazia tudo, ou concluía
+que não tinha funcionado. Isso durava até o servidor reportar a versão nova, o
+que leva alguns minutos. Agora a tela reconhece o fim na hora e diz "Pronto —
+você está na versão X", sem oferecer nada.
+
+Você não precisa fazer nada para adotar.

--- a/app/api/v1/system/version/route.test.ts
+++ b/app/api/v1/system/version/route.test.ts
@@ -359,6 +359,84 @@ describe("GET /api/v1/system/version", () => {
     expect(body.data.run.from_version).toBe("1.0.0");
   });
 
+  it("terminou BEM e o host ainda não bateu: a tela já sabe, e o botão some", async () => {
+    // O defeito: `run_result` com sucesso fecha o run e NÃO toca
+    // `current_version` — quem escreve essa coluna é o heartbeat do host, de 5
+    // em 5 minutos. Nessa janela `latest !== current` continuava verdadeiro e a
+    // tela voltava do reinício oferecendo "Atualizar agora" para a versão que
+    // acabou de ser instalada. Quem clicou fazia tudo de novo.
+    versionRow.current_version = "1.0.0";
+    versionRow.latest_version = "1.1.0";
+    versionRow.updated_at = "2026-09-11T13:55:00.000Z";
+    runRow = {
+      id: "77777777-7777-4777-8777-777777777777",
+      status: "success",
+      last_step: "banco",
+      dispatched_at: "2026-09-11T13:58:00.000Z",
+      finished_at: "2026-09-11T14:00:00.000Z",
+      from_version: "1.0.0",
+      to_version: "1.1.0",
+      log_tail: "",
+    };
+    vi.mocked(loadAuthUser).mockResolvedValue(OWNER as never);
+    const { GET } = await import("../version/route");
+    const body = await (await GET(get())).json();
+    expect(body.data.current_version).toBe("1.1.0");
+    expect(
+      body.data.update_available,
+      "a tela voltaria oferecendo a versão que acabou de ser instalada",
+    ).toBe(false);
+    expect(body.data.just_updated).toBe(true);
+  });
+
+  it("o host confirmou: a janela se fecha sozinha, sem ninguém limpar nada", async () => {
+    // O fim de validade. Depois da batida, quem manda volta a ser o host —
+    // senão um run de sucesso nomearia a versão no ar para sempre, que é
+    // exatamente o defeito que o `rollbackFoiSuperado` já pagou uma vez.
+    versionRow.current_version = "1.1.0";
+    versionRow.latest_version = "1.1.0";
+    versionRow.updated_at = "2026-09-11T14:05:00.000Z";
+    runRow = {
+      id: "77777777-7777-4777-8777-777777777777",
+      status: "success",
+      last_step: "banco",
+      dispatched_at: "2026-09-11T13:58:00.000Z",
+      finished_at: "2026-09-11T14:00:00.000Z",
+      from_version: "1.0.0",
+      to_version: "1.1.0",
+      log_tail: "",
+    };
+    vi.mocked(loadAuthUser).mockResolvedValue(OWNER as never);
+    const { GET } = await import("../version/route");
+    const body = await (await GET(get())).json();
+    expect(body.data.current_version).toBe("1.1.0");
+    expect(body.data.just_updated).toBe(false);
+  });
+
+  it("o pedido em espera carrega `dispatched_at` — é o relógio da tela", async () => {
+    // Entre o clique e o agente pegar o pedido passam até 5 minutos, e nesse
+    // tempo `last_step` é nulo: a tela mostrava quatro círculos vazios, imóveis,
+    // sem nada que distinguisse "esperando" de "travou". Sem esta data não há
+    // como contar o tempo — e recarregar a página não pode zerar a conta, então
+    // ela vem do servidor, nunca de quando a aba abriu.
+    runRow = {
+      id: "88888888-8888-4888-8888-888888888888",
+      status: "dispatched",
+      last_step: null,
+      dispatched_at: "2026-09-11T13:58:00.000Z",
+      finished_at: null,
+      from_version: "1.0.0",
+      to_version: "1.1.0",
+      log_tail: "",
+    };
+    vi.mocked(loadAuthUser).mockResolvedValue(OWNER as never);
+    const { GET } = await import("../version/route");
+    const body = await (await GET(get())).json();
+    expect(body.data.run.dispatched_at).toBe("2026-09-11T13:58:00.000Z");
+    expect(body.data.run.last_step).toBeNull();
+    expect(body.data.just_updated).toBe(false);
+  });
+
   it("sem `finished_at`, o run velho ainda decide — ausência de prova não é prova de deploy", async () => {
     // A guarda acima só pode agir quando existe o par de datas. Um run gravado
     // por uma versão antiga do agente não tem `finished_at`, e aí o

--- a/app/api/v1/system/version/route.ts
+++ b/app/api/v1/system/version/route.ts
@@ -12,7 +12,13 @@ import { loadAuthUser } from "@/lib/auth/server";
 import { logger } from "@/lib/logger";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { extractChangelogRange } from "@/lib/system/changelog";
-import { isRunStale, rollbackFoiSuperado, type RunStatus, type RunStep } from "@/lib/system/update-run";
+import {
+  isRunStale,
+  rollbackFoiSuperado,
+  sucessoJaInstalado,
+  type RunStatus,
+  type RunStep,
+} from "@/lib/system/update-run";
 
 export const dynamic = "force-dynamic";
 
@@ -90,10 +96,18 @@ export async function GET(_req: NextRequest): Promise<Response> {
     current,
     run,
   );
+  // O outro lado do mesmo silêncio: o run deu CERTO e o host ainda não bateu.
+  // `current_version` segue nomeando a versão antiga por até 5 minutos, e sem
+  // isto `update_available` continua verdadeiro — a tela volta do reinício
+  // oferecendo "Atualizar agora" para a versão que acabou de ser instalada.
+  const acabouDeInstalar = sucessoJaInstalado(version?.updated_at, run?.finished_at, run);
+
   const running =
     run?.status === "failed_rolled_back" && run.from_version && !rollbackSuperado
       ? run.from_version
-      : current;
+      : acabouDeInstalar && run?.to_version
+        ? run.to_version
+        : current;
 
   if (!user.is_platform_admin) {
     return ok({ current_version: running, is_owner: false });
@@ -127,6 +141,11 @@ export async function GET(_req: NextRequest): Promise<Response> {
     // não tocada por nenhum heartbeat, coluna com o default da migration).
     has_known_release: version?.has_known_release ?? true,
     agent_online: !Number.isNaN(lastSeen) && now.getTime() - lastSeen < AGENT_OFFLINE_AFTER_MS,
+    // A janela em que a atualização TERMINOU e o host ainda não contou. É o que
+    // deixa a tela dizer "pronto, está na versão X" em vez de cair no texto
+    // genérico de quem nunca atualizou nada — e ela se fecha sozinha na batida
+    // seguinte do agente.
+    just_updated: acabouDeInstalar,
     notes:
       faixa && faixa.secoes.length > 0
         ? {
@@ -147,6 +166,10 @@ export async function GET(_req: NextRequest): Promise<Response> {
     run: run
       ? {
           id: run.id,
+          // A tela CONTA o tempo desde aqui. Sem esta data, o intervalo entre o
+          // clique e o agente pegar o pedido é uma lista de quatro círculos
+          // vazios, parada, sem nada que se mexa.
+          dispatched_at: run.dispatched_at,
           // `unknown` é derivado aqui, não gravado: um agente morto não
           // consegue anunciar a própria morte.
           status:

--- a/app/app/settings/atualizacao/_components/UpdatePanel.tsx
+++ b/app/app/settings/atualizacao/_components/UpdatePanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { apiClient } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/types";
@@ -88,6 +88,25 @@ export function UpdatePanel() {
   const nova = semV(data.latest_version);
 
   if (rodando) {
+    /**
+     * ESTE É O TRECHO EM QUE A TELA PARECIA TRAVADA.
+     *
+     * O `POST /update` não executa nada: ele registra o pedido e vai embora.
+     * Quem executa é o `agent.sh` no host, e ele roda de 5 em 5 minutos — entre
+     * o clique e o primeiro passo passam até 5 minutos. Nesse intervalo
+     * `last_step` é nulo, os quatro círculos ficam todos vazios e nada se mexe.
+     *
+     * A pessoa que clicou não tem como distinguir isso de "quebrou". E a lista
+     * de passos, mostrada antes de qualquer passo existir, afirma que o sistema
+     * está trabalhando quando ele ainda nem recebeu a ordem.
+     *
+     * Então o estado de espera é SEU PRÓPRIO estado, com nome, com a razão da
+     * demora e com um relógio que anda.
+     */
+    if (!data.run?.last_step) {
+      return <AguardandoOServidor dispatchedAt={data.run?.dispatched_at} destino={nova} />;
+    }
+
     return (
       <Layout titulo={`${t("Atualizando para a versão")} ${nova}`}>
         <ol className="space-y-2 text-sm">
@@ -105,6 +124,35 @@ export function UpdatePanel() {
         <p className="mt-4 text-sm text-muted-foreground">
           {t(
             "O sistema sai do ar por alguns instantes e volta sozinho. Pode deixar esta página aberta.",
+          )}
+        </p>
+      </Layout>
+    );
+  }
+
+  /**
+   * O OUTRO LADO DO MESMO SILÊNCIO — e este era pior que parecer travado.
+   *
+   * `run_result` com sucesso fecha o run e não toca `current_version`: quem
+   * escreve essa coluna é o heartbeat do host, de 5 em 5 minutos. Nesse
+   * intervalo `update_available` continuava verdadeiro, e a tela voltava do
+   * reinício oferecendo "Atualizar agora" para a versão que ACABOU de ser
+   * instalada — quem clicou fazia tudo de novo, ou concluía que não funcionou.
+   *
+   * `just_updated` é essa janela, e só ela: na batida seguinte o host confirma,
+   * o campo vira `false` sozinho e a tela cai no texto normal de quem está em
+   * dia. Não é um estado que alguém precise fechar.
+   */
+  if (data.just_updated) {
+    return (
+      <Layout titulo={`${t("Pronto — você está na versão")} ${versao}`}>
+        <p className="text-sm">
+          {t("A atualização terminou e o sistema já está no ar na versão")}{" "}
+          <strong>{versao}</strong>.
+        </p>
+        <p className="mt-3 text-sm text-muted-foreground">
+          {t(
+            "O servidor confirma isso na próxima vez que falar comigo, daqui a alguns minutos — até lá, esta tela já sabe.",
           )}
         </p>
       </Layout>
@@ -370,6 +418,74 @@ export function UpdatePanel() {
       <BotaoAtualizar mutate={() => atualizar.mutate()} isPending={atualizar.isPending} erro={erro} />
     </Layout>
   );
+}
+
+/**
+ * A ESPERA, com nome e com relógio.
+ *
+ * O pedido fica numa fila que o servidor lê de tempos em tempos — o `agent.sh`
+ * roda de 5 em 5 minutos no host. Antes disto a tela já mostrava a lista dos
+ * quatro passos, todos vazios, dizendo "Atualizando para a versão X": afirmava
+ * trabalho que ainda não tinha começado, e ficava imóvel por até cinco minutos.
+ *
+ * Três coisas, e nenhuma é enfeite:
+ *
+ * 1. **O nome certo do estado.** "Pedido enviado" ≠ "atualizando".
+ * 2. **A razão da demora**, dita antes de ela assustar. Quem sabe que o
+ *    servidor confere a cada poucos minutos não lê a imobilidade como defeito.
+ * 3. **Um relógio que anda.** É o que separa "esperando" de "travou" quando
+ *    não há mais nada se mexendo na tela — e ele conta o tempo do SERVIDOR
+ *    (`dispatched_at`), não o de quando a aba foi aberta: recarregar a página
+ *    não zera a conta.
+ */
+function AguardandoOServidor({
+  dispatchedAt,
+  destino,
+}: {
+  dispatchedAt: string | undefined;
+  destino: string;
+}) {
+  const t = useT();
+  // Um segundo, e não os 5s do poll: o poll traz dado do servidor, este tique
+  // só faz o relógio andar. Sem ele o número saltaria de 5 em 5 segundos.
+  const [agora, setAgora] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setAgora(Date.now()), 1_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const inicio = dispatchedAt ? Date.parse(dispatchedAt) : NaN;
+  const segundos = Number.isNaN(inicio) ? null : Math.max(0, Math.floor((agora - inicio) / 1000));
+
+  return (
+    <Layout titulo={t("Pedido enviado — esperando o servidor pegar")}>
+      <p className="text-sm">
+        {t("Anotei o pedido de atualizar para a versão")} <strong>{destino}</strong>.{" "}
+        {t(
+          "O servidor confere se há algo a fazer de poucos em poucos minutos, então a atualização pode levar até cerca de cinco minutos para começar.",
+        )}
+      </p>
+      <p className="mt-3 text-sm">
+        <strong>{t("Esta tela ficar parada nesse tempo é normal")}</strong>
+        {t(" — ela se mexe sozinha assim que o servidor começar.")}
+      </p>
+      {segundos !== null && (
+        <p className="mt-3 text-sm tabular-nums text-muted-foreground" data-testid="espera-decorrida">
+          {t("Esperando há")} {formataEspera(segundos)}.
+        </p>
+      )}
+      <p className="mt-3 text-sm text-muted-foreground">
+        {t("Pode fechar esta página: o pedido já está registrado e não se perde.")}
+      </p>
+    </Layout>
+  );
+}
+
+/** "43 segundos" / "2 min 05 s" — sem biblioteca, e sem virar "0:5". */
+function formataEspera(segundos: number): string {
+  if (segundos < 60) return `${segundos} s`;
+  const min = Math.floor(segundos / 60);
+  return `${min} min ${String(segundos % 60).padStart(2, "0")} s`;
 }
 
 function BotaoAtualizar({

--- a/hooks/system/useSystemVersion.ts
+++ b/hooks/system/useSystemVersion.ts
@@ -14,6 +14,11 @@ export interface SystemVersion {
   /** O host já viu ao menos uma tag `v*` publicada neste repositório. */
   has_known_release?: boolean;
   agent_online?: boolean;
+  /**
+   * A atualização terminou bem e o host ainda não confirmou (janela de até 5
+   * min). Fora dela é `false` — o campo se fecha sozinho.
+   */
+  just_updated?: boolean;
   notes?: {
     /** Um por versão da faixa que tem aviso, do mais novo ao mais antigo. */
     requires_attention: Array<{ version: string; texto: string }>;
@@ -26,6 +31,8 @@ export interface SystemVersion {
     id: string;
     status: string;
     last_step: string | null;
+    /** Quando o pedido foi registrado — a tela conta o tempo a partir daqui. */
+    dispatched_at?: string;
     /** Versão que estava instalada quando o run começou. */
     from_version: string;
     /** Versão que o run tentou instalar. */

--- a/lib/i18n/dicionario.ts
+++ b/lib/i18n/dicionario.ts
@@ -3853,6 +3853,35 @@ export const DICIONARIO: Traducoes = {
     es: "No pude iniciar la actualización. Intenta de nuevo en instantes.",
   },
   "Atualizando para a versão": { es: "Actualizando a la versión" },
+  // ── A espera antes de o servidor pegar o pedido, e o fim reconhecido na hora.
+  //    Os dois estados que a tela ganhou quando parou de fingir que a conversa
+  //    com o host é instantânea (ver o cabeçalho do `UpdatePanel`).
+  "Pedido enviado — esperando o servidor pegar": {
+    es: "Pedido enviado — esperando que el servidor lo tome",
+  },
+  "Anotei o pedido de atualizar para a versão": {
+    es: "Anoté el pedido de actualizar a la versión",
+  },
+  "O servidor confere se há algo a fazer de poucos em poucos minutos, então a atualização pode levar até cerca de cinco minutos para começar.": {
+    es: "El servidor revisa si hay algo que hacer cada pocos minutos, así que la actualización puede tardar hasta unos cinco minutos en empezar.",
+  },
+  "Esta tela ficar parada nesse tempo é normal": {
+    es: "Que esta pantalla quede quieta durante ese tiempo es normal",
+  },
+  " — ela se mexe sozinha assim que o servidor começar.": {
+    es: " — se mueve sola en cuanto el servidor empiece.",
+  },
+  "Esperando há": { es: "Esperando hace" },
+  "Pode fechar esta página: o pedido já está registrado e não se perde.": {
+    es: "Puedes cerrar esta página: el pedido ya está registrado y no se pierde.",
+  },
+  "Pronto — você está na versão": { es: "Listo — estás en la versión" },
+  "A atualização terminou e o sistema já está no ar na versão": {
+    es: "La actualización terminó y el sistema ya está en línea en la versión",
+  },
+  "O servidor confirma isso na próxima vez que falar comigo, daqui a alguns minutos — até lá, esta tela já sabe.": {
+    es: "El servidor lo confirma la próxima vez que hable conmigo, en unos minutos — hasta entonces, esta pantalla ya lo sabe.",
+  },
   "O sistema sai do ar por alguns instantes e volta sozinho. Pode deixar esta página aberta.": {
     es: "El sistema se apaga por unos instantes y vuelve solo. Puedes dejar esta página abierta.",
   },

--- a/lib/system/update-run.test.ts
+++ b/lib/system/update-run.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { canTransition, isRunStale, rollbackFoiSuperado, RUN_STALE_AFTER_MS } from "./update-run";
+import {
+  canTransition,
+  isRunStale,
+  rollbackFoiSuperado,
+  sucessoJaInstalado,
+  RUN_STALE_AFTER_MS,
+} from "./update-run";
 
 describe("canTransition", () => {
   it("aceita o desfecho reportado pelo agente", () => {
@@ -88,5 +94,68 @@ describe("rollbackFoiSuperado", () => {
   it("data ilegível não vira comparação: NaN compara falso e mentiria por acidente", () => {
     expect(rollbackFoiSuperado("isso não é data", fimDoRun, "1.2.0", RUN)).toBe(false);
     expect(rollbackFoiSuperado("2026-09-05T15:35:02.000Z", "isso não é data", "1.2.0", RUN)).toBe(false);
+  });
+});
+
+
+/**
+ * A JANELA EM QUE A ATUALIZAÇÃO DEU CERTO E A TELA AINDA NÃO SABIA.
+ *
+ * `run_result` com `success` fecha o run e não escreve em
+ * `system_version.current_version` — quem escreve é o heartbeat do host, de 5 em
+ * 5 minutos. Nessa janela `update_available` (`latest !== current`) continuava
+ * verdadeiro, e a tela voltava do reinício oferecendo "Atualizar agora" para a
+ * versão que acabou de ser instalada.
+ *
+ * O desempate é o mesmo de `rollbackFoiSuperado`, na direção contrária: lá o
+ * host mais novo vence o run; aqui o run vence enquanto o host não falou.
+ */
+describe("sucessoJaInstalado", () => {
+  const FIM = "2026-09-11T14:00:00.000Z";
+  const RUN = { status: "success", to_version: "1.1.0" };
+
+  it("run bem-sucedido e host ainda calado: o run manda", () => {
+    expect(sucessoJaInstalado("2026-09-11T13:55:00.000Z", FIM, RUN)).toBe(true);
+  });
+
+  it("host bateu DEPOIS do fim: quem manda volta a ser o host", () => {
+    // É o fim de validade desta função — e ele chega sozinho, em minutos.
+    expect(sucessoJaInstalado("2026-09-11T14:05:00.000Z", FIM, RUN)).toBe(false);
+  });
+
+  it("empate de segundo conta como host calado — o degrau que não reoferece", () => {
+    // As duas escritas vêm de relógios diferentes. Errar aqui para o lado de
+    // "já atualizou" custa alguns minutos de rótulo otimista; errar para o
+    // outro lado devolve o botão que manda instalar de novo o que já está lá.
+    expect(sucessoJaInstalado(FIM, FIM, RUN)).toBe(true);
+  });
+
+  it("host nunca reportou nada: o run é a única notícia que existe", () => {
+    expect(sucessoJaInstalado(null, FIM, RUN)).toBe(true);
+    expect(sucessoJaInstalado(undefined, FIM, RUN)).toBe(true);
+    expect(sucessoJaInstalado("isso não é data", FIM, RUN)).toBe(true);
+  });
+
+  it("só vale para SUCESSO — falha e rollback têm dono próprio nesta tela", () => {
+    for (const status of ["dispatched", "failed", "failed_rolled_back"]) {
+      expect(sucessoJaInstalado("2026-09-11T13:55:00.000Z", FIM, { status, to_version: "1.1.0" })).toBe(
+        false,
+      );
+    }
+  });
+
+  it("sem `to_version` não há o que afirmar", () => {
+    expect(sucessoJaInstalado("2026-09-11T13:55:00.000Z", FIM, { status: "success" })).toBe(false);
+    expect(sucessoJaInstalado("2026-09-11T13:55:00.000Z", FIM, { status: "success", to_version: "" })).toBe(
+      false,
+    );
+    expect(sucessoJaInstalado("2026-09-11T13:55:00.000Z", FIM, null)).toBe(false);
+  });
+
+  it("sem `finished_at` (run de agente antigo) não afirma nada", () => {
+    // Sem a data não dá para saber se o host já falou depois — e o degrau
+    // conservador é o comportamento de antes desta função existir.
+    expect(sucessoJaInstalado("2026-09-11T13:55:00.000Z", null, RUN)).toBe(false);
+    expect(sucessoJaInstalado("2026-09-11T13:55:00.000Z", "isso não é data", RUN)).toBe(false);
   });
 });

--- a/lib/system/update-run.ts
+++ b/lib/system/update-run.ts
@@ -92,3 +92,55 @@ export function rollbackFoiSuperado(
   const descritasPeloRun = [run?.to_version, run?.from_version].filter(Boolean);
   return !descritasPeloRun.includes(versaoReportadaPeloHost);
 }
+
+/**
+ * O run terminou BEM e o host ainda não teve chance de contar?
+ *
+ * ## O silêncio de até 5 minutos depois de dar certo
+ *
+ * `run_result` com `status: "success"` escreve só em `system_update_runs` — ele
+ * **não toca** `system_version.current_version`. Quem escreve essa coluna é o
+ * heartbeat do `agent.sh`, e ele roda de 5 em 5 minutos — o cabeçalho do
+ * próprio `agent.sh` diz "a cada 5 minutos", e a linha de cron que o instalador
+ * escreve está em `hostgator-setup-kit/test-validators.sh`.
+ *
+ * Então, na janela entre o fim da atualização e a batida seguinte,
+ * `current_version` ainda nomeia a versão ANTIGA — e `update_available`
+ * (`latest !== current`) continua verdadeiro. A tela volta do reinício
+ * oferecendo o botão "Atualizar agora" para a versão que **acabou de ser
+ * instalada**. Quem clicou faz tudo de novo, ou conclui que não funcionou.
+ *
+ * ## Por que assumir o `to_version` é seguro aqui
+ *
+ * `success` é o agente do host dizendo que o `update.sh` foi até o fim — a
+ * troca de imagem incluída. Diferente do caso de rollback (onde o host reporta
+ * a versão que QUEBROU e o run precisa contradizê-lo), aqui os dois concordam;
+ * o host só ainda não falou.
+ *
+ * E é auto-corrigível por construção: assim que a batida chega,
+ * `system_version.updated_at` passa a ser posterior ao `finished_at` e esta
+ * função devolve `false` — o host volta a mandar, sem exceção nenhuma. É o
+ * mesmo desempate temporal de `rollbackFoiSuperado`, na direção contrária.
+ *
+ * Sem `finished_at` (run antigo, agente velho) devolve `false`: sem a data não
+ * há como saber se o host já falou depois, e o degrau conservador é o de antes.
+ * Sem `versionUpdatedAt` devolve `true` — o host nunca reportou coisa alguma, e
+ * o run é a única notícia que existe.
+ */
+export function sucessoJaInstalado(
+  versionUpdatedAt: string | null | undefined,
+  runFinishedAt: string | null | undefined,
+  run?: { status?: string | null; to_version?: string | null } | null,
+): boolean {
+  if (run?.status !== "success" || !run.to_version) return false;
+  if (!runFinishedAt) return false;
+  const terminou = Date.parse(runFinishedAt);
+  if (Number.isNaN(terminou)) return false;
+  if (!versionUpdatedAt) return true;
+  const gravado = Date.parse(versionUpdatedAt);
+  if (Number.isNaN(gravado)) return true;
+  // Empate conta como "o host ainda não falou": a escrita do `run_result` e a
+  // do heartbeat são de relógios diferentes, e na janela de um segundo o degrau
+  // seguro é o que NÃO volta a oferecer a versão já instalada.
+  return gravado <= terminou;
+}

--- a/tests/e2e/system-update.spec.ts
+++ b/tests/e2e/system-update.spec.ts
@@ -271,30 +271,58 @@ test("o dono vê a versão nova na sidebar e atualiza pela tela", async ({ page,
   expect(atencao!.y).toBeLessThan(botao!.y);
 
   await page.getByRole("button", { name: /atualizar agora/i }).click();
-  await expect(page.getByRole("heading", { name: /atualizando para a versão 1\.1\.0/i })).toBeVisible();
-  await expect(page.getByText(/Guardando uma cópia de segurança/)).toBeVisible();
-  await page.screenshot({ path: ".superpowers/evidence/task9-2-atualizando.png" });
+
+  // ── PONTA 1: o clique NÃO começa a atualização ──────────────────────────
+  //
+  // O `POST /update` só registra o pedido; quem executa é o `agent.sh`, que
+  // roda de 5 em 5 minutos no host. Este caso AFIRMAVA o defeito: esperava a
+  // lista de passos ("Guardando uma cópia de segurança") logo depois do clique
+  // — a tela dizia que o sistema estava trabalhando quando ele ainda nem tinha
+  // recebido a ordem, e ficava assim, imóvel, por até cinco minutos.
+  await expect(
+    page.getByRole("heading", { name: /pedido enviado/i }),
+    "logo após o clique a tela ainda afirma que está atualizando",
+  ).toBeVisible();
+  await expect(page.getByText(/ficar parada nesse tempo é normal/i)).toBeVisible();
+  await expect(page.getByTestId("espera-decorrida")).toBeVisible();
+  await page.screenshot({ path: ".superpowers/evidence/task9-2a-pedido-enviado.png" });
 
   // O agente do host detecta o pedido no próximo heartbeat...
   const { data } = await heartbeat(request, { latest_version: "1.1.0" });
   expect(data.update_requested).toBe(true);
   expect(data.run_id).not.toBeNull();
 
+  // ...e aí sim a lista de passos aparece, porque aí sim há um passo.
+  await runProgress(request, data.run_id!, "backup");
+  await expect(page.getByRole("heading", { name: /atualizando para a versão 1\.1\.0/i })).toBeVisible();
+  await expect(page.getByText(/Guardando uma cópia de segurança/)).toBeVisible();
+  await page.screenshot({ path: ".superpowers/evidence/task9-2b-atualizando.png" });
+
   // ...executa (fora deste teste — é o `agent.sh`/`update.sh` reais, provados
   // na task 8) e reporta o desfecho.
-  const runResult = await request.post("/api/v1/system/agent", {
-    headers: { Authorization: `Bearer ${SECRET}` },
-    data: { kind: "run_result", run_id: data.run_id, status: "success", log_tail: "ok" },
-  });
-  expect(runResult.status()).toBe(200);
+  await runResult(request, data.run_id!, "success", "ok");
 
-  // Depois do sucesso, o agente reinicia e o próximo heartbeat já anuncia a
-  // versão nova como a instalada — é o que a tela usa pra sair do estado
-  // "atualizando" e mostrar "você está em dia".
+  // ── PONTA 2: terminou, e o host ainda não teve chance de contar ─────────
+  //
+  // `run_result` fecha o run e NÃO escreve `current_version` — quem escreve é o
+  // heartbeat, até 5 minutos depois. Sem o conserto, esta recarga trazia de
+  // volta "Versão 1.1.0 disponível" e o botão "Atualizar agora", oferecendo a
+  // versão que acabou de ser instalada. Repare que NENHUM heartbeat foi enviado
+  // entre o `run_result` e esta linha: é exatamente a janela do defeito.
+  await page.reload();
+  await expect(
+    page.getByRole("heading", { name: /pronto — você está na versão 1\.1\.0/i }),
+    "a tela voltou oferecendo a versão que acabou de ser instalada",
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: /atualizar agora/i })).toHaveCount(0);
+  await page.screenshot({ path: ".superpowers/evidence/task9-3a-acabou-de-atualizar.png" });
+
+  // E quando o host finalmente confirma, a janela se fecha sozinha: volta o
+  // texto normal de quem está em dia, sem ninguém limpar estado nenhum.
   await heartbeat(request, { current_version: "1.1.0", latest_version: "1.1.0" });
   await page.reload();
-  await expect(page.getByRole("heading", { name: /você está na versão 1\.1\.0/i })).toBeVisible();
-  await page.screenshot({ path: ".superpowers/evidence/task9-3-em-dia.png" });
+  await expect(page.getByRole("heading", { name: /^você está na versão 1\.1\.0/i })).toBeVisible();
+  await page.screenshot({ path: ".superpowers/evidence/task9-3b-em-dia.png" });
 });
 
 test("quando a atualização falha, a tela nomeia a versão certa, mostra o log e dá saída", async ({


### PR DESCRIPTION
As duas pontas têm a mesma causa: o app e o host conversam por batidas de 5 em 5 minutos, e a tela afirma estado como se a conversa fosse instantânea.

## Ponta 1 — o clique não começa a atualização

`POST /api/v1/system/update` só registra o pedido; quem executa é o `agent.sh`, no ciclo seguinte. Até lá `last_step` é nulo — e a tela já mostrava o título "Atualizando para a versão X" com os quatro círculos vazios. Ela **afirma trabalho que ainda nem começou**, e fica imóvel por até cinco minutos. Quem clicou não tem como distinguir isso de travamento.

Agora a espera é estado próprio, com nome ("Pedido enviado — esperando o servidor pegar"), com a razão da demora, com o aviso de que ficar parada é normal, e com um relógio que anda — contado do `dispatched_at` do servidor, para recarregar a página não zerar a conta. A lista de passos só aparece quando existe um passo.

## Ponta 2 — e esta era pior

`run_result` com `success` fecha o run e **não escreve** `current_version`; quem escreve é o heartbeat. Nessa janela `update_available` (`latest !== current`) segue verdadeiro e a tela volta do reinício **oferecendo "Atualizar agora" para a versão que acabou de ser instalada**. Quem clicou refaz tudo, ou conclui que não funcionou.

O conserto é `sucessoJaInstalado`, irmão de `rollbackFoiSuperado` e no mesmo módulo: o mesmo desempate temporal, na direção contrária. Lá o host mais novo vence o run; aqui o run vence enquanto o host não falou. **Tem fim de validade por construção** — na batida seguinte devolve `false` sozinho, sem ninguém limpar estado nenhum.

Empate de segundo conta como "host calado": as duas escritas vêm de relógios diferentes, e errar para esse lado custa um rótulo otimista por minutos, enquanto errar para o outro devolve o botão que manda instalar de novo o que já está lá.

## O que medi

⚠️ **O caso e2e do caminho feliz AFIRMAVA o defeito da ponta 1** — esperava "Guardando uma cópia de segurança" logo após o clique, ou seja, cobrava que a tela mentisse. Reescrito: percorre as duas pontas, e a janela do defeito ficou explícita — **entre o `run_result` e a recarga não há heartbeat nenhum**.

- `lib/system/update-run.test.ts` — 7 casos novos no `sucessoJaInstalado`, incluindo o fim de validade e o empate
- `app/api/v1/system/version/route.test.ts` — 3 casos: a janela, o fechamento pela batida do host, e o `dispatched_at` que a tela usa de relógio
- as dez frases novas entram no dicionário (o gate de espanhol as pegou; sem elas, quem opera em espanhol via a tela em português justo nos estados que explicam a demora)

Sabotagem conferida: `acabouDeInstalar` forçado a `false` derruba **1 de 28** no teste da rota — o previsto.

Gates na prévia do merge: `typecheck` 0, testes da área 58/58.

**Provado em tela**, numa VPS real, atualizando de verdade: o "Pedido enviado" com o contador subindo, e o "Pronto — você está na versão X" sem botão ao terminar.

## O que NÃO medi

- `pnpm test:unit` inteiro nesta branch (rodei na branch de origem: 5 vermelhos, os 4 conhecidos de Windows + o do espanhol, que este PR já traz corrigido)
- a corrida do `pnpm test:e2e` — a spec alterada roda no CI, em `SPECS_PARTE_1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)