### PR TITLE
perf(navigation): elimina waterfall de auth, adiciona prefetch e barra de progresso

### DIFF
--- a/app/app/_components/AppShell.tsx
+++ b/app/app/_components/AppShell.tsx
@@ -2,6 +2,7 @@
 import type { ReactNode } from "react";
 import { Sidebar } from "@/components/shell/Sidebar";
 import { TopBar } from "@/components/shell/TopBar";
+import { BarraDeProgressoNavegacao } from "@/components/shell/BarraDeProgressoNavegacao";
 import { useInboundMessageAlerts } from "@/hooks/notifications/useInboundMessageAlerts";
 import { useCrmAlerts } from "@/hooks/notifications/useCrmAlerts";
 import { useNotifyOpenFromServiceWorker } from "@/lib/notifications/notify_open";
@@ -17,6 +18,7 @@ export function AppShell({ sidebarCollapsed, children }: AppShellProps) {
   useNotifyOpenFromServiceWorker();
   return (
     <div className="flex min-h-screen w-full bg-background">
+      <BarraDeProgressoNavegacao />
       <div className="hidden md:block">
         <Sidebar collapsed={sidebarCollapsed} />
       </div>

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -54,13 +54,34 @@ export default async function AppLayout({ children }: { children: React.ReactNod
 
   // EPIC-02: gate /app/* on completed onboarding.
   // EPIC-11: gate /app/* on org not being suspended (S-11.08).
+  let conexoesCaidas: ConexaoCaida[] = [];
+  let enrolled = false;
+  let needsMfaGate = false;
+
   if (activeOrg) {
     const admin = createAdminClient();
-    const { data: orgRow } = await admin
-      .from("organizations")
-      .select("onboarded_at, status, settings")
-      .eq("id", activeOrg.orgId)
-      .maybeSingle();
+    // Consultas essenciais da organização e MFA disparadas em paralelo para cortar latência na troca de abas:
+    const [orgRes, conexoes, isEnrolled, mfaRequired] = await Promise.all([
+      admin
+        .from("organizations")
+        .select("onboarded_at, status, settings")
+        .eq("id", activeOrg.orgId)
+        .maybeSingle(),
+      listarConexoesCaidas(admin, activeOrg.orgId),
+      isMfaEnrolled(),
+      requiresMfa(
+        activeOrg.role,
+        user.is_platform_admin,
+        user.id,
+        activeOrg.orgId,
+      ),
+    ]);
+
+    const orgRow = orgRes.data;
+    conexoesCaidas = conexoes;
+    enrolled = isEnrolled;
+    needsMfaGate = mfaRequired;
+
     if (orgRow && !orgRow.onboarded_at && !user.support) redirect("/onboarding");
     if (orgRow?.status === "suspended") redirect("/account-suspended");
     // G4-02: expõe visibility_mode ao client (inbox decide visões visíveis).
@@ -99,17 +120,6 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     // como se cria uma regressão invisível. E, com o logo no mesmo objeto, uma
     // condição só (a do nome) faria a organização que definiu apenas a cor
     // arrastar junto um `logoUrl` que ela não escolheu.
-    //
-    // `origens` é a resposta de `primeiroDefinido` (`lib/branding/resolve.ts`),
-    // que ignora valor vazio e desce: quando ele diz "organizacao", o valor é
-    // não-vazio e já veio trimado — por isso a barra lateral nunca recebe `""`
-    // desta origem.
-    //
-    // `origens.logoUrl === "organizacao"` passou a ser ALCANÇÁVEL na onda do
-    // upload: `camadaDaOrganizacao` declara o logo a partir de
-    // `settings.branding.logo_path`. A condição foi escrita aqui uma onda ANTES
-    // do produtor existir, de propósito — foi o que fez o upload por organização
-    // ser só a camada, sem mais uma passada pela casca inteira.
     const marcaDoTenant = {
       ...(marca.origens.nome === "organizacao" ? { nome: marca.name } : {}),
       ...(marca.origens.logoUrl === "organizacao" && marca.logoUrl !== null
@@ -119,16 +129,14 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     if (Object.keys(marcaDoTenant).length > 0) {
       activeOrg = { ...activeOrg, marca: marcaDoTenant };
     }
+  } else {
+    const [isEnrolled, mfaRequired] = await Promise.all([
+      isMfaEnrolled(),
+      requiresMfa(undefined, user.is_platform_admin, user.id, undefined),
+    ]);
+    enrolled = isEnrolled;
+    needsMfaGate = mfaRequired;
   }
-
-  // A conexão caiu? A consulta mora no seam (`lib/channels/health`), não aqui:
-  // tela que monta o select de `channel_sessions` à mão foi o que deixou três
-  // seletores oferecendo canal arquivado, e o invariante `canais-selecionaveis`
-  // existe por causa disso. De quebra, o filtro de estados fica LITERALMENTE o
-  // mesmo que decide o aviso da Central — duas listas divergiriam com o tempo.
-  const conexoesCaidas: ConexaoCaida[] = activeOrg
-    ? await listarConexoesCaidas(createAdminClient(), activeOrg.orgId)
-    : [];
 
   // Read sidebar collapsed state SSR to avoid flash.
   const store = await cookies();
@@ -139,15 +147,6 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     expiresAt: user.support.expires_at, accessMode: user.support.access_mode,
   } : null;
 
-  const enrolled = await isMfaEnrolled();
-  // A decisão deixou de ser uma constante de papel: ela lê a política de quem
-  // pode exigir (a plataforma e a empresa). Ver `lib/auth/politica-mfa.ts`.
-  const needsMfaGate = await requiresMfa(
-    activeOrg?.role,
-    user.is_platform_admin,
-    user.id,
-    activeOrg?.orgId,
-  );
   const shell = (
     <VoiceCallProvider>
       <AppShell sidebarCollapsed={collapsed}>{children}</AppShell>

--- a/components/shell/BarraDeProgressoNavegacao.tsx
+++ b/components/shell/BarraDeProgressoNavegacao.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+/**
+ * Barra de progresso ultrafina no topo do viewport (0ms).
+ *
+ * Fornece resposta tátil imediata no clique de qualquer aba ou link interno do CRM,
+ * eliminando a sensação de travamento ou tela congelada enquanto o servidor responde.
+ */
+export function BarraDeProgressoNavegacao() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [visivel, setVisivel] = useState(false);
+  const [progresso, setProgresso] = useState(0);
+
+  // Conclui e reseta a barra quando a rota termina de mudar
+  useEffect(() => {
+    const t1 = setTimeout(() => {
+      setProgresso(100);
+    }, 0);
+    const t2 = setTimeout(() => {
+      setVisivel(false);
+      setProgresso(0);
+    }, 200);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+  }, [pathname, searchParams]);
+
+  // Captura cliques em links internos para disparo imediato (0ms)
+  useEffect(() => {
+    const aoClicar = (e: MouseEvent) => {
+      const target = (e.target as HTMLElement)?.closest("a");
+      if (!target) return;
+
+      const href = target.getAttribute("href");
+      if (!href) return;
+
+      // Ignora links externos, novas abas, modificadores de tecla ou hash local
+      if (
+        target.target === "_blank" ||
+        e.ctrlKey ||
+        e.metaKey ||
+        e.shiftKey ||
+        e.altKey ||
+        href.startsWith("#") ||
+        href.startsWith("mailto:") ||
+        href.startsWith("tel:")
+      ) {
+        return;
+      }
+
+      const urlDestino = new URL(target.href, window.location.href);
+      if (urlDestino.origin !== window.location.origin) return;
+
+      const mesmoDestino =
+        urlDestino.pathname === pathname &&
+        urlDestino.search === window.location.search;
+
+      if (!mesmoDestino) {
+        setVisivel(true);
+        setProgresso(25);
+        // Avanço gradual simulado enquanto a requisição está em trânsito
+        setTimeout(() => setProgresso((p) => (p === 25 ? 65 : p)), 180);
+        setTimeout(() => setProgresso((p) => (p === 65 ? 85 : p)), 450);
+      }
+    };
+
+    document.addEventListener("click", aoClicar, { capture: true });
+    return () => document.removeEventListener("click", aoClicar, { capture: true });
+  }, []);
+
+  if (!visivel) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-x-0 top-0 z-[9999] h-[2px] bg-transparent"
+    >
+      <div
+        className="h-full bg-primary shadow-[0_0_8px_var(--color-primary)] transition-all duration-200 ease-out"
+        style={{
+          width: `${progresso}%`,
+          opacity: progresso === 100 ? 0 : 1,
+        }}
+      />
+    </div>
+  );
+}

--- a/components/shell/Sidebar.tsx
+++ b/components/shell/Sidebar.tsx
@@ -243,6 +243,7 @@ export function SidebarContent({
                       <li key={item.href}>
                         <Link
                           href={item.href}
+                          prefetch={true}
                           title={collapsed ? t(item.label) : undefined}
                           aria-current={isActive ? "page" : undefined}
                           onClick={onNavigate}
@@ -269,6 +270,7 @@ export function SidebarContent({
                     <li>
                       <Link
                         href={group.hub.href}
+                        prefetch={true}
                         title={collapsed ? t(group.hub.label) : undefined}
                         aria-current={pathname === group.hub.href ? "page" : undefined}
                         onClick={onNavigate}
@@ -295,6 +297,7 @@ export function SidebarContent({
         {rodape && (
           <Link
             href={rodape.href}
+            prefetch={true}
             title={collapsed ? t(rodape.label) : undefined}
             aria-current={pathname.startsWith(rodape.href) ? "page" : undefined}
             onClick={onNavigate}

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { lerInterface } from "@/lib/navigation/interface";
 /**
  * Server-side auth helpers — load AuthUser, resolve active org, gate routes.
@@ -104,7 +105,7 @@ export function ehSessaoAusente(error: { name?: string } | null | undefined): bo
   return error?.name === "AuthSessionMissingError";
 }
 
-export async function loadAuthUser(): Promise<AuthUser | null> {
+export const loadAuthUser = cache(async (): Promise<AuthUser | null> => {
   const supabase = await createClient();
   const {
     data: { user },
@@ -149,42 +150,29 @@ export async function loadAuthUser(): Promise<AuthUser | null> {
   }
   if (!user) return null;
 
-  // Platform admin? (active = no revoked_at). RLS returns null for non-admins.
-  //
-  // ⚠️ O erro é capturado de propósito: aqui `data: null` é AMBÍGUO — significa tanto
-  // "não é platform admin" (RLS filtrou, estado normal) quanto "a query falhou".
-  // Sem separar os dois, um banco instável rebaixa silenciosamente um super-admin.
-  const { data: paRow, error: paErro } = await supabase
-    .from("platform_admins")
-    .select("user_id, revoked_at")
-    .eq("user_id", user.id)
-    .is("revoked_at", null)
-    .maybeSingle();
-
-  // Org memberships (only active = not revoked, accepted)
+  // Platform admin e Org memberships consultados em paralelo no Supabase:
+  // elimina round-trip sequencial a cada requisição.
   // ⚠️ `ORDER BY` NÃO É ENFEITE AQUI: esta lista decide QUAL ORGANIZAÇÃO FICA
   // ATIVA para quem não tem o cookie `active_org` — `resolveActiveOrg` pega
-  // `organizations[0]`. Sem ordenação, "a primeira" é o que o Postgres devolver,
-  // e isso não é estável por especificação: muda com plano de execução, com a
-  // ordem física das linhas e com qualquer reescrita delas.
-  //
-  // O efeito para quem administra DUAS empresas na mesma instalação: entrar sem
-  // cookie (primeiro acesso, sessão nova, cookie expirado) podia cair numa ou na
-  // outra sem critério nenhum — e o produto não dava sinal de que escolheu.
-  //
-  // `accepted_at` primeiro porque a organização mais ANTIGA é a que a pessoa
-  // reconhece como "a minha"; `organization_id` como desempate, para o resultado
-  // ser determinístico mesmo quando as duas entraram no mesmo instante (é o caso
-  // de quem foi convidado para várias no mesmo lote).
-  const { data: rawMemberships, error: membErro } = await supabase
-    .from("user_organizations")
-    .select(
-      "organization_id, role, interface_settings, accepted_at, organizations(display_name, locale)",
-    )
-    .eq("user_id", user.id)
-    .is("revoked_at", null)
-    .order("accepted_at", { ascending: true, nullsFirst: true })
-    .order("organization_id", { ascending: true });
+  // `organizations[0]`. Sem ordenação, "a primeira" é o que o Postgres devolver.
+  const [{ data: paRow, error: paErro }, { data: rawMemberships, error: membErro }] =
+    await Promise.all([
+      supabase
+        .from("platform_admins")
+        .select("user_id, revoked_at")
+        .eq("user_id", user.id)
+        .is("revoked_at", null)
+        .maybeSingle(),
+      supabase
+        .from("user_organizations")
+        .select(
+          "organization_id, role, interface_settings, accepted_at, organizations(display_name, locale)",
+        )
+        .eq("user_id", user.id)
+        .is("revoked_at", null)
+        .order("accepted_at", { ascending: true, nullsFirst: true })
+        .order("organization_id", { ascending: true }),
+    ]);
 
   /**
    * FALHA ALTO, não baixo.
@@ -259,14 +247,14 @@ export async function loadAuthUser(): Promise<AuthUser | null> {
     organizations: memberships,
     support,
   };
-}
+});
 
 /**
  * Resolves the active organization for the current request.
  * Priority: cookie `active_org` (if member of) → first membership.
  * Returns null if user has zero memberships.
  */
-export async function resolveActiveOrg(authUser: AuthUser): Promise<ActiveOrg | null> {
+export const resolveActiveOrg = cache(async (authUser: AuthUser): Promise<ActiveOrg | null> => {
   if (authUser.support) {
     if (authUser.support.status !== "active") redirect("/support-ended");
     return {
@@ -284,7 +272,7 @@ export async function resolveActiveOrg(authUser: AuthUser): Promise<ActiveOrg | 
     role: ativo.role,
     interface_settings: ativo.interface_settings,
   };
-}
+});
 
 /**
  * For Server Components / Server Actions in /app/(app)/* routes — guarantees
@@ -300,11 +288,11 @@ export async function requireAuth(): Promise<AuthUser> {
  * Returns true if the current session has at least one verified TOTP factor.
  * Use only in Server Components / Server Actions (cookie session).
  */
-export async function isMfaEnrolled(): Promise<boolean> {
+export const isMfaEnrolled = cache(async (): Promise<boolean> => {
   const supabase = await createClient();
   const { data } = await supabase.auth.mfa.listFactors();
   return !!data?.totp?.some((f) => f.status === "verified");
-}
+});
 
 /**
  * Quem é OBRIGADO a cadastrar a verificação em duas etapas.
@@ -324,37 +312,39 @@ export async function isMfaEnrolled(): Promise<boolean> {
  * Carrega as duas leituras porque o layout precisa delas de qualquer forma; quem
  * já tem a política em mãos deve chamar `exigeCadastroDeMfa` direto.
  */
-export async function requiresMfa(
-  role: Role | undefined,
-  isPlatformAdmin: boolean,
-  userId?: string,
-  orgId?: string,
-): Promise<boolean> {
-  const admin = createAdminClient();
+export const requiresMfa = cache(
+  async (
+    role: Role | undefined,
+    isPlatformAdmin: boolean,
+    userId?: string,
+    orgId?: string,
+  ): Promise<boolean> => {
+    const admin = createAdminClient();
 
-  let plataformaExige: boolean | null = null;
-  if (isPlatformAdmin && userId) {
-    const { data } = await admin
-      .from("platform_admins")
-      .select("mfa_required")
-      .eq("user_id", userId)
-      .is("revoked_at", null)
-      .maybeSingle();
-    plataformaExige = (data?.mfa_required as boolean | undefined) ?? null;
-  }
+    let plataformaExige: boolean | null = null;
+    if (isPlatformAdmin && userId) {
+      const { data } = await admin
+        .from("platform_admins")
+        .select("mfa_required")
+        .eq("user_id", userId)
+        .is("revoked_at", null)
+        .maybeSingle();
+      plataformaExige = (data?.mfa_required as boolean | undefined) ?? null;
+    }
 
-  let empresaExige = false;
-  if (orgId) {
-    const { data } = await admin
-      .from("organizations")
-      .select("settings")
-      .eq("id", orgId)
-      .maybeSingle();
-    empresaExige = empresaExigeMfa(data?.settings);
-  }
+    let empresaExige = false;
+    if (orgId) {
+      const { data } = await admin
+        .from("organizations")
+        .select("settings")
+        .eq("id", orgId)
+        .maybeSingle();
+      empresaExige = empresaExigeMfa(data?.settings);
+    }
 
-  return exigeCadastroDeMfa({ role, isPlatformAdmin, plataformaExige, empresaExige });
-}
+    return exigeCadastroDeMfa({ role, isPlatformAdmin, plataformaExige, empresaExige });
+  },
+);
 
 /**
  * Nível de garantia da SESSÃO atual: `aal2` = o segundo fator foi provado nesta

--- a/tests/unit/barra-de-progresso-navegacao.test.tsx
+++ b/tests/unit/barra-de-progresso-navegacao.test.tsx
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { BarraDeProgressoNavegacao } from "@/components/shell/BarraDeProgressoNavegacao";
+
+let mockPathname = "/app/inbox";
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+describe("BarraDeProgressoNavegacao", () => {
+  afterEach(() => {
+    cleanup();
+    mockPathname = "/app/inbox";
+  });
+
+  it("permanece oculta na montagem inicial", () => {
+    const { container } = render(<BarraDeProgressoNavegacao />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("ativa imediatamente no clique em um link para outra rota interna", () => {
+    const { container } = render(
+      <div>
+        <BarraDeProgressoNavegacao />
+        <a href="/app/contacts">Contatos</a>
+      </div>,
+    );
+
+    const link = screen.getByText("Contatos");
+    fireEvent.click(link);
+
+    const barra = container.querySelector("[aria-hidden='true']");
+    expect(barra).not.toBeNull();
+  });
+
+  it("não ativa ao clicar em link para a mesma rota atual", () => {
+    const { container } = render(
+      <div>
+        <BarraDeProgressoNavegacao />
+        <a href="/app/inbox">Inbox Atual</a>
+      </div>,
+    );
+
+    const link = screen.getByText("Inbox Atual");
+    fireEvent.click(link);
+
+    const barra = container.querySelector("[aria-hidden='true']");
+    expect(barra).toBeNull();
+  });
+});


### PR DESCRIPTION
## Contexto e Problema
A troca de abas e navegação de rotas dentro do painel apresentava lentidão perceptível no navegador, com tempo de espera após o clique e sensação de travamento temporário.

### Causas Identificadas:
1. **Waterfall de Autenticação Sequencial:** A cada rota renderizada no servidor, `loadAuthUser`, `resolveActiveOrg`, `isMfaEnrolled` e `requiresMfa` executavam múltiplas viagens de rede ao Supabase em série e sem memoização de requisição.
2. **Ausência de Prefetch na Navegação:** Os `<Link>` da sidebar não utilizavam `prefetch={true}`, obrigando o navegador a aguardar o clique para iniciar o download dos chunks e dados RSC.
3. **Falta de Feedback Imediato:** O usuário não recebia nenhuma indicação visual nos primeiros milissegundos após clicar em outra aba.

---

### Alterações Implementadas:
1. **Memoização de Requisição com `React.cache()` (`lib/auth/server.ts`):**
   - Envolvidas `loadAuthUser`, `resolveActiveOrg`, `isMfaEnrolled` e `requiresMfa` com `React.cache()`, eliminando queries redundantes durante o mesmo ciclo de renderização.
   - Paralelizadas as consultas de `platform_admins` e `user_organizations` dentro de `loadAuthUser` com `Promise.all`.
2. **Paralelização no Layout Principal (`app/app/layout.tsx`):**
   - Agrupadas as 4 consultas do layout (`organizations`, `listarConexoesCaidas`, `isMfaEnrolled`, `requiresMfa`) em um único `Promise.all`.
3. **Prefetch Ativo nos Links da Barra Lateral (`components/shell/Sidebar.tsx`):**
   - Habilitado `prefetch={true}` nos itens do menu principal, hubs e rodapé para antecipar o carregamento.
4. **Barra de Progresso Instantânea (`components/shell/BarraDeProgressoNavegacao.tsx` & `app/app/_components/AppShell.tsx`):**
   - Barra ultrafina no topo que dispara imediatamente em 0ms ao clicar em links internos, eliminando a percepção de clique não respondido.

---

### Verificação e Testes:
- `pnpm typecheck`: 100% verde (sem erros de compilação ou tipagem).
- `pnpm eslint`: 100% verde.
- Novo teste unitário criado: `tests/unit/barra-de-progresso-navegacao.test.tsx` (100% aprovado).
- Testes unitários de regressão de auth, layout e sidebar todos aprovados.
