### PR TITLE
fix(agentes): a tela de teste espera o runner, e o run sai de running

### DIFF
--- a/app/api/v1/ai/agents/[id]/versions/[vid]/test/route.test.ts
+++ b/app/api/v1/ai/agents/[id]/versions/[vid]/test/route.test.ts
@@ -135,10 +135,49 @@ describe("POST .../versions/:vid/test — core compartilhado", () => {
       message: "Não foi possível executar o teste. Confira modelo, credencial e materiais do agente.",
     });
     expect(body.error?.message).not.toContain("AI_GATEWAY_API_KEY");
+    // 'failed', não 'error': ai_agent_runs_status_check aceita
+    // ('pending','running','completed','failed','aborted','handoff'). Este teste
+    // fixava o valor que o código gravava, não o que a tabela aceita — e por isso
+    // passava enquanto todo update falhava calado em produção.
     expect(atualizacoes).toContainEqual(expect.objectContaining({
-      status: "error",
+      status: "failed",
       error_code: "preview_failed",
     }));
+  });
+  /**
+   * O run bem-sucedido tem de sair de `running`.
+   *
+   * `ai_agent_runs_status_check` aceita
+   * ('pending','running','completed','failed','aborted','handoff'). O código
+   * gravava 'ok' — fora da lista —, o UPDATE falhava por violação de CHECK e o
+   * retorno não era lido, então o erro não chegava a log nenhum. Efeito medido
+   * numa instalação real: 19 runs em 'running', inclusive os que a tela
+   * reportou como concluídos.
+   *
+   * O assert é contra a LISTA da constraint, não contra a string: fixar apenas
+   * "completed" deixaria o próximo valor inventado passar do mesmo jeito.
+   */
+  it("run que conclui sai de running com status aceito pela constraint", async () => {
+    const STATUS_ACEITOS = ["pending", "running", "completed", "failed", "aborted", "handoff"];
+    vi.mocked(testAgentVersion).mockResolvedValueOnce({
+      candidates: [{ body: "Oi! Posso te ajudar." }],
+      proposals: [],
+    } as never);
+
+    const { POST } = await import("./route");
+    const req = new NextRequest("http://localhost/x", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sample_message: "oi" }),
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: AGENT, vid: VERSION }) });
+
+    expect(res.status).toBe(200);
+    const gravados = atualizacoes.map((u) => u.status);
+    expect(gravados).toContain("completed");
+    for (const st of gravados) {
+      expect(STATUS_ACEITOS).toContain(st);
+    }
   });
 });
 

--- a/app/api/v1/ai/agents/[id]/versions/[vid]/test/route.ts
+++ b/app/api/v1/ai/agents/[id]/versions/[vid]/test/route.ts
@@ -129,7 +129,11 @@ export async function POST(req: NextRequest, ctx: Ctx): Promise<Response> {
     await admin
       .from("ai_agent_runs")
       .update({
-        status: "ok",
+        // 'ok'/'error' NÃO existem em ai_agent_runs_status_check
+        // ('pending','running','completed','failed','aborted','handoff'): todo
+        // update falhava por violação de CHECK e, como o retorno não era lido,
+        // o erro sumia — os runs ficavam 'running' para sempre.
+        status: "completed",
         completed_at: new Date().toISOString(),
         tool_calls: JSON.parse(JSON.stringify(result.proposals)),
       })
@@ -139,7 +143,7 @@ export async function POST(req: NextRequest, ctx: Ctx): Promise<Response> {
     await admin
       .from("ai_agent_runs")
       .update({
-        status: "error",
+        status: "failed",
         completed_at: new Date().toISOString(),
         error_code: "preview_failed",
       })

--- a/app/app/ai/agents/[id]/_actions.ts
+++ b/app/app/ai/agents/[id]/_actions.ts
@@ -414,6 +414,9 @@ export async function publishAgentAction(
     .insert({
       organization_id: activeOrg.orgId,
       event_type: "ai_agent.published",
+      // NOT NULL sem default: sem esta linha o insert viola a constraint e o
+      // evento de publicação nunca é gravado.
+      entity_kind: "ai_agent",
       payload: {
         agent_id: result.agent_id,
         version_id: result.version_id,
@@ -614,6 +617,9 @@ export async function revertToVersionAction(
     .insert({
       organization_id: activeOrg.orgId,
       event_type: "ai_agent.published",
+      // NOT NULL sem default: sem esta linha o insert viola a constraint e o
+      // evento de publicação nunca é gravado.
+      entity_kind: "ai_agent",
       payload: {
         agent_id: result.agent_id,
         version_id: result.version_id,

--- a/app/app/ai/agents/[id]/_components/TestPanel.tsx
+++ b/app/app/ai/agents/[id]/_components/TestPanel.tsx
@@ -171,9 +171,18 @@ export function TestPanel({ agent, draft, published, readOnly }: Props) {
           ...(contactPhone.trim() ? { phone: contactPhone.trim() } : {}),
         };
       }
+      // O teste roda o MESMO runner do agente: cinco chamadas ao provedor
+      // (stage_classifier, jailbreak_detect, promise_semantic, o turno e o
+      // checkpoint). Medido em instalação real: ~9s no caso rápido e >20s com
+      // modelo lento ou provedor sob rate limit. O padrão do apiClient é 10s,
+      // então a tela abortava a requisição enquanto o servidor ainda trabalhava
+      // — e como AbortError não é ApiError, o usuário via "Erro inesperado."
+      // sem nenhuma pista. O Caddyfile já reserva 320s para esse runner em
+      // /api/internal/agents/run*; aqui o cliente precisava da mesma folga.
       const res = await apiClient.post<TestResponse>(
         `/api/v1/ai/agents/${agent.id}/versions/${target.id}/test`,
         body,
+        { timeoutMs: 300_000 },
       );
       setResult(res.data);
       qc.invalidateQueries({ queryKey: agentRunsKey(agent.id) });


### PR DESCRIPTION
# O que este PR faz

Faz a tela **Testar agente** parar de mostrar "Erro inesperado." em testes que funcionam, e faz o run aparecer como concluído no histórico em vez de ficar eternamente em `running`.

São três defeitos do mesmo fluxo, encontrados ao investigar um único sintoma numa instalação self-host.

## 1. O cliente desiste antes do servidor responder

`TestPanel.tsx` chama `apiClient.post` sem `timeoutMs` e herda o `DEFAULT_TIMEOUT_MS = 10_000`. Mas a rota executa o **mesmo runner** de um turno real — cinco chamadas ao provedor por teste:

```
stage_classifier    1,2 s
jailbreak_detect    1,2 s
agent_preview      13,4 s     ← ~29k tokens de entrada
promise_semantic    1,1 s
checkpoint          3,9 s
                   ───────
total              ~21 s
```

Aos 10 segundos o navegador aborta. `AbortError`/`TimeoutError` **não é** `ApiError`, então o `catch` cai no ramo genérico e a pessoa lê **"Erro inesperado."** — sem código, sem request id, sem pista. No servidor, enquanto isso, tudo conclui e loga verde.

Medições em três runs consecutivos do mesmo agente: 9,2 s · 10,2 s · 11,9 s. Dois dos três estouravam o teto — a tela funcionava por sorte, a cada clique.

O `Caddyfile` já reserva 320 s para esse runner em `/api/internal/agents/run*`, com o comentário de que ele "pode levar até ~5min". Faltava a mesma folga no cliente.

## 2. O run nunca sai de `running`

O update grava `status: "ok"` e `status: "error"`. A constraint aceita outra coisa:

```sql
CHECK (status = ANY (ARRAY['pending','running','completed','failed','aborted','handoff']))
```

Todo update falha por violação de CHECK. E como o retorno do `.update()` não é lido, o erro não chega a log nenhum. Reproduzido diretamente no banco:

```
ERROR: new row for relation "ai_agent_runs"
violates check constraint "ai_agent_runs_status_check"
```

Efeito numa instalação real: 19 runs em `running`, inclusive os que a tela reportou como concluídos. O histórico nunca reflete a realidade.

Vale notar que o `status` do `resultPayload` (`"ok"`/`"blocked"`) é o contrato da **resposta HTTP** e está correto — é o que a tela exibe. Só o valor gravado no banco estava fora da constraint, e este PR toca apenas esse.

## 3. O `event_log` da publicação nunca grava

O insert em `_actions.ts` omite `entity_kind`, que é `NOT NULL` sem default:

```
[saveAgentDraftAction/publish] event_log error
null value in column "entity_kind" of relation "event_log" violates not-null constraint
```

A publicação funciona (o insert é `void` + `.then()`), mas o evento de auditoria se perde em silêncio. Usei `"ai_agent"`, seguindo o padrão dos outros inserts do repo (`contact`, `conversation`, `ai_agent_run`, `channel_session`…).

## Testes

`app/api/v1/ai/agents/[id]/versions/[vid]/test/route.test.ts`:

- **Corrigida** a asserção existente, que fixava `status: "error"` — ela afirmava o valor que o código gravava, não o que a tabela aceita, e por isso passava enquanto todo update falhava calado em produção.
- **Novo** caso para o caminho de sucesso. Ele assevera contra a **lista** da constraint, não contra a string: fixar apenas `"completed"` deixaria o próximo valor inventado passar do mesmo jeito.

Verifiquei que pegam o defeito — reintroduzindo só as duas strings no código, os dois testes falham; revertendo, voltam ao verde.

O timeout do item 1 não tem teste: seria preciso exercitar o `AbortController` do cliente contra um handler lento, e não encontrei precedente disso na suíte. Se vocês tiverem um padrão para isso, escrevo com prazer.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado (0 errors; os 349 warnings são pré-existentes, nenhum nos arquivos tocados)
- [x] `pnpm lint:channels` ok — nenhuma dívida nova
- [x] Testes relevantes existem e passam (`pnpm test:unit`)
- [x] Audit log emitido — é justamente o item 3
- [x] Sem `console.log` esquecido
- [ ] Fragmento em `.changes/` — não escrevi; sigo a orientação do template de que isso fica com vocês
- [ ] Mudança de schema — não se aplica, nenhuma migration

Sobre a suíte completa: `tests/unit/leads-import-route.test.ts` falha 11 testes na `main` **sem** este PR — confirmei com `git stash`. Não mexi nesse caminho.
