### PR TITLE
fix: título curto nas páginas do app que caíam no default

### DIFF
--- a/app/app/activities/page.tsx
+++ b/app/app/activities/page.tsx
@@ -1,9 +1,11 @@
+import type { Metadata } from "next";
 import { requireAuth } from "@/lib/auth/server";
 import { traduzir } from "@/lib/i18n/dicionario";
 
 import { ActivityReportClient } from "./_components/ActivityReportClient";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Atividades" };
 
 export default async function ActivitiesReportPage() {
   const user = await requireAuth();

--- a/app/app/ai/page.tsx
+++ b/app/app/ai/page.tsx
@@ -1,7 +1,9 @@
+import type { Metadata } from "next";
 import { NavHub } from "@/components/shell/NavHub";
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Agente de IA" };
 
 /**
  * Hub da área de IA.

--- a/app/app/analise/page.tsx
+++ b/app/app/analise/page.tsx
@@ -1,8 +1,10 @@
+import type { Metadata } from "next";
 import { NavHub } from "@/components/shell/NavHub";
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
 import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Análise" };
 
 /**
  * Hub da Análise.

--- a/app/app/audit/page.tsx
+++ b/app/app/audit/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
@@ -6,6 +7,7 @@ import { ROLE_RANK } from "@/lib/auth/types";
 import { AuditClient } from "./_client";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Audit Log" };
 
 export default async function AuditPage() {
   const user = await requireAuth();

--- a/app/app/connections/page.tsx
+++ b/app/app/connections/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
@@ -6,6 +7,7 @@ import { ConexoesShell } from "@/components/connections/ConexoesShell";
 import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Conexões" };
 
 export default async function ConnectionsPage() {
   const user = await requireAuth();

--- a/app/app/contacts/page.tsx
+++ b/app/app/contacts/page.tsx
@@ -1,6 +1,8 @@
+import type { Metadata } from "next";
 import { ContactsListClient } from "./_client";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Contatos" };
 
 export default function ContactsPage() {
   return <ContactsListClient />;

--- a/app/app/crm/page.tsx
+++ b/app/app/crm/page.tsx
@@ -1,8 +1,10 @@
+import type { Metadata } from "next";
 import { NavHub } from "@/components/shell/NavHub";
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
 import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "CRM" };
 
 /**
  * Hub do CRM.

--- a/app/app/inbox/page.tsx
+++ b/app/app/inbox/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { loadAuthUser, resolveActiveOrg } from "@/lib/auth/server";
@@ -5,6 +6,7 @@ import { InboxLayout } from "@/components/inbox/InboxLayout";
 import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Inbox" };
 
 export default async function InboxPage({
   searchParams,

--- a/app/app/kanban/page.tsx
+++ b/app/app/kanban/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
 import { Kanban } from "@/lib/ui/icons";
@@ -8,6 +9,7 @@ import { traduzir } from "@/lib/i18n/dicionario";
 import { FunisClient, type FunilDaLista } from "./_client";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Funis" };
 
 /**
  * A lista de funis — e o lugar onde eles se gerenciam.

--- a/app/app/metrics/page.tsx
+++ b/app/app/metrics/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
 import { traduzir } from "@/lib/i18n/dicionario";
 import { ROLE_RANK } from "@/lib/auth/types";
@@ -5,6 +6,7 @@ import { ROLE_RANK } from "@/lib/auth/types";
 import { MetricsClient } from "./_components/MetricsClient";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Desempenho" };
 
 export default async function MetricsPage() {
   const user = await requireAuth();

--- a/app/app/products/page.tsx
+++ b/app/app/products/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
@@ -9,6 +10,7 @@ import { createClient } from "@/lib/supabase/server";
 import { ProdutosClient } from "./_client";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Produtos" };
 
 /**
  * O CATÁLOGO DA LOJA — onde o preço que a IA responde é cadastrado.

--- a/app/app/radar/page.tsx
+++ b/app/app/radar/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
@@ -5,6 +6,7 @@ import { traduzir } from "@/lib/i18n/dicionario";
 import { RiskRadarList } from "./_components/RiskRadarList";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Radar" };
 
 export default async function RadarPage() {
   const user = await requireAuth();

--- a/app/app/settings/page.tsx
+++ b/app/app/settings/page.tsx
@@ -1,8 +1,10 @@
+import type { Metadata } from "next";
 import { NavHub } from "@/components/shell/NavHub";
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
 import { traduzir } from "@/lib/i18n/dicionario";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Configurações" };
 
 /**
  * Hub de Organização.

--- a/app/app/tasks/page.tsx
+++ b/app/app/tasks/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
@@ -6,6 +7,7 @@ import { ROLE_RANK } from "@/lib/auth/types";
 import { TarefasClient } from "./_components/TarefasClient";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Tarefas" };
 
 /**
  * TAREFAS — "ligar de volta na terça", num lugar que não é a memória de ninguém.

--- a/app/app/team/page.tsx
+++ b/app/app/team/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
@@ -10,6 +11,7 @@ import { TeamInvitesClient } from "./_components/TeamInvitesClient";
 import { AttendantsClient } from "./_components/AttendantsClient";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Equipe" };
 
 /**
  * As duas abas são endereçáveis, e isso não é conveniência.

--- a/app/app/templates/page.tsx
+++ b/app/app/templates/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
 import { traduzir } from "@/lib/i18n/dicionario";
@@ -5,6 +6,7 @@ import { ROLE_RANK } from "@/lib/auth/types";
 import { TemplatesClient } from "./_components/TemplatesClient";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Respostas rápidas" };
 
 export default async function TemplatesPage() {
   const user = await requireAuth();

--- a/app/app/webhooks/page.tsx
+++ b/app/app/webhooks/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
 import { ROLE_RANK } from "@/lib/auth/types";
@@ -5,6 +6,7 @@ import { traduzir } from "@/lib/i18n/dicionario";
 import { WebhooksClient } from "./_components/WebhooksClient";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = { title: "Webhooks" };
 
 export default async function WebhooksPage() {
   const user = await requireAuth();


### PR DESCRIPTION
## Resumo
- 17 páginas de `/app/*` (Tarefas, Contatos, CRM, Funis, Inbox, etc.) não declaravam `metadata.title` e herdavam o `default` do layout raiz — o título completo da landing (nome + descrição inteira), em vez de `Página · Nome`.
- Adicionado `export const metadata: Metadata = { title: "..." }` em cada uma, usando o mesmo rótulo já usado no menu lateral (`lib/navigation/catalogo.ts`).

## Test plan
- `pnpm exec tsc --noEmit -p tsconfig.typecheck.json` — sem erros.
- Verificado manualmente em dev: título da aba passa a ser curto (ex.: "Tarefas · Anditec CRM") em vez do texto longo da landing.