### PR TITLE
fix(kit): o instalador não para em "Ativando as automações" numa VPS sem crontab

### DIFF
--- a/.changes/instalador-nao-para-sem-crontab.md
+++ b/.changes/instalador-nao-para-sem-crontab.md
@@ -1,0 +1,11 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O instalador não para mais em "Ativando as automações" numa VPS nova
+---
+
+Numa VPS recém-criada, o root ainda não tem agendamento nenhum, e o instalador
+parava logo depois de "chave de cifra ativa no banco", sem mensagem de erro,
+mostrando "A instalação parou" com o CRM já no ar. Rodar o instalador de novo
+contornava. Agora ele agenda as automações e o agente de atualização direto,
+na primeira rodada. Quem já instalou não precisa fazer nada. Crédito: @rafaelbatistazz.

--- a/hostgator-setup-kit/_common.sh
+++ b/hostgator-setup-kit/_common.sh
@@ -795,7 +795,10 @@ setup_event_log_drain_cron() {
   if crontab -l 2>/dev/null | grep -qF -e "$url_drain"; then first_time=0; fi
 
   local cron_line="* * * * * curl -fsS -H \"Authorization: Bearer ${secret}\" \"${url_drain}\" >/dev/null 2>&1 ${marcador}"
-  ( crontab -l 2>/dev/null | cron_merge "$marcador" "$url_drain" "$cron_line" ) | crontab -
+  # `|| true` no `crontab -l`: sem crontab ele sai 1 ("no crontab for root"), e sob
+  # `pipefail` o cano inteiro falhava — o `set -e` derrubava o install.sh logo
+  # depois de a linha já estar gravada, numa VPS nova (#715).
+  ( { crontab -l 2>/dev/null || true; } | cron_merge "$marcador" "$url_drain" "$cron_line" ) | crontab -
   c_grn "✓ automações ativas (cron do event-log-drain, a cada minuto)"
 
   if [ "$first_time" = 1 ]; then
@@ -834,7 +837,7 @@ setup_update_agent_cron() {
   local legado="cd ${PROJECT_DIR} && bash hostgator-setup-kit/agent.sh"
   local marcador; marcador="$(cron_tag agent)"
   local cron_line="*/5 * * * * ${legado} >/dev/null 2>&1 ${marcador}"
-  ( crontab -l 2>/dev/null | cron_merge "$marcador" "$legado" "$cron_line" ) | crontab -
+  ( { crontab -l 2>/dev/null || true; } | cron_merge "$marcador" "$legado" "$cron_line" ) | crontab -
   c_grn "✓ atualização pela tela ativa (agente a cada 5 minutos)"
 }
 

--- a/hostgator-setup-kit/test-validators.sh
+++ b/hostgator-setup-kit/test-validators.sh
@@ -2566,6 +2566,33 @@ reexec_neg() {
 reexec_neg
 reexec_ok "o bloco de variáveis conhecidas acha o kit depois do cd"
 
+echo "cron numa VPS sem crontab nenhum (#715)"
+# VPS nova não tem crontab para o root: `crontab -l` sai 1. As rodadas acima
+# nunca mediram isso, porque o sandbox já tinha linhas quando elas agendavam — e
+# o install.sh morria em "Ativando as automações" em toda VPS recém-criada. As
+# duas funções rodam aqui sob o MESMO `set -euo pipefail` do install.sh, com o
+# dublê de crontab apontado para um arquivo que não existe.
+cron_vazio() (
+  # Subshell: `montar_vps` define VPS_* globais, e os blocos seguintes da suíte
+  # não podem herdar esta fixture.
+  montar_vps "$SUITE_TMP/cron-vazio" projeto < <(printf '#!/bin/sh\nexit 0\n')
+  local sandbox="$SUITE_TMP/crontab-vazio.txt"; rm -f "$sandbox"
+  local out rc
+  out="$(cd "$VPS_PROJ" && env PATH="$VPS_RAIZ/bin:$PATH" CRONTAB_SANDBOX="$sandbox" \
+    INTERNAL_SECRET=segredo-de-teste NEXT_PUBLIC_APP_URL=https://crm.exemplo.com.br PROJECT_DIR="$VPS_PROJ" \
+    bash -c 'set -euo pipefail; . "$1/_common.sh"; psql_run() { :; }
+             setup_event_log_drain_cron; setup_update_agent_cron; echo CHEGOU-AO-FIM' _ "$VPS_RAIZ" 2>&1)" \
+    && rc=0 || rc=$?
+  if [ $rc -ne 0 ] || ! printf '%s' "$out" | grep -q CHEGOU-AO-FIM; then
+    printf '  ✗ agendar o cron numa VPS sem crontab derrubou o script (saída %s)\n' "$rc"; return 1
+  fi
+  if [ "$(grep -c '# deskcomm:' "$sandbox" 2>/dev/null)" != 2 ]; then
+    printf '  ✗ esperava 2 linhas (drain + agente) no crontab, veio %s\n' "$(grep -c '# deskcomm:' "$sandbox" 2>/dev/null || echo 0)"; return 1
+  fi
+  printf '  ✓ sem crontab prévio, drain e agente agendados e o script segue\n'
+)
+cron_vazio || fail=1
+
 echo "isolamento: a suíte não escreve no crontab da máquina"
 # Isto não é hipótese defensiva: os testes JÁ escreveram 10 linhas órfãs no
 # crontab do mantenedor, uma delas um `curl` com Bearer disparando a cada minuto


### PR DESCRIPTION
## O que muda para quem usa

Numa VPS nova, o `install.sh` parava logo depois de `✓ chave de cifra ativa no banco`, sem erro nenhum na tela, e mostrava "A instalação parou" — com os contêineres já saudáveis e o CRM no ar. Rodar o instalador de novo passava, o que escondia a causa.

O motivo é o crontab vazio: numa máquina recém-criada o root não tem agendamento, `crontab -l` sai `1` ("no crontab for root") e, sob o `set -euo pipefail` do `install.sh` (linha 12), o cano inteiro devolvia `1`. O `set -e` derrubava o script **depois** de o `crontab -` já ter gravado a linha do drain; o `2>/dev/null` escondia a mensagem, por isso a tela não dizia nada.

O conserto tolera o crontab vazio nas duas funções que agendam — `setup_event_log_drain_cron` e `setup_update_agent_cron`:

```bash
( { crontab -l 2>/dev/null || true; } | cron_merge ... ) | crontab -
```

Closes #715

## O teste

O dublê de `crontab` da suíte já simulava o "no crontab" (sai `1` quando o sandbox não existe), mas nenhuma rodada agendava com ele **vazio** — as rodadas de integração já tinham linhas gravadas quando chegavam ali. O teste novo monta uma fixture própria, aponta o sandbox para um arquivo que não existe e roda as duas funções sob o mesmo `set -euo pipefail` do instalador, cobrando as duas linhas no fim.

## O que eu medi

```
bash hostgator-setup-kit/test-validators.sh   → 258 ✓ / 0 ✗
pnpm test:shell                               → todos os validadores passaram (exit 0)
pnpm test:unit                                → Test Files 788 passed (788)
                                                Tests 8361 passed | 1 expected fail (8362)
pnpm typecheck                                → exit 0
pnpm lint                                     → 0 errors (349 warnings, pré-existentes)
pnpm lint:channels                            → exit 0
pnpm release:conferir                          → fragmento aceito
```

**Sabotagem** (revertendo só a linha do conserto, sem desfazer o commit): previ 1 vermelho, o do teste novo, e foi exatamente isso — `257 ✓ / 1 ✗`, com a mensagem `✗ agendar o cron numa VPS sem crontab derrubou o script (saída 1)`. Restaurei depois.

**Onde achei:** instalando numa VPS que já tinha o Traefik da Coolify nas portas 80/443 (`REVERSE_PROXY=traefik`, detectado pelo próprio instalador), em modo `--yes`.

## O que NÃO medi

- **`pnpm test:db` e `pnpm test:e2e`** — não rodei. A mudança é de shell e não toca schema nem UI, mas fica declarado.
- **Instalação fresca de ponta a ponta depois do conserto** — provei o caminho pelo teste, não repetindo a instalação numa VPS virgem (a minha já tem crontab agora, então ela não reproduz mais o estado).
- O pré-voo acusa um `⚠ marca/config de instalação no diff` apontando para `NEXT_PUBLIC_APP_URL=https://crm.exemplo.com.br` — é valor de fixture do meu teste, o mesmo domínio de exemplo que o resto da suíte usa, não marca de instalação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
