### PR TITLE
fix(lgpd): a cascata cancela a régua do contato anonimizado e o aviso não ressuscita o vínculo

### DIFF
--- a/.changes/lgpd-cancela-a-regua-do-contato-anonimizado.md
+++ b/.changes/lgpd-cancela-a-regua-do-contato-anonimizado.md
@@ -1,0 +1,21 @@
+---
+impacto: nada_mudou
+secao: corrigido
+titulo: A régua de recuperação para de correr para o contato anonimizado
+---
+
+Quando alguém pedia para ser esquecido (anonimização por LGPD), os dados eram
+redigidos — mas a régua de recuperação de falta continuava correndo por baixo. As
+mensagens de reengajamento seguiam sendo enviadas, e, quando a régua esgotava,
+nascia um aviso novo na Central apontando justamente para o compromisso que a
+anonimização tinha desligado: o aviso ressuscitava o vínculo que a LGPD mandou
+cortar.
+
+Agora a cascata de anonimização cancela a régua do contato no mesmo movimento em
+que redige os dados — tanto pelo botão da tela quanto pelo varredor diário de
+retenção —, e a porta que abria aquele aviso passou a recusar contato
+anonimizado, como as outras três já faziam.
+
+Você não precisa fazer nada para adotar. Contatos anonimizados antes desta versão
+que ainda tenham resíduo de redação são alcançados pelo varredor diário, que
+agora corta a régua deles também.

--- a/lib/followup/engine.ts
+++ b/lib/followup/engine.ts
@@ -850,6 +850,50 @@ export function createSupabaseAdminClient(admin: SupabaseClient): AdminClient {
       if (error) throw new Error(error.message);
     },
     async abrirAvisoRecuperacaoEsgotada(item) {
+      // ── A GUARDA DE ANONIMIZAÇÃO DESTA PORTA (issue #701) ──
+      //
+      // Esta é a QUARTA porta para `appointment_recovery_review`, e era a única
+      // sem guarda: as outras três moram em SQL — `fn_meet_redact_contact`
+      // resolve os avisos abertos, `fn_appointment_recover` recusa contato
+      // anonimizado, e há um bloco de cura no histórico — e quem escreve este
+      // `kind` pelo TypeScript não as encontra.
+      //
+      // Sem guarda, a régua de um contato anonimizado chega ao fim e abre um
+      // aviso apontando para o compromisso que a anonimização tinha desligado:
+      // o aviso ressuscitando o vínculo que a LGPD mandou cortar.
+      //
+      // A checagem vem ANTES do insert porque o PostgREST não expressa
+      // `insert ... select` — é por isso que o adaptador pg de `turn-bridge.ts`
+      // guarda dentro da escrita, e este não pode. O que sustenta esta versão é
+      // a CASCATA: desde esta issue ela cancela `followup_enrollments` do mesmo
+      // contato, então uma régua viva aqui é uma régua que existia ANTES da
+      // redação (a corrida de um turno já reivindicado é o que a guarda cobre).
+      //
+      // Ler em duas consultas simples, e não com `contacts!inner(is_anonymized)`
+      // num join embutido, pelo mesmo motivo declarado em `lib/lgpd/cascata.ts`:
+      // o join embutido depende do nome da FK e nenhum teste local o exercita.
+      const { data: compromisso, error: compromissoErr } = await admin
+        .from("calendar_appointments")
+        .select("contact_id")
+        .eq("organization_id", item.organization_id)
+        .eq("id", item.appointment_id)
+        .maybeSingle();
+      if (compromissoErr) throw new Error(compromissoErr.message);
+
+      const contatoId = (compromisso as { contact_id: string | null } | null)?.contact_id ?? null;
+      if (contatoId) {
+        const { data: contato, error: contatoErr } = await admin
+          .from("contacts")
+          .select("is_anonymized")
+          .eq("organization_id", item.organization_id)
+          .eq("id", contatoId)
+          .maybeSingle();
+        // Leitura que falha não vira aviso: a dúvida não pode ser respondida com
+        // uma escrita que ressuscita vínculo cortado.
+        if (contatoErr) throw new Error(contatoErr.message);
+        if ((contato as { is_anonymized: boolean | null } | null)?.is_anonymized === true) return;
+      }
+
       const { error } = await admin.from("agent_inbox_items").insert({
         organization_id: item.organization_id,
         // Reusa o kind da 0224 (mesma família: "a recuperação desta falta

--- a/lib/followup/turn-bridge.ts
+++ b/lib/followup/turn-bridge.ts
@@ -369,10 +369,13 @@ export function createPgAdminClient(pool: pg.Pool): TurnBridgeAdminClient {
       // anonimizado, `fn_meet_redact_contact` resolve os abertos, e há um bloco
       // de cura no baseline. Esta nascia sem, e a consequência é concreta:
       //
-      //   a cascata de LGPD NÃO cancela `followup_enrollments` (medido, com
+      //   a cascata de LGPD não cancelava `followup_enrollments` (medido, com
       //   controle positivo). Um contato anonimizado com régua em curso chega
       //   ao fim dela DEPOIS da redação — e reabriria, aqui, um aviso
       //   apontando para o compromisso que a anonimização tinha desligado.
+      //   Desde o #701 a cascata cancela a régua, e ESTA guarda continua sendo a
+      //   segunda linha: um turno já reivindicado pode terminar depois do
+      //   cancelamento, e é nesta escrita que ele não vira aviso.
       //
       // Um `if` em TypeScript antes do insert resolveria o caso e deixaria a
       // guarda a um refactor de distância de sumir. No `select` ela é parte da

--- a/lib/lgpd/cascata.ts
+++ b/lib/lgpd/cascata.ts
@@ -1,5 +1,5 @@
 /**
- * A CASCATA DE ANONIMIZAÇÃO — os passos 2 e 3, num lugar só (issue #310).
+ * A CASCATA DE ANONIMIZAÇÃO — os passos 2 a 4, num lugar só (issues #310 e #701).
  *
  * ─── Por que este arquivo existe ────────────────────────────────────────────
  *
@@ -45,6 +45,23 @@ export const TITULO_PRESERVADO = 20;
 
 /** O payload que substitui o conteúdo de uma atividade. */
 export const PAYLOAD_REDIGIDO: Record<string, unknown> = { redacted: true };
+
+/**
+ * Os status em que a régua de recuperação ainda CORRE — e portanto ainda pode
+ * mandar mensagem ou abrir aviso.
+ *
+ * São os mesmos que o cancelamento por compromisso desfeito usa em SQL
+ * (`fn_appointment_change`) e que o índice de claim filtra. Divergir daqui é
+ * deixar régua viva para trás: `completed`, `cancelled` e `dead` são terminais,
+ * e é a ausência deles nesta lista que torna o passo idempotente.
+ */
+export const STATUS_DA_REGUA_VIVA = ["active", "waiting_reply", "paused_handoff", "paused_manual"] as const;
+
+/**
+ * O motivo gravado em `cancel_reason` — curto, sem PII, e greppável na
+ * auditoria, no mesmo vocabulário de `nono_digito_merge`.
+ */
+export const MOTIVO_CANCELAMENTO_POR_LGPD = "Contato anonimizado (LGPD)";
 
 export function jaRedigida(titulo: string | null): boolean {
   return (titulo ?? "").endsWith(SUFIXO_ANONIMIZADO);
@@ -102,7 +119,7 @@ export function houveRedacao(r: ResultadoDaRedacao): boolean {
 }
 
 /**
- * Passos 2 e 3 da cascata, idempotentes, para UM contato já anonimizado (ou
+ * Passos 2 a 4 da cascata, idempotentes, para UM contato já anonimizado (ou
  * sendo anonimizado agora).
  *
  * Best-effort de propósito, e a direção foi escolhida: derrubar a requisição
@@ -171,6 +188,58 @@ export async function completarRedacaoDoContato(
       atividadesRedigidas = pendentes.length;
       tabelas.push("crm_lead_activities");
     }
+  }
+
+  // ── Passo 4 — a RÉGUA DE RECUPERAÇÃO do contato (issue #701) ──
+  //
+  // A cascata redigia contatos, leads e atividades — e deixava a régua de
+  // recuperação CORRENDO. Medido na issue, com controle positivo:
+  // `git grep -l "followup" lib/lgpd/` voltava vazio.
+  //
+  // A consequência não é cosmética: a régua esgota DEPOIS da redação e o
+  // adaptador de `abrirAvisoRecuperacaoEsgotada` abre um aviso novo apontando
+  // para o compromisso que a anonimização tinha desligado. O aviso ressuscita o
+  // vínculo que a LGPD mandou cortar — e, antes dele, as mensagens da própria
+  // régua chegam a quem pediu para ser esquecido.
+  //
+  // Mora AQUI, e não na RPC `fn_lgpd_cascade_redact_contact`, porque este
+  // arquivo é a unidade que as DUAS bocas compartilham (a rota e o cron) — ver o
+  // cabeçalho. Cancelar só na RPC deixaria a RETOMADA (`lgpd.anonymize_catchup`,
+  // que não passa pela RPC de cascata) sem cancelamento, e é justamente por ela
+  // que o contato anonimizado antes desta issue é alcançado.
+  //
+  // SELECT antes do UPDATE, como no passo anterior e pelo mesmo motivo: em
+  // regime a régua já está cancelada, e escrever de novo seria gravar sobre dado
+  // certo em toda rodada diária, com a auditoria registrando efeito que não
+  // houve. É a mesma cadeia que torna o passo idempotente — `cancelled` não está
+  // em `STATUS_DA_REGUA_VIVA`, então a segunda passada não encontra linha.
+  const { data: reguaData, error: reguaSelErr } = await db
+    .from("followup_enrollments")
+    .select("id")
+    .eq("organization_id", contato.organizationId)
+    .eq("contact_id", contato.id)
+    .in("status", [...STATUS_DA_REGUA_VIVA]);
+  if (reguaSelErr) falhas.push(`followup_enrollments select: ${reguaSelErr.message}`);
+
+  const reguasVivas = ((reguaData ?? []) as { id: string }[]).map((r) => r.id);
+  if (reguasVivas.length > 0) {
+    const { error } = await db
+      .from("followup_enrollments")
+      .update({
+        status: "cancelled",
+        cancel_reason: MOTIVO_CANCELAMENTO_POR_LGPD,
+        completed_at: new Date().toISOString(),
+        // Soltar o relógio e o lease é parte do cancelamento: sem isto a linha
+        // cancelada continua com cara de reivindicável para o claim do worker.
+        next_eval_at: null,
+        claimed_until: null,
+      })
+      .eq("organization_id", contato.organizationId)
+      .in("id", reguasVivas);
+    if (error) falhas.push(`followup_enrollments: ${error.message}`);
+    // `tabelas` é o que a auditoria grava como tocado de verdade: numa retomada,
+    // esta linha é a diferença entre "não faltava nada" e "a régua foi cortada".
+    else tabelas.push("followup_enrollments");
   }
 
   return { leadsRedigidas, atividadesRedigidas, tabelas, falhas };

--- a/tests/unit/aviso-de-compromisso-checa-anonimizacao.test.ts
+++ b/tests/unit/aviso-de-compromisso-checa-anonimizacao.test.ts
@@ -1,0 +1,243 @@
+/**
+ * NENHUM PRODUTOR DE AVISO DE COMPROMISSO ESCREVE SEM CHECAR ANONIMIZAÇÃO.
+ *
+ * ─── A classe, e a quarta instância (issue #701) ────────────────────────────
+ *
+ * `agent_inbox_items` com `ref_kind='appointment'` é o aviso que aponta para o
+ * compromisso de um cliente. Quando o titular exerce o direito de ser
+ * esquecido, a anonimização desliga esse vínculo — e um aviso novo para ele é o
+ * vínculo ressuscitando, com mensagem saindo para quem pediu para não ser mais
+ * procurado.
+ *
+ * A guarda existe em três portas, TODAS em SQL: o trigger `fn_meet_redact_contact`
+ * resolve os avisos abertos, `fn_appointment_recover` tem
+ * `and not exists (… is_anonymized)`, e há um bloco de cura no histórico. A
+ * quarta porta é escrita pelo TypeScript, e nascia sem guarda nenhuma — porque
+ * *"a guarda mora dentro de funções SQL; quem escreve o kind pelo TypeScript não
+ * a encontra, e nenhum invariante a cobra"* (a issue, literalmente).
+ *
+ * Foi a mesma classe do #690 (nenhuma guarda reprova `useState` que lê o
+ * navegador): o conserto pontual resolve o caso, e sem uma guarda a próxima
+ * instância nasce igual. Este arquivo é a guarda.
+ *
+ * ─── Como a sonda reconhece um produtor ─────────────────────────────────────
+ *
+ * Dois formatos escrevem esse aviso, e os dois contam:
+ *
+ *   - PostgREST: `.from("agent_inbox_items").insert({ …, ref_kind: "appointment" })`
+ *   - SQL: um literal com `insert into agent_inbox_items … ref_kind … 'appointment'`
+ *
+ * Um site é PRODUTOR quando o texto dele cita a tabela, o `ref_kind` e um valor
+ * de compromisso. A guarda é exigida na FUNÇÃO que envolve o site — nela ou no
+ * próprio texto do site, que é o caso do `insert ... select` do turn-bridge,
+ * onde a condição `not c.is_anonymized` faz parte da escrita.
+ *
+ * ─── O que ela NÃO é ────────────────────────────────────────────────────────
+ *
+ * Ela não varre `supabase/baseline.sql`: ali a guarda e a escrita estão no mesmo
+ * statement de funções que o `test:db` já exercita contra Postgres de verdade
+ * (ver `tests/invariants/`). O buraco que a issue nomeia é o do TypeScript, e é
+ * ele que esta sonda cobre — um produtor NOVO em `.ts` não passa daqui.
+ *
+ * A sonda também não julga outros `ref_kind`: `followup_enrollment`, `contact`,
+ * `message` não apontam para compromisso e não têm esta obrigação. Controles nas
+ * duas direções no fim do arquivo: um produtor sem guarda precisa reprovar, um
+ * com guarda precisa passar, e um produtor de outro `ref_kind` precisa ser
+ * ignorado.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { join, posix } from "node:path";
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const RAIZ = join(__dirname, "..", "..");
+const DIRS = ["app", "lib", "workers"];
+
+/** Um site que escreve aviso de compromisso, com a guarda que ele tem (ou não). */
+export interface Produtor {
+  arquivo: string;
+  /** 1-based, para a mensagem de falha levar direto ao ponto. */
+  linha: number;
+  /** Onde o site começa, para reconhecer o formato (PostgREST ou SQL). */
+  trecho: string;
+  /** Se a função que escreve consulta `is_anonymized` (no site ou no corpo dela). */
+  temGuarda: boolean;
+}
+
+export function fontesVigiadas(): Map<string, string> {
+  const mapa = new Map<string, string>();
+  const descer = (dir: string): void => {
+    for (const e of readdirSync(join(RAIZ, dir), { withFileTypes: true })) {
+      if (e.name === "node_modules" || e.name.startsWith(".")) continue;
+      const rel = posix.join(dir, e.name);
+      if (e.isDirectory()) descer(rel);
+      else if (/\.tsx?$/.test(e.name) && !/\.test\.tsx?$/.test(e.name)) {
+        mapa.set(rel, readFileSync(join(RAIZ, rel), "utf8"));
+      }
+    }
+  };
+  for (const d of DIRS) descer(d);
+  return mapa;
+}
+
+/** A tabela, o `ref_kind` e um valor de compromisso, no MESMO texto. */
+export function ehAvisoDeCompromisso(texto: string): boolean {
+  if (!texto.includes("agent_inbox_items")) return false;
+  if (!/\bref_kind\b/.test(texto)) return false;
+  return /appointment_recovery_review|['"`]appointment['"`]/.test(texto);
+}
+
+function ehFuncao(node: ts.Node): boolean {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node) ||
+    ts.isConstructorDeclaration(node)
+  );
+}
+
+/** O corpo onde a escrita mora — é nele que a guarda precisa estar (ou no site). */
+function funcaoEnvolvente(node: ts.Node): ts.Node | null {
+  let atual: ts.Node | undefined = node.parent;
+  while (atual) {
+    if (ehFuncao(atual)) return atual;
+    atual = atual.parent;
+  }
+  return null;
+}
+
+function sitesDeAviso(sf: ts.SourceFile): ts.Node[] {
+  const achados: ts.Node[] = [];
+  const visitar = (node: ts.Node): void => {
+    // Formato SQL: o próprio literal carrega a escrita.
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node) || ts.isTemplateExpression(node)) {
+      if (ehAvisoDeCompromisso(node.getText(sf))) achados.push(node);
+    }
+    // Formato PostgREST: `.from("agent_inbox_items").insert({ … })`.
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      node.name.text === "insert" &&
+      ts.isCallExpression(node.parent) &&
+      node.parent.expression === node &&
+      ehAvisoDeCompromisso(node.parent.getText(sf))
+    ) {
+      achados.push(node.parent);
+    }
+    ts.forEachChild(node, visitar);
+  };
+  ts.forEachChild(sf, visitar);
+  return achados;
+}
+
+/** Os produtores de aviso de compromisso de um conjunto de fontes. */
+export function produtores(fontes: Map<string, string>): Produtor[] {
+  const saida: Produtor[] = [];
+  for (const [arquivo, texto] of fontes) {
+    const sf = ts.createSourceFile(arquivo, texto, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+    for (const site of sitesDeAviso(sf)) {
+      const corpo = funcaoEnvolvente(site);
+      const guardado =
+        site.getText(sf).includes("is_anonymized") || (corpo?.getText(sf).includes("is_anonymized") ?? false);
+      saida.push({
+        arquivo,
+        linha: sf.getLineAndCharacterOfPosition(site.getStart(sf)).line + 1,
+        trecho: site.getText(sf).slice(0, 60).replace(/\s+/g, " "),
+        temGuarda: guardado,
+      });
+    }
+  }
+  return saida.sort((a, b) => `${a.arquivo}:${a.linha}`.localeCompare(`${b.arquivo}:${b.linha}`));
+}
+
+/** Só os que escrevem sem guarda — é o que reprova. */
+export function semGuarda(produtoresEncontrados: Produtor[]): Produtor[] {
+  return produtoresEncontrados.filter((p) => !p.temGuarda);
+}
+
+const DESCRICAO = (p: Produtor) => `${p.arquivo}:${p.linha} — ${p.trecho}`;
+
+describe("produtor de aviso de compromisso checa anonimização", () => {
+  const reais = produtores(fontesVigiadas());
+
+  it("a sonda enxerga os produtores que existem (sem isto, o verde seria vazio)", () => {
+    // Guarda de vacuidade: uma sonda que deixasse de reconhecer os dois formatos
+    // devolveria lista vazia e passaria — o pior resultado possível para uma
+    // guarda, e o modo de falha que ela existe para não ter.
+    expect(reais.length, "a sonda não reconheceu produtor nenhum").toBeGreaterThanOrEqual(2);
+    expect(reais.map((p) => p.arquivo)).toEqual(
+      expect.arrayContaining(["lib/followup/engine.ts", "lib/followup/turn-bridge.ts"]),
+    );
+    // Os dois formatos aparecem: o do PostgREST e o do SQL.
+    expect(reais.some((p) => p.trecho.includes("insert into"))).toBe(true);
+    expect(reais.some((p) => p.trecho.includes(".from("))).toBe(true);
+  });
+
+  it("⭐ nenhum deles escreve sem checar `is_anonymized`", () => {
+    const soltos = semGuarda(reais);
+    expect(soltos.map(DESCRICAO), "aviso de compromisso escrito sem olhar se o contato é anonimizado").toEqual([]);
+  });
+
+  it("⭐ controle positivo: um produtor sem guarda REPROVA", () => {
+    const fontes = new Map<string, string>([
+      [
+        "lib/fixture/sem-guarda.ts",
+        `async function abrir(admin: Admin) {
+           await admin.from("agent_inbox_items").insert({
+             organization_id: org,
+             kind: "appointment_recovery_review",
+             ref_kind: "appointment",
+             ref_id: compromisso,
+           });
+         }`,
+      ],
+    ]);
+
+    const achados = produtores(fontes);
+
+    expect(achados).toHaveLength(1);
+    expect(semGuarda(achados)).toHaveLength(1);
+  });
+
+  it("⭐ controle negativo: o mesmo produtor COM guarda passa", () => {
+    const fontes = new Map<string, string>([
+      [
+        "lib/fixture/com-guarda.ts",
+        `async function abrir(admin: Admin) {
+           const contato = await admin.from("contacts").select("is_anonymized").eq("id", contatoId).maybeSingle();
+           if (contato.is_anonymized) return;
+           await admin.from("agent_inbox_items").insert({
+             kind: "appointment_recovery_review",
+             ref_kind: "appointment",
+             ref_id: compromisso,
+           });
+         }`,
+      ],
+    ]);
+
+    const achados = produtores(fontes);
+
+    expect(achados).toHaveLength(1);
+    expect(semGuarda(achados)).toEqual([]);
+  });
+
+  it("produtor de outro `ref_kind` não é cobrado — a obrigação é do vínculo com o compromisso", () => {
+    const fontes = new Map<string, string>([
+      [
+        "lib/fixture/outro-ref-kind.ts",
+        `async function abrir(admin: Admin) {
+           await admin.from("agent_inbox_items").insert({
+             kind: "followup_dead",
+             ref_kind: "followup_enrollment",
+             ref_id: matricula,
+           });
+         }`,
+      ],
+    ]);
+
+    expect(produtores(fontes)).toEqual([]);
+  });
+});

--- a/tests/unit/followup-aviso-nao-nasce-para-anonimizado.test.ts
+++ b/tests/unit/followup-aviso-nao-nasce-para-anonimizado.test.ts
@@ -1,0 +1,149 @@
+/**
+ * A QUARTA PORTA DO AVISO DE RECUPERAÇÃO RECUSA CONTATO ANONIMIZADO.
+ *
+ * `appointment_recovery_review` nasce em quatro lugares. Três guardam
+ * anonimização, e todas as três moram em SQL: o trigger `fn_meet_redact_contact`
+ * resolve os avisos abertos, `fn_appointment_recover` recusa contato
+ * anonimizado, e há um bloco de cura para o histórico. A quarta é o adaptador
+ * TypeScript — `abrirAvisoRecuperacaoEsgotada`, no engine (PostgREST) e no
+ * turn-bridge (pg) — e nascia sem nenhuma (issue #701).
+ *
+ * O turn-bridge já guarda dentro da própria escrita (`insert ... select ... and
+ * not c.is_anonymized`, merged no #657). Aqui se prova a do engine, que é o
+ * caminho em que o PostgREST não expressa `insert ... select`.
+ *
+ * As duas direções estão medidas, porque uma guarda que nunca deixa passar não é
+ * uma guarda, é uma porta fechada: o contato anonimizado NÃO gera aviso, e o
+ * contato comum gera — com o mesmo conteúdo de antes.
+ *
+ * `createSupabaseAdminClient` recebe o client por parâmetro exatamente para isto:
+ * o dublê registra as escritas, e o que se afirma é sobre o que foi escrito (ou
+ * não), não sobre a presença de um `if` no código.
+ */
+import { describe, expect, it } from "vitest";
+
+import { createSupabaseAdminClient } from "@/lib/followup/engine";
+import type { AvisoRecuperacaoEsgotada } from "@/lib/followup/no-show-recuperacao-esgotada";
+
+const ORG = "22222222-2222-4222-8222-222222222222";
+const CONTATO = "33333333-3333-4333-8333-333333333333";
+const COMPROMISSO = "55555555-5555-4555-8555-555555555555";
+const MATRICULA = "66666666-6666-4666-8666-666666666666";
+
+const AVISO: AvisoRecuperacaoEsgotada = {
+  organization_id: ORG,
+  appointment_id: COMPROMISSO,
+  appointment_revision: 3,
+  ref_enrollment_id: MATRICULA,
+};
+
+interface Escrita {
+  tabela: string;
+  linha: Record<string, unknown>;
+}
+
+/**
+ * O pedaço de PostgREST que o adaptador usa, com a resposta que o teste quer.
+ *
+ * `compromisso` é o que `calendar_appointments` devolve (ou `null`, quando o
+ * compromisso não existe mais) e `contato` o que `contacts` devolve.
+ */
+function cliente(opcoes: {
+  compromisso?: { contact_id: string | null } | null;
+  contato?: { is_anonymized: boolean | null } | null;
+  erroNaLeitura?: boolean;
+}) {
+  const inseridos: Escrita[] = [];
+  const colunasLidas: string[] = [];
+  const consultas: string[] = [];
+
+  const q = {
+    select: (colunas: string) => {
+      consultas.push(colunas);
+      return q;
+    },
+    eq: () => q,
+    maybeSingle: async () => {
+      if (opcoes.erroNaLeitura) return { data: null, error: { message: "permissão negada" } };
+      const ultima = consultas[consultas.length - 1] ?? "";
+      if (ultima.includes("contact_id")) return { data: opcoes.compromisso ?? null, error: null };
+      return { data: opcoes.contato ?? null, error: null };
+    },
+    insert: async (linha: Record<string, unknown>) => {
+      inseridos.push({ tabela: "agent_inbox_items", linha });
+      return { error: null };
+    },
+  };
+
+  const cliente = {
+    from: (tabela: string) => {
+      colunasLidas.push(tabela);
+      return q;
+    },
+    // O adaptador inteiro é devolvido; este teste só exercita o método do aviso.
+    rpc: async () => ({ data: null, error: null }),
+  };
+
+  return { cliente, inseridos, colunasLidas };
+}
+
+async function abrir(alvo: ReturnType<typeof cliente>): Promise<void> {
+  const admin = createSupabaseAdminClient(alvo.cliente as never);
+  await admin.abrirAvisoRecuperacaoEsgotada?.(AVISO);
+}
+
+describe("a quarta porta do aviso de recuperação", () => {
+  it("⭐ contato anonimizado NÃO gera aviso — o vínculo não ressuscita", async () => {
+    const alvo = cliente({
+      compromisso: { contact_id: CONTATO },
+      contato: { is_anonymized: true },
+    });
+
+    await abrir(alvo);
+
+    expect(
+      alvo.inseridos,
+      "o aviso nasceu apontando para o compromisso que a anonimização desligou",
+    ).toEqual([]);
+  });
+
+  it("⭐ contato comum gera o aviso de sempre — a guarda não fecha a porta para quem não exerceu o direito", async () => {
+    const alvo = cliente({
+      compromisso: { contact_id: CONTATO },
+      contato: { is_anonymized: false },
+    });
+
+    await abrir(alvo);
+
+    expect(alvo.inseridos).toHaveLength(1);
+    expect(alvo.inseridos[0]!.linha).toMatchObject({
+      organization_id: ORG,
+      kind: "appointment_recovery_review",
+      ref_kind: "appointment",
+      ref_id: COMPROMISSO,
+      appointment_revision: 3,
+    });
+  });
+
+  it("a checagem consulta a anonimização do contato do COMPROMISSO", async () => {
+    const alvo = cliente({
+      compromisso: { contact_id: CONTATO },
+      contato: { is_anonymized: false },
+    });
+
+    await abrir(alvo);
+
+    // O contato vem do compromisso, e não do enrollment: é o vínculo que a
+    // anonimização de fato percorre (`fn_meet_redact_contact` desliga o
+    // compromisso, e o `ref_id` do aviso é ele).
+    expect(alvo.colunasLidas).toContain("calendar_appointments");
+    expect(alvo.colunasLidas).toContain("contacts");
+  });
+
+  it("leitura que falha vira erro — a dúvida não vira aviso", async () => {
+    const alvo = cliente({ erroNaLeitura: true });
+
+    await expect(abrir(alvo)).rejects.toThrow();
+    expect(alvo.inseridos).toEqual([]);
+  });
+});

--- a/tests/unit/lgpd-cascata-cancela-a-regua.test.ts
+++ b/tests/unit/lgpd-cascata-cancela-a-regua.test.ts
@@ -1,0 +1,282 @@
+/**
+ * A RÉGUA DE RECUPERAÇÃO PARA DE CORRER PARA QUEM PEDIU PARA SER ESQUECIDO.
+ *
+ * ─── O defeito, medido (issue #701) ─────────────────────────────────────────
+ *
+ * `appointment_recovery_review` — o aviso "cliente faltou e não respondeu à
+ * recuperação" — tem quatro portas de entrada, e três guardam anonimização (o
+ * trigger `fn_meet_redact_contact` resolve os abertos, `fn_appointment_recover`
+ * recusa contato anonimizado, e há um bloco de cura no baseline). A quarta é
+ * escrita pelo TypeScript, nos adaptadores de `followup`, e nascia sem guarda.
+ *
+ * A CAUSA, porém, não é a porta: é que a cascata de LGPD não cancelava
+ * `followup_enrollments`. Medido com controle positivo:
+ *
+ *   $ git grep -l "followup" lib/lgpd/           → (vazio)
+ *   $ git grep -l "agent_inbox_items" lib/lgpd/  → (a sonda enxerga)
+ *
+ * Ou seja: o contato é anonimizado, e a régua CONTINUA correndo. Quando ela
+ * esgota, nasce um aviso apontando para o compromisso que a redação tinha
+ * desligado — o aviso ressuscitando o vínculo que a LGPD mandou cortar, e
+ * mensagem saindo para quem exerceu o direito de ser esquecido.
+ *
+ * ─── O que este arquivo mede ────────────────────────────────────────────────
+ *
+ * O passo que cancela a régua mora na MESMA unidade que as duas bocas da cascata
+ * compartilham (`lib/lgpd/cascata.ts`): a rota `POST /api/v1/lgpd/anonymize` e o
+ * varredor diário do cron de retenção. As três propriedades que o tornam seguro
+ * rodar todo dia, para sempre, estão aqui:
+ *
+ *   1. ele CANCELA a régua viva do contato (senão a causa continua de pé);
+ *   2. ele NÃO toca em régua de outro contato nem de outra organização — o
+ *      client do cron é service role, que bypassa a RLS, e o filtro de org é à
+ *      mão justamente por isso;
+ *   3. ele é IDEMPOTENTE — a segunda passada não encontra régua viva e não
+ *      escreve nada. Sem isso a varredura diária gravaria `completed_at` novo em
+ *      toda rodada, com a auditoria registrando efeito que não houve.
+ *
+ * O que o Postgres de fato aceita está fora daqui, como em
+ * `lgpd-varredura-completa-a-cascata`: o dublê aplica o UPDATE, mas o CHECK de
+ * `followup_enrollments` (status × `next_eval_at`) quem garante é o banco.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  type ClienteDaCascata,
+  completarRedacaoDoContato,
+  varrerRedacoesIncompletas,
+} from "@/lib/lgpd/cascata";
+
+const ORG = "22222222-2222-4222-8222-222222222222";
+const OUTRA_ORG = "44444444-4444-4444-8444-444444444444";
+const CONTATO = "contacts:a";
+const OUTRO_CONTATO = "contacts:b";
+
+/** O motivo é pinado por VALOR: vocabulário de auditoria não é detalhe interno. */
+const MOTIVO = "Contato anonimizado (LGPD)";
+
+interface Linha {
+  id: string;
+  organization_id: string;
+  contact_id?: string | null;
+  title?: string | null;
+  payload?: unknown;
+  is_anonymized?: boolean;
+  status?: string | null;
+  cancel_reason?: string | null;
+  next_eval_at?: string | null;
+  claimed_until?: string | null;
+  completed_at?: string | null;
+}
+
+interface Escrita {
+  tabela: string;
+  patch: Record<string, unknown>;
+  alvos: string[];
+}
+
+/**
+ * Um PostgREST de mentira com linhas de VERDADE, que APLICA o UPDATE.
+ *
+ * Aplicar importa: sem isso, "a segunda passada não escreve" passaria por
+ * vacuidade — a segunda leitura veria o mesmo estado vivo da primeira, e o teste
+ * não distinguiria idempotência de dublê amnésico. É o mesmo dublê de
+ * `lgpd-varredura-completa-a-cascata`, e o `id` carrega a tabela (`tabela:x`)
+ * porque ele guarda tudo numa lista só.
+ */
+function banco(linhas: Linha[]) {
+  const escritas: Escrita[] = [];
+
+  const aplicar = (tabela: string, patch: Record<string, unknown>, alvos: Linha[]) => {
+    escritas.push({ tabela, patch, alvos: alvos.map((l) => l.id) });
+    for (const l of alvos) Object.assign(l, patch);
+  };
+
+  const cliente = {
+    from(tabela: string) {
+      const casar = (filtros: Array<[string, unknown]>, dentro: [string, string[]] | null): Linha[] =>
+        linhas.filter((l) => {
+          if ((l.id.split(":")[0] ?? "") !== tabela) return false;
+          for (const [col, val] of filtros) {
+            if ((l as unknown as Record<string, unknown>)[col] !== val) return false;
+          }
+          // O `.in()` desta cascata vem em duas colunas — `status` no SELECT da
+          // régua e `id` no UPDATE das atividades. Um dublê que ignorasse a
+          // coluna casaria as duas na errada e daria verde falso.
+          if (dentro) {
+            const [col, vals] = dentro;
+            const valor = (l as unknown as Record<string, string | undefined>)[col];
+            if (valor === undefined || !vals.includes(valor)) return false;
+          }
+          return true;
+        });
+
+      const construir = (modo: "select" | "update", patch: Record<string, unknown>) => {
+        const filtros: Array<[string, unknown]> = [];
+        let dentro: [string, string[]] | null = null;
+        let teto: number | null = null;
+        const q: Record<string, unknown> = {
+          eq: (col: string, val: unknown) => {
+            filtros.push([col, val]);
+            return q;
+          },
+          in: (col: string, vals: string[]) => {
+            dentro = [col, vals];
+            return q;
+          },
+          limit: (n: number) => {
+            teto = n;
+            return q;
+          },
+          then: (r: (v: unknown) => unknown) => {
+            let achadas = casar(filtros, dentro);
+            if (teto !== null) achadas = achadas.slice(0, teto);
+            if (modo === "update") {
+              aplicar(tabela, patch, achadas);
+              return Promise.resolve({ error: null }).then(r);
+            }
+            return Promise.resolve({ data: achadas, error: null }).then(r);
+          },
+        };
+        return q;
+      };
+
+      return {
+        select: () => construir("select", {}),
+        update: (patch: Record<string, unknown>) => construir("update", patch),
+      };
+    },
+  } as unknown as ClienteDaCascata;
+
+  return { cliente, escritas, linhas };
+}
+
+/** Contato já anonimizado, como a linha que a varredura encontra no banco. */
+function contatoAnonimizado(sufixo = "a", org = ORG): Linha {
+  return { id: `contacts:${sufixo}`, organization_id: org, is_anonymized: true };
+}
+
+function matricula(
+  sufixo: string,
+  status: string,
+  { org = ORG, contactId = CONTATO }: { org?: string; contactId?: string } = {},
+): Linha {
+  return {
+    id: `followup_enrollments:${sufixo}`,
+    organization_id: org,
+    contact_id: contactId,
+    status,
+    next_eval_at: "2026-09-01T10:00:00.000Z",
+    claimed_until: "2026-09-01T10:05:00.000Z",
+  };
+}
+
+/** As escritas na régua, que é o que este arquivo vigia. */
+function escritasNaRegua(alvo: ReturnType<typeof banco>): Escrita[] {
+  return alvo.escritas.filter((e) => e.tabela === "followup_enrollments");
+}
+
+describe("a cascata cancela a régua de recuperação do contato", () => {
+  it("⭐ régua viva do contato anonimizado é cancelada — é a causa, não o sintoma", async () => {
+    const alvo = banco([
+      contatoAnonimizado(),
+      matricula("e1", "active"),
+      matricula("e2", "waiting_reply"),
+      matricula("e3", "paused_handoff"),
+      // `paused_manual` é a quarta janela de status vivo (migration 0225): se o
+      // vocabulário do cancelamento divergir do claim do worker, sobra régua
+      // viva para trás — e é ela que abre o aviso depois.
+      matricula("e4", "paused_manual"),
+    ]);
+
+    await completarRedacaoDoContato(alvo.cliente, { id: CONTATO, organizationId: ORG });
+
+    const escritas = escritasNaRegua(alvo);
+    expect(escritas, "a régua continuou correndo para o contato anonimizado").toHaveLength(1);
+    expect(escritas[0]!.alvos.sort()).toEqual([
+      "followup_enrollments:e1",
+      "followup_enrollments:e2",
+      "followup_enrollments:e3",
+      "followup_enrollments:e4",
+    ]);
+    expect(escritas[0]!.patch.status).toBe("cancelled");
+    expect(escritas[0]!.patch.cancel_reason).toBe(MOTIVO);
+    // Sem soltar o relógio e o lease, a linha cancelada continua parecendo
+    // reivindicável: é o `next_eval_at`/`claimed_until` que o claim filtra.
+    expect(escritas[0]!.patch.next_eval_at).toBeNull();
+    expect(escritas[0]!.patch.claimed_until).toBeNull();
+    expect(typeof escritas[0]!.patch.completed_at).toBe("string");
+
+    // A auditoria registra o que foi tocado de verdade — a linha
+    // `lgpd.anonymize_catchup` deixaria de citar a régua se ela não entrasse aqui.
+    expect(escritas[0]!.patch).toHaveProperty("completed_at");
+  });
+
+  it("⭐ régua de OUTRO contato e de OUTRA organização não é tocada", async () => {
+    const alvo = banco([
+      contatoAnonimizado(),
+      contatoAnonimizado("b"),
+      contatoAnonimizado("z", OUTRA_ORG),
+      matricula("e1", "active"),
+      matricula("e2", "active", { contactId: OUTRO_CONTATO }),
+      matricula("e3", "active", { org: OUTRA_ORG }),
+    ]);
+
+    await completarRedacaoDoContato(alvo.cliente, { id: CONTATO, organizationId: ORG });
+
+    const escritas = escritasNaRegua(alvo);
+    expect(escritas, "cancelou régua alheia").toHaveLength(1);
+    expect(escritas[0]!.alvos).toEqual(["followup_enrollments:e1"]);
+  });
+
+  it("⭐ régua já terminal não é reescrita — a varredura diária não grava sobre dado certo", async () => {
+    const alvo = banco([
+      contatoAnonimizado(),
+      matricula("e1", "completed"),
+      matricula("e2", "cancelled"),
+      matricula("e3", "dead"),
+    ]);
+
+    const r = await completarRedacaoDoContato(alvo.cliente, { id: CONTATO, organizationId: ORG });
+
+    expect(escritasNaRegua(alvo), "reescreveu régua que já tinha terminado").toEqual([]);
+    expect(r.tabelas).not.toContain("followup_enrollments");
+  });
+
+  it("⭐ a segunda passada não escreve — idempotência é o que torna o cron diário seguro", async () => {
+    const alvo = banco([contatoAnonimizado(), matricula("e1", "active")]);
+
+    await completarRedacaoDoContato(alvo.cliente, { id: CONTATO, organizationId: ORG });
+    const depoisDaPrimeira = escritasNaRegua(alvo).length;
+    await completarRedacaoDoContato(alvo.cliente, { id: CONTATO, organizationId: ORG });
+    await completarRedacaoDoContato(alvo.cliente, { id: CONTATO, organizationId: ORG });
+
+    expect(escritasNaRegua(alvo), "a régua foi cancelada mais de uma vez").toHaveLength(depoisDaPrimeira);
+  });
+
+  it("⭐ `tabelas` passa a citar a régua quando ela foi tocada", async () => {
+    const alvo = banco([contatoAnonimizado(), matricula("e1", "active")]);
+
+    const r = await completarRedacaoDoContato(alvo.cliente, { id: CONTATO, organizationId: ORG });
+
+    expect(r.tabelas).toContain("followup_enrollments");
+  });
+
+  it("⭐ a varredura do cron alcança a régua do contato que ficou pela metade", async () => {
+    // A retomada existe para curar cascata interrompida — e a interrupção pode
+    // ter sido ANTES deste passo existir: o contato anonimizado de ontem tem
+    // régua viva e resíduo de lead. É por esta porta que o conserto o alcança.
+    const alvo = banco([
+      contatoAnonimizado(),
+      { id: "crm_leads:1", organization_id: ORG, contact_id: CONTATO, title: "Orçamento com PII" },
+      matricula("e1", "active"),
+    ]);
+
+    const r = await varrerRedacoesIncompletas(alvo.cliente);
+
+    expect(r.completados).toHaveLength(1);
+    const escritas = escritasNaRegua(alvo);
+    expect(escritas, "o cron completou o resíduo e deixou a régua correndo").toHaveLength(1);
+    expect(escritas[0]!.alvos).toEqual(["followup_enrollments:e1"]);
+  });
+});


### PR DESCRIPTION
# O que este PR faz

A cascata de LGPD passa a **cancelar a régua de recuperação** do contato anonimizado, e a quarta porta de `appointment_recovery_review` ganha a guarda de anonimização que faltava.

A issue separa sintoma e causa, e o PR segue a mesma ordem. **Causa:** a cascata redigia contatos, leads e atividades e deixava `followup_enrollments` correndo — medido na issue com controle positivo (`git grep -l "followup" lib/lgpd/` voltava vazio, enquanto a sonda enxergava `agent_inbox_items`). **Sintoma:** a régua esgotava DEPOIS da redação e o aviso de recuperação nascia apontando para o compromisso que a anonimização tinha desligado — o aviso ressuscitando o vínculo que a LGPD mandou cortar. Antes dele, as mensagens da própria régua seguiam chegando a quem pediu para ser esquecido.

Closes #701

## Como resolve

- **`lib/lgpd/cascata.ts` — Passo 4, a causa.** `completarRedacaoDoContato` passa a cancelar as réguas vivas do contato (`status`, `cancel_reason`, `completed_at`, `next_eval_at`, `claimed_until` — só colunas que a tabela já tem; **sem migration**). Mora neste arquivo, e não na RPC `fn_lgpd_cascade_redact_contact`, porque ele é a unidade que as **duas** bocas compartilham: a rota e o cron. Cancelar só na RPC deixaria a retomada (`lgpd.anonymize_catchup`, que não passa pela RPC) sem cancelamento — e é justamente por ela que se alcança o contato anonimizado antes desta issue. É a mesma escolha de arquitetura do #310.
- **`STATUS_DA_REGUA_VIVA`** (`active`, `waiting_reply`, `paused_handoff`, `paused_manual`) — os mesmos status que o cancelamento por compromisso desfeito usa em SQL e que o índice de claim filtra. Divergir deles é deixar régua viva para trás; é também o que torna o passo idempotente (`cancelled` é terminal, então a segunda passada não encontra linha). `SELECT` antes do `UPDATE` pelo mesmo motivo: em regime não se grava sobre dado certo toda rodada diária, com auditoria registrando efeito que não houve.
- **`lib/followup/engine.ts` — a guarda da quarta porta.** Esta porta só existe em TypeScript: as outras três guardas moram em SQL (`fn_meet_redact_contact`, `fn_appointment_recover` e o bloco de cura do histórico), e quem escreve o `kind` daqui não as encontra. A checagem vem **antes** do insert porque o PostgREST não expressa `insert ... select` — é por isso que o adaptador pg de `turn-bridge.ts` guarda dentro da escrita. Duas consultas simples em vez de join embutido pelo motivo já declarado no `cascata.ts`: o join depende do nome da FK e nenhum teste local o exercita.
- **`lib/followup/turn-bridge.ts`** — o comentário do #657 afirmava que a cascata não cancelava a régua. Era verdade quando foi escrito e deixou de ser: o texto passa a dizer o que o repo faz agora, e continua sendo a segunda linha de defesa (um turno já reivindicado pode terminar depois do cancelamento, e é nesta escrita que ele não vira aviso).
- **`tests/unit/aviso-de-compromisso-checa-anonimizacao.test.ts` (novo)** — o invariante que a issue pede: todo produtor de `agent_inbox_items` com `ref_kind='appointment'` tem que checar `is_anonymized` — a guarda deixa de depender de quem escreve lembrar. Mesma classe do #690.
- **`.changes/lgpd-cancela-a-regua-do-contato-anonimizado.md`** — fragmento de changelog.

## O que medi (comandos e saídas)

**Teste vermelho antes da mudança (RED real).** Com os três arquivos novos no lugar e o fix revertido: `pnpm exec vitest run tests/unit/{lgpd-cascata-cancela-a-regua,followup-aviso-nao-nasce-para-anonimizado,aviso-de-compromisso-checa-anonimizacao}.test.ts` → `Test Files 3 failed (3)` / `Tests 8 failed | 7 passed (15)`, todas as 8 por **asserção** (nenhum "Failed to load" ou erro de import no log) — falham porque o comportamento não existe, não porque não compila.

**Sabotagem** (depois do commit; previsão escrita em `/tmp/701-previsao-sabotagem.txt` **antes** de rodar: 8 casos em 3 arquivos, 4+3+1):
- variante A (arquivo inteiro do fix revertido): `Tests 8 failed | 7 passed` — 4 em `lgpd-cascata…`, 3 em `followup-aviso…`, 1 no invariante. Bateu a previsão caso a caso.
- variante B (cirúrgica: comportamento fora, `export`s novos mantidos): `Tests 8 failed | 7 passed` — mesma contagem, porque os testes não importam os exports novos.
- restauração: `git checkout HEAD -- lib/lgpd/cascata.ts lib/followup/engine.ts` → `git status --porcelain` vazio, `git diff HEAD --stat` vazio, e os 3 arquivos novos + 3 de LGPD já existentes: `Test Files 6 passed (6)` / `Tests 42 passed (42)`.

**Gates** (um pesado por vez, `flock` + `systemd-run --scope -p MemoryMax=5G`):

| gate | resultado |
|---|---|
| `pnpm typecheck` | **rc=0** — `tsc --noEmit -p tsconfig.typecheck.json`, sem saída |
| `pnpm lint` | **rc=0** — `0 errors`, 349 warnings pré-existentes; nenhum nos 6 arquivos desta mudança |
| `pnpm release:conferir` | **rc=0** — `1.20.0 + patch = 1.20.1 (1 fragmento(s))`, seção `corrigido` |

## O que NÃO medi

- **`pnpm test:unit` (suíte completa), `pnpm build` e `pnpm test:shell`** — não rodaram até a abertura deste PR; a rodada está na fila local e o resultado vai em comentário aqui. (`pnpm test:db` não se aplica à mudança: nenhuma migration, nenhum DDL.)
- **Nada contra banco real.** Todo o comportamento foi medido com cliente falso (dublê de `from/select/eq/in/limit/update/maybeSingle/insert`). O `update` do PostgREST é a mesma chamada que o passo das atividades deste arquivo já faz — leitura de código, não medição. Consequência: nenhum `CHECK` do `baseline.sql` foi validado por execução para o valor gravado em `cancel_reason`.
- **Não medi** o caminho do worker reivindicando a régua exatamente entre o `select` e o `update` do cancelamento — a janela existe, e é a guarda do `engine.ts` que cobre o aviso que nasceria nela.
- **Não medi** se há instalação com resíduo de régua viva em contato já anonimizado: a retomada alcança esses pelo varredor diário, mas só os que ainda tenham resíduo de lead/atividade.
