### PR TITLE
fix(followup): excluir nó ou aresta passa a pedir confirmação (#700)

### DIFF
--- a/.changes/excluir-no-pede-confirmacao.md
+++ b/.changes/excluir-no-pede-confirmacao.md
@@ -1,0 +1,19 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: Excluir nó ou aresta no builder de follow-up agora pede confirmação
+---
+
+O botão de excluir a seleção no builder de follow-up dividia o mesmo assento da barra com o
+botão que apaga o fluxo inteiro: mesmo ícone de lixeira, mesma cor destrutiva, mesma posição.
+Os dois eram confundidos justamente porque só um deles perguntava antes — quem aprendeu que a
+lixeira daquele canto pede confirmação clicava no outro com a mesma confiança e perdia o
+trabalho do canvas sem aviso.
+
+Agora os dois se comportam igual: clicar em Excluir (nó ou aresta) abre uma confirmação que diz
+o que vai embora. O título nomeia o alvo — "Excluir este nó?" ou "Excluir esta aresta?", conforme
+a seleção — e a frase explica a consequência: apagar um nó leva junto as arestas ligadas a ele,
+e não há como desfazer. A exclusão só acontece no clique de confirmação; cancelar não muda nada.
+
+Para quem opera uma VPS, nada muda: é conserto de tela, sem comando novo, sem variável nova e
+sem migração. Ninguém precisa fazer nada ao atualizar.

--- a/app/app/ai/followups/[id]/_components/PublishBar.test.tsx
+++ b/app/app/ai/followups/[id]/_components/PublishBar.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * A barra de publicação é o call-site do canvas: é ela quem segura o botão que
+ * apaga o nó ou a aresta selecionada — no MESMO assento do irmão que apaga o
+ * fluxo inteiro (mesmo ícone de lixeira, mesmo canto). Era essa simetria que
+ * faltava (issue #700): um irmão perguntava, o outro não.
+ *
+ * O canvas (XYFlow) não renderiza em jsdom — depende de medição de DOM. A barra
+ * renderiza, então o teste é de COMPORTAMENTO no ponto exato do contrato: até a
+ * confirmação, `onDeleteSelection` não é chamado; depois dela, é chamado uma
+ * vez; e o diálogo NOMEIA o alvo (nó × aresta), porque quem lê a confirmação
+ * precisa saber o que vai embora antes de decidir.
+ */
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { FollowupFlowDetailRow } from "@/hooks/followup/useFollowupFlow";
+import type { FlowGraph } from "@/lib/followup/graph-schema";
+
+import { PublishBar } from "./PublishBar";
+
+// As mutações da barra não participam do fluxo testado — excluir a seleção é
+// callback do canvas (estado local), não request. Mutação inerte, sem QueryClient.
+vi.mock("@/hooks/followup/useFollowupFlow", () => {
+  const mutacao = () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false });
+  return {
+    useDeleteFollowupFlow: mutacao,
+    useDisableFollowupFlow: mutacao,
+    usePublishFollowupFlow: mutacao,
+    useRollbackFollowupFlow: mutacao,
+    useSaveFollowupFlowDraft: mutacao,
+    useUpdateHandoffPolicy: mutacao,
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock("./TriggerConfigControl", () => ({ TriggerConfigControl: () => null }));
+
+const FLUXO: FollowupFlowDetailRow = {
+  id: "fluxo-1",
+  name: "Boas-vindas",
+  status: "draft",
+  active_version_id: null,
+  draft_graph: null,
+  handoff_policy: "pause",
+  trigger_config: {},
+  created_at: "2026-09-01T00:00:00.000Z",
+  updated_at: "2026-09-01T00:00:00.000Z",
+  versions_count: 1,
+  previous_version_id: null,
+};
+
+const GRAFO: FlowGraph = { nodes: [], edges: [] };
+
+function montar(selection: "node" | "edge" | null) {
+  const onDeleteSelection = vi.fn();
+  render(
+    <PublishBar
+      flowId="fluxo-1"
+      flow={FLUXO}
+      graph={GRAFO}
+      dirty={false}
+      selection={selection}
+      onDeleteSelection={onDeleteSelection}
+      onSaved={() => {}}
+      onPublishErrors={() => {}}
+      onPublishSuccess={() => {}}
+      canAutoFit={false}
+    />,
+  );
+  return onDeleteSelection;
+}
+
+function usuario() {
+  return userEvent.setup({ delay: null });
+}
+
+describe("PublishBar — excluir a seleção pede confirmação", () => {
+  it("clicar em Excluir nó não exclui nada, só abre a confirmação", async () => {
+    const onDeleteSelection = montar("node");
+
+    await usuario().click(screen.getByTestId("delete-selection"));
+
+    const dialogo = await screen.findByRole("alertdialog");
+    expect(dialogo).toHaveTextContent("Excluir este nó?");
+    expect(dialogo).toHaveTextContent("Não é possível desfazer");
+    expect(onDeleteSelection).not.toHaveBeenCalled();
+  });
+
+  it("cancelar fecha a confirmação e segue sem excluir", async () => {
+    const onDeleteSelection = montar("node");
+    const user = usuario();
+
+    await user.click(screen.getByTestId("delete-selection"));
+    const dialogo = await screen.findByRole("alertdialog");
+    await user.click(within(dialogo).getByRole("button", { name: "Cancelar" }));
+
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+    expect(onDeleteSelection).not.toHaveBeenCalled();
+  });
+
+  it("confirmar é o que exclui — uma vez", async () => {
+    const onDeleteSelection = montar("node");
+    const user = usuario();
+
+    await user.click(screen.getByTestId("delete-selection"));
+    const dialogo = await screen.findByRole("alertdialog");
+    await user.click(within(dialogo).getByRole("button", { name: "Excluir" }));
+
+    expect(onDeleteSelection).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+  });
+
+  it("com aresta selecionada, a confirmação diz que é a aresta — não o nó", async () => {
+    const onDeleteSelection = montar("edge");
+    const user = usuario();
+
+    await user.click(screen.getByTestId("delete-selection"));
+    const dialogo = await screen.findByRole("alertdialog");
+
+    expect(dialogo).toHaveTextContent("Excluir esta aresta?");
+    expect(dialogo).not.toHaveTextContent("Excluir este nó?");
+
+    await user.click(within(dialogo).getByRole("button", { name: "Excluir" }));
+    expect(onDeleteSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("sem seleção, o irmão do fluxo ocupa o lugar — o botão da seleção não existe", () => {
+    montar(null);
+
+    expect(screen.queryByTestId("delete-selection")).toBeNull();
+    expect(screen.getByTestId("delete-followup-flow")).toBeInTheDocument();
+  });
+});

--- a/app/app/ai/followups/[id]/_components/PublishBar.tsx
+++ b/app/app/ai/followups/[id]/_components/PublishBar.tsx
@@ -1,7 +1,19 @@
 "use client";
 
+import { useState } from "react";
+
 import { toast } from "sonner";
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -63,6 +75,7 @@ export function PublishBar({
   canAutoFit = false,
 }: Props) {
   const t = useT();
+  const [openDeleteSelection, setOpenDeleteSelection] = useState(false);
   const save = useSaveFollowupFlowDraft(flowId);
   const publish = usePublishFollowupFlow(flowId);
   const disable = useDisableFollowupFlow(flowId);
@@ -180,17 +193,45 @@ export function PublishBar({
           </Button>
         )}
         {selection ? (
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="text-destructive"
-            data-testid="delete-selection"
-            onClick={onDeleteSelection}
-          >
-            <Trash size={14} aria-hidden className="mr-1" />
-            {selection === "node" ? t("Excluir nó") : t("Excluir aresta")}
-          </Button>
+          <>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="text-destructive"
+              data-testid="delete-selection"
+              onClick={() => setOpenDeleteSelection(true)}
+            >
+              <Trash size={14} aria-hidden className="mr-1" />
+              {selection === "node" ? t("Excluir nó") : t("Excluir aresta")}
+            </Button>
+            <AlertDialog open={openDeleteSelection} onOpenChange={setOpenDeleteSelection}>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>
+                    {selection === "node" ? t("Excluir este nó?") : t("Excluir esta aresta?")}
+                  </AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {selection === "node"
+                      ? t("Este nó e as arestas ligadas a ele são apagados. Não é possível desfazer.")
+                      : t("A aresta entre os dois nós é apagada. Não é possível desfazer.")}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>{t("Cancelar")}</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setOpenDeleteSelection(false);
+                      onDeleteSelection();
+                    }}
+                  >
+                    {t("Excluir")}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </>
         ) : (
           <DeleteFollowupFlowButton flowId={flowId} flowName={flow.name} redirectToList />
         )}

--- a/docs/doctrine/destrutivo-pede-confirmacao.md
+++ b/docs/doctrine/destrutivo-pede-confirmacao.md
@@ -1,0 +1,70 @@
+# Doutrina da Ação Destrutiva
+
+> Lei sobre o **clique que apaga**: toda ação que destrói trabalho na tela pede confirmação, e a
+> confirmação diz **o que vai embora**. Complementa `docs/doctrine/versionamento.md` (o número que
+> a mudança produz) tratando do que a mudança **faz com o trabalho de quem está na tela**.
+
+## O princípio-raiz
+
+A pergunta não é *"esta ação é perigosa?"* — quem escreveu o código responde "não" para o próprio
+botão. A pergunta é:
+
+> **"Se este clique estiver errado, o que o operador perde?"**
+
+Se a resposta inclui trabalho que ele não refaz de memória — um canvas montado à mão durante
+meia hora, um fluxo com versões publicadas —, o clique não pode ser o primeiro. Não é sobre
+medo do usuário: é que o custo do erro é assimétrico. Confirmar custa um segundo; perder o
+canvas custa o turno.
+
+## O caso que originou a regra (issue #700)
+
+No builder de follow-up, o botão de excluir a **seleção** (nó ou aresta) e o botão de excluir o
+**fluxo inteiro** dividem o mesmo assento da barra: mesmo ícone de lixeira, mesma cor destrutiva,
+mesmo tamanho, a poucos pixels de distância — em
+`app/app/ai/followups/[id]/_components/PublishBar.tsx`.
+
+Só um dos dois pedia confirmação. O arranjo resultante é o pior possível entre dois irmãos: o
+botão mais à mão (o que existe para limpar o que o operador acabou de selecionar) disparava a
+exclusão no primeiro clique, enquanto o vizinho — o ícone idêntico que apaga o fluxo e, com ele,
+versões e inscrições — perguntava antes. Quem aprendeu a confiar na lixeira daquele canto
+confiava com metade da proteção, e o erro custava o trabalho do canvas.
+
+**A assimetria era o defeito.** Não o botão: a ação é legítima e precisa existir. Dois botões
+gêmeos no mesmo lugar não podem ter contratos diferentes.
+
+## A régua
+
+| O clique… | Confirmação |
+|---|---|
+| Não apaga trabalho (salvar, publicar, organizar, alternar seleção) | **Nenhuma** — atrito puro não protege ninguém |
+| Apaga trabalho (nó, aresta, fluxo, template, fonte, credencial) | **Obrigatória**, com o **alvo nomeado** no título |
+| Apaga em lote ou tira a tela do lugar (ex.: excluir o fluxo aberto) | Obrigatória, dizendo **o que vai junto** e que **não há desfazer** |
+
+O alvo nomeado é metade da regra. "Tem certeza?" não informa nada: quem clicou por engano
+confirma de novo pelo mesmo motivo que errou. *"Excluir este nó?"* é uma pergunta que só faz
+sentido se era isso mesmo que ele queria — e o erro morre ali.
+
+## Como aplicar
+
+O padrão da casa é o `AlertDialog` de `components/ui/alert-dialog`, o mesmo de
+`DeleteFollowupFlowButton`:
+
+1. O botão destrutivo **só abre o diálogo** (`setOpen(true)`) — nunca chama a exclusão.
+2. O título nomeia o alvo no vocabulário da tela: *"Excluir este nó?"*, *"Excluir esta aresta?"*.
+3. A descrição diz a **consequência** em uma frase: o que é apagado junto e que não há desfazer.
+4. Ações: `Cancelar` e a que exclui — **a exclusão acontece no clique de dentro do diálogo**.
+5. Quando o alvo varia (nó × aresta), o texto acompanha a seleção; variedade sem texto próprio
+   não é confirmação, é ruído.
+
+## Verificação
+
+O contrato do call-site é medido em teste, não em prosa:
+`app/app/ai/followups/[id]/_components/PublishBar.test.tsx` fixa que nada é excluído antes da
+confirmação, que cancelar não exclui, que confirmar exclui uma vez, e que o diálogo nomeia o
+alvo conforme a seleção. Do lado do canvas,
+`tests/unit/followup-excluir-no-leva-as-arestas.test.ts` garante que apagar o nó continua levando
+as arestas ligadas — a frase que a confirmação promete.
+
+Não há gate de varredura: a regra se cobra na revisão de quem adiciona o próximo botão
+destrutivo e nos testes do call-site. Um alerta que só existe para telas já corrigidas não
+envelhece melhor que os outros.

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,6 +90,7 @@ Detalham schema SQL e payloads exatos. **Consulte antes de modelar qualquer cois
 | [`doctrine/restricao-de-canal.md`](doctrine/restricao-de-canal.md) | Auto-restrição × hetero-restrição de canais externos; contrato de parâmetros derivado |
 | [`doctrine/separacao-fala-e-operacao.md`](doctrine/separacao-fala-e-operacao.md) | Vocabulário interno nunca vaza para o cliente |
 | [`doctrine/packaging.md`](doctrine/packaging.md) | **Doutrina de Packaging — a LEI.** 8 invariantes + política de canais + checklist de release (item 15 do DoD) |
+| [`doctrine/destrutivo-pede-confirmacao.md`](doctrine/destrutivo-pede-confirmacao.md) | Ação destrutiva pede confirmação que **nomeia o alvo** — dois botões gêmeos, o mesmo contrato |
 | [`adr/0001-packaging-e-distribuicao.md`](adr/0001-packaging-e-distribuicao.md) | ADR do packaging: namespace, os 3 packages, e o que foi recusado |
 | [`architecture/agent-turn.html`](architecture/agent-turn.html) | Diagrama do turno do agente (inbound → guardrails → outbound) |
 | [`specs/pre-go-live-whatsapp.md`](specs/pre-go-live-whatsapp.md) | Modo de teste do WhatsApp por canal: lista de telefones, abertura ao público e compatibilidade com autorização por origem |

--- a/lib/i18n/dicionario.ts
+++ b/lib/i18n/dicionario.ts
@@ -1289,6 +1289,14 @@ export const DICIONARIO: Traducoes = {
   "Condição da aresta": { es: "Condición de la arista" },
   "Excluir nó": { es: "Eliminar nodo" },
   "Excluir aresta": { es: "Eliminar arista" },
+  "Excluir este nó?": { es: "¿Eliminar este nodo?" },
+  "Excluir esta aresta?": { es: "¿Eliminar esta arista?" },
+  "Este nó e as arestas ligadas a ele são apagados. Não é possível desfazer.": {
+    es: "Este nodo y las aristas ligadas a él se borran. No se puede deshacer.",
+  },
+  "A aresta entre os dois nós é apagada. Não é possível desfazer.": {
+    es: "La arista entre los dos nodos se borra. No se puede deshacer.",
+  },
   Organizar: { es: "Organizar" },
   "Quando seguir por esta aresta": { es: "Cuándo seguir por esta arista" },
   "São as saídas do nó": { es: "Son las salidas del nodo" },


### PR DESCRIPTION
# O que este PR faz

Excluir nó ou aresta no builder de follow-up passa a pedir confirmação: o botão de excluir a seleção abre um diálogo, e a exclusão só acontece na confirmação.

Antes, o botão ocupava o lugar do "Excluir fluxo", com o mesmo ícone e **sem** confirmação — um clique errado apagava a seleção.

Closes #700

## Como resolve

- `app/app/ai/followups/[id]/_components/PublishBar.tsx` — o botão de excluir a seleção passa a apenas abrir o `AlertDialog`; a exclusão acontece no clique de confirmação.
- `app/app/ai/followups/[id]/_components/PublishBar.test.tsx` (novo) — 5 testes de comportamento.
- `lib/i18n/dicionario.ts` — 4 chaves novas PT→ES (títulos e descrições, nó × aresta).
- `docs/doctrine/destrutivo-pede-confirmacao.md` (novo) — a regra, como a issue pediu; `docs/index.md` ganha a linha na tabela de doutrina.
- `.changes/excluir-no-pede-confirmacao.md` — fragmento (`impacto: nada_mudou`, `secao: corrigido`).

## O que medi (comandos e saídas)

- `pnpm exec vitest run app/app/ai/followups/[id]/_components/PublishBar.test.tsx` com os vizinhos → **5 files passed, 23 tests** na rodada de referência (4,84s); os 5 novos são de comportamento no call-site.

**Sabotagem** (pós-commit; previsão escrita antes: **os 4 testes do diálogo em vermelho, o 5º "sem seleção" verde**): revertendo os **dois** arquivos que carregam o fix (`PublishBar.tsx` + `dicionario.ts`) → **Tests 4 failed | 19 passed (23)**, exatamente as 4 do diálogo — a última em `PublishBar.test.tsx:122`, com `findByRole("alertdialog")` não achando nada porque o botão voltou a excluir direto. A previsão **extra** — o gate `i18n-espanhol-cobre-a-tela` ficar vermelho — **errou, e o motivo fica registrado**: o gate mede *chave usada sem tradução*; revertendo componente **e** dicionário os dois lados ficam consistentes e ele passa. Restaurado com `git checkout HEAD -- <os dois>` → `git status` limpo e verdes de novo.

**Gates** — `eslint --max-warnings=0` nos três arquivos **rc=0** nas medições focadas; `release:conferir` **rc=0** (`1.20.0 + patch = 1.20.1`, fragmento `.changes/excluir-no-pede-confirmacao.md`); e a fila local completa (um pesado por vez — `flock` + `systemd-run --scope -p MemoryMax=5G`):

| gate | resultado |
|---|---|
| `pnpm typecheck` | **rc=0** (10s) |
| `pnpm lint` | **rc=0** (re-rodada — ver nota) |
| `pnpm lint:channels` | **rc=0** (1s) |
| `pnpm lint:role-rank` | **rc=0** (2s) |
| `pnpm release:conferir` | **rc=0** (1s) |
| `pnpm test:unit` | **rc=0** (432s) — 792 arquivos · 8.368 provas (+ 1 *expected fail*) |
| `pnpm test:shell` | **rc=0** (60s) |
| `pnpm build` | **rc=0** (172s) |

Nota: o primeiro `lint` da fila foi interrompido por SIGTERM (rc=143), travado em espera de I/O (estado `D`) com dois lotes de gate concorrentes na máquina; a re-rodada fechou **rc=0** com 0 *errors* (os avisos são pré-existentes do repo) — está na tabela acima.

## O que NÃO medi

- **Sem prova em tela** — a prova é o teste de comportamento no call-site, não screenshot.
- **`tests/invariants/**`** — precisa de Postgres/Docker, fora do include do vitest focado.
- **Uma corrida anômala**: logo depois do restauro, uma execução voltou `2 failed | 1 passed (3)` com 416s (transform 304s) — cara de contenção de máquina; as execuções imediatamente anterior e posterior, mesmo comando, deram verdes em ~5s. Não reproduziu e não investiguei a fundo.
- **`prettier --check`** não é gate do CI (`gov:verify` não inclui `format:check`) e reprova arquivos pré-existentes; não rodei `--write` para não inflar o diff.
