### PR TITLE
fix(waha): o nome da sessão nasce num lugar só e cabe no teto de 54

### DIFF
--- a/.changes/nome-da-sessao-nao-passa-do-teto-do-waha.md
+++ b/.changes/nome-da-sessao-nao-passa-do-teto-do-waha.md
@@ -1,0 +1,18 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O nome da sessão do WhatsApp nasce num lugar só e cabe no limite
+---
+
+O botão "Conectar novo WhatsApp", na Central de Conexões, falhava sempre com "Falha na comunicação
+com o WhatsApp (WAHA)". O identificador interno que o CRM manda para o WAHA saía com 69
+caracteres, e o WAHA recusa acima de 54, então a sessão nem chegava a ser criada do outro lado e o
+card ficava em "Parado" pedindo reparo. O onboarding não tinha o problema porque montava o
+identificador curto por conta própria, num segundo lugar do código.
+
+Agora o formato curto é um só, usado pelas duas telas — onboarding e Conexões —, e o CRM confere o
+limite antes de falar com o WAHA: acima de 54 caracteres a conexão para aqui, com motivo próprio e
+sem criar nada do outro lado, no lugar de um erro de comunicação que não dizia o que havia de
+errado.
+
+Nada muda para quem já tem número conectado.

--- a/app/api/v1/channel-sessions/route.ts
+++ b/app/api/v1/channel-sessions/route.ts
@@ -113,7 +113,9 @@ export async function POST(req: NextRequest): Promise<Response> {
     return ok(result.channel, { requestId, status: result.replay ? 200 : 201 });
   } catch (error) {
     if (error instanceof ChannelConnectionError) return fail(error.code,
-      error.code === "connection_in_progress" ? t("A conexão ainda está sendo preparada. Aguarde e tente novamente.") : t("Não foi possível concluir a conexão. Abra Conexões para tentar novamente ou reparar o número."),
+      error.code === "connection_in_progress" ? t("A conexão ainda está sendo preparada. Aguarde e tente novamente.")
+        : error.code === "connection_session_name_too_long" ? t("O identificador desta conexão passou do limite que o WhatsApp aceita. Nada foi criado no WhatsApp — atualize o sistema e tente novamente.")
+        : t("Não foi possível concluir a conexão. Abra Conexões para tentar novamente ou reparar o número."),
       error.status, { requestId, details: error.technical });
     return fail("internal_error", t("Não foi possível concluir a conexão. Tente novamente."), 500, { requestId });
   }

--- a/app/api/v1/onboarding/whatsapp/session/route.ts
+++ b/app/api/v1/onboarding/whatsapp/session/route.ts
@@ -42,7 +42,9 @@ export async function POST(req: Request): Promise<Response> {
     return ok({ status: result.channel.status, session: result.channel.waha_session_name, channel_session_id: result.channel.id }, { requestId });
   } catch (error) {
     if (error instanceof ChannelConnectionError) return fail(error.code,
-      error.code === "connection_in_progress" ? "A conexão ainda está sendo preparada. Aguarde e tente novamente." : "Não foi possível concluir a conexão. Tente novamente ou repare o número em Conexões.",
+      error.code === "connection_in_progress" ? "A conexão ainda está sendo preparada. Aguarde e tente novamente."
+        : error.code === "connection_session_name_too_long" ? "O identificador desta conexão passou do limite que o WhatsApp aceita. Nada foi criado no WhatsApp — atualize o sistema e tente novamente."
+        : "Não foi possível concluir a conexão. Tente novamente ou repare o número em Conexões.",
       error.status, { requestId, details: error.technical });
     return fail("internal_error", "Não foi possível concluir a conexão. Tente novamente.", 500, { requestId });
   }

--- a/app/onboarding/connect-whatsapp/page.tsx
+++ b/app/onboarding/connect-whatsapp/page.tsx
@@ -1,6 +1,7 @@
 import { requireAuth, resolveActiveOrg } from "@/lib/auth/server";
 import { redirect } from "next/navigation";
 import { metaPodeReceber } from "@/lib/channels/meta/webhook";
+import { nomeCurtoDaSessao } from "@/lib/channels/nome-da-sessao";
 import { getWahaClient } from "@/lib/waha/client";
 import { ConnectWhatsappClient } from "./_client";
 import { traduzir } from "@/lib/i18n/dicionario";
@@ -37,7 +38,7 @@ export default async function ConnectWhatsappPage() {
       </p>
       <ConnectWhatsappClient
         wahaConfigured={wahaConfigured}
-        sessionName={`org_${activeOrg.orgId.slice(0, 8)}`}
+        sessionName={nomeCurtoDaSessao(activeOrg.orgId)}
         oficialPodeReceber={oficialPodeReceber}
       />
     </div>

--- a/lib/channels/connect-waha.test.ts
+++ b/lib/channels/connect-waha.test.ts
@@ -5,15 +5,16 @@ vi.mock("@/lib/audit", () => ({ audit: vi.fn() }));
 const org = "20000000-0000-4000-8000-000000000001";
 const key = "20000000-0000-4000-8000-000000000002";
 const channel = { id: key, organization_id: org, waha_session_name: "owned", status: "STARTING", archived_at: null };
-function fixture() {
+function fixture(nomeDaSessao = "owned") {
   const finishes: Record<string, unknown>[] = [];
+  const reservado = { ...channel, waha_session_name: nomeDaSessao };
   const db = { rpc: vi.fn(async (name: string, args: Record<string, unknown>) => {
-    if (name === "fn_reserve_channel_connection") return { data: { channel, receipt_id: key, lease_token: key, replay: false }, error: null };
+    if (name === "fn_reserve_channel_connection") return { data: { channel: reservado, receipt_id: key, lease_token: key, replay: false }, error: null };
     finishes.push(args);
-    return { data: { ...channel, status: args.p_status }, error: null };
+    return { data: { ...reservado, status: args.p_status }, error: null };
   }) } as unknown as SupabaseClient;
-  const transport = { getVerifiedSession: vi.fn(async () => null), createSession: vi.fn(async () => ({ created: true, session: { name: "owned", status: "STOPPED" } })),
-    startExistingSession: vi.fn(async () => ({ name: "owned", status: "SCAN_QR_CODE" })),
+  const transport = { getVerifiedSession: vi.fn(async () => null), createSession: vi.fn(async () => ({ created: true, session: { name: nomeDaSessao, status: "STOPPED" } })),
+    startExistingSession: vi.fn(async () => ({ name: nomeDaSessao, status: "SCAN_QR_CODE" })),
     deleteSession: vi.fn(async () => {}), stopSession: vi.fn(async () => {}) };
   return { db, transport, finishes, input: { organizationId: org, idempotencyKey: key, userId: key, requestId: key } };
 }
@@ -64,5 +65,37 @@ describe("conexão recuperável", () => {
     vi.mocked(f.db.rpc).mockResolvedValue({ data: { channel: { ...channel, status: "SCAN_QR_CODE" }, receipt_id: key, replay: true }, error: null } as never);
     expect((await connectWahaChannel(f.db, f.db, f.transport, f.input)).replay).toBe(true);
     expect(f.transport.createSession).not.toHaveBeenCalled();expect(f.transport.deleteSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("teto do nome da sessão no WAHA", () => {
+  // Formato que o banco gerava antes de encurtar o identificador: `org_<32>_<32>`,
+  // 69 caracteres. É o nome que fazia o botão de Conexões falhar sempre, com
+  // `400 name must be shorter than or equal to 54 characters`.
+  const nomeAntigo = `org_${org.replaceAll("-", "")}_${key.replaceAll("-", "")}`;
+  it("nome acima do teto morre no CRM, com motivo, sem chegar ao transporte", async () => {
+    expect(nomeAntigo).toHaveLength(69);
+    const f = fixture(nomeAntigo);
+    await expect(connectWahaChannel(f.db, f.db, f.transport, f.input)).rejects.toMatchObject({
+      code: "connection_session_name_too_long", status: 409,
+      technical: { waha_session_name: nomeAntigo, comprimento: 69, teto: 54 },
+    });
+    expect(f.transport.createSession).not.toHaveBeenCalled();
+    expect(f.transport.startExistingSession).not.toHaveBeenCalled();
+    expect(f.transport.deleteSession).not.toHaveBeenCalled();
+    expect(f.finishes.at(-1)).toMatchObject({ p_status: "FAILED", p_reason: "session_name_too_long" });
+  });
+  it("nome exatamente no teto (54) segue pelo caminho normal", async () => {
+    const nome = "o".repeat(54);
+    const f = fixture(nome);
+    expect((await connectWahaChannel(f.db, f.db, f.transport, f.input)).channel.status).toBe("SCAN_QR_CODE");
+    expect(f.transport.createSession).toHaveBeenCalledWith(nome);
+  });
+  it("nome que o banco gera hoje (45) segue pelo caminho normal", async () => {
+    const nome = `org_${org.replaceAll("-", "").slice(0, 8)}_${key.replaceAll("-", "")}`;
+    expect(nome).toHaveLength(45);
+    const f = fixture(nome);
+    expect((await connectWahaChannel(f.db, f.db, f.transport, f.input)).channel.status).toBe("SCAN_QR_CODE");
+    expect(f.transport.startExistingSession).toHaveBeenCalledWith(nome);
   });
 });

--- a/lib/channels/connect-waha.ts
+++ b/lib/channels/connect-waha.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { z } from "zod";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { audit } from "@/lib/audit";
+import { TETO_NOME_DE_SESSAO_WAHA, nomeDaSessaoCabeNoWaha } from "@/lib/channels/nome-da-sessao";
 import type { WahaClient } from "@/lib/waha/client";
 import { WahaSessionError } from "@/lib/waha/client";
 
@@ -51,6 +52,22 @@ export async function connectWahaChannel(authDb: SupabaseClient, serviceDb: Supa
     });
     if (result.error) throw new ChannelConnectionError("connection_checkpoint_failed", 503);
     return result.data;
+  }
+  // Teto do WAHA conferido AQUI, antes de qualquer chamada ao transporte.
+  //
+  // Deixar passar é o defeito da issue #667: o WAHA devolve um 400 opaco no meio
+  // do fluxo, com a reserva já feita, e o card de Conexões fica preso em
+  // `Parado`. Nome acima do teto não é falha de transporte — é dado de uma
+  // instalação que ainda não encurtou o identificador, e o operador precisa
+  // saber disso, não receber um erro genérico. A reserva é fechada em `FAILED`
+  // para não travar a próxima tentativa.
+  if (!nomeDaSessaoCabeNoWaha(channel.waha_session_name)) {
+    await finish("FAILED", "session_name_too_long");
+    throw new ChannelConnectionError("connection_session_name_too_long", 409, {
+      waha_session_name: channel.waha_session_name,
+      comprimento: channel.waha_session_name.length,
+      teto: TETO_NOME_DE_SESSAO_WAHA,
+    });
   }
   try {
     if (input.restart) await waha.stopSession(channel.waha_session_name);

--- a/lib/channels/nome-da-sessao.ts
+++ b/lib/channels/nome-da-sessao.ts
@@ -1,0 +1,44 @@
+/**
+ * O nome da sessão que o CRM manda para o WAHA, num lugar só.
+ *
+ * ─── Por que este arquivo existe ───────────────────────────────────────────
+ *
+ * O formato curto (`org_` + os 8 primeiros caracteres do uuid da organização —
+ * 12 no total) nasceu dentro da tela de onboarding. O banco montava o dele por
+ * conta própria, e por um tempo montou `org_<32>_<32>`: 69 caracteres, acima do
+ * `@MaxLength(54)` do WAHA, que responde
+ * `400 name must be shorter than or equal to 54 characters`.
+ *
+ * O onboarding escapava porque gastava o formato curto. O botão "Conectar novo
+ * WhatsApp" da tela de Conexões, que gasta o nome vindo do banco, falhava
+ * SEMPRE — e o operador só via o card preso em `Parado`.
+ *
+ * Duas lições ficaram, e são as duas regras deste arquivo:
+ *
+ *   1. superfície não monta o nome da sessão à mão; deriva daqui;
+ *   2. o teto é conferido do lado do CRM — descobrir o limite por um 400 opaco
+ *      do transporte, depois da reserva feita, é o que prendia o card.
+ */
+
+/**
+ * Teto do `name` de sessão no WAHA (`@MaxLength(54)`).
+ *
+ * Não é folga: é o limite do outro lado. Mudar aqui só com o WAHA mudando lá.
+ */
+export const TETO_NOME_DE_SESSAO_WAHA = 54;
+
+/**
+ * Formato curto e estável da sessão — o mesmo que o onboarding sempre usou.
+ *
+ * O prefixo `org_` não é decorativo: `lib/channels/onboarding-session.ts`
+ * procura exatamente esta string para achar a linha legada da própria
+ * organização. Mudar o formato aqui é mudar a busca lá.
+ */
+export function nomeCurtoDaSessao(organizationId: string): string {
+  return `org_${organizationId.slice(0, 8)}`;
+}
+
+/** O nome cabe no teto do WAHA? Falso = não pode chegar ao transporte. */
+export function nomeDaSessaoCabeNoWaha(nome: string): boolean {
+  return nome.length <= TETO_NOME_DE_SESSAO_WAHA;
+}

--- a/lib/channels/onboarding-session.ts
+++ b/lib/channels/onboarding-session.ts
@@ -1,10 +1,11 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { nomeCurtoDaSessao } from "@/lib/channels/nome-da-sessao";
 /** Nome legado só localiza linha da própria org; nunca autoriza acesso remoto. */
 export async function loadOnboardingChannel(db: SupabaseClient, organizationId: string) {
   const { data, error } = await db.from("channel_sessions")
     .select("id, organization_id, waha_session_name, status, archived_at")
     .eq("organization_id", organizationId).eq("provider", "waha")
-    .or(`metadata->>onboarding.eq.true,waha_session_name.eq.org_${organizationId.slice(0, 8)}`)
+    .or(`metadata->>onboarding.eq.true,waha_session_name.eq.${nomeCurtoDaSessao(organizationId)}`)
     .order("created_at").limit(1).maybeSingle();
   if (error) throw new Error(error.message);
   return data as { id: string; organization_id: string; waha_session_name: string; status: string; archived_at: string | null } | null;

--- a/tests/unit/nome-da-sessao-do-waha.test.ts
+++ b/tests/unit/nome-da-sessao-do-waha.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { TETO_NOME_DE_SESSAO_WAHA, nomeCurtoDaSessao, nomeDaSessaoCabeNoWaha } from "@/lib/channels/nome-da-sessao";
+
+const RAIZ = process.cwd();
+const ORG = "20000000-0000-4000-8000-000000000001";
+const AJUDANTE = join("lib", "channels", "nome-da-sessao.ts");
+/** Montagem à mão do formato curto: `org_${…slice(0, 8)}` fora do helper. */
+const MONTAGEM_A_MAO = /`org_\$\{[^}]*slice\(\s*0\s*,\s*8\s*\)/;
+/** Construções à mão que ficam de fora, com o motivo escrito. */
+const EXCECOES: Record<string, string> = {
+  // Mesmo formato curto, mas para o WaCalls (voz), não para o WAHA: o nome já
+  // nasce com 12 caracteres e não tem o defeito da #667. Trocar o motor de voz
+  // não é assunto desta correção.
+  [join("app", "api", "v1", "voice", "sessions", "pair", "route.ts")]: "WaCalls, não WAHA",
+};
+
+function varrer(dir: string, achados: string[] = []): string[] {
+  for (const entrada of readdirSync(dir, { withFileTypes: true })) {
+    const caminho = join(dir, entrada.name);
+    if (entrada.isDirectory()) {
+      if (["node_modules", ".next", "dist", "coverage"].includes(entrada.name)) continue;
+      varrer(caminho, achados);
+    } else if (/\.(ts|tsx)$/.test(entrada.name) && !/\.(test|spec)\./.test(entrada.name)) achados.push(caminho);
+  }
+  return achados;
+}
+
+describe("nome da sessão do WAHA cabe no teto de 54", () => {
+  it("o teto é o `@MaxLength(54)` do WAHA", () => {
+    expect(TETO_NOME_DE_SESSAO_WAHA).toBe(54);
+  });
+  it("o formato curto do onboarding cabe com folga", () => {
+    const nome = nomeCurtoDaSessao(ORG);
+    expect(nome).toBe("org_20000000");
+    expect(nome).toHaveLength(12);
+    expect(nomeDaSessaoCabeNoWaha(nome)).toBe(true);
+  });
+  it("o limite é inclusivo: 54 cabe, 55 não", () => {
+    expect(nomeDaSessaoCabeNoWaha("x".repeat(54))).toBe(true);
+    expect(nomeDaSessaoCabeNoWaha("x".repeat(55))).toBe(false);
+  });
+  it("o formato antigo do banco (69) passava do teto; o de hoje (45) não", () => {
+    const antigo = `org_${ORG.replaceAll("-", "")}_${ORG.replaceAll("-", "")}`;
+    const hoje = `org_${ORG.replaceAll("-", "").slice(0, 8)}_${ORG.replaceAll("-", "")}`;
+    expect(antigo).toHaveLength(69);
+    expect(nomeDaSessaoCabeNoWaha(antigo)).toBe(false);
+    expect(hoje).toHaveLength(45);
+    expect(nomeDaSessaoCabeNoWaha(hoje)).toBe(true);
+  });
+  it("nenhuma superfície monta o nome à mão — a fonte é uma só", () => {
+    const arquivos = [...varrer(join(RAIZ, "app")), ...varrer(join(RAIZ, "lib"))];
+    // a varredura só vale alguma coisa se tiver varrido a árvore de verdade
+    expect(arquivos.length).toBeGreaterThan(200);
+    expect(arquivos.some((a) => a.endsWith(join("app", "onboarding", "connect-whatsapp", "page.tsx")))).toBe(true);
+    const permitido = (a: string) => a.endsWith(AJUDANTE) || Object.keys(EXCECOES).some((e) => a.endsWith(e));
+    expect(arquivos.filter((a) => !permitido(a) && MONTAGEM_A_MAO.test(readFileSync(a, "utf8")))).toEqual([]);
+  });
+  it("as duas superfícies derivam do helper", () => {
+    const tela = readFileSync(join(RAIZ, "app", "onboarding", "connect-whatsapp", "page.tsx"), "utf8");
+    const sessao = readFileSync(join(RAIZ, "lib", "channels", "onboarding-session.ts"), "utf8");
+    expect(tela).toContain("nomeCurtoDaSessao(activeOrg.orgId)");
+    expect(sessao).toContain("nomeCurtoDaSessao(organizationId)");
+  });
+});


### PR DESCRIPTION
# O que este PR faz

O nome da sessão que o CRM manda para o WAHA passa a nascer em **um único lugar**, e o CRM confere o teto de 54 caracteres do WAHA **antes** de falar com o transporte.

Antes, esse nome saía de dois lugares que ninguém comparava: o onboarding montava `org_${orgId.slice(0,8)}` à mão, num arquivo, e o botão **"Conectar novo WhatsApp"** (Central de Conexões) usava o nome vindo do banco — sem que nenhuma superfície conhecesse o limite do WAHA. Um nome acima de 54 caracteres só se revelava como o `400 name must be shorter than or equal to 54 characters` do WAHA **no meio do fluxo**, com a reserva já feita: a sessão nunca era criada do outro lado (o `GET /api/sessions` do WAHA devolvia `[]`) e o card ficava preso em `Parado`, dizendo "Não foi possível concluir a conexão. Abra Conexões para tentar novamente ou reparar o número.".

Closes #667

## Como resolve

- **`lib/channels/nome-da-sessao.ts` (novo)** — fonte única do formato curto (`nomeCurtoDaSessao`, 12 caracteres) e da conferência do teto (`TETO_NOME_DE_SESSAO_WAHA = 54`, `nomeDaSessaoCabeNoWaha`). O prefixo `org_` é contrato: `lib/channels/onboarding-session.ts` procura exatamente essa string para achar a linha legada da organização.
- **`app/onboarding/connect-whatsapp/page.tsx`** e **`lib/channels/onboarding-session.ts`** passam a derivar do helper — o comportamento não muda: o formato é o mesmo de antes, byte a byte.
- **`lib/channels/connect-waha.ts`** — confere o teto **antes** de qualquer chamada ao transporte. Acima dele: fecha a reserva em `FAILED` (`session_name_too_long`) e lança `connection_session_name_too_long` (409) com nome, comprimento e teto em `technical`. O transporte não é tocado (nem `stopSession`), então **nada é criado do outro lado** — em vez de um 400 opaco no meio do fluxo.
- **As duas rotas** que traduzem `ChannelConnectionError` (`app/api/v1/channel-sessions/route.ts` e `app/api/v1/onboarding/whatsapp/session/route.ts`) ganham a mensagem desse caso: o operador lê o limite, e não um erro de comunicação genérico.

Este PR **não** mexe na função do banco (`fn_reserve_channel_connection`): o `main` já gera o formato de 45 caracteres (migration `0232`). O que faltava era a superfície de Conexões deixar de depender de duas fontes e o CRM conhecer o teto.

## O que medi (comandos e saídas)

**Testes focados** — `pnpm exec vitest run lib/channels/connect-waha.test.ts tests/unit/nome-da-sessao-do-waha.test.ts` → `Test Files 2 passed (2)` / `Tests 16 passed (16)`, exit 0.

São 3 casos novos no caminho de Conexões (nome de 69 caracteres morre no CRM com motivo e sem tocar no transporte; 54 exatos e 45 do banco seguem pelo caminho normal) e 6 casos novos no invariante: o teto é 54, o limite é inclusivo (54 cabe, 55 não), o formato antigo (69) e o de hoje (45), e uma varredura de fonte que reprova qualquer superfície que volte a montar o nome à mão.

**Sabotagem** (depois do commit; previsão escrita antes de rodar: **1 vermelho de 16**, e era o previsto): `git checkout HEAD~1 -- lib/channels/connect-waha.ts` → `Tests 1 failed | 15 passed (16)`. O vermelho é `nome acima do teto morre no CRM, com motivo, sem chegar ao transporte`, com `promise resolved "{ channel: {...}, replay: false }" instead of rejecting` — sem a guarda, o nome de 69 caracteres atravessa o fluxo inteiro. Restaurado com `git checkout HEAD -- lib/channels/connect-waha.ts` (hash do arquivo = blob do commit; `git status` limpo).

**Gates** (um pesado por vez, `flock` + `systemd-run --scope -p MemoryMax=5G`):

| gate | resultado |
|---|---|
| `pnpm typecheck` | **rc=0** — `tsc --noEmit -p tsconfig.typecheck.json`, sem saída |
| `pnpm lint` | **rc=0** — `✖ 349 problems (0 errors, 349 warnings)`; nenhum aviso nos arquivos tocados |
| `pnpm lint:channels` | **rc=0** — `lint-channels: ok (62 arquivos de dívida conhecida, nenhum novo)` |
| `pnpm release:conferir` | **rc=0** — `.changes/nome-da-sessao-nao-passa-do-teto-do-waha.md` → `1.20.0 + patch = 1.20.1 (1 fragmento(s))` |

## O que NÃO medi

- **`pnpm test:unit` (suíte completa), `pnpm build`, `pnpm test:db`, `pnpm test:shell`** — não rodei localmente; o CI (`verify`, `build-and-size`, `invariants`, `e2e`, `imagens-ok`) é a medição delas neste PR. Não toquei schema/RLS nem `hostgator-setup-kit/`.
- **Prova em tela (`test:e2e`)** — não há instalação viva/Docker aqui; o clique em Conexões não foi exercitado por mim.
- **WAHA real** — não repeti o `POST /api/sessions` contra um WAHA de verdade: o `400 ... 54 characters` e o `GET /api/sessions` vazio estão citados do corpo da #667, não reproduzidos nestas máquinas.
- **Rota de voz (`app/api/v1/voice/sessions/pair/route.ts`)** monta o mesmo formato curto à mão para o **WaCalls** (não WAHA) e fica declarada como exceção da varredura, com o motivo escrito no teste: 12 caracteres desde sempre, sem o defeito desta issue.
