### PR TITLE
fix(ia): o interruptor de segurança grava a camada, não o nome de tela

### DIFF
--- a/.changes/interruptor-de-seguranca-liga-de-verdade.md
+++ b/.changes/interruptor-de-seguranca-liga-de-verdade.md
@@ -1,0 +1,14 @@
+---
+impacto: capacidade_nova
+secao: corrigido
+titulo: As duas verificações opcionais de segurança agora ligam de verdade
+---
+
+Em Agentes › Confere antes de enviar, ligar "Detectar tentativa de manipular o
+assistente" ou "Conferir promessas em texto livre" não gravava nada: o pedido
+era recusado e o interruptor voltava sozinho, sem explicação na tela. As duas
+verificações ficavam no que o servidor definia, e quem quisesse ligá-las por
+organização não conseguia — em nenhuma instalação.
+
+Agora o interruptor grava a escolha. Se você tentou ligar alguma das duas e
+achou que o clique não pegava, era isto; tente de novo. Crédito: @rafaelbatistazz.

--- a/app/app/ai/agents/[id]/_components/PainelDeSeguranca.tsx
+++ b/app/app/ai/agents/[id]/_components/PainelDeSeguranca.tsx
@@ -65,7 +65,8 @@ function Conferencia({
   estado: CamadaDeSeguranca | undefined;
   podeEditar: boolean;
   salvando: boolean;
-  onToggle: (layer: string, v: boolean) => void;
+  /** Só o valor: QUAL camada gravar é decisão de quem monta o item, não do item. */
+  onToggle: (v: boolean) => void;
 }) {
   const t = useT();
   // Prefixo próprio para o ITEM: os controles dentro dele têm testid começando em
@@ -95,7 +96,7 @@ function Conferencia({
                 data-testid={`conferencia-${c.nome}-liga`}
                 checked={estado?.efetivo ?? false}
                 disabled={!podeEditar || salvando}
-                onCheckedChange={(v) => onToggle(c.nome, v)}
+                onCheckedChange={(v) => onToggle(v)}
                 aria-label={t(c.rotulo)}
               />
               <span className="text-xs text-muted-foreground">
@@ -130,12 +131,18 @@ export function PainelDeSeguranca() {
 
   const porNome = new Map((camadas.data?.camadas ?? []).map((c) => [c.layer as string, c]));
   const podeEditar = camadas.data?.podeEditar ?? false;
-  const props = (camada: string | null) => ({
+  // `camada` — a chave de `org_guardrail_layers` — e NÃO `nome`, que é o
+  // identificador de tela. O interruptor mandava `c.nome` ("jailbreak_detect"),
+  // a rota valida contra o enum de camadas ("jailbreak"), e ligar qualquer uma
+  // das duas devolvia 422 em toda instalação. O `as` de antes escondia isso do
+  // typecheck; sem ele, trocar de campo vira erro de compilação.
+  const props = (camada: ConferenciaDeSaida["camada"]) => ({
     estado: camada === null ? undefined : porNome.get(camada),
     podeEditar,
     salvando: gravar.isPending,
-    onToggle: (layer: string, v: boolean) =>
-      gravar.mutate({ layer: layer as CamadaDeSeguranca["layer"], enabled: v }),
+    onToggle: (v: boolean) => {
+      if (camada !== null) gravar.mutate({ layer: camada, enabled: v });
+    },
   });
 
   return (

--- a/tests/unit/painel-de-seguranca-liga-a-camada-certa.test.tsx
+++ b/tests/unit/painel-de-seguranca-liga-a-camada-certa.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * O INTERRUPTOR TEM DE GRAVAR A CAMADA, NÃO O NOME DA TELA.
+ *
+ * Cada conferência tem dois identificadores: `nome` ("jailbreak_detect"), que é
+ * de tela, e `camada` ("jailbreak"), que é a chave de `org_guardrail_layers` e o
+ * único valor que `PUT /api/v1/ai/guardrail-layers` aceita — a rota valida
+ * contra o enum `CAMADAS_SEMANTICAS`.
+ *
+ * O interruptor mandava o `nome`, e ligar qualquer uma das duas camadas
+ * devolvia 422 em toda instalação. A posição do controle parecia certa porque a
+ * LEITURA já usava `camada`; só a escrita divergia.
+ *
+ * O typecheck não pegava: o call site fazia `layer as CamadaDeSeguranca["layer"]`,
+ * e um `as` desliga exatamente a checagem que reprovaria isto. O conserto tira o
+ * cast — mas um cast volta fácil num refactor, então a fiação fica medida aqui.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+
+const gravar = vi.fn();
+
+vi.mock("@/hooks/ai/useGuardrailLayers", () => ({
+  useGuardrailLayers: () => ({
+    data: {
+      camadas: [
+        { layer: "promessa_semantica", escolha: false, padraoDoAmbiente: false, efetivo: false },
+        { layer: "jailbreak", escolha: false, padraoDoAmbiente: false, efetivo: false },
+      ],
+      podeEditar: true,
+    },
+  }),
+  useSetGuardrailLayer: () => ({ mutate: gravar, isPending: false }),
+}));
+
+import { PainelDeSeguranca } from "@/app/app/ai/agents/[id]/_components/PainelDeSeguranca";
+import { CONFERENCIA_DE_ENTRADA, CONFERENCIAS_DE_SAIDA } from "@/lib/ai/guardrails/lista-de-conferencia";
+
+function montar() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <PainelDeSeguranca />
+    </QueryClientProvider>,
+  );
+}
+
+/** As conferências que TÊM interruptor — as outras não se desligam. */
+const COM_ESCOLHA = [...CONFERENCIAS_DE_SAIDA, CONFERENCIA_DE_ENTRADA].filter(
+  (c) => c.camada !== null,
+);
+
+describe("o interruptor de segurança grava a camada, não o nome de tela", () => {
+  it("o instrumento está vivo: existe conferência com escolha, e nome ≠ camada", () => {
+    // Controle positivo. Se a lista ficasse vazia (refactor, renomeação), o
+    // `it.each` abaixo passaria por vacuidade — zero caso é zero reprovação.
+    expect(COM_ESCOLHA.length).toBeGreaterThanOrEqual(2);
+    expect(COM_ESCOLHA.some((c) => c.nome !== c.camada)).toBe(true);
+  });
+
+  it.each(COM_ESCOLHA)("«$rotulo» manda layer=$camada", (c) => {
+    gravar.mockClear();
+    montar();
+
+    fireEvent.click(screen.getByTestId(`conferencia-${c.nome}-liga`));
+
+    expect(gravar).toHaveBeenCalledTimes(1);
+    expect(gravar).toHaveBeenCalledWith({ layer: c.camada, enabled: true });
+    // O nome de tela NÃO pode chegar à rota: é o valor que ela recusa com 422.
+    expect(gravar).not.toHaveBeenCalledWith(expect.objectContaining({ layer: c.nome }));
+  });
+});


### PR DESCRIPTION
## O que muda para quem usa

Em **Agentes › Confere antes de enviar**, os dois únicos controles que têm escolha — "Detectar tentativa de manipular o assistente" e "Conferir promessas em texto livre" — não ligavam: o pedido voltava `422`, o interruptor voltava sozinho e a tela não dizia nada. Nenhuma organização conseguia ligá-las; valia sempre o padrão do ambiente.

Closes #729

## A causa

Cada conferência de `lib/ai/guardrails/lista-de-conferencia.ts` tem dois identificadores: `nome` (de tela, `jailbreak_detect`) e `camada` (a chave de `org_guardrail_layers`, `jailbreak`). O interruptor mandava o `nome`; a rota valida contra `CAMADAS_SEMANTICAS` e recusa com `invalid_body`.

A posição do controle parecia certa porque a **leitura** já usava `camada` (`props(c.camada)` monta o `estado`) — só a escrita divergia, e é por isso que o defeito não aparecia olhando a tela parada.

## Por que não é só trocar o argumento

O call site tinha `layer as CamadaDeSeguranca["layer"]`, e o `as` desliga exatamente a checagem que reprovaria a troca de campo. Trocar o argumento e manter o cast deixaria a mesma armadilha armada para o próximo refactor.

Então `onToggle` passa a receber **só o booleano**, e quem monta o item fecha sobre a `camada` (que já é tipada como `"promessa_semantica" | "jailbreak" | null`). O cast some, e usar o campo errado agora é erro de compilação.

## O que eu medi

```
pnpm typecheck        → exit 0 (com o cast removido)
pnpm lint             → 0 errors (349 warnings, pré-existentes)
pnpm lint:channels    → exit 0
pnpm test:unit        → Test Files 789 passed (789)
                        Tests 8364 passed | 1 expected fail (8365)
pnpm release:conferir → fragmento aceito
```

**Sabotagem**: repondo o envio do `nome` no clique, previ 2 vermelhos (um por interruptor) e o controle positivo verde — deu exatamente `2 failed | 1 passed`, com as duas mensagens nomeando `layer='promessa_semantica'` e `layer='jailbreak'`. Restaurei depois.

O teste percorre as conferências que têm `camada` (não uma lista fixa), então uma terceira camada nasce coberta. O primeiro caso é controle positivo: se a lista ficar vazia ou `nome` virar igual a `camada`, ele reprova em vez de deixar o `it.each` passar por vacuidade.

## O que NÃO medi

- **Prova em tela (Playwright) e `pnpm test:db`** — não rodei. A mudança é de call site no cliente e não toca schema; a fiação ficou coberta pelo teste de componente com o hook dublado, não por navegador de verdade.
- **A gravação de ponta a ponta na instalação** (clicar e conferir a linha em `org_guardrail_layers`) — provei a requisição que sai, não o efeito no banco.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
