### PR TITLE
fix(canal-oficial): a credencial da tela volta a enviar — a elegibilidade passa a ser do `send`

### DIFF
--- a/.changes/credencial-do-oficial-pela-tela-envia.md
+++ b/.changes/credencial-do-oficial-pela-tela-envia.md
@@ -1,0 +1,11 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O WhatsApp oficial conectado pela tela volta a enviar — sem depender do .env
+---
+
+Uma instalação que conectou o número oficial pela **Central de Conexões** guarda a credencial **cifrada no banco** e não escreve nada no `.env` — e as mensagens ficavam paradas na fila, sem erro, com o canal conectado e funcionando na tela.
+
+A pergunta "dá para tentar enviar?" era respondida só pelo `.env`, num ponto que não consegue consultar o banco. Agora quem decide é o próprio envio, que resolve a credencial da sessão primeiro — e o `.env` continua valendo como fallback para instalações antigas de número único. Sem credencial nenhuma, a mensagem fica na fila com o motivo nomeado (em vez de nunca ser tentada); falha na consulta da credencial vira erro visível na mensagem, em vez de silêncio.
+
+Quem já tinha a chave no `.env` não vê diferença nenhuma.

--- a/lib/channels/adapters/meta-cloud.ts
+++ b/lib/channels/adapters/meta-cloud.ts
@@ -38,11 +38,10 @@ function toE164Digits(raw: string): string {
 /**
  * Credencial do ambiente — o caminho de instalação de número único.
  *
- * `isConfigured()` continua olhando só o env de propósito: ele responde "dá para
- * tentar?" de forma SÍNCRONA, e a resposta certa para uma instalação que gravou a
- * credencial na sessão vem do banco. Quem sabe disso é o `send`, que é async.
- * Devolver `false` aqui com sessão configurada faria o handler gravar `queued` sem
- * motivo — por isso o `send` resolve de novo, com a sessão, antes de desistir.
+ * O env continua sendo LIDO (`resolveMetaCreds`, que o `send` chama como
+ * fallback depois da sessão), mas ele já não é quem decide se o canal está
+ * configurado: essa pergunta não tem resposta síncrona honesta — ver
+ * `isConfigured`.
  */
 import { metaCredsFromEnv } from "../meta/credentials";
 export { metaCredsFromEnv as getMetaCreds };
@@ -97,28 +96,28 @@ export const metaCloudAdapter: ChannelAdapter = {
   },
 
   /**
-   * DÍVIDA CONHECIDA, deixada de propósito — não é descuido.
+   * SEMPRE `true`, e isso não é preguiça: para este canal a pergunta não tem
+   * resposta síncrona honesta.
    *
-   * A credencial deste canal também pode viver na SESSÃO (a tela de "Conectar
-   * canal oficial" grava `meta_token_encrypted` desde a 0118), e `isConfigured`
-   * é síncrono: não consulta o banco. Numa instalação que conectou pela tela e
-   * não escreveu `.env`, isto devolve `false`, e o handler (`_handler.ts:370`)
-   * grava `queued` com `queued_reason: meta_not_configured` sem nunca chamar
-   * `send` — mensagem parada no inbox, sem erro, com o canal conectado.
+   * A credencial vive na SESSÃO (a tela de "Conectar canal oficial" grava
+   * `meta_token_encrypted` desde a 0118), e `isConfigured` é síncrono — não
+   * consulta o banco. Olhar só o env respondia "não configurado" para toda
+   * instalação que conectou pela tela: o handler gravava `queued` com
+   * `queued_reason: meta_not_configured` sem NUNCA chamar `send`, e a mensagem
+   * ficava parada no inbox, sem erro, com o canal conectado e funcionando
+   * (issue #674). O canal intermediado pagou o mesmo defeito antes e resolveu
+   * assim — ver `adapters/zernio.ts`, que adotou este contrato primeiro.
    *
-   * O canal intermediado JÁ passou por isso e resolveu devolvendo `true` e
-   * fazendo o `send` lançar (ver `adapters/zernio.ts`). O mesmo conserto cabe
-   * aqui, mas ele muda um contrato com dois testes explícitos
-   * (`tests/unit/channel-adapter-meta.test.ts`) cuja justificativa escrita é
-   * "mesmo contrato do outro canal" — justificativa que o fork já não sustenta.
-   *
-   * Trocar contrato testado exige uma mudança própria, com os testes revistos de
-   * propósito e não de passagem. Fica registrado aqui para quem for fazê-la.
+   * O custo de responder `true` é que `send` precisa ser quem desiste — e ele
+   * LANÇA `meta_not_configured` em vez de devolver `{externalId: null}`, para o
+   * handler gravar `queued` com o motivo em vez de um `sent` sem id, que diria
+   * "enviado" para algo que nunca saiu. O fallback de ambiente para instalações
+   * legadas segue vivo DENTRO do `send` (`resolveMetaCreds`): sessão primeiro,
+   * env depois.
    */
   isConfigured(): boolean {
-    // Síncrono por contrato. Com credencial na sessão, quem confirma é o `send`
-    // (async) — ver o comentário acima.
-    return metaCredsFromEnv() !== null;
+    // Quem decide é `send()`, que pode consultar o banco. Ver o comentário.
+    return true;
   },
 
   /**
@@ -270,9 +269,16 @@ export const metaCloudAdapter: ChannelAdapter = {
       organizationId: envelope.organizationId,
       phoneNumberId: envelope.sessionRef,
     });
-    // Mesmo contrato do outro canal: sem credencial é NOOP, não exceção. A UI mostra
-    // o banner de "canal não conectado"; transformar em erro mudaria comportamento.
-    if (!creds) return { externalId: null };
+    // LANÇA, não devolve null: com `isConfigured` sempre true, quem desiste é
+    // este ponto — e `{externalId: null}` faria o handler gravar `sent` sem id,
+    // dizendo "enviado" para algo que nunca saiu. O handler traduz o prefixo
+    // `meta_not_configured` para `queued` com o motivo: credencial ausente é
+    // canal ainda não conectado, não falha desta mensagem.
+    if (!creds) {
+      throw new Error(
+        "meta_not_configured: nenhuma credencial para esta sessão (nem na sessão, nem no ambiente).",
+      );
+    }
 
     const corpo =
       contactPayload(envelope) ??

--- a/lib/channels/meta/send-template-for-session.ts
+++ b/lib/channels/meta/send-template-for-session.ts
@@ -43,6 +43,24 @@ export async function sendTemplateForSession(
     throw new Error("template_incompleto: nome e idioma são obrigatórios em type=template");
   }
 
+  // A credencial de AMBIENTE é o único caminho deste envio, e a guarda vem
+  // ANTES da consulta ao espelho de propósito: "canal não conectado" é desfecho
+  // da classe `queued` (recuperável), e a ordem dos desfechos é comportamento
+  // neste repo. Sem ela, uma instalação que conectou o número pela TELA
+  // (credencial cifrada no banco, `.env` sem chave) tentaria a Graph com
+  // `Bearer` vazio e viraria `failed` com um erro que não nomeia o motivo real
+  // — a mudança de elegibilidade da #674 transformaria uma fila recuperável em
+  // falha. Com ela, o desfecho é o mesmo de antes do #674: `queued` com
+  // `meta_not_configured`.
+  //
+  // Enviar template com a credencial da SESSÃO é um passo próprio (o adapter
+  // ainda não implementa `sendTemplate`); até lá, este caminho é só do env.
+  if (!process.env.META_PHONE_NUMBER_ID || !process.env.META_SYSTEM_USER_TOKEN) {
+    throw new Error(
+      "meta_not_configured: sem credencial de ambiente para enviar template (a conexão feita pela tela ainda não é usada por este caminho).",
+    );
+  }
+
   const { data: linha, error } = await db
     .from("meta_templates")
     .select("name, language, status, contract_hash, components")

--- a/tests/unit/channel-adapter-meta.test.ts
+++ b/tests/unit/channel-adapter-meta.test.ts
@@ -8,7 +8,22 @@ import { getAdapter } from "@/lib/channels";
  * chamada à Graph API — foi assim que estes testes vermelharam quando a resolução
  * por sessão entrou, e o vermelho foi correto.
  */
-const sessaoNoBanco: { token: string | null } = { token: null };
+/**
+ * O estado do "banco" que a resolução por sessão enxerga.
+ *
+ * - `token`   → instalação de uma organização só (quem conectou pela tela);
+ * - `porOrg`  → busca filtrada por organização (#236): a chave é
+ *               `organization_id|phone_number_id`, e cada tenant tem o SEU
+ *               cifrado e o SEU token;
+ * - `erro`    → falha de consulta (PGRST116 etc.);
+ * - `decifravel: false` → a decifra devolve null (GUC da chave ausente).
+ */
+const sessaoNoBanco: {
+  token: string | null;
+  porOrg: Record<string, { cifrado: string; token: string }> | null;
+  erro: { code?: string; message?: string } | null;
+  decifravel: boolean;
+} = { token: null, porOrg: null, erro: null, decifravel: true };
 
 /**
  * Cadeia ENCADEÁVEL, não de um nível só.
@@ -19,25 +34,48 @@ const sessaoNoBanco: { token: string | null } = { token: null };
  * que não casa com o código testa o mock. Aqui qualquer combinação de
  * `.eq()/.is()` volta para o mesmo objeto e o terminal é `maybeSingle`.
  */
-function cadeia(): Record<string, unknown> {
+function cadeia(filtros: Record<string, unknown>): Record<string, unknown> {
   const alvo: Record<string, unknown> = {
-    maybeSingle: async () => ({
-      data: sessaoNoBanco.token
-        ? { meta_phone_number_id: "sessao-pn", meta_token_encrypted: "\\xdeadbeef" }
-        : null,
-      error: null,
-    }),
+    maybeSingle: async () => {
+      if (sessaoNoBanco.erro) return { data: null, error: sessaoNoBanco.erro };
+      const chave = `${filtros.organization_id ?? ""}|${filtros.meta_phone_number_id ?? ""}`;
+      const daOrg = sessaoNoBanco.porOrg?.[chave];
+      const cifrado = sessaoNoBanco.porOrg
+        ? (daOrg?.cifrado ?? null)
+        : sessaoNoBanco.token
+          ? "\\xdeadbeef"
+          : null;
+      return {
+        data: cifrado
+          ? { meta_phone_number_id: "sessao-pn", meta_token_encrypted: cifrado }
+          : null,
+        error: null,
+      };
+    },
   };
   alvo.select = () => alvo;
-  alvo.eq = () => alvo;
+  alvo.eq = (col: string, val: unknown) => {
+    filtros[col] = val;
+    return alvo;
+  };
   alvo.is = () => alvo;
   return alvo;
 }
 
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({
-    from: () => cadeia(),
-    rpc: async () => ({ data: sessaoNoBanco.token, error: null }),
+    from: () => cadeia({}),
+    rpc: async (nome: string, args: { ciphertext?: string }) => {
+      if (nome !== "fn_decrypt_oauth" || !sessaoNoBanco.decifravel) {
+        return { data: null, error: null };
+      }
+      const cifrado = String(args?.ciphertext ?? "");
+      const daOrg = Object.values(sessaoNoBanco.porOrg ?? {}).find((s) => s.cifrado === cifrado);
+      return {
+        data: daOrg?.token ?? (sessaoNoBanco.porOrg ? null : sessaoNoBanco.token),
+        error: null,
+      };
+    },
   }),
 }));
 
@@ -69,6 +107,9 @@ afterEach(() => {
   vi.unstubAllEnvs();
   vi.unstubAllGlobals();
   sessaoNoBanco.token = null;
+  sessaoNoBanco.porOrg = null;
+  sessaoNoBanco.erro = null;
+  sessaoNoBanco.decifravel = true;
 });
 
 describe("adapter meta_cloud — endereçamento", () => {
@@ -93,23 +134,30 @@ describe("adapter meta_cloud — endereçamento", () => {
 });
 
 describe("adapter meta_cloud — configuração", () => {
-  it("sem credencial NÃO está configurado", () => {
+  it("isConfigured é SEMPRE true — a credencial pode viver na sessão, e isto é síncrono", () => {
+    // O contrato anterior ("sem env → false") travava em `queued` toda
+    // instalação que conectou o número pela TELA: o pre-check respondia "não
+    // configurado" para um canal conectado e funcionando (issue #674). Quem
+    // decide é o `send`, que consulta o banco — o mesmo desenho do zernio.
     vi.stubEnv("META_PHONE_NUMBER_ID", "");
     vi.stubEnv("META_SYSTEM_USER_TOKEN", "");
-    expect(a().isConfigured()).toBe(false);
-  });
-
-  it("com credencial está configurado", () => {
+    expect(a().isConfigured()).toBe(true);
     configurar();
     expect(a().isConfigured()).toBe(true);
   });
 
-  it("não configurado é NOOP no envio, nunca exceção", async () => {
-    // Mesmo contrato do outro canal: a UI mostra banner, o handler grava `queued`.
+  it("sem credencial NENHUMA o envio LANÇA meta_not_configured — e nada vai à rede", async () => {
+    // `{externalId: null}` faria o handler gravar `sent` sem id — "enviado"
+    // para algo que nunca saiu. O prefixo é o que o handler traduz para
+    // `queued` com motivo.
     vi.stubEnv("META_PHONE_NUMBER_ID", "");
     vi.stubEnv("META_SYSTEM_USER_TOKEN", "");
-    const r = await a().send({ organizationId: ORG, sessionRef: "x", to: "5531999", kind: "text", body: "oi" });
-    expect(r).toEqual({ externalId: null });
+    const spy = vi.fn();
+    vi.stubGlobal("fetch", spy);
+    await expect(
+      a().send({ organizationId: ORG, sessionRef: "x", to: "5531999", kind: "text", body: "oi" }),
+    ).rejects.toThrow(/meta_not_configured/);
+    expect(spy).not.toHaveBeenCalled();
   });
 
   it("os códigos carregam o nome do provider — por isso vivem no adapter", () => {
@@ -288,5 +336,67 @@ describe("credencial por sessão — o que destrava multi-tenant", () => {
 
     const [, init] = spy.mock.calls[0]!;
     expect((init.headers as Record<string, string>).Authorization).toBe("Bearer tok");
+  });
+});
+
+describe("elegibilidade é do `send` — os desfechos da #674", () => {
+  it("sessão válida SEM ambiente: o envio sai, com o token da sessão", async () => {
+    sessaoNoBanco.token = "token-da-sessao";
+    const spy = stubFetch({ messages: [{ id: "wamid.S" }] });
+
+    const r = await a().send({ organizationId: ORG, sessionRef: "sessao-pn", to: "5531", kind: "text", body: "oi" });
+
+    expect(r).toEqual({ externalId: "wamid.S" });
+    const [url, init] = spy.mock.calls[0]!;
+    expect(String(url)).toContain("/sessao-pn/messages");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer token-da-sessao");
+  });
+
+  it("sessão AUSENTE e sem ambiente: lança meta_not_configured", async () => {
+    const spy = vi.fn();
+    vi.stubGlobal("fetch", spy);
+    await expect(
+      a().send({ organizationId: ORG, sessionRef: "sessao-pn", to: "5531", kind: "text", body: "oi" }),
+    ).rejects.toThrow(/meta_not_configured/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("falha de CONSULTA fecha a ação com o código — não cai no env", async () => {
+    // O env está VÁLIDO de propósito: erro de resolução tem de fechar a ação e
+    // abrir a informação (#236), nunca virar caminho feliz de outra conta.
+    configurar();
+    sessaoNoBanco.erro = { code: "PGRST116", message: "duas linhas casaram" };
+    const spy = vi.fn();
+    vi.stubGlobal("fetch", spy);
+    await expect(
+      a().send({ organizationId: ORG, sessionRef: "sessao-pn", to: "5531", kind: "text", body: "oi" }),
+    ).rejects.toThrow(/meta_creds_lookup_failed/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("decifragem que falha, sem env: meta_not_configured (não vira `sent` sem id)", async () => {
+    sessaoNoBanco.token = "cifrado-existe";
+    sessaoNoBanco.decifravel = false;
+    const spy = vi.fn();
+    vi.stubGlobal("fetch", spy);
+    await expect(
+      a().send({ organizationId: ORG, sessionRef: "sessao-pn", to: "5531", kind: "text", body: "oi" }),
+    ).rejects.toThrow(/meta_not_configured/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("duas organizações: cada envio sai com o token do SEU tenant", async () => {
+    const OUTRA = "00000000-0000-4000-8000-0000000000bb";
+    sessaoNoBanco.porOrg = {
+      [`${ORG}|pn-a`]: { cifrado: "\\xaa", token: "tok-A" },
+      [`${OUTRA}|pn-b`]: { cifrado: "\\xbb", token: "tok-B" },
+    };
+    const spy = stubFetch({ messages: [{ id: "wamid.X" }] });
+
+    await a().send({ organizationId: ORG, sessionRef: "pn-a", to: "5531", kind: "text", body: "oi" });
+    await a().send({ organizationId: OUTRA, sessionRef: "pn-b", to: "5531", kind: "text", body: "oi" });
+
+    const auth = spy.mock.calls.map((c) => (c[1].headers as Record<string, string>).Authorization);
+    expect(auth).toEqual(["Bearer tok-A", "Bearer tok-B"]);
   });
 });

--- a/tests/unit/messages-handler-canal-intermediado.test.ts
+++ b/tests/unit/messages-handler-canal-intermediado.test.ts
@@ -33,12 +33,19 @@
  *
  * ## 2. Nenhum desfecho pode dizer `sent` sem nada ter saído
  *
- * `sent` é o que a Central mostra como entregue ao canal. Com credencial
- * ausente, `zernioAdapter.send` devolve `{ externalId: null }` sem tocar a rede
- * (é o contrato de "canal não conectado", herdado do canal oficial) — e o
- * handler, que só olha se houve exceção, grava `sent`. Num produto self-host
- * ninguém está olhando: o dono da instalação lê "enviada" e conclui que o
- * produto funciona.
+ * `sent` é o que a Central mostra como entregue ao canal. Histórico medido: com
+ * credencial ausente, `zernioAdapter.send` devolvia `{ externalId: null }` sem
+ * tocar a rede — o contrato de "canal não conectado" que o oficial também
+ * carregava — e o handler, que só olha se houve exceção, gravava `sent`. Num
+ * produto self-host ninguém está olhando: o dono da instalação lê "enviada" e
+ * conclui que o produto funciona.
+ *
+ * Os DOIS canais trocaram esse contrato por LANÇAR `*_not_configured`, e quem
+ * decide passou a ser o `send` (async), porque o pre-check síncrono não alcança
+ * o banco — onde a credencial de quem conectou pela tela mora (o intermediado
+ * primeiro; o oficial na #674). Este arquivo cobre os dois lados pelo canal
+ * oficial: o envio que SAI com a credencial da sessão e a fila com motivo
+ * nomeado quando não há credencial nenhuma.
  */
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -58,6 +65,24 @@ const THREAD = "6a76a2dc4b8fe115e5f6c300";
 // O admin client é usado para assinar mídia e para resolver a credencial de
 // sessão. Aqui a sessão NUNCA tem credencial gravada (é o estado de quem só
 // configurou env), então o `select` devolve linha vazia.
+/**
+ * O estado da credencial de sessão que a resolução encontra no "banco".
+ *
+ * - `token` → instalação de uma organização só (quem conectou pela tela e não
+ *   escreveu `.env`);
+ * - `porOrg` → busca filtrada por organização (#236): a chave é
+ *   `organization_id|phone_number_id`, e cada tenant tem o SEU cifrado e o SEU
+ *   token — é o que prova que cada organização envia pelo token dela;
+ * - `erro` → falha de consulta (PGRST116 etc.);
+ * - `decifravel: false` → a decifra devolve null (GUC da chave ausente).
+ */
+const credencialDaSessao: {
+  token: string | null;
+  porOrg: Record<string, { cifrado: string; token: string }> | null;
+  erro: { code?: string; message?: string } | null;
+  decifravel: boolean;
+} = { token: null, porOrg: null, erro: null, decifravel: true };
+
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({
     storage: {
@@ -73,13 +98,46 @@ vi.mock("@/lib/supabase/admin", () => ({
     // migration 0165). Um stub em que `eq()` já entrega `maybeSingle` deixa de
     // casar com o código real — e mock que não casa testa o mock.
     from: () => {
+      const filtros: Record<string, unknown> = {};
       const alvo: Record<string, unknown> = {
-        maybeSingle: async () => ({ data: null, error: null }),
+        maybeSingle: async () => {
+          if (credencialDaSessao.erro) return { data: null, error: credencialDaSessao.erro };
+          const chave = `${filtros.organization_id ?? ""}|${filtros.meta_phone_number_id ?? ""}`;
+          const daOrg = credencialDaSessao.porOrg?.[chave];
+          const cifrado = credencialDaSessao.porOrg
+            ? (daOrg?.cifrado ?? null)
+            : credencialDaSessao.token
+              ? "\\xdeadbeef"
+              : null;
+          return {
+            data: cifrado
+              ? {
+                  meta_phone_number_id: String(filtros.meta_phone_number_id ?? "pn"),
+                  meta_token_encrypted: cifrado,
+                }
+              : null,
+            error: null,
+          };
+        },
       };
       alvo.select = () => alvo;
-      alvo.eq = () => alvo;
+      alvo.eq = (col: string, val: unknown) => {
+        filtros[col] = val;
+        return alvo;
+      };
       alvo.is = () => alvo;
       return alvo;
+    },
+    rpc: async (nome: string, args: { ciphertext?: string }) => {
+      if (nome !== "fn_decrypt_oauth" || !credencialDaSessao.decifravel) {
+        return { data: null, error: null };
+      }
+      const cifrado = String(args?.ciphertext ?? "");
+      const daOrg = Object.values(credencialDaSessao.porOrg ?? {}).find((s) => s.cifrado === cifrado);
+      return {
+        data: daOrg?.token ?? (credencialDaSessao.porOrg ? null : credencialDaSessao.token),
+        error: null,
+      };
     },
   }),
 }));
@@ -134,6 +192,8 @@ function projetar(linha: Row, select: string): Row {
 interface Forma {
   providerConversationId?: string | null;
   provider?: string;
+  /** Canal excluído pela tela (migration 0106) — comporta o ramo `channel_archived`. */
+  archivedAt?: string | null;
 }
 
 function conversaCompleta(forma: Forma = {}): Row {
@@ -153,7 +213,7 @@ function conversaCompleta(forma: Forma = {}): Row {
       meta_phone_number_id: provider === "meta_cloud" ? "1103328999528818" : null,
       zernio_account_id: provider === "zernio" ? CONTA : null,
       status: "WORKING",
-      archived_at: null,
+      archived_at: forma.archivedAt ?? null,
     },
   };
 }
@@ -273,9 +333,22 @@ function respostaOk(messageId = "wamid.OK") {
   }));
 }
 
+/** Resposta da Graph API (canal oficial): o id vem em `messages[0].id`. */
+function respostaMeta(messageId = "wamid.M") {
+  return vi.fn(async (..._args: unknown[]) => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ messages: [{ id: messageId }] }),
+  }));
+}
+
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.unstubAllGlobals();
+  credencialDaSessao.token = null;
+  credencialDaSessao.porOrg = null;
+  credencialDaSessao.erro = null;
+  credencialDaSessao.decifravel = true;
 });
 
 describe("o projetor do dublê é discriminante (guarda de vacuidade)", () => {
@@ -432,8 +505,10 @@ describe("nenhum desfecho diz `sent` sem nada ter saído", () => {
 
   it("CONTROLE: o canal oficial, com env igualmente incompleto, fica `queued`", async () => {
     // O par é o que dá sentido ao caso acima: mesma classe de má configuração,
-    // desfecho oposto. `metaCredsFromEnv()` exige as duas vars e `isConfigured()`
-    // deriva DELE, então o pre-check já barra e a linha fica em fila.
+    // desfecho oposto. Desde a #674 a decisão de elegibilidade é do `send` (o
+    // pre-check síncrono não alcança o banco): ele resolve a sessão, cai no env
+    // e, sem credencial nenhuma, LANÇA — o handler traduz o prefixo para
+    // `queued` com motivo. O desfecho observável é o mesmo de antes.
     vi.stubEnv("META_PHONE_NUMBER_ID", "");
     vi.stubEnv("META_SYSTEM_USER_TOKEN", "tok");
     const fetchMock = vi.fn();
@@ -490,5 +565,105 @@ describe("nenhum desfecho diz `sent` sem nada ter saído", () => {
     expect(msg.status).toBe("queued");
     expect((msg.metadata as Record<string, unknown>).queued_reason).toBe("zernio_not_configured");
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * A promessa da TELA de conexão, do lado do handler (issue #674): quem conectou
+ * o número oficial pela Central de Conexões guarda a credencial cifrada no
+ * banco — e o envio tem de SAIR, sem `.env`. O pre-check síncrono respondia
+ * "não configurado" para essa instalação e a mensagem morria em fila, sem erro,
+ * sem nunca tentar.
+ */
+describe("canal oficial conectado pela TELA — a credencial da sessão manda (#674)", () => {
+  it("sessão válida SEM ambiente: a mensagem SAI, com o token da sessão", async () => {
+    credencialDaSessao.token = "tok-da-sessao";
+    const fetchMock = respostaMeta("wamid.M1");
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { supabase } = makeSupabase(conversaCompleta({ provider: "meta_cloud" }));
+    const msg = await sendMessageHandler(supabase, ctx, texto());
+
+    expect(msg.status).toBe("sent");
+    expect(msg.external_id).toBe("wamid.M1");
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toContain("/1103328999528818/messages");
+    expect((init as { headers: Record<string, string> }).headers.Authorization).toBe("Bearer tok-da-sessao");
+  });
+
+  it("sessão ausente e sem ambiente: `queued` com `meta_not_configured`, nada na rede", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { supabase } = makeSupabase(conversaCompleta({ provider: "meta_cloud" }));
+    const msg = await sendMessageHandler(supabase, ctx, texto());
+
+    expect(msg.status).toBe("queued");
+    expect((msg.metadata as Record<string, unknown>).queued_reason).toBe("meta_not_configured");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("falha de CONSULTA fecha a ação com o código — não engole em `sent`", async () => {
+    // Doutrina da #236: resolução que falha fecha a ação e abre a informação.
+    credencialDaSessao.erro = { code: "PGRST116", message: "duas linhas casaram" };
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { supabase } = makeSupabase(conversaCompleta({ provider: "meta_cloud" }));
+    const msg = await sendMessageHandler(supabase, ctx, texto());
+
+    expect(msg.status).toBe("failed");
+    expect(msg.error_code).toBe("meta_error");
+    expect(String(msg.error_message)).toMatch(/meta_creds_lookup_failed/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("decifragem que falha e sem env: `queued` — canal não conectado é recuperável", async () => {
+    credencialDaSessao.token = "cifrado-existe";
+    credencialDaSessao.decifravel = false;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { supabase } = makeSupabase(conversaCompleta({ provider: "meta_cloud" }));
+    const msg = await sendMessageHandler(supabase, ctx, texto());
+
+    expect(msg.status).toBe("queued");
+    expect((msg.metadata as Record<string, unknown>).queued_reason).toBe("meta_not_configured");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("sessão ARQUIVADA: `failed` com `channel_archived`, sem consultar credencial", async () => {
+    credencialDaSessao.token = "tok-que-nao-deve-ser-usado";
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { supabase } = makeSupabase(
+      conversaCompleta({ provider: "meta_cloud", archivedAt: "2026-08-01T00:00:00.000Z" }),
+    );
+    const msg = await sendMessageHandler(supabase, ctx, texto());
+
+    expect(msg.status).toBe("failed");
+    expect(msg.error_code).toBe("channel_archived");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("duas organizações: cada envio sai com o token do SEU tenant", async () => {
+    const OUTRA = "99999999-9999-4999-8999-999999999999";
+    credencialDaSessao.porOrg = {
+      [`${ORG}|1103328999528818`]: { cifrado: "\\xaa", token: "tok-A" },
+      [`${OUTRA}|1103328999528818`]: { cifrado: "\\xbb", token: "tok-B" },
+    };
+    const fetchMock = respostaMeta("wamid.T");
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { supabase: sbA } = makeSupabase(conversaCompleta({ provider: "meta_cloud" }));
+    await sendMessageHandler(sbA, ctx, texto());
+    const { supabase: sbB } = makeSupabase(conversaCompleta({ provider: "meta_cloud" }));
+    await sendMessageHandler(sbB, { ...ctx, organization_id: OUTRA }, texto());
+
+    const auth = fetchMock.mock.calls.map(
+      (c) => (c[1] as { headers: Record<string, string> }).headers.Authorization,
+    );
+    expect(auth).toEqual(["Bearer tok-A", "Bearer tok-B"]);
   });
 });


### PR DESCRIPTION
# O que este PR faz

Uma instalação que conectou o WhatsApp oficial **pela tela** volta a enviar. A pergunta "o canal está configurado?" deixa de ser respondida só pelo `.env` — que não tem a credencial de quem conectou pela Central de Conexões — e passa a ser decidida pelo próprio envio, que resolve a credencial da sessão (sessão primeiro; `.env` como fallback legado).

Antes: com sessão oficial ativa/`WORKING` e sem `.env`, o pre-check síncrono respondia "não configurado", o handler gravava `queued` com `queued_reason: meta_not_configured` sem **nunca** chamar `send`, e a mensagem ficava parada no inbox — sem erro, com o canal conectado e funcionando. É exatamente o que a tela de conexão promete e o que a #674 mediu.

Closes #674

## Como resolve

- `metaCloudAdapter.isConfigured()` → `true`, com a justificativa escrita: a pergunta não tem resposta síncrona honesta (o método não alcança o banco). É o **mesmo contrato** que o canal intermediado já adotou (`adapters/zernio.ts`) — e que o próprio adapter da Meta documentava como o conserto que "cabe aqui", pedindo explicitamente que os testes fossem revistos **de propósito, não de passagem**.
- `send()` passa a **lançar** `meta_not_configured` quando não resolve credencial nenhuma: `{externalId: null}` faria o handler gravar `sent` sem id. O handler já traduz esse prefixo para `queued` com motivo, então o desfecho observável de "sem credencial" **não muda** — o que muda é a instalação conectada pela tela passar a **tentar**.
- Guarda no caminho de template (`sendTemplateForSession`, que fala só com o env; vem antes da consulta ao espelho porque a ordem dos desfechos é comportamento): sem ela, a instalação conectada pela tela tentaria a Graph com `Bearer` vazio e a fila recuperável viraria `failed` com erro opaco. O gap — template com credencial de sessão — fica declarado no comentário: é passo próprio.

## O que medi (comandos e saídas)

**Testes focados** (4 arquivos, antes dos gates): **79 ✓ / 0 ✗**.

**Sabotagem**: revertendo o adapter ao contrato anterior → **7 vermelhos de 37, e eram os 7 previstos** — previsão escrita antes de rodar: `isConfigured` sempre-true, os três "lança" do nível da resolução, o envio que sai pela sessão, a falha de consulta que não pode cair no env (doutrina da #236) e o par de organizações. Restaurei em seguida.

**Gates** (um por vez, `systemd-run --scope -p MemoryMax=5G`):

| gate | resultado |
|---|---|
| `pnpm typecheck` | **rc=0** (53s) — a primeira rodada pegou um `init` mal tipado no teste novo; corrigido, e a rodada final é a que vale |
| `pnpm lint` | **rc=0** (50s) |
| `pnpm lint:channels` | **rc=0** |
| `pnpm release:conferir` | **rc=0** — fragmento válido (entra na 1.20.0) |
| `pnpm test:unit` | **rc=0** — 791 arquivos · 8379 passaram (1 *expected fail*) |
| `pnpm test:shell` | **rc=0** (58s) |
| `pnpm build` | **rc=0** (45s) |

## O que NÃO medi

- **Envio real contra a Graph API** (não há conta Meta nesta máquina): medido com o `fetch` dublado, como os testes existentes do arquivo já fazem.
- **Prova em tela (`test:e2e`)**: não mexi em UI.
- **Template com credencial de sessão**: fora do escopo deste PR (o adapter ainda não implementa `sendTemplate`); o comportamento atual da fila foi preservado por guarda, e o gap está nomeado no código.
