### PR TITLE
fix(inbox): a sugestão de resposta diz por que falhou, e a rejeitada sai da tela

### DIFF
--- a/.changes/sugestao-diz-o-motivo-e-solta-a-tela.md
+++ b/.changes/sugestao-diz-o-motivo-e-solta-a-tela.md
@@ -1,0 +1,17 @@
+---
+impacto: capacidade_nova
+secao: corrigido
+titulo: A sugestão de resposta diz por que falhou, e a rejeitada sai da tela
+---
+
+Duas coisas na caixa de entrada, medidas numa instalação real.
+
+**A sugestão rejeitada não saía da tela.** O painel mostrava a sugestão mais recente sem olhar a situação dela — e uma rejeitada continua sendo a mais recente. O texto ficava ali, numa caixa desabilitada, sem botão de fechar (não havia nenhum). Pior no caso comum: quem rejeita costuma pedir outra em seguida; se essa segunda falha, nada substitui a primeira e a tela **trava** naquele texto.
+
+Agora a sugestão rejeitada — e também a obsoleta e a já enviada — solta o painel, que volta ao botão **Sugerir resposta**. A sugestão que falhou continua aparecendo de propósito: a frase dela é a única pista que sobra.
+
+**O erro não dizia nada.** Qualquer falha ao gerar virava a mesma frase — "Confira a publicação e a configuração do agente" —, mesmo quando o problema era outro, e **o motivo real era descartado sem ser registrado**. A tela ainda mostrava o identificador da requisição junto, o que fazia a mensagem parecer rastreável: não era, porque não havia nada gravado para procurar.
+
+Agora a tela diz qual dos motivos foi — nenhum agente publicado atende o canal, ou a conversa não pode receber sugestão (contato que pediu para não receber mensagens, contato anonimizado, histórico ilegível) — e, quando a causa é outra, admite que é outra e **registra** no servidor, onde o identificador finalmente encontra alguma coisa.
+
+Nada muda para quem opera: sem passo manual, sem mexer em configuração.

--- a/app/api/v1/conversations/[id]/draft-reply/route.ts
+++ b/app/api/v1/conversations/[id]/draft-reply/route.ts
@@ -6,6 +6,8 @@ import { createClient } from "@/lib/supabase/server";
 import { getRequestPool } from "@/lib/agent-engine/db/request-pool";
 import { requestTurnDeps } from "@/lib/agent-engine/agent/request-deps";
 import { generateReplyDraft } from "@/lib/agent-engine/agent/reply-drafts";
+import { motivoDaFalha } from "@/lib/agent-engine/agent/sugestao-de-resposta";
+import { logger } from "@/lib/logger";
 import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
 import { traduzir } from "@/lib/i18n/dicionario";
@@ -71,12 +73,18 @@ export async function POST(_req: NextRequest, ctx: Ctx) {
       { draft: draft.original_body ?? "", draft_id: draft.id, status: draft.status },
       { requestId },
     );
-  } catch {
-    return fail(
-      "reply_unavailable",
-      c.t("Não foi possível gerar a sugestão. Confira a publicação e a configuração do agente."),
-      422,
-      { requestId },
-    );
+  } catch (erro) {
+    const motivo = motivoDaFalha(erro);
+    // O `catch` daqui era SEM NOME, e a causa morria nesta linha. Registrar é
+    // metade do conserto: a outra metade é a frase, que antes mandava conferir
+    // a publicação do agente mesmo quando o problema era outro.
+    logger.error("[draft-reply] não foi possível gerar a sugestão", {
+      requestId,
+      organizationId: c.auth.org.orgId,
+      conversationId,
+      motivo: motivo.codigo,
+      erro: erro instanceof Error ? erro.message : String(erro),
+    });
+    return fail(motivo.codigo, c.t(motivo.texto), 422, { requestId });
   }
 }

--- a/components/inbox/composer/ReplyReviewPanel.tsx
+++ b/components/inbox/composer/ReplyReviewPanel.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { useT } from "@/hooks/i18n/useT";
+import { sugestaoParaMostrar } from "@/lib/agent-engine/agent/sugestao-de-resposta";
 type Draft = {
   id: string;
   revision: string;
@@ -43,7 +44,9 @@ export function ReplyReviewPanel({
       message: string;
       kind: "success" | "error";
     } | null>(null);
-  const draft = query.data?.data.drafts[0];
+  // Antes: `drafts[0]`, o mais recente, QUALQUER que fosse o estado dele — então
+  // uma sugestão rejeitada ficava na tela para sempre, sem botão de fechar.
+  const draft = sugestaoParaMostrar(query.data?.data.drafts);
   const body = draft ? (edits[draft.id] ?? draft.edited_body ?? draft.original_body ?? "") : "";
   async function generate() {
     setNotice(null);
@@ -184,11 +187,18 @@ export function ReplyReviewPanel({
           )}
         </>
       )}
+      {/*
+        A confirmação da rejeição ("o feedback será usado na próxima sugestão")
+        estava amarrada a `draft` existir. Agora a rejeitada some da tela — que é
+        o conserto —, e sem esta mudança a confirmação sumiria junto com ela: a
+        pessoa clicaria em Rejeitar e a tela apenas esvaziaria, sem dizer nada.
+        Quando ainda há sugestão, o aviso continua amarrado a ela.
+      */}
       {notice &&
-        draft &&
-        notice.draftId === draft.id &&
-        (notice.kind === "error" ||
-          ["approved", "sending", "sent", "dismissed"].includes(draft.status)) && (
+        (!draft ||
+          (notice.draftId === draft.id &&
+            (notice.kind === "error" ||
+              ["approved", "sending", "sent", "dismissed"].includes(draft.status)))) && (
           <p role="status" className="text-xs">
             {notice.message}
           </p>

--- a/lib/agent-engine/agent/sugestao-de-resposta.ts
+++ b/lib/agent-engine/agent/sugestao-de-resposta.ts
@@ -1,0 +1,122 @@
+/**
+ * As duas regras que a tela de sugestão de resposta erra quando ficam soltas.
+ *
+ * Vivem aqui, fora da rota e fora do componente, porque as duas são decisões
+ * puras — entra um valor, sai um valor — e porque as duas já falharam em
+ * produção sem que nenhum teste pudesse alcançá-las de onde estavam.
+ */
+
+/** Os estados que uma sugestão pode ter, iguais aos de `ai_reply_drafts`. */
+export type StatusDaSugestao =
+  | "generating"
+  | "pending"
+  | "approved"
+  | "sending"
+  | "sent"
+  | "dismissed"
+  | "stale"
+  | "failed";
+
+/**
+ * Uma sugestão nestes estados não tem mais nada a oferecer a quem atende.
+ *
+ * ## O defeito, medido em produção em 2026-09-12
+ *
+ * O painel pedia as cinco últimas sugestões da conversa (`order by created_at
+ * desc limit 5`), mostrava a primeira e **não olhava o estado dela**. Rejeitar
+ * não fecha nada: a sugestão rejeitada continua sendo a mais recente, então o
+ * painel seguia exibindo o texto morto — com a caixa de edição desabilitada,
+ * sem botão de aprovar, sem botão de fechar (não existe nenhum no componente).
+ *
+ * E o caso que travou de vez: quem rejeita costuma pedir outra em seguida. Se
+ * essa geração falha, nada substitui a rejeitada, e a tela fica presa naquele
+ * texto indefinidamente. Foi exatamente o que aconteceu.
+ *
+ * `sent` entra na lista porque o texto enviado já aparece na conversa, logo
+ * acima — repeti-lo numa caixa desabilitada é dizer duas vezes a mesma coisa.
+ *
+ * `failed` NÃO entra, de propósito: ela ainda diz o que conferir, e essa frase
+ * é a única pista que sobra para quem não sabe por que a sugestão não veio.
+ */
+const SEM_NADA_A_OFERECER: ReadonlySet<string> = new Set<StatusDaSugestao>([
+  "dismissed",
+  "stale",
+  "sent",
+]);
+
+/**
+ * Qual sugestão o painel mostra — ou nenhuma, e aí ele volta ao estado neutro
+ * (o título genérico e o botão "Sugerir resposta").
+ *
+ * Olha **só a mais recente**, de propósito. A alternativa — procurar na lista a
+ * primeira que ainda sirva — ressuscitaria uma sugestão antiga logo depois de a
+ * atual ser rejeitada, e quem atende veria um texto que já tinha sumido voltar
+ * sozinho à tela. Entre mostrar demais e mostrar de menos, aqui o erro barato é
+ * mostrar de menos: o botão de gerar outra está sempre ali.
+ */
+export function sugestaoParaMostrar<T extends { status: string }>(
+  sugestoes: readonly T[] | undefined,
+): T | undefined {
+  const maisRecente = sugestoes?.[0];
+  if (!maisRecente) return undefined;
+  return SEM_NADA_A_OFERECER.has(maisRecente.status) ? undefined : maisRecente;
+}
+
+/** O que a tela diz quando a geração falha, e com que código. */
+export interface MotivoDaFalha {
+  readonly codigo: string;
+  /** Em português; quem chama passa pelo `t()` para o idioma de quem lê. */
+  readonly texto: string;
+  /**
+   * `true` quando a causa é conhecida e acionável — quem lê sabe o que fazer.
+   * `false` quando caímos no genérico, e aí só o registro no servidor ajuda.
+   */
+  readonly acionavel: boolean;
+}
+
+/**
+ * Traduz a exceção de `generateReplyDraft` na frase que quem atende lê.
+ *
+ * ## O defeito que isto conserta
+ *
+ * A rota fazia `} catch {` — **sem nome**. A causa era descartada ali mesmo, e
+ * três situações sem nada em comum viravam a mesma frase: "Não foi possível
+ * gerar a sugestão. Confira a publicação e a configuração do agente."
+ *
+ * Pior: a tela mostra o identificador da requisição junto, o que faz a mensagem
+ * parecer rastreável. Não era — nada tinha sido registrado, em lugar nenhum,
+ * então o identificador não levava a nada. Um número que promete e não entrega
+ * é pior que nenhum número: manda a pessoa procurar onde não há o que achar.
+ *
+ * Medido: o dono da instalação levou o erro para o suporte com o identificador
+ * em mãos, e não havia como descobrir a causa nem lendo o código — só sabotando
+ * cada caminho para ver qual produzia aquela frase.
+ *
+ * As duas causas nomeadas são as que `generateReplyDraft` lança de propósito;
+ * o resto (falha do provedor de IA, tempo esgotado, rede, erro de SQL) cai no
+ * genérico — e aí a frase deixa de fingir que sabe, e diz que o motivo ficou
+ * registrado.
+ */
+export function motivoDaFalha(erro: unknown): MotivoDaFalha {
+  const marca = erro instanceof Error ? erro.message : String(erro ?? "");
+  if (marca === "reply_no_agent")
+    return {
+      codigo: "reply_no_agent",
+      texto:
+        "Nenhum agente publicado atende este canal. Publique uma versão do agente em IA › Agentes.",
+      acionavel: true,
+    };
+  if (marca === "reply_context_unavailable")
+    return {
+      codigo: "reply_context_unavailable",
+      texto:
+        "Não dá para sugerir nesta conversa: o contato pediu para não receber mensagens, foi anonimizado, ou o histórico não pôde ser lido.",
+      acionavel: true,
+    };
+  return {
+    codigo: "reply_unavailable",
+    texto:
+      "Não foi possível gerar a sugestão. O motivo ficou registrado no servidor com o identificador abaixo.",
+    acionavel: false,
+  };
+}

--- a/lib/i18n/dicionario.ts
+++ b/lib/i18n/dicionario.ts
@@ -82,6 +82,17 @@ export const DICIONARIO: Traducoes = {
   "Enviando resposta aprovada…": { es: "Enviando respuesta aprobada…" },
   "Resposta aprovada enviada": { es: "Respuesta aprobada enviada" },
   "Sugestão rejeitada": { es: "Sugerencia rechazada" },
+  "Nenhum agente publicado atende este canal. Publique uma versão do agente em IA › Agentes.": {
+    es: "Ningún agente publicado atiende este canal. Publica una versión del agente en IA › Agentes.",
+  },
+  "Não dá para sugerir nesta conversa: o contato pediu para não receber mensagens, foi anonimizado, ou o histórico não pôde ser lido.":
+    {
+      es: "No se puede sugerir en esta conversación: el contacto pidió no recibir mensajes, fue anonimizado, o no se pudo leer el historial.",
+    },
+  "Não foi possível gerar a sugestão. O motivo ficou registrado no servidor com o identificador abaixo.":
+    {
+      es: "No se pudo generar la sugerencia. El motivo quedó registrado en el servidor con el identificador de abajo.",
+    },
   "Sugestão obsoleta: a conversa mudou": { es: "Sugerencia obsoleta: la conversación cambió" },
   "Não foi possível concluir a sugestão ou o envio": {
     es: "No se pudo completar la sugerencia o el envío",

--- a/tests/unit/sugestao-de-resposta.test.ts
+++ b/tests/unit/sugestao-de-resposta.test.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  motivoDaFalha,
+  sugestaoParaMostrar,
+} from "@/lib/agent-engine/agent/sugestao-de-resposta";
+
+/**
+ * Os dois defeitos medidos em produção em 2026-09-12, na tela de atendimento.
+ *
+ * **1. A sugestão rejeitada não saía da tela.** O painel mostrava a mais recente
+ * sem olhar o estado. Rejeitar não fecha nada, e não há botão de fechar no
+ * componente — então o texto morto ficava ali. Quando a geração seguinte também
+ * falhava, a tela travava naquele estado, sem saída.
+ *
+ * **2. O erro não dizia nada, e o identificador não levava a lugar nenhum.** A
+ * rota fazia `} catch {`, sem nome: a causa era descartada, três situações
+ * diferentes viravam a mesma frase, e nada era registrado — mas a tela exibia o
+ * identificador da requisição, o que faz a mensagem parecer rastreável.
+ *
+ * Os dois casos cobrem o CAMINHO DO ERRO, que é o que paga: a sugestão que some
+ * e a causa que aparece. Cada regra tem também o seu controle no sentido oposto,
+ * porque uma função que devolvesse SEMPRE `undefined` (ou sempre o genérico)
+ * passaria por metade destes casos sem conservar nada.
+ */
+
+type Sugestao = { id: string; status: string };
+const s = (status: string, id = "d1"): Sugestao => ({ id, status });
+
+describe("qual sugestão o painel mostra", () => {
+  it("⛔ a REJEITADA sai da tela — é o defeito que travou a tela do dono", () => {
+    expect(sugestaoParaMostrar([s("dismissed")])).toBeUndefined();
+  });
+
+  it("⛔ a OBSOLETA e a JÁ ENVIADA também saem", () => {
+    // A enviada já aparece na conversa logo acima; repeti-la numa caixa
+    // desabilitada diz duas vezes a mesma coisa.
+    expect(sugestaoParaMostrar([s("stale")])).toBeUndefined();
+    expect(sugestaoParaMostrar([s("sent")])).toBeUndefined();
+  });
+
+  it("CONTROLE: a que espera revisão CONTINUA aparecendo", () => {
+    // Sem este caso, uma implementação que escondesse tudo passaria nos de cima
+    // e apagaria o recurso inteiro — o erro em espelho, e o mais fácil de fazer.
+    expect(sugestaoParaMostrar([s("pending")])?.status).toBe("pending");
+  });
+
+  it("CONTROLE: as intermediárias continuam aparecendo", () => {
+    for (const vivo of ["generating", "approved", "sending"])
+      expect(sugestaoParaMostrar([s(vivo)])?.status, vivo).toBe(vivo);
+  });
+
+  it("a que FALHOU continua aparecendo — ela é a única pista que sobra", () => {
+    // Deliberado: o texto dela diz o que conferir. Esconder deixaria quem
+    // atende sem nenhuma explicação para a sugestão que não veio.
+    expect(sugestaoParaMostrar([s("failed")])?.status).toBe("failed");
+  });
+
+  it("⛔ NÃO ressuscita uma sugestão antiga quando a atual é rejeitada", () => {
+    // A correção ingênua — procurar na lista a primeira que ainda sirva — faria
+    // um texto que o atendente acabou de rejeitar voltar sozinho para a tela,
+    // vindo de uma sugestão anterior. Olha só a mais recente, de propósito.
+    expect(sugestaoParaMostrar([s("dismissed", "novo"), s("pending", "velho")])).toBeUndefined();
+  });
+
+  it("sem sugestão nenhuma, painel neutro", () => {
+    expect(sugestaoParaMostrar([])).toBeUndefined();
+    expect(sugestaoParaMostrar(undefined)).toBeUndefined();
+  });
+});
+
+describe("o que a tela diz quando a geração falha", () => {
+  it("⛔ 'não há agente publicado' deixa de virar a frase genérica", () => {
+    const m = motivoDaFalha(new Error("reply_no_agent"));
+    expect(m.codigo).toBe("reply_no_agent");
+    expect(m.acionavel).toBe(true);
+    expect(m.texto).toMatch(/publicad/i);
+  });
+
+  it("⛔ 'contexto indisponível' diz as três causas reais", () => {
+    const m = motivoDaFalha(new Error("reply_context_unavailable"));
+    expect(m.codigo).toBe("reply_context_unavailable");
+    expect(m.acionavel).toBe(true);
+  });
+
+  it("causa desconhecida NÃO finge saber, e promete o registro", () => {
+    // A frase antiga mandava "conferir a publicação e a configuração do agente"
+    // mesmo quando o problema era o provedor de IA fora do ar. Mandar a pessoa
+    // mexer na configuração certa é pior que admitir que não se sabe.
+    const m = motivoDaFalha(new Error("timeout do provedor"));
+    expect(m.codigo).toBe("reply_unavailable");
+    expect(m.acionavel).toBe(false);
+    expect(m.texto).not.toMatch(/Confira a publicação/i);
+  });
+
+  it("não quebra com o que não é Error", () => {
+    for (const estranho of [undefined, null, "texto solto", 42])
+      expect(motivoDaFalha(estranho).codigo).toBe("reply_unavailable");
+  });
+
+  it("CONTROLE: as três frases são distintas — senão o conserto é só aparência", () => {
+    const textos = [
+      motivoDaFalha(new Error("reply_no_agent")).texto,
+      motivoDaFalha(new Error("reply_context_unavailable")).texto,
+      motivoDaFalha(new Error("outro")).texto,
+    ];
+    expect(new Set(textos).size).toBe(3);
+  });
+});
+
+describe("a rota não volta a engolir a causa", () => {
+  const ROTA = path.join(
+    process.cwd(),
+    "app",
+    "api",
+    "v1",
+    "conversations",
+    "[id]",
+    "draft-reply",
+    "route.ts",
+  );
+  const fonte = fs.readFileSync(ROTA, "utf8");
+
+  it("⛔ nenhum `catch` sem nome — foi ele que descartou a causa", () => {
+    // A cerca é por forma porque o defeito é de forma: `} catch {` compila,
+    // passa no lint, passa no typecheck e passa na suíte. Só um leitor humano
+    // percebia — e por meses ninguém percebeu.
+    expect(/catch\s*\{/.test(fonte), "há um `catch {` sem nome nesta rota").toBe(false);
+  });
+
+  it("⛔ a causa é REGISTRADA — senão o identificador na tela não leva a nada", () => {
+    expect(fonte).toMatch(/logger\.error\(/);
+  });
+
+  it("CONTROLE: a cerca acima reprovaria mesmo — ela casa com a forma proibida", () => {
+    // Guarda de vacuidade: se a expressão parasse de casar com qualquer coisa,
+    // o caso de cima ficaria verde para sempre, inclusive com o defeito de volta.
+    expect(/catch\s*\{/.test("try { x() } catch { }")).toBe(true);
+  });
+});


### PR DESCRIPTION
Dois defeitos da tela de atendimento, medidos numa instalação real em 2026-09-12.

## O que muda para quem atende

| antes | depois |
|---|---|
| Rejeitar uma sugestão **não a tirava da tela** — o texto ficava numa caixa desabilitada, sem botão de fechar | A rejeitada solta o painel, que volta ao botão **Sugerir resposta** |
| Qualquer falha ao gerar virava a mesma frase: *"Confira a publicação e a configuração do agente"* | A tela diz **qual** foi o motivo — e, quando não sabe, admite e registra |

## 1. A sugestão rejeitada não saía da tela

`ReplyReviewPanel` pedia as cinco últimas sugestões da conversa e mostrava a
primeira **sem olhar o estado dela**:

```
order by created_at desc limit 5      ← app/api/v1/conversations/[id]/draft-reply/route.ts
const draft = query.data?.data.drafts[0];   ← ReplyReviewPanel.tsx
```

Rejeitar não fecha nada: a rejeitada continua sendo a mais recente. E não há
botão de fechar no componente — procurei, não existe.

**O caso que trava de vez**, e foi o que aconteceu: quem rejeita costuma pedir
outra em seguida. Se essa geração falha, nada substitui a rejeitada e a tela
fica presa naquele texto, indefinidamente.

Agora `dismissed`, `stale` e `sent` soltam o painel. `failed` **não** — a frase
dela é a única pista que sobra para quem não sabe por que a sugestão não veio.

Duas decisões que valem explicar:

- **Olha só a mais recente.** A correção mais curta — procurar na lista a
  primeira que ainda sirva — ressuscitaria uma sugestão anterior logo depois de
  a atual ser rejeitada: um texto que o atendente acabou de recusar voltando
  sozinho para a tela. Há um caso cobrindo exatamente isso.
- **A confirmação da rejeição estava amarrada a `draft` existir.** Sem ajustar
  junto, o conserto faria o aviso *"o feedback será usado na próxima sugestão"*
  sumir com a sugestão, e o clique em Rejeitar apenas esvaziaria a tela em
  silêncio.

## 2. O erro descartava a causa — e o identificador não levava a nada

A rota fazia `} catch {` — **sem nome**. A causa morria ali, e três situações
sem nada em comum viravam a mesma frase, que manda conferir a publicação do
agente mesmo quando o problema é o provedor de IA fora do ar:

| causa real | o que era dito |
|---|---|
| `reply_no_agent` | "Confira a publicação e a configuração do agente" |
| `reply_context_unavailable` | idem |
| falha de IA, tempo esgotado, rede, SQL | idem |

**E nada era registrado** — nem `logger`, nem Sentry — enquanto a tela exibia o
`requestId` ao lado da mensagem, o que a faz **parecer** rastreável. Não era:
não havia nada gravado para procurar com aquele identificador. Um número que
promete e não entrega manda a pessoa procurar onde não há o que achar. Foi
assim que este defeito chegou até aqui: com o identificador em mãos e sem
caminho nenhum para a causa.

Agora `motivoDaFalha` nomeia as duas causas que `generateReplyDraft` lança de
propósito, o resto admite que é outra coisa, e a causa vai para `logger.error`
com organização, conversa e `requestId`.

## O que eu medi e DESCARTEI

A primeira hipótese era que a falha vinha de enviar conteúdo vazio. **Não se
sustenta** — os três caminhos já validavam, e está medido:

- `Composer.tsx:111` (`if (!body || …) return`) e `:344` (botão desabilitado)
- "Aprovar e enviar": `disabled={… || !body.trim()}`
- "Sugerir resposta": não tem campo nenhum; o POST manda `{}`

Não falta validação. Falta a causa aparecer — que é o defeito 2. Registro aqui
para ninguém refazer esse caminho.

## O que eu medi

| | |
|---|---|
| `typecheck` | 0 |
| `lint` (arquivos tocados) | 0 |
| casos novos | 15, todos verdes |
| suíte inteira | **5 arquivos / 7 casos vermelhos — idênticos aos da `main` sem este PR** |

**Sabotagem, previsto × medido** — cada conserto desfeito sozinho, um por vez,
com restauração conferida em passo separado:

| sabotagem | previsto | medido |
|---|---|---|
| `sugestaoParaMostrar` volta a devolver a mais recente | 3 vermelhos, controles verdes | ✅ exatamente 3 |
| `} catch {` sem nome volta | 2 vermelhos (a cerca e o registro) | ✅ exatamente 2 |

Os cinco vermelhos são de ambiente desta máquina (resolução do `pdfjs-dist` no
Windows) e estão medidos nos dois lados. Uma primeira rodada trouxe três
arquivos a mais; rodados sozinhos, os três passam, e a segunda rodada da suíte
inteira voltou aos mesmos cinco — instabilidade da máquina, registrada aqui em
vez de omitida.

Os controles positivos ficaram verdes nas duas: a sugestão que espera revisão
continua aparecendo, e as três frases de erro continuam distintas. Sem eles,
uma implementação que escondesse tudo — ou que devolvesse sempre o genérico —
passaria por metade dos casos sem conservar nada.

## O que eu NÃO medi

- **Não rodei Playwright.** Não há prova de tela deste PR. Os dois consertos são
  visíveis, e merecem ser conferidos por quem revisar.
- **Não reproduzi a causa raiz do erro original.** Ela continua desconhecida — é
  justamente o que o defeito 2 impedia de saber. O que este PR garante é que a
  próxima ocorrência diga qual foi.
- **Não mexi em `generateReplyDraft`.** As duas exceções que ela lança já
  existiam; só pararam de ser descartadas.

## Checklist (Definition of Done)

- [x] `pnpm typecheck` zerado
- [x] `pnpm lint` zerado
- [x] Testes relevantes existem e passam (`pnpm test:unit`)
- [ ] RLS testada — **não se aplica**: nenhuma tabela nova, nenhuma policy tocada
- [ ] Audit log — **não se aplica**: o caminho de sucesso já auditava e não mudou; o de erro não é mutação
- [x] Zod valida todo input externo novo — não há input novo; o POST segue sem corpo
- [x] Sem `console.log` esquecido
- [ ] Mudança de schema — **não há**
- [ ] Doc de contrato — **não muda contrato**: os códigos de erro ficaram mais específicos (`reply_no_agent`, `reply_context_unavailable`) e o antigo `reply_unavailable` continua sendo o genérico

Fragmento em `.changes/` incluído.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
