### PR TITLE
fix(team): revogar e devolver acesso pintam a linha na hora

### DIFF
--- a/.changes/revogar-e-devolver-acesso-pintam-na-hora.md
+++ b/.changes/revogar-e-devolver-acesso-pintam-na-hora.md
@@ -1,0 +1,24 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Revogar e devolver acesso aparecem na hora na lista de Equipe
+---
+
+Em Equipe, revogar o acesso de alguém — ou devolvê-lo — deixava a linha da
+pessoa parada até recarregar a página. Quem clicava não via nada acontecer e
+clicava de novo, sem saber se o primeiro clique tinha valido.
+
+O servidor sempre fez a parte dele; era a tela que só se atualizava depois. E o
+problema só apareceu agora porque antes o membro revogado sumia da lista: some
+ou não some era resposta suficiente. Desde que ele passa a ficar na lista com o
+estado mudado, uma linha que não muda é uma tela que mente sobre o que acabou de
+acontecer.
+
+Agora a linha muda no clique e, se o servidor recusar, ela volta ao que era e o
+erro aparece — nunca fica dizendo "ativo" para quem não foi reativado. Devolver
+acesso também passou a confirmar que deu certo, como revogar já fazia: é
+justamente a ação que se faz com receio de ter errado.
+
+Você não precisa fazer nada para adotar.
+
+Crédito: @paulolimajr77.

--- a/hooks/team/useReactivateMember.ts
+++ b/hooks/team/useReactivateMember.ts
@@ -1,8 +1,10 @@
 "use client";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 import { apiClient } from "@/lib/api/client";
 import { showApiError } from "@/components/feedback/ApiErrorToast";
+import { useT } from "@/hooks/i18n/useT";
 import type { TeamMember } from "@/hooks/team/useTeamMembers";
 
 const MEMBERS_KEY = ["team", "members"] as const;
@@ -26,6 +28,7 @@ const MEMBERS_KEY = ["team", "members"] as const;
  */
 export function useReactivateMember() {
   const qc = useQueryClient();
+  const t = useT();
   return useMutation({
     mutationFn: async (userId: string) =>
       apiClient.post<{
@@ -51,6 +54,12 @@ export function useReactivateMember() {
       // servidor recusou reativar — pior que não ter atualizado.
       if (context?.previous) qc.setQueryData(MEMBERS_KEY, context.previous);
       showApiError(err);
+    },
+    onSuccess: () => {
+      // Revogar avisa; devolver nao avisava. Achado pela tela: quem clicava
+      // ficava sem confirmacao de que o clique valeu — e a acao e justamente
+      // a que a pessoa faz com receio de ter errado.
+      toast.success(t("Acesso devolvido."));
     },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: ["team"] });

--- a/hooks/team/useReactivateMember.ts
+++ b/hooks/team/useReactivateMember.ts
@@ -1,9 +1,29 @@
 "use client";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+
 import { apiClient } from "@/lib/api/client";
 import { showApiError } from "@/components/feedback/ApiErrorToast";
+import type { TeamMember } from "@/hooks/team/useTeamMembers";
 
-/** O inverso de `useRevokeMember`. Espelho dele, de propósito. */
+const MEMBERS_KEY = ["team", "members"] as const;
+
+/**
+ * Devolve o acesso de um membro revogado — o inverso de `useRevokeMember`.
+ *
+ * ─── Por que OTIMISTA, e não só invalidar ───────────────────────────────────
+ *
+ * Achado pela tela em 2026-09-10: só invalidar deixava a linha parada até
+ * alguém recarregar a página. Quem clicava não via nada acontecer e clicava de
+ * novo.
+ *
+ * Antes desta mudança o defeito era invisível: o revogado SUMIA da lista (a
+ * rota o filtrava fora), então qualquer atraso de atualização parecia efeito.
+ * Agora que a linha fica e só o estado muda, a atualização tem de ser imediata
+ * — senão a tela mente sobre o que acabou de acontecer.
+ *
+ * Mesmo desenho de `useChangeRole`: pinta na hora, desfaz se o servidor
+ * recusar, e reconcilia no fim.
+ */
 export function useReactivateMember() {
   const qc = useQueryClient();
   return useMutation({
@@ -11,8 +31,28 @@ export function useReactivateMember() {
       apiClient.post<{
         data: { user_id: string; reactivated_at?: string; already_active?: boolean };
       }>(`/api/v1/team/${userId}/reactivate`, {}),
-    onError: showApiError,
-    onSuccess: () => {
+    onMutate: async (userId) => {
+      await qc.cancelQueries({ queryKey: MEMBERS_KEY });
+      const previous = qc.getQueryData<{ data: TeamMember[] }>(MEMBERS_KEY);
+      qc.setQueryData<{ data: TeamMember[] }>(MEMBERS_KEY, (old) =>
+        old
+          ? {
+              ...old,
+              data: old.data.map((m) =>
+                m.user_id === userId ? { ...m, revoked_at: null } : m,
+              ),
+            }
+          : old,
+      );
+      return { previous };
+    },
+    onError: (err, _userId, context) => {
+      // Desfaz: sem isto a tela ficaria dizendo "ativo" para alguém que o
+      // servidor recusou reativar — pior que não ter atualizado.
+      if (context?.previous) qc.setQueryData(MEMBERS_KEY, context.previous);
+      showApiError(err);
+    },
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: ["team"] });
     },
   });

--- a/hooks/team/useRevokeMember.ts
+++ b/hooks/team/useRevokeMember.ts
@@ -1,8 +1,20 @@
 "use client";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+
 import { apiClient } from "@/lib/api/client";
 import { showApiError } from "@/components/feedback/ApiErrorToast";
+import type { TeamMember } from "@/hooks/team/useTeamMembers";
 
+const MEMBERS_KEY = ["team", "members"] as const;
+
+/**
+ * Revoga o acesso de um membro.
+ *
+ * OTIMISTA pelo mesmo motivo de `useReactivateMember`: desde que o revogado
+ * passou a FICAR na lista (antes ele era filtrado fora pela rota), só invalidar
+ * deixava a linha parada até alguém recarregar a página — e quem clicava não
+ * via nada acontecer. Medido pela tela em 2026-09-10.
+ */
 export function useRevokeMember() {
   const qc = useQueryClient();
   return useMutation({
@@ -11,8 +23,26 @@ export function useRevokeMember() {
         `/api/v1/team/${userId}/revoke`,
         {},
       ),
-    onError: showApiError,
-    onSuccess: () => {
+    onMutate: async (userId) => {
+      await qc.cancelQueries({ queryKey: MEMBERS_KEY });
+      const previous = qc.getQueryData<{ data: TeamMember[] }>(MEMBERS_KEY);
+      qc.setQueryData<{ data: TeamMember[] }>(MEMBERS_KEY, (old) =>
+        old
+          ? {
+              ...old,
+              data: old.data.map((m) =>
+                m.user_id === userId ? { ...m, revoked_at: new Date().toISOString() } : m,
+              ),
+            }
+          : old,
+      );
+      return { previous };
+    },
+    onError: (err, _userId, context) => {
+      if (context?.previous) qc.setQueryData(MEMBERS_KEY, context.previous);
+      showApiError(err);
+    },
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: ["team"] });
     },
   });

--- a/lib/i18n/dicionario.ts
+++ b/lib/i18n/dicionario.ts
@@ -6010,6 +6010,7 @@ export const DICIONARIO: Traducoes = {
   //  de compilação, e é assim que o dicionário evita duas traduções da mesma
   //  frase divergirem.)
   "Devolver acesso": { es: "Devolver el acceso" },
+  "Acesso devolvido.": { es: "Acceso devuelto." },
   // ("Seu nome" já existe mais acima — a chave é o próprio texto.)
   "Informe seu nome": { es: "Escribe tu nombre" },
   "Você já tem uma conta com este e-mail": {

--- a/tests/unit/team-revogacao-pinta-na-hora.test.tsx
+++ b/tests/unit/team-revogacao-pinta-na-hora.test.tsx
@@ -1,0 +1,206 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TeamMember } from "@/hooks/team/useTeamMembers";
+
+/**
+ * REVOGAR E DEVOLVER ACESSO PINTAM A LINHA NA HORA.
+ *
+ * ─── O defeito, achado pela tela ────────────────────────────────────────────
+ *
+ * Enquanto o revogado SUMIA da lista (a rota o filtrava fora), qualquer atraso
+ * de atualização parecia efeito: a linha desaparecia e pronto. Depois que ele
+ * passou a FICAR na lista e só o ESTADO mudar, só invalidar a query deixava a
+ * linha parada até alguém recarregar a página — quem clicava não via nada
+ * acontecer e clicava de novo.
+ *
+ * ─── Por que o rollback importa tanto quanto a pintura ──────────────────────
+ *
+ * Pintar sem desfazer é pior que não pintar: uma recusa do servidor deixaria a
+ * tela dizendo "ativo" para quem NÃO foi reativado. Os dois lados são cobrados
+ * aqui, nos dois hooks.
+ *
+ * ─── O que este arquivo cobre, e o que não ──────────────────────────────────
+ *
+ * Cobre o CACHE — que é o que a linha lê. Não cobre pixel: a prova de tela do
+ * fluxo de equipe é do Playwright, e está declarada no corpo do PR.
+ *
+ * ⚠️ O momento é o ponto. `apiClient.post` fica PENDENTE de propósito nos casos
+ * de pintura: assertar o cache depois que a promessa resolve não distingue
+ * "pintou na hora" de "recarregou no fim" — que é exatamente o defeito. Quem
+ * tirar o `onMutate` e deixar só o `invalidateQueries` passa numa asserção
+ * feita tarde demais.
+ */
+
+const post = vi.fn();
+const toastSuccess = vi.fn();
+const erroMostrado = vi.fn();
+
+vi.mock("@/lib/api/client", () => ({ apiClient: { post: (...a: unknown[]) => post(...a) } }));
+vi.mock("@/components/feedback/ApiErrorToast", () => ({
+  showApiError: (...a: unknown[]) => erroMostrado(...a),
+}));
+vi.mock("sonner", () => ({ toast: { success: (...a: unknown[]) => toastSuccess(...a) } }));
+// O dicionário tem contexto próprio; aqui o texto degrada para ele mesmo, que é
+// o contrato de `traduzir` quando não há entrada.
+vi.mock("@/hooks/i18n/useT", () => ({ useT: () => (texto: string) => texto }));
+
+import { useReactivateMember } from "@/hooks/team/useReactivateMember";
+import { useRevokeMember } from "@/hooks/team/useRevokeMember";
+
+const MEMBERS_KEY = ["team", "members"] as const;
+const ANA = "11111111-1111-4111-8111-111111111111";
+const BRUNO = "22222222-2222-4222-8222-222222222222";
+
+function membro(userId: string, revokedAt: string | null): TeamMember {
+  return {
+    user_id: userId,
+    role: "agent",
+    invited_at: null,
+    accepted_at: "2026-09-01T12:00:00.000Z",
+    revoked_at: revokedAt,
+    created_at: "2026-09-01T12:00:00.000Z",
+    email: `${userId.slice(0, 4)}@exemplo.com.br`,
+    full_name: null,
+    last_sign_in_at: null,
+  };
+}
+
+let qc: QueryClient;
+
+/** Uma promessa que EU decido quando (e como) termina. */
+function pendente() {
+  let resolver!: (v: unknown) => void;
+  let rejeitar!: (e: unknown) => void;
+  const promessa = new Promise((res, rej) => {
+    resolver = res;
+    rejeitar = rej;
+  });
+  post.mockImplementation(() => promessa);
+  // A promessa é rejeitada de propósito em alguns casos; sem este `catch` o
+  // Node acusa rejeição não tratada e derruba a suíte por fora do teste.
+  promessa.catch(() => undefined);
+  return { resolver, rejeitar };
+}
+
+const linha = (userId: string) =>
+  qc.getQueryData<{ data: TeamMember[] }>(MEMBERS_KEY)?.data.find((m) => m.user_id === userId);
+
+function envolve({ children }: { children: ReactNode }) {
+  return createElement(QueryClientProvider, { client: qc }, children);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  qc = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  // Ana ATIVA, Bruno REVOGADO — os dois sentidos partem daqui.
+  qc.setQueryData(MEMBERS_KEY, {
+    data: [membro(ANA, null), membro(BRUNO, "2026-09-05T09:00:00.000Z")],
+  });
+});
+
+describe("CONTROLE do instrumento", () => {
+  it("o cache semeado parte do estado que os casos assumem", () => {
+    // Sem isto, um `setQueryData` com chave errada deixaria `linha()` sempre
+    // `undefined` e as asserções de estado passariam sobre nada.
+    expect(linha(ANA)?.revoked_at).toBeNull();
+    expect(linha(BRUNO)?.revoked_at).toBe("2026-09-05T09:00:00.000Z");
+  });
+});
+
+describe("useRevokeMember", () => {
+  it("pinta a linha ANTES de o servidor responder", async () => {
+    const { resolver } = pendente();
+    const { result } = renderHook(() => useRevokeMember(), { wrapper: envolve });
+
+    act(() => result.current.mutate(ANA));
+
+    await waitFor(() =>
+      expect(
+        linha(ANA)?.revoked_at,
+        "a linha só mudou depois da resposta — quem clicou ficou sem retorno, " +
+          "que é o defeito inteiro desta correção",
+      ).not.toBeNull(),
+    );
+    // E o vizinho não foi arrastado junto.
+    expect(linha(BRUNO)?.revoked_at).toBe("2026-09-05T09:00:00.000Z");
+
+    await act(async () => {
+      resolver({ data: { user_id: ANA } });
+    });
+  });
+
+  it("DESFAZ quando o servidor recusa — senão a tela mente", async () => {
+    const { rejeitar } = pendente();
+    const { result } = renderHook(() => useRevokeMember(), { wrapper: envolve });
+
+    act(() => result.current.mutate(ANA));
+    await waitFor(() => expect(linha(ANA)?.revoked_at).not.toBeNull());
+
+    await act(async () => {
+      rejeitar(new Error("403"));
+    });
+
+    await waitFor(() =>
+      expect(
+        linha(ANA)?.revoked_at,
+        "o servidor recusou e a tela continuou dizendo que o acesso foi revogado",
+      ).toBeNull(),
+    );
+    expect(erroMostrado).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useReactivateMember", () => {
+  it("pinta a linha ANTES de o servidor responder", async () => {
+    const { resolver } = pendente();
+    const { result } = renderHook(() => useReactivateMember(), { wrapper: envolve });
+
+    act(() => result.current.mutate(BRUNO));
+
+    await waitFor(() => expect(linha(BRUNO)?.revoked_at).toBeNull());
+    expect(linha(ANA)?.revoked_at).toBeNull();
+
+    await act(async () => {
+      resolver({ data: { user_id: BRUNO } });
+    });
+  });
+
+  it("AVISA que deu certo — revogar avisava, devolver não", async () => {
+    // É a ação que se faz com receio de ter errado: sem confirmação, quem clicou
+    // não sabe se valeu.
+    const { resolver } = pendente();
+    const { result } = renderHook(() => useReactivateMember(), { wrapper: envolve });
+
+    act(() => result.current.mutate(BRUNO));
+    await act(async () => {
+      resolver({ data: { user_id: BRUNO } });
+    });
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledTimes(1));
+    expect(toastSuccess).toHaveBeenCalledWith("Acesso devolvido.");
+  });
+
+  it("recusa do servidor desfaz E não comemora", async () => {
+    const { rejeitar } = pendente();
+    const { result } = renderHook(() => useReactivateMember(), { wrapper: envolve });
+
+    act(() => result.current.mutate(BRUNO));
+    await waitFor(() => expect(linha(BRUNO)?.revoked_at).toBeNull());
+
+    await act(async () => {
+      rejeitar(new Error("403"));
+    });
+
+    await waitFor(() => expect(linha(BRUNO)?.revoked_at).toBe("2026-09-05T09:00:00.000Z"));
+    expect(
+      toastSuccess,
+      "avisou que o acesso foi devolvido depois de o servidor recusar",
+    ).not.toHaveBeenCalled();
+    expect(erroMostrado).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Achado pela tela, usando o produto: em Equipe › Membros, revogar o acesso de alguém — ou devolvê-lo — deixa a linha da pessoa **parada** até recarregar a página. Quem clica não vê nada acontecer e clica de novo.

Antes o defeito era **invisível**: o revogado sumia da lista (a rota o filtrava fora), então some-ou-não-some já era resposta suficiente. Desde que ele passa a **ficar** na lista com o estado mudado, uma linha que não muda é uma tela mentindo sobre o que acabou de acontecer.

Mesmo desenho de `useChangeRole`, que o produto já usa para troca de papel: pinta na hora, desfaz se o servidor recusar, reconcilia no fim. **Sem o desfazer seria pior que não pintar** — a tela ficaria dizendo "ativo" para quem o servidor recusou reativar.

O segundo commit fecha o par que faltava: **revogar avisava, devolver não**. É justamente a ação que se faz com receio de ter errado — sem confirmação, quem clicou não sabe se valeu.

## O que medi

**Nenhum teste cobria esses hooks** — `useRevokeMember` e `useReactivateMember` não eram citados por arquivo de teste nenhum. Escrevi `tests/unit/team-revogacao-pinta-na-hora.test.tsx` (6 casos).

⚠️ **O momento é o ponto.** `apiClient.post` fica **pendente** de propósito nos casos de pintura: assertar o cache depois que a promessa resolve não distingue "pintou na hora" de "recarregou no fim" — que é exatamente o defeito. Quem tirar o `onMutate` e deixar só o `invalidateQueries` passaria numa asserção feita tarde demais.

O rollback é cobrado junto, e o caso de erro assere também que **não houve comemoração**.

Sabotagem conferida, com previsão escrita antes de rodar:

| sabotagem | previ | caiu |
|---|---|---|
| `onMutate` fora de `useRevokeMember` | 2 de 6 | 2 de 6 |
| `onSuccess` (o aviso) fora de `useReactivateMember` | 1 de 6 | 1 de 6 |

Cobre o **cache**, que é o que a linha lê. Não cobre pixel.

Gates na prévia do merge: `typecheck` 0, `lint` 0 erros, `lint:channels` ok, testes da área 29/29. Pré-voo do guia de contribuição: tudo verde.

## O que NÃO medi

- `pnpm test:unit` inteiro nesta branch
- a prova em tela por Playwright — precisa de Supabase local e app buildado. O comportamento foi observado usando o produto numa VPS real, que foi como o defeito apareceu, mas isso não é uma spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)