### PR TITLE
docs(navegacao): o endereço de onde se declara uma porta estava errado nos dois lugares

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -495,7 +495,17 @@ Antes de declarar uma task pronta:
 11. **Mudança de schema saiu como migration versionada + linha no MANIFEST** (ver Doutrina de Migrations) — clones conseguem atualizar
 12. **Se tocou UI/fluxo de usuário: provado pela tela como um leigo faria**, em ambiente fresco estilo VPS, com evidência visual (ver Doutrina de QA Visual com Recursos Reais) — curl não conta
 13. **Living System Checklist respondido** (lei em `docs/doctrine/sistema-vivo.md`; racional no manual `docs/doctrine/sistema-vivo/`) — a feature não é ilha: tem entrada + saída, emite atividade/log, aparece na tela, tem porta na navegação, tem mecanismo anti-morte, **declara seu laço de retorno** (invariante 7 — o que muda no sistema quando ela erra), e o mapa vivo (`docs/architecture/`) reflete peça nova com ≥2 arestas. Resposta que não **nomeia o artefato concreto** (consumidor real, tela real, log real) não conta
-14. **Tela nova tem porta** — declarada em `lib/navigation/registry.ts` com seu grupo, ou na allowlist de `tests/unit/navegacao-completude.test.ts` **com justificativa escrita**. Ter tela e ser alcançável são coisas diferentes: o CI reprova tela que existe mas em que só se chega digitando a URL
+14. **Tela nova tem porta** — declarada em **`lib/navigation/catalogo.ts`** (no `NAV_CATALOG`, com seu grupo), ou na allowlist de `tests/unit/navegacao-completude.test.ts` **com justificativa escrita**. Ter tela e ser alcançável são coisas diferentes: o CI reprova tela que existe mas em que só se chega digitando a URL.
+
+    ⚠️ Esta linha dizia `lib/navigation/registry.ts`, e quem a seguisse abria um
+    arquivo **sem um único lugar onde declarar**: o `registry.ts` só deriva
+    (`NAV_DESTINATIONS` sai de `NAV_CATALOG`) e reexporta. Ele é a FACE do
+    módulo — é dele que o teste importa, e por isso o engano é fácil. Quem
+    declara é o catálogo. Para conferir sem acreditar nesta linha:
+
+    ```bash
+    grep -c 'href:' lib/navigation/catalogo.ts lib/navigation/registry.ts
+    ```
 15. **Se tocou Dockerfile, compose ou setup kit: a mudança chega a quem já instalou** (lei em `docs/doctrine/packaging.md`) — nenhum serviço de produção ficou `build:`-only; variável nova tem default que não quebra `.env` antigo; a atualização não pede edição manual de arquivo; e, se mudou o que a imagem contém, o `update.sh` alcança essa peça. Rode `pnpm test:shell` — é o único gate que exercita o kit
 16. **Se o PR muda comportamento, procure a afirmação de estado sobre esse comportamento.** Só
     sobre o que você mudou, e só nos documentos de autoridade — não saia caçando pelo repo. A

--- a/tests/unit/navegacao-completude.test.ts
+++ b/tests/unit/navegacao-completude.test.ts
@@ -75,8 +75,16 @@ describe("completude da navegação", () => {
     );
     expect(
       semPorta,
+      // ⚠️ O ENDEREÇO AQUI É O `catalogo.ts`, e não o `registry.ts`.
+      //
+      // Esta mensagem mandava ao `registry.ts` — que é de onde este arquivo
+      // IMPORTA, mas onde não há nada a declarar: ele deriva `NAV_DESTINATIONS`
+      // de `NAV_CATALOG` e reexporta. Quem fosse reprovado pelo CI abriria um
+      // arquivo sem um único lugar para pôr a tela. É a mensagem de erro que a
+      // pessoa lê no pior momento; mandá-la ao arquivo errado é o defeito mais
+      // caro dos dois (o `CLAUDE.md` repetia o mesmo engano, já corrigido).
       `Tela sem porta — existe mas não se chega nela pela navegação.\n` +
-        `Adicione ao registro (lib/navigation/registry.ts) declarando grupo, ou\n` +
+        `Declare em lib/navigation/catalogo.ts (NAV_CATALOG), com seu grupo, ou\n` +
         `à NAV_ALLOWLIST deste arquivo COM a justificativa:\n  ${semPorta.join("\n  ")}`,
     ).toEqual([]);
   });


### PR DESCRIPTION
O item 14 do Definition of Done manda declarar tela nova em `lib/navigation/registry.ts`. Quem segue abre um arquivo **sem um único lugar onde declarar**: o `registry.ts` só deriva (`NAV_DESTINATIONS` sai de `NAV_CATALOG`) e reexporta.

```console
$ grep -c 'href:' lib/navigation/catalogo.ts lib/navigation/registry.ts
lib/navigation/catalogo.ts:49
lib/navigation/registry.ts:0
```

O engano é fácil porque o `registry.ts` é a **face** do módulo — é dele que o teste de completude importa. Mas quem declara é o catálogo.

## E era nos dois lugares

A mensagem de falha do próprio `tests/unit/navegacao-completude.test.ts` também mandava ao `registry.ts`. **Essa é a pior das duas**: é o texto que a pessoa lê no exato momento em que o CI a reprova, quando está justamente procurando onde pôr a tela.

Consertar só a doutrina deixaria viva a instância que mais dói.

## Nota

A linha do `CLAUDE.md` ganhou o comando que a confere ao lado, como a própria doutrina de afirmação de estado pede (item 16) — comando não envelhece, número sim.

`AGENTS.md` não repete este item; nada a sincronizar lá.

Medido: `tests/unit/navegacao-completude.test.ts` 6/6 na prévia do merge.

## O que NÃO medi

`pnpm test:unit` inteiro nesta branch — a mudança é prosa e uma string de mensagem de erro; nenhum comportamento muda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)