### PR TITLE
test(agenda): a régua do agora tinha uma janela de um minuto em que a spec discordava do componente

### DIFF
--- a/tests/e2e/agenda-tela-do-produto.spec.ts
+++ b/tests/e2e/agenda-tela-do-produto.spec.ts
@@ -173,16 +173,42 @@ test.describe("a Agenda como o dono do produto a usa", () => {
       ).toHaveAttribute("aria-pressed", "true");
     }
 
-    // A régua do agora só existe quando o instante cabe na faixa desenhada
-    // (07h–21h). Fora dela a ausência é CORRETA, e exigir presença faria a spec
-    // ficar vermelha de madrugada — que é o defeito que este repo já pagou nos
+    // A régua do agora só existe quando o instante cabe na faixa desenhada.
+    // Fora dela a ausência é CORRETA, e exigir presença faria a spec ficar
+    // vermelha de madrugada — que é o defeito que este repo já pagou nos
     // invariantes de turno.
-    const hora = new Date().getHours();
+    //
+    // ⚠️ A FAIXA É CALCULADA COMO O COMPONENTE CALCULA, e não "7 a 21".
+    //
+    // `GradeDaAgenda.tsx` desenha quando
+    // `0 <= (hora - 7) * 60 + minuto <= (21 - 7 + 1) * 60`, ou seja até as
+    // **22:00:59** — o limite superior é `<= 900`, não `< 900`. A versão
+    // anterior desta spec comparava `hora >= 7 && hora <= 21`, e as duas réguas
+    // discordavam numa janela de UM MINUTO por dia: às 22:00 o componente ainda
+    // desenha e a spec exigia ausência.
+    //
+    // Um minuto em 1440 parece desprezível até acontecer. Aconteceu em
+    // 11/09/2026, em DOIS PRs de contribuidores diferentes, cujos `e2e`
+    // começaram às `22:00:12` e `22:00:24` — os dois ficaram vermelhos por um
+    // defeito que não era deles, num arquivo que eles não tocaram.
+    //
+    // A régua aqui passou a ser a MESMA conta do componente. Duplicar a regra
+    // continua sendo duplicação; o que muda é que agora ela duplica o que o
+    // componente faz, em vez de uma aproximação dele.
+    const agora = new Date();
+    const minutosDesdeOTopo = (agora.getHours() - 7) * 60 + agora.getMinutes();
+    const dentroDaFaixa = minutosDesdeOTopo >= 0 && minutosDesdeOTopo <= (21 - 7 + 1) * 60;
     const regua = page.getByTestId("regua-do-agora");
-    if (hora >= 7 && hora <= 21) {
-      await expect(regua, "dentro da faixa 07h–21h e sem régua do agora").toBeVisible();
+    if (dentroDaFaixa) {
+      await expect(
+        regua,
+        `dentro da faixa desenhada (${agora.getHours()}h${String(agora.getMinutes()).padStart(2, "0")}) e sem régua do agora`,
+      ).toBeVisible();
     } else {
-      await expect(regua, "fora da faixa e a régua apareceu mesmo assim").toHaveCount(0);
+      await expect(
+        regua,
+        `fora da faixa (${agora.getHours()}h${String(agora.getMinutes()).padStart(2, "0")}) e a régua apareceu mesmo assim`,
+      ).toHaveCount(0);
     }
   });
 


### PR DESCRIPTION
Dois PRs de contribuidores (#717 e #718) ficaram vermelhos hoje num arquivo que **nenhum dos dois tocou**. Persegui até o fim em vez de chamar de instabilidade, e o resultado é uma aritmética simples.

## A janela

`GradeDaAgenda.tsx` desenha a régua quando

```
0 <= (hora - 7) * 60 + minuto <= (21 - 7 + 1) * 60
```

O limite de cima é `<= 900`, então ela **ainda aparece às 22:00:59**. A spec comparava `hora >= 7 && hora <= 21` e exigia ausência a partir das 22h.

Varri as duas réguas minuto a minuto:

```
minutos em que a régua ANTIGA discordava do componente: 1  [(22, 0)]
minutos em que a régua NOVA discorda:                    0
```

E os dois `e2e` começaram às **22:00:12** e **22:00:24**.

## Por que "um minuto em 1440" não é desprezível aqui

Porque os disparos são **correlacionados**: o CI enfileira e as execuções saem em lote, no mesmo instante. A raridade de um evento não protege quando as tentativas não são independentes — dois PRs entraram na mesma janela porque entraram na mesma fila.

## O que NÃO é

Não é defeito de produto: a régua às 22:00 em ponto é borda de desenho e não incomoda ninguém. O defeito era a spec duplicar a regra **por aproximação**.

Ela continua duplicando — uma spec de Playwright não importa helper de componente cliente —, mas agora duplica **a conta**, não o resumo dela. E a mensagem de falha passa a dizer a hora e o minuto medidos, que é o dado que faltava para entender o vermelho sem reabrir o log.

## NÃO MEDIDO

Não rodei a spec (precisa da stack de e2e local). O que está medido é a equivalência das duas réguas, minuto a minuto, e o `typecheck` exit 0.