### PR TITLE
fix(rag): trecho que não grava derruba a indexação em vez de ativar versão furada

### DIFF
--- a/.changes/rag-nao-ativa-versao-incompleta.md
+++ b/.changes/rag-nao-ativa-versao-incompleta.md
@@ -1,0 +1,25 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: O indexador RAG para de ativar versão com trechos faltando
+---
+
+Ao reindexar uma fonte de conhecimento (uma FAQ, um documento, o catálogo), cada
+trecho do material é gravado um a um. Quando a gravação de um trecho falhava, o
+erro ia só para o log do servidor e a indexação seguia em frente: bastava que
+algum outro trecho tivesse gravado para a versão nova ser dada como pronta e
+entrar no ar. Quem conversava com o agente passava a receber respostas apoiadas
+num acervo furado, e a versão anterior, completa, saía de cena sem aviso — a
+pessoa só descobria o buraco ao perguntar exatamente o que faltou.
+
+Agora falha de gravação derruba a indexação inteira. Se qualquer trecho não
+gravar, a versão nova é registrada como falha, com o motivo (quantos trechos
+faltaram e em quais posições), e a versão anterior continua ativa e respondendo.
+O registro da falha também aponta o detalhe `trechos_nao_gravados:N`, para a
+triagem dizer de bate-pronto se o problema foi parcial. Quando nada grava, o
+detalhe segue sendo o `nenhum_trecho_gravado` de sempre.
+
+Não muda nada quando tudo grava: a versão nova é marcada como pronta e ativada
+como antes, e o caminho de erro de embedding (chave ausente ou provedor
+recusando) continua igual, derrubando a indexação sem ativar. Quem nunca viu um
+buraco no índice não vê diferença nenhuma.

--- a/tests/unit/rag-nao-ativa-versao-incompleta.test.ts
+++ b/tests/unit/rag-nao-ativa-versao-incompleta.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { indexarFonte } from "@/workers/rag-indexer";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { embedText } from "@/lib/ai/embed";
+import {
+  activateVersion,
+  createKnowledgeVersion,
+  markVersionFailed,
+  markVersionReady,
+} from "@/lib/ai/rag/version";
+
+/**
+ * FALHA PARCIAL NÃO ATIVA VERSÃO (issue #675).
+ *
+ * O caminho medido: numa FAQ com dois trechos, o upsert do segundo voltava com
+ * `error` e isso só virava `console.warn`. Como `gravados` era 1 (> 0), o fim do
+ * laço chamava `markVersionReady` + `activateVersion`, e o índice entrava no ar
+ * com um buraco — quem perguntasse exatamente o que faltou recebia "não sei",
+ * com a versão carimbada como pronta. O aviso só existia quando NADA gravava.
+ *
+ * O contrato que estes testes travam: qualquer trecho não gravado é falha
+ * explícita — `markVersionFailed` com o motivo, retorno `tipo: "erro"`, detalhe
+ * `trechos_nao_gravados:N` (ou o `nenhum_trecho_gravado` de sempre quando não
+ * gravou nenhum), e nem `markVersionReady` nem `activateVersion` são chamados,
+ * então a versão anterior segue ativa.
+ */
+
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
+vi.mock("@/lib/ai/embed", () => ({
+  embedText: vi.fn(),
+  SemChaveDeEmbeddingError: class SemChaveDeEmbeddingError extends Error {},
+}));
+vi.mock("@/lib/ai/embeddings/chave", () => ({ resolverChaveDeEmbedding: vi.fn() }));
+vi.mock("@/lib/ai/rag/debounce", () => ({ acquireDebounce: vi.fn() }));
+// O documento puxa os extratores (pdf); o caminho exercitado aqui é o de FAQ.
+vi.mock("@/lib/ai/rag/ingest/documento", () => ({
+  extrairTextoDoArquivo: vi.fn(),
+  ErroDeExtracao: class ErroDeExtracao extends Error {},
+}));
+vi.mock("@/lib/ai/rag/version", () => ({
+  createKnowledgeVersion: vi.fn(),
+  markVersionReady: vi.fn(),
+  markVersionFailed: vi.fn(),
+  activateVersion: vi.fn(),
+}));
+
+const FONTE = {
+  id: "ks-1",
+  organization_id: "org-1",
+  agent_id: null,
+  source_type: "faq",
+  name: "FAQ da loja",
+  status: "ready",
+  is_active: true,
+  source_metadata: null,
+};
+
+const CHAVE = { origem: "org" };
+
+const FAQ = [
+  { question: "Qual o prazo?", answer: "Cinco dias úteis." },
+  { question: "Tem frete grátis?", answer: "Acima de cem reais." },
+];
+
+/** Mensagem de erro do upsert para cada posição; `null` = grava. */
+let falhaDeUpsert: (posicao: number) => string | null = () => null;
+/** Posições em que o `embedText` rejeita. */
+let falhaDeEmbed: Set<number> = new Set();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  falhaDeUpsert = () => null;
+  falhaDeEmbed = new Set();
+
+  vi.mocked(createAdminClient).mockReturnValue({
+    from: (tabela: string) => {
+      if (tabela === "ai_faq_items") {
+        const cadeia = {
+          select: () => cadeia,
+          eq: () => cadeia,
+          order: () => Promise.resolve({ data: FAQ, error: null }),
+        };
+        return cadeia;
+      }
+      if (tabela === "ai_chunks") {
+        return {
+          upsert: (linha: { position: number }) => {
+            const mensagem = falhaDeUpsert(linha.position);
+            return Promise.resolve(mensagem ? { error: { message: mensagem } } : { error: null });
+          },
+        };
+      }
+      throw new Error(`tabela não dublada no teste: ${tabela}`);
+    },
+  } as never);
+
+  vi.mocked(embedText).mockImplementation(async (texto: string) => {
+    const posicao = FAQ.findIndex((item) => texto.includes(item.question));
+    if (falhaDeEmbed.has(posicao)) throw new Error("quota estourou");
+    return { embedding: [0.1, 0.2, 0.3] } as never;
+  });
+
+  vi.mocked(createKnowledgeVersion).mockResolvedValue({
+    versionId: "v-2",
+    versionNumber: 2,
+  } as never);
+  vi.mocked(markVersionReady).mockResolvedValue(undefined as never);
+  vi.mocked(markVersionFailed).mockResolvedValue(undefined as never);
+  vi.mocked(activateVersion).mockResolvedValue(undefined as never);
+});
+
+describe("indexarFonte — falha parcial não ativa versão", () => {
+  it("grava os 2 trechos: ok + markVersionReady + activateVersion", async () => {
+    const resultado = await indexarFonte(FONTE as never, CHAVE as never, {});
+
+    expect(resultado).toEqual({ tipo: "ok", versionId: "v-2", chunks: 2 });
+    expect(markVersionReady).toHaveBeenCalledWith("v-2", "org-1", 2);
+    expect(activateVersion).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      knowledgeSourceId: "ks-1",
+      versionId: "v-2",
+    });
+    expect(markVersionFailed).not.toHaveBeenCalled();
+  });
+
+  it("1 de 2 trechos não grava: erro, versão falha e SEM ready/activate", async () => {
+    falhaDeUpsert = (posicao) => (posicao === 1 ? "deadlock detected" : null);
+
+    const resultado = await indexarFonte(FONTE as never, CHAVE as never, {});
+
+    expect(resultado).toEqual({ tipo: "erro", detalhe: "trechos_nao_gravados:1" });
+    expect(markVersionFailed).toHaveBeenCalledTimes(1);
+    const chamada = vi.mocked(markVersionFailed).mock.calls[0]!;
+    expect(chamada[0]).toBe("v-2");
+    expect(chamada[1]).toBe("org-1");
+    expect(chamada[2]).toContain("posição 1");
+    expect(chamada[2]).toContain("deadlock detected");
+    expect(markVersionReady).not.toHaveBeenCalled();
+    expect(activateVersion).not.toHaveBeenCalled();
+  });
+
+  it("2 de 2 trechos não gravam: erro com detalhe nenhum_trecho_gravado", async () => {
+    falhaDeUpsert = () => "permission denied";
+
+    const resultado = await indexarFonte(FONTE as never, CHAVE as never, {});
+
+    expect(resultado).toEqual({ tipo: "erro", detalhe: "nenhum_trecho_gravado" });
+    expect(markVersionFailed).toHaveBeenCalledWith("v-2", "org-1", "nenhum trecho gravado");
+    expect(markVersionReady).not.toHaveBeenCalled();
+    expect(activateVersion).not.toHaveBeenCalled();
+  });
+
+  it("embedding falha no 1º trecho: erro, versão falha e SEM ready/activate", async () => {
+    falhaDeEmbed = new Set([0]);
+
+    const resultado = await indexarFonte(FONTE as never, CHAVE as never, {});
+
+    expect(resultado).toEqual({
+      tipo: "erro",
+      detalhe: "embedding falhou no trecho 0: quota estourou",
+    });
+    expect(markVersionFailed).toHaveBeenCalledWith("v-2", "org-1", "embed@0: quota estourou");
+    expect(markVersionReady).not.toHaveBeenCalled();
+    expect(activateVersion).not.toHaveBeenCalled();
+  });
+});

--- a/workers/rag-indexer.ts
+++ b/workers/rag-indexer.ts
@@ -313,8 +313,14 @@ async function credenciaisDaLoja(
  * material antigo em vez de ficar sem material nenhum. E **nunca ativa versão
  * vazia** — trocar um acervo que funcionava por um acervo vazio é pior que a
  * indexação ter falhado.
+ *
+ * O "se algo falhar" inclui o UPSERT de um trecho: antes, o erro de gravação
+ * virava só `console.warn` e, com pelo menos um trecho gravado, a versão era
+ * marcada pronta e ativada — um índice com buracos entrava no ar sem ninguém
+ * saber. Agora qualquer trecho não gravado derruba a indexação inteira: a
+ * versão falha com o motivo e a anterior segue ativa.
  */
-async function indexarFonte(
+export async function indexarFonte(
   fonte: FonteRow,
   chave: ChaveDeEmbedding,
   extra: { productId?: string },
@@ -365,6 +371,9 @@ async function indexarFonte(
 
   const admin = createAdminClient();
   let gravados = 0;
+  // Trecho que não gravou NÃO pode seguir para a ativação: a versão fica
+  // incompleta e a anterior — que funciona — é quem deve continuar no ar.
+  const falhas: Array<{ posicao: number; mensagem: string }> = [];
 
   for (let i = 0; i < pedacos.length; i++) {
     const p = pedacos[i]!;
@@ -403,7 +412,7 @@ async function indexarFonte(
     );
 
     if (upErr) {
-      console.warn(`[rag-indexer] trecho ${i} não gravou:`, upErr.message);
+      falhas.push({ posicao: i, mensagem: upErr.message });
     } else {
       gravados++;
     }
@@ -412,6 +421,17 @@ async function indexarFonte(
   if (gravados === 0) {
     await markVersionFailed(versionId, fonte.organization_id, "nenhum trecho gravado");
     return { tipo: "erro", detalhe: "nenhum_trecho_gravado" };
+  }
+
+  if (falhas.length > 0) {
+    await markVersionFailed(
+      versionId,
+      fonte.organization_id,
+      `${falhas.length} de ${pedacos.length} trechos não gravaram: ${falhas
+        .map((f) => `posição ${f.posicao} (${f.mensagem})`)
+        .join("; ")}`,
+    );
+    return { tipo: "erro", detalhe: `trechos_nao_gravados:${falhas.length}` };
   }
 
   await markVersionReady(versionId, fonte.organization_id, gravados);


### PR DESCRIPTION
# O que este PR faz

O indexador de RAG deixa de ativar uma versão quando trechos não foram gravados: falha parcial agora derruba a indexação em vez de marcar a versão furada como pronta.

Antes, `indexarFonte` acumulava os upserts e, se **algum** trecho falhasse (sem que todos falhassem), seguia para `markVersionReady` + `activateVersion` — a versão entrava no ar faltando trecho e a falha só aparecia depois, no atendimento.

Closes #675

## Como resolve

- `workers/rag-indexer.ts` — as falhas de upsert passam a ser acumuladas: com `gravados === 0` segue `nenhum_trecho_gravado` (como antes) e com `falhas.length > 0` chama `markVersionFailed` (motivo com a posição e a mensagem de cada trecho) e devolve `{ tipo: "erro", detalhe: "trechos_nao_gravados:N" }`, **sem** `markVersionReady`/`activateVersion`. O caminho de erro de embedding fica inalterado; `indexarFonte` ganha `export` (mudança mínima, para o teste).

## O que medi (comandos e saídas)

**Testes focados** — `pnpm exec vitest run tests/unit/rag-nao-ativa-versao-incompleta.test.ts tests/unit/dreno-nao-perde-evento.test.ts` → **2 files passed / 8 tests passed**. Os 4 cenários novos: 2/2 gravados → ok + ready + activate; 1/2 falha → erro + `markVersionFailed` + sem ready/activate; 2/2 falham → `nenhum_trecho_gravado`; `embedText` rejeitando no 1º trecho → erro + `markVersionFailed`.

**Sabotagem** (depois do commit, em duas variantes):

1. Revertendo `workers/rag-indexer.ts` inteiro → **4 failed | 4 passed**: o vermelho vem de `TypeError: indexarFonte is not a function` nos 4 cenários, porque o revert também tira o `export` que o teste novo importa.
2. **Cirúrgica** (devolvendo só o `export`, guarda ainda ausente) → **1 failed | 7 passed**, com o cenário do meio mostrando o bug ao vivo: esperava `{tipo:"erro"}`, recebeu `{tipo:"ok", chunks:1, versionId:"v-2"}` — versão ativada com trecho faltando.

Restaurado com `git checkout HEAD -- workers/rag-indexer.ts` → `git status` limpo e 8/8 verdes de novo.

**Gates** — `eslint --max-warnings=0` nos 2 arquivos **rc=0** nas medições focadas; `release:conferir` **rc=0** (fragmento `.changes/rag-nao-ativa-versao-incompleta.md`); e a fila local completa (um pesado por vez — `flock` + `systemd-run --scope -p MemoryMax=5G`):

| gate | resultado |
|---|---|
| `pnpm typecheck` | **rc=0** (10s) |
| `pnpm lint` | **rc=0** (re-rodada — ver nota) |
| `pnpm lint:channels` | **rc=0** (2s) |
| `pnpm lint:role-rank` | **rc=0** (2s) |
| `pnpm release:conferir` | **rc=0** (1s) |
| `pnpm test:unit` | **rc=0** (481s) — 792 arquivos · 8.367 provas (+ 1 *expected fail*) |
| `pnpm test:shell` | **rc=0** (58s) |
| `pnpm build` | **rc=0** (157s) |

Nota honesta das primeiras passadas: o primeiro `lint` da fila foi interrompido por SIGTERM (rc=143) após travar em espera de I/O (estado `D`, máquina com dois lotes de gate concorrentes) — re-rodado: **rc=0**, 0 *errors* (os avisos são pré-existentes do repo). O primeiro `test:unit` fechou rc=1 com todas as **8.363 provas verdes** (o único erro foi `[vitest-pool]: Timeout starting forks runner`, infraestrutura). As re-rodadas estão na tabela acima.

## O que NÃO medi

- **e2e / prova em tela** — não se aplica (mudança de worker); nada foi filmado.
- **`tests/invariants/**`** — precisa de Postgres/Docker, fora do include do vitest focado.
- **Indexação real com provider de embedding de verdade** — os testes usam dublês, como os vizinhos do arquivo.
