### PR TITLE
docs(skills): evidência do Antigravity e a bancada de prova com agy

### DIFF
--- a/evidence/skills-embutidas/2026-09-10/README.md
+++ b/evidence/skills-embutidas/2026-09-10/README.md
@@ -52,14 +52,27 @@ prompt e contribuição o Claude também leu as referências e rodou `quem-sou.s
 Resumo em `antes.json`. Em nenhuma das cinco a IA achou um guia — não havia; ela varreu o
 repositório (até 191 ferramentas numa pergunta) e respondeu por conta própria.
 
+## Antigravity — o CLI (`agy --print`), 11/set
+
+O app instala um CLI (`agy`) com modo sem interface. Rodei as cinco perguntas nele (modo plano,
+permissões auto-aprovadas — sem isso o primeiro comando pedido pela doutrina global do dono
+encerra a corrida sem resposta). Resultado: **o CLI não enxerga as skills do workspace** —
+perguntado diretamente "quais skills do workspace você tem no contexto?", respondeu "NENHUMA".
+Nas cinco corridas, o guia certo foi encontrado **por exploração** em duas (montar clínica: leu o
+`SKILL.md` e as referências depois de 30 ferramentas; instalar: foi buscar o guia no GitHub), e não
+foi encontrado em três (métricas, prompt, contribuir), que responderam por conta própria. Resumo
+em `antigravity.json`. A prova do **app** Antigravity (que, pelas docs, lê `.agents/skills/`)
+segue à mão.
+
 ## O que NÃO ficou provado
 
 - **Hook de início de sessão** (`.claude/settings.json` → `sessao.sh`): em `claude -p` os hooks
   de projeto **não executaram** nesta versão, mesmo com a pasta confiada em `~/.claude.json` —
   medido com um hook que gravava um marcador em disco (nunca apareceu). A sessão interativa não foi
   medida. O acionamento não depende dele: a descrição basta.
-- **Cursor e Antigravity**: sem modo sem interface nesta máquina. Roteiro à mão em
-  "Decisão Implementações/CRED-003".
+- **Cursor**: o CLI (`agent`) foi instalado em 11/set e exige `agent login` — a prova fica para
+  depois do login. **Antigravity**: o CLI não carrega skills do workspace (acima); o app segue com o
+  roteiro à mão em "Decisão Implementações/CRED-003".
 - **Codex com muitas skills globais**: numa instalação com centenas de skills pessoais o Codex
   encurta e depois remove as descrições da lista (medido em 08/set); o gate limita o que o repo
   gasta desse orçamento, mas não o que a pessoa já tem.

--- a/evidence/skills-embutidas/2026-09-10/antigravity.json
+++ b/evidence/skills-embutidas/2026-09-10/antigravity.json
@@ -1,0 +1,75 @@
+[
+ {
+  "fase": "depois (CLI do Antigravity, agy --print, modo plan, permissões auto-aprovadas)",
+  "cli": "antigravity-cli",
+  "pergunta": "p1_instalar",
+  "skill_esperada": "deskcomm-instalar",
+  "skill_encontrada_por_exploracao": true,
+  "ferramentas": 19,
+  "turnos": 1,
+  "duracao_s": 78,
+  "leituras_de_skill": [
+   "run_command → {\"CommandLine\":\"python3 -c '\\nimport urllib.request\\n\\nurl = \\\"https://raw.githubusercontent.com/melgarafael/DeskcommCRM/main/.agents/skills/deskc",
+   "run_command → {\"CommandLine\":\"python3 -c '\\nimport urllib.request\\n\\nurl = \\\"https://raw.githubusercontent.com/melgarafael/DeskcommCRM/main/.agents/skills/deskc",
+   "run_command → {\"CommandLine\":\"python3 -c '\\nimport urllib.request\\n\\nurl = \\\"https://raw.githubusercontent.com/melgarafael/DeskcommCRM/main/.agents/skills/deskc"
+  ],
+  "inicio_da_resposta": "Criei um plano passo a passo no documento de implantação:\n👉 [plano_instalacao_deskcomm_hostgator.md](file:///Users/rafaelmelgaco/.gemini/antigravity-cli/brain/dea7dc1f-79dc-4dc5-be8f-35cc291c5147/plano_instalacao_deskcomm_hostgator.md)\n\nO DeskcommCRM possui um instalador automatizado oficial feito "
+ },
+ {
+  "fase": "depois (CLI do Antigravity, agy --print, modo plan, permissões auto-aprovadas)",
+  "cli": "antigravity-cli",
+  "pergunta": "p2_cliente",
+  "skill_esperada": "deskcomm-cliente-novo",
+  "skill_encontrada_por_exploracao": true,
+  "ferramentas": 42,
+  "turnos": 1,
+  "duracao_s": 170,
+  "leituras_de_skill": [
+   "view_file → {\"AbsolutePath\":\"/Users/rafaelmelgaco/wt/prova-skills/.agents/skills/DeskcommCRM/SKILL.md\"}",
+   "view_file → {\"AbsolutePath\":\"/Users/rafaelmelgaco/DeskcommCRM/.agents/skills/DeskcommCRM/SKILL.md\"}",
+   "run_command → {\"CommandLine\":\"find /Users/rafaelmelgaco/wt/prova-skills -name \\\"SKILL.md\\\"\"}",
+   "view_file → {\"AbsolutePath\":\"/Users/rafaelmelgaco/wt/prova-skills/.agents/skills/deskcomm-cliente-novo/SKILL.md\"}",
+   "view_file → {\"AbsolutePath\":\"/Users/rafaelmelgaco/wt/prova-skills/.agents/skills/deskcomm-cliente-novo/references/nichos.md\"}",
+   "view_file → {\"AbsolutePath\":\"/Users/rafaelmelgaco/wt/prova-skills/.agents/skills/deskcomm-cliente-novo/references/pela-tela.md\"}",
+   "view_file → {\"AbsolutePath\":\"/Users/rafaelmelgaco/wt/prova-skills/.agents/skills/deskcomm-cliente-novo/references/prompt-do-agente.md\"}",
+   "view_file → {\"AbsolutePath\":\"/Users/rafaelmelgaco/wt/prova-skills/.agents/skills/deskcomm-cliente-novo/references/triagem.md\"}"
+  ],
+  "inicio_da_resposta": "Elaborei o plano detalhado de configuração para o atendimento da sua clínica odontológica no artefato:\n👉 [plano_atendimento_clinica_odontologica.md](file:///Users/rafaelmelgaco/.gemini/antigravity-cli/brain/a166fdf3-fed1-4c68-b4f7-bd806086bd37/plano_atendimento_clinica_odontologica.md).\n\nO document"
+ },
+ {
+  "fase": "depois (CLI do Antigravity, agy --print, modo plan, permissões auto-aprovadas)",
+  "cli": "antigravity-cli",
+  "pergunta": "p3_metricas",
+  "skill_esperada": "deskcomm-metricas",
+  "skill_encontrada_por_exploracao": false,
+  "ferramentas": 63,
+  "turnos": 1,
+  "duracao_s": 228,
+  "leituras_de_skill": [],
+  "inicio_da_resposta": "Criei o plano detalhado de diagnóstico e análise no artefato [plano_analise_agente_vendas_ia.md](file:///Users/rafaelmelgaco/.gemini/antigravity-cli/brain/fcdd38b3-0879-4a1d-883a-16a50b91187e/plano_analise_agente_vendas_ia.md).\n\nO plano cobre de forma aprofundada os três pilares que você solicitou:\n"
+ },
+ {
+  "fase": "depois (CLI do Antigravity, agy --print, modo plan, permissões auto-aprovadas)",
+  "cli": "antigravity-cli",
+  "pergunta": "p4_prompt",
+  "skill_esperada": "deskcomm-prompt",
+  "skill_encontrada_por_exploracao": false,
+  "ferramentas": 7,
+  "turnos": 1,
+  "duracao_s": 66,
+  "leituras_de_skill": [],
+  "inicio_da_resposta": "Criei o plano detalhado para reestruturação do seu agente no arquivo [plano_otimizacao_agente_imobiliario.md](file:///Users/rafaelmelgaco/.gemini/antigravity-cli/brain/84a3b56b-ae01-499c-89d8-90ece737ad12/plano_otimizacao_agente_imobiliario.md).\n\n### Por onde começar (O Diagnóstico)\nO agente costuma"
+ },
+ {
+  "fase": "depois (CLI do Antigravity, agy --print, modo plan, permissões auto-aprovadas)",
+  "cli": "antigravity-cli",
+  "pergunta": "p5_contribuir",
+  "skill_esperada": "deskcomm-contribuir",
+  "skill_encontrada_por_exploracao": false,
+  "ferramentas": 21,
+  "turnos": 1,
+  "duracao_s": 81,
+  "leituras_de_skill": [],
+  "inicio_da_resposta": "Criei o plano detalhado de contribuição no artifact [`plano_contribuicao_bug_inbox.md`](file:///Users/rafaelmelgaco/.gemini/antigravity-cli/brain/d2a6362d-06f0-46f2-bcd0-d34551c67747/plano_contribuicao_bug_inbox.md).\n\nNo **DeskcommCRM**, o fluxo correto para contribuir pela primeira vez segue regras"
+ }
+]

--- a/scripts/skills-embutidas/provar.mjs
+++ b/scripts/skills-embutidas/provar.mjs
@@ -12,11 +12,12 @@
  * 200 s, US$ 3,08 para "por onde eu começo a instalar?") e o "depois". Um
  * teste automatizado não prova acionamento; só uma sessão real prova.
  *
- *   node scripts/skills-embutidas/provar.mjs --cli claude --dir /caminho/do/clone \
+ *   node scripts/skills-embutidas/provar.mjs --cli claude|codex|opencode|agy --dir /caminho/do/clone \
  *     --prompt "Comprei uma VPS e quero instalar o CRM. Por onde começo?" \
  *     --out /tmp/prova.jsonl [--max-turns 12] [--env CODEX_HOME=/tmp/codex-limpo] [--env GH_TOKEN=x]
  *
- * Cursor e Antigravity não têm modo sem interface: a prova neles é à mão.
+ * Antigravity roda por `agy --print` (o CLI que o app instala em ~/.local/bin). O Cursor
+ * tem o `agent` (curl https://cursor.com/install | bash), que exige `agent login`.
  */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
@@ -39,6 +40,10 @@ const cmd = {
   claude: ["claude", ["-p", opt.prompt, "--output-format", "stream-json", "--verbose", "--max-turns", String(opt["max-turns"] || 12), "--permission-mode", "plan"]],
   codex: ["codex", ["exec", "--json", "--ephemeral", "-s", "read-only", opt.prompt]],
   opencode: ["opencode", ["run", "--format", "json", "--dir", opt.dir, opt.prompt]],
+  // --dangerously-skip-permissions: em modo sem interface ninguém clica "permitir", e o
+  // primeiro run_command (que uma doutrina global do usuário pode pedir) encerra a corrida
+  // sem resposta. Auto-aprovar é o substituto fiel do clique; o clone de prova é descartável.
+  agy: ["agy", ["--print", opt.prompt, "--output-format", "stream-json", "--mode", "plan", "--print-timeout", "10m", "--dangerously-skip-permissions"]],
 }[opt.cli];
 if (!cmd) { console.error("cli desconhecido"); process.exit(2); }
 
@@ -50,7 +55,7 @@ if (r.stderr) fs.writeFileSync(opt.out + ".err", r.stderr);
 
 const linhas = (r.stdout || "").split("\n").filter(Boolean).map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
 const tools = []; let final = ""; let turns = 0; let custo = null; let uso = null;
-const ehSkill = (s) => /SKILL\.md|\.claude\/skills|\.agents\/skills|\.codex\/skills|\.opencode\/skill|\.cursor\/(rules|skills)|\.agent\/(skills|rules|workflows)/i.test(s || "");
+const ehSkill = (s) => /SKILL\.md|\.claude\/skills|\.agents\/skills|\.codex\/skills|\.opencode\/skill|\.cursor\/(rules|skills)|\.agent\/(skills|rules|workflows)|deskcomm-[a-z-]+/i.test(s || "");
 
 if (opt.cli === "claude") {
   for (const m of linhas) {
@@ -71,6 +76,14 @@ if (opt.cli === "claude") {
       else if (it.type === "error") tools.push({ nome: "ERRO", alvo: String(it.message || "").slice(0, 200) });
     }
     if (m.type === "turn.completed") { turns++; uso = m.usage; }
+  }
+} else if (opt.cli === "agy") {
+  for (const m of linhas) {
+    const su = m.step_update;
+    if (m.event === "step_update" && su && su.step_type === "tool" && su.state === "ACTIVE") {
+      tools.push({ nome: String(su.tool_name || "tool"), alvo: JSON.stringify(su.tool_info?.parameters || {}).slice(0, 160) });
+    }
+    if (m.event === "result" && m.result) { final = String(m.result.response || ""); turns = m.result.num_turns; uso = m.result.usage; }
   }
 } else if (opt.cli === "opencode") {
   for (const m of linhas) {


### PR DESCRIPTION
Acompanhamento do #689 (mesclado): dois commits que ficaram para trás na branch do épico.

- `scripts/skills-embutidas/provar.mjs` ganha o modo `agy` (o CLI do Antigravity, `agy --print` com saída stream-json), com permissões auto-aprovadas — em modo sem interface ninguém clica "permitir", e o primeiro comando encerrava a corrida.
- `evidence/skills-embutidas/2026-09-10/`: resultado das cinco perguntas no CLI do Antigravity. **Ele não carrega as skills do workspace** em modo sem interface (perguntado, responde "NENHUMA"); achou o guia por exploração em 2 de 5. A prova do app Antigravity segue à mão; o CLI do Cursor (`agent`) exige `agent login`.

Só docs e a bancada; nenhum código de runtime. Gates: `skills-embutidas` e `documentacao-aponta-para-o-que-existe` verdes; eslint da bancada zerado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4qXpr9LCmXoG2KR4TBrL3