### PR TITLE
fix(followup): grafo corrompido deixa de passar no schema (#699)

### DIFF
--- a/.changes/grafo-corrompido-nao-passa.md
+++ b/.changes/grafo-corrompido-nao-passa.md
@@ -1,0 +1,11 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Grafo corrompido deixa de passar no schema
+---
+
+O schema do fluxo validava cada nó e cada aresta isoladamente, então um grafo corrompido passava no salvamento: aresta apontando para nó que não existe mais (o estrago que o editor produz ao excluir um nó), dois nós com o mesmo id e duas arestas com o mesmo id. O `flowGraphSchema` agora tem uma catraca de integridade que rejeita os três casos com mensagem explícita dizendo o id a corrigir — `aresta "e-3" aponta para nó inexistente: "no-9"`, `id de nó repetido: "no-1"`, `id de aresta repetido: "e-2"`.
+
+Esses grafos só quebravam longe do defeito: no meio de um disparo, quando uma aresta não resolvia para nó nenhum. Como salvar o rascunho e carregar a versão usam a mesma porta, o erro passa a aparecer na hora de salvar, com o id na mensagem, em vez de virar um caso de suporte.
+
+Quem já tem rascunho corrompido passa a ver o erro ao abrir e salvar o fluxo e precisa corrigir a aresta — não há migração automática, decisão registrada na issue #699. Grafo íntegro e campo desconhecido seguem como antes, com controle nos testes.

--- a/lib/followup/graph-schema.test.ts
+++ b/lib/followup/graph-schema.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
   NODE_TYPES,
-  NodeType,
   waitConfigSchema,
   aiClassifyConfigSchema,
   matchReplyConfigSchema,
@@ -11,9 +10,6 @@ import {
   flowNodeSchema,
   flowEdgeSchema,
   flowGraphSchema,
-  FlowGraph,
-  FlowNode,
-  FlowEdge,
   FALLBACK_BRANCH_ID,
   NO_REPLY_BRANCH_ID,
   CONDITION_TRUE_BRANCH_ID,
@@ -23,6 +19,7 @@ import {
   branchIdForCondition,
   conditionForBranch,
 } from './graph-schema';
+import type { NodeType, FlowGraph, FlowNode, FlowEdge } from './graph-schema';
 import { toReactFlow, fromReactFlow } from './graph-mappers';
 
 describe('graph-schema', () => {
@@ -933,6 +930,93 @@ describe('graph-schema', () => {
         extra_key: 'should reject',
       });
       expect(result.success).toBe(false);
+    });
+
+    /**
+     * Integridade ENTRE nós e arestas (#699). Cada peça passava no schema
+     * sozinha — quem montava o grafo (o canvas, ao excluir um nó) produzia
+     * aresta órfã e ids repetidos que só quebravam longe do defeito. Aqui o
+     * contrato é de fora: rejeitar com o id a corrigir na mensagem.
+     */
+    describe('integridade: aresta órfã e ids repetidos (#699)', () => {
+      const noTrigger = (id: string) => ({
+        id,
+        type: 'trigger' as const,
+        label: 'Start',
+        position: { x: 0, y: 0 },
+        config: {},
+      });
+      const noEnd = (id: string) => ({
+        id,
+        type: 'end' as const,
+        label: 'End',
+        position: { x: 100, y: 100 },
+        config: { outcome: 'converted' as const },
+      });
+      const aresta = (id: string, source: string, target: string) => ({
+        id,
+        source,
+        target,
+        condition: { type: 'always' as const },
+      });
+
+      /** [] quando o grafo passou — a asserção de mensagem falha em vez de pular. */
+      function mensagensDe(resultado: ReturnType<typeof flowGraphSchema.safeParse>): string[] {
+        return resultado.success ? [] : resultado.error.issues.map((i) => i.message);
+      }
+
+      it('aceita grafo íntegro com aresta ligando dois nós existentes (controle)', () => {
+        const result = flowGraphSchema.safeParse({
+          nodes: [noTrigger('no-1'), noEnd('no-2')],
+          edges: [aresta('e-1', 'no-1', 'no-2')],
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('rejeita aresta cujo source aponta para nó inexistente', () => {
+        const result = flowGraphSchema.safeParse({
+          nodes: [noTrigger('no-1'), noEnd('no-2')],
+          edges: [aresta('e-3', 'no-9', 'no-2')],
+        });
+        expect(result.success).toBe(false);
+        expect(mensagensDe(result)).toContain('aresta "e-3" aponta para nó inexistente: "no-9"');
+      });
+
+      it('rejeita aresta cujo target aponta para nó inexistente', () => {
+        const result = flowGraphSchema.safeParse({
+          nodes: [noTrigger('no-1'), noEnd('no-2')],
+          edges: [aresta('e-3', 'no-1', 'no-9')],
+        });
+        expect(result.success).toBe(false);
+        expect(mensagensDe(result)).toContain('aresta "e-3" aponta para nó inexistente: "no-9"');
+      });
+
+      it('rejeita dois nós com o mesmo id', () => {
+        const result = flowGraphSchema.safeParse({
+          nodes: [noTrigger('no-1'), noTrigger('no-1'), noEnd('no-2')],
+          edges: [aresta('e-1', 'no-1', 'no-2')],
+        });
+        expect(result.success).toBe(false);
+        expect(mensagensDe(result)).toContain('id de nó repetido: "no-1"');
+      });
+
+      it('rejeita duas arestas com o mesmo id', () => {
+        const result = flowGraphSchema.safeParse({
+          nodes: [noTrigger('no-1'), noEnd('no-2')],
+          edges: [aresta('e-2', 'no-1', 'no-2'), aresta('e-2', 'no-1', 'no-2')],
+        });
+        expect(result.success).toBe(false);
+        expect(mensagensDe(result)).toContain('id de aresta repetido: "e-2"');
+      });
+
+      it('CONTROLE: campo desconhecido continua rejeitado', () => {
+        const result = flowGraphSchema.safeParse({
+          nodes: [noTrigger('no-1'), noEnd('no-2')],
+          edges: [aresta('e-1', 'no-1', 'no-2')],
+          campo_desconhecido: true,
+        });
+        expect(result.success).toBe(false);
+      });
     });
   });
 

--- a/lib/followup/graph-schema.ts
+++ b/lib/followup/graph-schema.ts
@@ -417,11 +417,62 @@ export type FlowEdgeCondition = FlowEdge['condition'];
 /**
  * Complete flow graph schema.
  * Contains nodes and edges defining the flow automation.
+ *
+ * O `strictObject` valida cada nó e cada aresta SOZINHOS; o `superRefine`
+ * abaixo é a catraca de INTEGRIDADE entre eles. Sem ela, um grafo com aresta
+ * apontando para nó inexistente ou com ids repetidos (o defeito que o #586
+ * produz no canvas) passava no `safeParse` de qualquer consumidor — salvar o
+ * rascunho (`draft_graph`), carregar a versão (engine, turn-bridge, enroll,
+ * silence-sweep, intervenção) e publicar. A porta é a mesma para todos: quem
+ * JÁ tiver rascunho corrompido recebe o erro com o id a corrigir em vez de um
+ * grafo que só quebra adiante, no meio de um disparo. Sem migração de
+ * rascunho — decisão registrada na issue #699.
  */
-export const flowGraphSchema = z.strictObject({
-  nodes: z.array(flowNodeSchema).min(2).max(60),
-  edges: z.array(flowEdgeSchema).max(120),
-});
+export const flowGraphSchema = z
+  .strictObject({
+    nodes: z.array(flowNodeSchema).min(2).max(60),
+    edges: z.array(flowEdgeSchema).max(120),
+  })
+  .superRefine((grafo, ctx) => {
+    const idsDeNo = new Set<string>();
+    grafo.nodes.forEach((no, i) => {
+      if (idsDeNo.has(no.id)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `id de nó repetido: "${no.id}"`,
+          path: ['nodes', i],
+        });
+      }
+      idsDeNo.add(no.id);
+    });
+
+    const idsDeAresta = new Set<string>();
+    grafo.edges.forEach((aresta, i) => {
+      if (idsDeAresta.has(aresta.id)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `id de aresta repetido: "${aresta.id}"`,
+          path: ['edges', i],
+        });
+      }
+      idsDeAresta.add(aresta.id);
+
+      if (!idsDeNo.has(aresta.source)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `aresta "${aresta.id}" aponta para nó inexistente: "${aresta.source}"`,
+          path: ['edges', i],
+        });
+      }
+      if (!idsDeNo.has(aresta.target)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `aresta "${aresta.id}" aponta para nó inexistente: "${aresta.target}"`,
+          path: ['edges', i],
+        });
+      }
+    });
+  });
 
 export type FlowGraph = z.infer<typeof flowGraphSchema>;
 

--- a/tests/unit/followup-excluir-no-leva-as-arestas.test.ts
+++ b/tests/unit/followup-excluir-no-leva-as-arestas.test.ts
@@ -19,12 +19,14 @@ import { describe, expect, it } from "vitest";
  * da conexão é a da própria aresta.
  *
  * O estrago é grafo com aresta órfã (source/target apontando para nó que não
- * existe mais), e o schema o ACEITA no salvamento — medido com controle
- * positivo: `flowGraphSchema.safeParse` devolve `success=true` para aresta
- * apontando a nó inexistente E para dois nós com o mesmo id (o defeito da
- * issue #586), enquanto rejeita campo desconhecido. Enquanto o schema não
- * fechar essa porta (decisão de produto: um `refine` que rejeita tranca quem
- * JÁ tem rascunho corrompido), o call site é a única rede.
+ * existe mais). No HEAD da prévia o schema o ACEITAVA no salvamento — medido
+ * com controle positivo: `flowGraphSchema.safeParse` devolvia `success=true`
+ * para aresta apontando a nó inexistente E para dois nós com o mesmo id (o
+ * defeito da issue #586), enquanto rejeitava campo desconhecido. A porta foi
+ * fechada na #699 (superRefine de integridade em `flowGraphSchema`, casos em
+ * `lib/followup/graph-schema.test.ts`). O call site continua sendo a PRIMEIRA
+ * rede: não produzir o grafo órfão é melhor do que só reprovar o rascunho
+ * depois de corrompido.
  *
  * Guarda de FONTE, não de comportamento: o canvas não renderiza em jsdom
  * (XYFlow precisa de medição de DOM). O recorte é o corpo do `deleteNode`,


### PR DESCRIPTION
# O que este PR faz

O esquema do grafo de follow-up passa a recusar grafo corrompido: aresta apontando para nó inexistente e id repetido (de nó ou de aresta) deixam de entrar.

Antes, `flowGraphSchema` aceitava essas estruturas — o builder salvava e publicava grafo com aresta órfã e o defeito só aparecia adiante, no motor.

Closes #699

## Como resolve

- `lib/followup/graph-schema.ts` — `superRefine` de integridade no `flowGraphSchema`: aresta órfã por `source` e por `target`, id de nó repetido e id de aresta repetido, com mensagens em PT-BR citando o id problemático.
- `lib/followup/graph-schema.test.ts` — 6 casos novos (4 rejeições + 2 controles: grafo válido passa, campo desconhecido segue rejeitado).
- `tests/unit/followup-excluir-no-leva-as-arestas.test.ts` — **só comentários** (o cabeçalho dizia que "o schema o ACEITA no salvamento"); nenhuma asserção mudou.

Efeito nos consumidores (pretendido, sem migração de rascunho): salvar/carregar rascunho (`lib/followup/api-schemas.ts`) passa a devolver 400 com o id na mensagem; a carga de versão publicada (`engine.ts`, `gatilho-etapa.ts`, `gatilho-caso.ts`, `enroll.ts`, `turn-bridge.ts`, `silence-sweep.ts`) falha alto em grafo corrompido em vez de rodar com aresta órfã; e `intervencao.ts` engata a branch `!success` que já existia, devolvendo "A versão do fluxo em que este follow-up anda não pôde ser lida.". Quem já tem rascunho corrompido corrige e salva.

## O que medi (comandos e saídas)

- `pnpm exec vitest run lib/followup/graph-schema.test.ts tests/unit/followup-excluir-no-leva-as-arestas.test.ts` → **132 passed (132)**, 1,37s.
- `pnpm exec vitest run lib/followup` → **24 files passed, 456 passed (456)**, 11,95s.
- Amostra de consumidores: `tests/api/followup-flows.test.ts tests/unit/o-fluxo-publicado-nao-abre-vazio.test.ts` → **40 passed (40)**.

**Sabotagem** (pós-commit; previsão escrita antes: **4 vermelhos**, exatamente os quatro previstos): `git checkout HEAD~1 -- lib/followup/graph-schema.ts` → **4 failed | 128 passed (132)** — `rejeita aresta cujo source aponta para nó inexistente`, `rejeita aresta cujo target aponta para nó inexistente`, `rejeita dois nós com o mesmo id`, `rejeita duas arestas com o mesmo id`. Restaurado com `git checkout HEAD -- lib/followup/graph-schema.ts` → `git status` limpo e 132/132 verdes de novo.

**Gates** — `eslint --max-warnings=0` nos três arquivos **rc=0** nas medições focadas; e a fila local completa (um pesado por vez — `flock` + `systemd-run --scope -p MemoryMax=5G`):

| gate | resultado |
|---|---|
| `pnpm typecheck` | **rc=0** (10s) |
| `pnpm lint` | **rc=0** (1.164s) |
| `pnpm lint:channels` | **rc=0** (1s) |
| `pnpm lint:role-rank` | **rc=0** (2s) |
| `pnpm release:conferir` | **rc=0** (1s) — fragmento `.changes/grafo-corrompido-nao-passa.md` aceito |
| `pnpm test:unit` | **rc=0** (415s) — 791 arquivos · **8.369 passed** (+ 1 *expected fail*) |
| `pnpm test:shell` | **rc=0** (57s) |
| `pnpm build` | **rc=0** (134s) |

## O que NÃO medi

- **`tests/invariants/**`** — precisa de Postgres/Docker, fora do include do vitest focado.
- **Prova em tela / e2e real do fluxo publicado** — não filmada; o desfecho do `parse` é coberto pelos testes dos consumidores.
