### PR TITLE
fix(conexoes): a proteção de envio abre depois de mexer nos canais — e o painel deixa de morrer mudo

### DIFF
--- a/.changes/protecao-de-envio-abre-e-avisa.md
+++ b/.changes/protecao-de-envio-abre-e-avisa.md
@@ -1,0 +1,11 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Proteção de envio abre depois de mexer nos canais — e nunca mais em silêncio
+---
+
+Quem criava, reconectava ou excluía uma conexão e logo abria a **Proteção de envio** encontrava o painel sem os dados daquela conexão. A lista de conexões era atualizada, mas a ficha de limites anti-ban (`pacing-knobs`) ficava com o cache velho. As duas andam juntas — agora qualquer mexida nos canais invalida as duas, e o painel abre com os números certos.
+
+Pior era o outro lado: quando a conexão já não estava mais na lista (excluída em outra aba ou máquina), o painel simplesmente **não aparecia** e o botão morria mudo. Agora a mesma folha abre com uma mensagem honesta — a proteção desta conexão não pôde ser carregada, ela pode ter sido removida ou a lista está desatualizada — e duas saídas: **Tentar de novo**, que recarrega a lista (quando a conexão reaparece, o formulário volta sozinho), e **Fechar**.
+
+Nada muda para quem abre a proteção de uma conexão que está na lista: o painel é o mesmo de sempre.

--- a/components/connections/AntiBanSheet.tsx
+++ b/components/connections/AntiBanSheet.tsx
@@ -6,6 +6,7 @@
  * mostra o valor); preenchido = override desta conexão.
  */
 import { useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { FUSOS_OFERECIDOS } from "@/lib/tempo/fusos";
 import { toast } from "sonner";
 
@@ -73,6 +74,7 @@ const msOrNull = (s: string): number | null =>
 export function AntiBanSheet({ item, canWrite, onClose }: Props) {
   const t = useT();
   const update = useUpdatePacingKnobs();
+  const qc = useQueryClient();
   const [form, setForm] = useState<FormState | null>(null);
 
   useEffect(() => {
@@ -87,7 +89,46 @@ export function AntiBanSheet({ item, canWrite, onClose }: Props) {
     return nomeDoCanal(item.channel_session, t);
   }, [item, t]);
 
-  if (!item || !form) return null;
+  // Duas saídas mudas moravam aqui, e as duas mentiam. `item` nulo NÃO é "painel
+  // fechado": o painel só é montado quando alguém o abre (ConnectionsClient), então
+  // item nulo significa que a conexão pedida sumiu da lista — excluída em outra aba
+  // ou máquina, cache velho — e o botão morria sem dizer nada, exatamente o
+  // `return` mudo que o Sistema Vivo proíbe. Virou estado visível, com caminho de
+  // volta: "Tentar de novo" invalida `pacing-knobs`; quando o item reaparecer, o
+  // efeito acima re-hidrata o formulário e o painel normal assume. Já `form` nulo é
+  // só o frame transitório entre o item chegar e a hidratação rodar (um render) —
+  // pintar o formulário nesse instante é que seria mentira. Por isso `!form`
+  // continua mudo, e só ele.
+  if (!item) {
+    return (
+      <Sheet open onOpenChange={(open) => !open && onClose()}>
+        <SheetContent className="flex w-full flex-col gap-0 overflow-y-auto sm:max-w-md">
+          <SheetHeader>
+            <SheetTitle>{t("Proteção de envio")}</SheetTitle>
+            <SheetDescription data-testid="anti-ban-indisponivel">
+              {t(
+                "Não foi possível carregar a proteção de envio desta conexão. Ela pode ter sido removida, ou esta lista está desatualizada.",
+              )}
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="mt-auto flex justify-end gap-2 border-t border-border px-4 py-3">
+            <Button variant="ghost" onClick={onClose}>
+              {t("Fechar")}
+            </Button>
+            <Button
+              onClick={() => void qc.invalidateQueries({ queryKey: ["pacing-knobs"] })}
+              data-testid="anti-ban-tentar-de-novo"
+            >
+              {t("Tentar de novo")}
+            </Button>
+          </div>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  if (!form) return null;
   const eff = item.effective;
   const set = (patch: Partial<FormState>) => setForm((f) => (f ? { ...f, ...patch } : f));
 

--- a/components/connections/ConnectionsClient.tsx
+++ b/components/connections/ConnectionsClient.tsx
@@ -125,10 +125,15 @@ export function ConnectionsClient({ wahaConfigured }: { wahaConfigured: boolean 
   const [toDelete, setToDelete] = useState<ChannelSession | null>(null);
   const pacingItems = usePacingKnobs().data?.items ?? [];
 
-  const invalidate = useCallback(
-    () => qc.invalidateQueries({ queryKey: ["channel-sessions"] }),
-    [qc],
-  );
+  // Mexer nos canais (criar, excluir, reconectar, health check) muda a LISTA de
+  // conexões — e a ficha de Proteção de envio (`pacing-knobs`) é indexada por
+  // ela. Invalidando só a primeira, a ficha ficava velha: o painel abria sem os
+  // dados da conexão recém-criada (ou apontando para a excluída). As duas
+  // listas andam juntas.
+  const invalidate = useCallback(() => {
+    void qc.invalidateQueries({ queryKey: ["channel-sessions"] });
+    void qc.invalidateQueries({ queryKey: ["pacing-knobs"] });
+  }, [qc]);
 
   // Health check ao vivo de todos os canais — consulta o WAHA e grava
   // last_health_check_at. É a verificação de saúde de verdade (o status do DB
@@ -400,11 +405,16 @@ export function ConnectionsClient({ wahaConfigured }: { wahaConfigured: boolean 
         </div>
       )}
 
-      <AntiBanSheet
-        item={pacingItems.find((i) => i.channel_session.id === antiBanId) ?? null}
-        canWrite
-        onClose={() => setAntiBanId(null)}
-      />
+      {/* Só monta quando alguém pediu para abrir: assim o AntiBanSheet distingue
+          "painel fechado" de "a conexão pedida sumiu da lista" — o segundo caso
+          vira estado visível ali dentro, não um painel mudo. */}
+      {antiBanId !== null && (
+        <AntiBanSheet
+          item={pacingItems.find((i) => i.channel_session.id === antiBanId) ?? null}
+          canWrite
+          onClose={() => setAntiBanId(null)}
+        />
+      )}
 
       {toDelete && (
         <ExcluirCanalDialog

--- a/lib/i18n/dicionario.ts
+++ b/lib/i18n/dicionario.ts
@@ -3582,6 +3582,7 @@ export const DICIONARIO: Traducoes = {
   "roteadores de IA": { es: "enrutadores de IA" },
   "ajuste de proteção de envio": { es: "ajuste de protección de envío" },
   "ajustes de proteção de envio": { es: "ajustes de protección de envío" },
+  "Não foi possível carregar a proteção de envio desta conexão. Ela pode ter sido removida, ou esta lista está desatualizada.": { es: "No se pudo cargar la protección de envío de esta conexión. Puede que se haya eliminado, o esta lista está desactualizada." },
   "conversa continua": { es: "conversación continúa" },
   "conversas continuam": { es: "conversaciones continúan" },
 

--- a/tests/unit/protecao-de-envio-abre-e-avisa.test.tsx
+++ b/tests/unit/protecao-de-envio-abre-e-avisa.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * Issue #669 — "Proteção de envio" abria depois de mexer nos canais sem os
+ * dados (cache velho) e, quando a conexão pedida já não estava na lista, o
+ * botão morria mudo.
+ *
+ * Prova 1 (comportamento): TODOS os caminhos que mexem nos canais — criar,
+ * excluir, reconectar e o health check — passam pelo MESMO `invalidate` do
+ * ConnectionsClient. Este teste dispara o funil pelo health check inicial e
+ * exige, com spy no queryClient, as DUAS chaves: `channel-sessions` (a lista)
+ * e `pacing-knobs` (a ficha que o painel lê). Sem a segunda, vermelho.
+ *
+ * Prova 2 (comportamento): com item nulo — conexão excluída em outra
+ * aba/máquina, lista velha — o AntiBanSheet mostra estado visível (mensagem
+ * honesta + "Tentar de novo", que invalida `pacing-knobs`, + "Fechar") em vez
+ * de sumir; quando a lista volta com a conexão, o formulário hidrata.
+ * Controle: com o item presente, o painel normal aparece e o aviso não.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+import type * as CanaisModule from "@/hooks/channels/useChannelSessions";
+import type { ChannelSession } from "@/hooks/channels/useChannelSessions";
+import type { PacingKnobs } from "@/lib/agent-engine/pacing/defaults";
+import type { PacingKnobsItem } from "@/hooks/channels/usePacingKnobs";
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+const deleteMock = vi.fn();
+vi.mock("@/lib/api/client", () => ({
+  apiClient: {
+    get: (...a: unknown[]) => getMock(...a),
+    post: (...a: unknown[]) => postMock(...a),
+    delete: (...a: unknown[]) => deleteMock(...a),
+  },
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+// A lista de pacing é dublada de propósito — o teste escolhe o que o painel vê
+// ("lista velha" = sem a conexão) e o funil de invalidação continua observável
+// pelo spy no queryClient, que é a asserção.
+const pacing = vi.hoisted(() => ({ lista: [] as PacingKnobsItem[], update: vi.fn() }));
+vi.mock("@/hooks/channels/usePacingKnobs", () => ({
+  usePacingKnobs: () => ({ data: { items: pacing.lista } }),
+  useUpdatePacingKnobs: () => ({ mutateAsync: pacing.update, isPending: false }),
+}));
+
+const listagem: {
+  data: ChannelSession[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  schemaOutdated: boolean;
+} = { data: [], isLoading: false, isError: false, schemaOutdated: false };
+
+// Só a listagem é dublada: `channelLabel`/`deriveOverallHealth` reais são o que
+// os cartões mostram (mesmo molde de conexoes-excluir-canal.test.tsx).
+vi.mock("@/hooks/channels/useChannelSessions", async (original) => {
+  const real = await original<typeof CanaisModule>();
+  return { ...real, useChannelSessions: () => listagem };
+});
+
+import { ConnectionsClient } from "@/components/connections/ConnectionsClient";
+import { AntiBanSheet } from "@/components/connections/AntiBanSheet";
+
+function canal(over: Partial<ChannelSession> = {}): ChannelSession {
+  return {
+    id: "canal-1",
+    waha_session_name: "org_1111_aaa",
+    display_name: "Vendas",
+    phone_number: "5511999999999",
+    status: "WORKING",
+    status_reason: null,
+    last_health_check_at: null,
+    last_status_change_at: null,
+    daily_message_limit: 250,
+    is_warmup_complete: null,
+    created_at: "2026-08-01T00:00:00Z",
+    ...over,
+  };
+}
+
+const KNOBS: PacingKnobs = {
+  throttleMs: 1_200,
+  jitterMaxMs: 800,
+  windowStartHour: 7,
+  windowEndHour: 22,
+  allowSunday: true,
+  timezone: "America/Sao_Paulo",
+  warmupDailyCaps: [
+    { minAgeDays: 0, cap: 20 },
+    { minAgeDays: 7, cap: 60 },
+    { minAgeDays: 30, cap: null },
+  ],
+};
+
+function itemDePacing(over: Partial<PacingKnobsItem> = {}): PacingKnobsItem {
+  return {
+    channel_session: {
+      id: "canal-1",
+      waha_session_name: "org_1111_aaa",
+      display_name: "Vendas",
+      phone_number: "5511999999999",
+      status: "WORKING",
+      daily_message_limit: 250,
+    },
+    effective: KNOBS,
+    warmup: { number_activated_at: null, age_days: 0, skipped: false, cap_today: 20 },
+    overrides: null,
+    defaults: KNOBS,
+    bounds: {
+      intervalMaxMs: 600_000,
+      hourLastStart: 23,
+      hourEnd: 24,
+      daily_limit: { min: 1, max: 2_000 },
+    },
+    ...over,
+  };
+}
+
+function novoCliente() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function wrap(ui: ReactNode, qc: QueryClient = novoCliente()) {
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  getMock.mockReset();
+  postMock.mockReset();
+  deleteMock.mockReset();
+  pacing.lista = [];
+  pacing.update.mockReset();
+  listagem.data = [];
+  listagem.isLoading = false;
+  listagem.isError = false;
+  listagem.schemaOutdated = false;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("#669 — mexer nos canais invalida AS DUAS listas", () => {
+  it("o funil único (por onde passam criar/excluir/reconectar/health check) invalida channel-sessions e pacing-knobs", async () => {
+    listagem.data = [canal()];
+    const qc = novoCliente();
+    const invalidar = vi.spyOn(qc, "invalidateQueries");
+
+    render(wrap(<ConnectionsClient wahaConfigured />, qc));
+
+    await waitFor(() =>
+      expect(invalidar).toHaveBeenCalledWith({ queryKey: ["pacing-knobs"] }),
+    );
+    expect(invalidar).toHaveBeenCalledWith({ queryKey: ["channel-sessions"] });
+  });
+});
+
+describe("#669 — painel não morre mudo quando a conexão sumiu da lista", () => {
+  it("com item nulo o painel abre com aviso honesto e as duas saídas, não em branco", () => {
+    render(wrap(<AntiBanSheet item={null} canWrite onClose={vi.fn()} />));
+
+    expect(screen.getByTestId("anti-ban-indisponivel")).toHaveTextContent(
+      /pode ter sido removida/,
+    );
+    expect(screen.getByRole("button", { name: "Tentar de novo" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Fechar" })).toBeInTheDocument();
+    expect(screen.queryByTestId("anti-ban-form")).toBeNull();
+  });
+
+  it("'Tentar de novo' invalida pacing-knobs; 'Fechar' fecha", async () => {
+    const qc = novoCliente();
+    const invalidar = vi.spyOn(qc, "invalidateQueries");
+    const onClose = vi.fn();
+
+    render(wrap(<AntiBanSheet item={null} canWrite onClose={onClose} />, qc));
+
+    fireEvent.click(screen.getByTestId("anti-ban-tentar-de-novo"));
+    await waitFor(() =>
+      expect(invalidar).toHaveBeenCalledWith({ queryKey: ["pacing-knobs"] }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Fechar" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("quando a lista volta com a conexão, o formulário hidrata e o painel normal assume", async () => {
+    const qc = novoCliente();
+    const onClose = vi.fn();
+    const { rerender } = render(
+      wrap(<AntiBanSheet item={null} canWrite onClose={onClose} />, qc),
+    );
+    expect(screen.queryByTestId("anti-ban-form")).toBeNull();
+
+    rerender(wrap(<AntiBanSheet item={itemDePacing()} canWrite onClose={onClose} />, qc));
+
+    expect(await screen.findByTestId("anti-ban-form")).toBeInTheDocument();
+    expect(screen.queryByTestId("anti-ban-indisponivel")).toBeNull();
+  });
+
+  it("controle: com a conexão na lista, o painel normal aparece e o aviso NÃO", async () => {
+    render(wrap(<AntiBanSheet item={itemDePacing()} canWrite onClose={vi.fn()} />));
+
+    expect(await screen.findByTestId("anti-ban-form")).toBeInTheDocument();
+    expect(screen.getByText(/Proteção de envio —/)).toBeInTheDocument();
+    expect(screen.queryByTestId("anti-ban-indisponivel")).toBeNull();
+  });
+
+  it("ponta a ponta: clicar em 'Proteção de envio' com a lista velha mostra o aviso, não o silêncio", async () => {
+    listagem.data = [canal()];
+    pacing.lista = []; // lista velha: a conexão existe, a ficha de pacing não chegou
+
+    render(wrap(<ConnectionsClient wahaConfigured />));
+
+    // Antes de abrir, nada de painel fantasma (o Sheet só monta quando pedido).
+    expect(screen.queryByTestId("anti-ban-indisponivel")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Proteção de envio/ }));
+
+    expect(await screen.findByTestId("anti-ban-indisponivel")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Tentar de novo" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# O que este PR faz

Depois de criar, excluir ou reconectar um canal na mesma visita, o painel **"Proteção de envio"** volta a abrir; e quando a conexão some da lista, ele abre com um aviso honesto em vez de morrer mudo.

Antes: o funil único de invalidação (`invalidate`) invalidava só `["channel-sessions"]`, então o cache de `pacing-knobs` ficava velho e o painel abria sem os dados da conexão; e o `<AntiBanSheet>` era montado sempre, com `if (!item || !form) return null` — "painel fechado" e "conexão sumiu da lista" davam no mesmo silêncio: nada abria, nada explicava.

Closes #669

## Como resolve

- `components/connections/ConnectionsClient.tsx` — o callback `invalidate` (por onde passam criar, excluir, reconectar e o health check) invalida `["channel-sessions"]` **e** `["pacing-knobs"]`; e o `<AntiBanSheet>` só é montado quando `antiBanId` está setado, para "painel fechado" e "conexão sumiu da lista" deixarem de ser a mesma coisa.
- `components/connections/AntiBanSheet.tsx` — com `item` nulo a MESMA folha abre com título, mensagem honesta ("não foi possível carregar a proteção desta conexão; ela pode ter sido removida, ou esta lista está desatualizada") e as saídas **Tentar de novo** (invalida `pacing-knobs`; quando o item aparece, o `useEffect` existente hidrata o formulário e o painel normal assume) e **Fechar**. O `!form` segue mudo de propósito: é o frame transitório de hidratação.

## O que medi (comandos e saídas)

**Testes focados** — `pnpm exec vitest run tests/unit/protecao-de-envio-abre-e-avisa.test.tsx` → **6 passed (6)**, rc=0, 4,88s. Com os vizinhos (`conexoes-excluir-canal`, `protecao-de-envio-aceita-data-em-branco`, `anti-ban-nao-congela-o-padrao`, `fuso-horario`): **5 files passed, 47 passed (47)**, rc=0.

Os testes são de comportamento (React Testing Library + `QueryClientProvider`), não guarda de fonte: a prova 1 usa spy em `queryClient.invalidateQueries` exigindo as DUAS chaves; a prova 2 renderiza o `AntiBanSheet` com `item=null` e exige a mensagem e o botão "Tentar de novo"; há controle do fluxo normal (item presente) e um caso ponta a ponta pelo cartão da conexão no `ConnectionsClient`.

**Sabotagem** (depois do commit; previsão escrita antes de rodar: **4 vermelhos de 6**, e eram os previstos): `git checkout HEAD~1 -- components/connections/ConnectionsClient.tsx components/connections/AntiBanSheet.tsx` → **Tests 4 failed | 2 passed (6)**. Restaurado com `git checkout HEAD -- <os dois>` → 6/6 verdes de novo e `git status` limpo.

**Gates** — `eslint` nos 3 arquivos tocados **rc=0**, com 1 warning pré-existente (`react-hooks/set-state-in-effect` no `useEffect` antigo do `AntiBanSheet`, confirmado idêntico no HEAD) — nenhum warning novo, nada silenciado e nada refatorado fora do escopo; e a fila local completa (um pesado por vez — `flock` + `systemd-run --scope -p MemoryMax=5G`):

| gate | resultado |
|---|---|
| `pnpm typecheck` | **rc=0** (12s) |
| `pnpm lint` | **rc=0** (3.159s) |
| `pnpm lint:channels` | **rc=0** (2s) |
| `pnpm lint:role-rank` | **rc=0** (1s) |
| `pnpm release:conferir` | **rc=0** (1s) |
| `pnpm test:unit` | **rc=0** (444s) — 792 arquivos · **8.369 passed** (+ 1 *expected fail*) |
| `pnpm test:shell` | **rc=0** (58s) |
| `pnpm build` | **rc=0** (128s) |

Nota honesta da primeira passada: a rodada inicial do `test:unit` pegou a catraca de i18n — a frase nova do painel estava sem a entrada em `lib/i18n/dicionario.ts` (**1 failed | 8.368 passed**). A tradução entrou no mesmo branch (commit `d0def504`) e a re-rodada fechou limpa.

## O que NÃO medi

- **e2e de navegador / prova em tela** — a prova é unitária (jsdom + Testing Library) no call-site; o painel no browser real não foi filmado.
- **`tests/invariants/**`** — precisa de Postgres/Docker, fora do include do vitest focado.
