### PR TITLE
fix(sec): hardening de crons, upload seguro de templates e indices de fks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Channel provider leak
         run: pnpm lint:channels
 
+      # Auditoria de autorização e papel: impede comparações diretas de papel
+      # fora de lib/auth/ que contornem o gate de MFA e requireRole().
+      - name: Role rank audit
+        run: pnpm lint:role-rank
+
       - name: Unit tests
         run: pnpm test:unit
 

--- a/app/api/v1/channels/partner/templates/media/route.ts
+++ b/app/api/v1/channels/partner/templates/media/route.ts
@@ -27,7 +27,8 @@ import { randomUUID } from "node:crypto";
 import type { NextRequest } from "next/server";
 
 import { fail, ok } from "@/lib/api/wrappers";
-import { loadAuthUser, resolveActiveOrg } from "@/lib/auth/server";
+import { requireRole } from "@/lib/auth/require-role";
+import { extensaoDe, farejarTipo, pareceSvg } from "@/lib/branding/logo-arquivo";
 import { traduzir } from "@/lib/i18n/dicionario";
 import { logger } from "@/lib/logger";
 import { createAdminClient } from "@/lib/supabase/admin";
@@ -37,13 +38,7 @@ export const dynamic = "force-dynamic";
 /** A revisão leva até 24h; a margem tem de caber num feriado. */
 const VALIDADE_SEGUNDOS = 7 * 24 * 60 * 60;
 
-/**
- * Só imagem, e só os formatos que a plataforma aceita no cabeçalho.
- *
- * Recusar aqui é melhor que deixar subir: o arquivo iria para o storage, a
- * definição seria criada, e a recusa chegaria horas depois falando de um
- * formato que o operador escolheu porque a tela deixou.
- */
+/** Só imagem, e só os formatos que a plataforma aceita no cabeçalho. */
 const TIPOS = new Set(["image/jpeg", "image/png"]);
 const TAMANHO_MAX = 5 * 1024 * 1024;
 
@@ -53,11 +48,10 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   const requestId = randomUUID();
 
-  const user = await loadAuthUser();
-  if (!user) return fail("unauthenticated", "Faça login.", 401, { requestId });
+  const authz = await requireRole("agent", { requestId, resource: "channel_templates" });
+  if (!authz.ok) return authz.response;
+  const { user, org } = authz;
   const t = (texto: string) => traduzir(texto, user.idioma);
-  const org = await resolveActiveOrg(user);
-  if (!org) return fail("forbidden", t("Sem organização ativa."), 403, { requestId });
 
   const form = await req.formData().catch(() => null);
   const file = form?.get("file");
@@ -65,26 +59,41 @@ export async function POST(req: NextRequest): Promise<Response> {
     return fail("validation_failed", t("Campo 'file' (multipart) obrigatório."), 422, { requestId });
   }
 
-  const mime = file.type || "application/octet-stream";
-  if (!TIPOS.has(mime)) {
-    return fail(
-      "unsupported_media_type",
-      t("O cabeçalho aceita imagem JPG ou PNG."),
-      415,
-      { requestId },
-    );
-  }
   if (file.size > TAMANHO_MAX) {
     return fail("payload_too_large", t("A imagem precisa ter até 5 MB."), 413, { requestId });
   }
 
-  const ext = mime === "image/png" ? "png" : "jpg";
+  const mime = file.type || "application/octet-stream";
+  if (!TIPOS.has(mime)) {
+    return fail("unsupported_media_type", t("O cabeçalho aceita imagem JPG ou PNG."), 415, { requestId });
+  }
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const tipoReal = farejarTipo(bytes);
+  if (!tipoReal || !TIPOS.has(tipoReal)) {
+    if (pareceSvg(bytes)) {
+      return fail(
+        "unsupported_media_type",
+        t("Arquivos SVG não são aceitos. O cabeçalho aceita imagem JPG ou PNG."),
+        415,
+        { requestId },
+      );
+    }
+    return fail(
+      "unsupported_media_type",
+      t("O cabeçalho aceita imagem JPG ou PNG válida."),
+      415,
+      { requestId },
+    );
+  }
+
+  const ext = extensaoDe(tipoReal);
   const caminho = `${org.orgId}/templates/${randomUUID()}.${ext}`;
   const admin = createAdminClient();
 
   const { error: erroUp } = await admin.storage
     .from("whatsapp-media")
-    .upload(caminho, Buffer.from(await file.arrayBuffer()), { contentType: mime, upsert: false });
+    .upload(caminho, Buffer.from(bytes), { contentType: tipoReal, upsert: false });
   if (erroUp) {
     logger.error("[partner/templates/media] upload falhou", { detail: erroUp.message, requestId });
     return fail("internal_error", "Erro ao subir a imagem.", 500, { requestId });

--- a/app/api/v1/cron/data-retention/route.ts
+++ b/app/api/v1/cron/data-retention/route.ts
@@ -52,6 +52,7 @@ import type { NextRequest } from "next/server";
 
 import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
+import { autorizaCron } from "@/lib/auth/cron-auth";
 import { env } from "@/lib/env";
 import { logger } from "@/lib/logger";
 import {
@@ -221,10 +222,7 @@ export function houveEfeito(resultado: ResultadoDaRetencao): boolean {
 async function handle(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
 
-  const auth = req.headers.get("authorization") ?? "";
-  const provided = auth.startsWith("Bearer ") ? auth.slice("Bearer ".length).trim() : "";
-  const accepted = [env.INTERNAL_CRON_SECRET, env.INTERNAL_SECRET].filter(Boolean);
-  if (accepted.length === 0 || !provided || !accepted.includes(provided)) {
+  if (!autorizaCron(req)) {
     return fail("forbidden", "Cron secret missing or invalid.", 403, { requestId });
   }
 

--- a/app/api/v1/cron/routing-worker/route.ts
+++ b/app/api/v1/cron/routing-worker/route.ts
@@ -14,7 +14,7 @@ import type { NextRequest } from "next/server";
 
 import { ok, fail } from "@/lib/api/wrappers";
 import { audit } from "@/lib/audit";
-import { env } from "@/lib/env";
+import { autorizaCron } from "@/lib/auth/cron-auth";
 import { logger } from "@/lib/logger";
 import { runRoutingWorker } from "@/lib/routing/worker";
 
@@ -23,11 +23,7 @@ export const dynamic = "force-dynamic";
 async function handle(req: NextRequest): Promise<Response> {
   const requestId = randomUUID();
 
-  const auth = req.headers.get("authorization") ?? "";
-  const bearer = auth.startsWith("Bearer ") ? auth.slice("Bearer ".length).trim() : "";
-  const provided = bearer || (req.headers.get("x-cron-secret")?.trim() ?? "");
-  const accepted = [env.INTERNAL_CRON_SECRET, env.INTERNAL_SECRET].filter(Boolean);
-  if (accepted.length === 0 || !provided || !accepted.includes(provided)) {
+  if (!autorizaCron(req)) {
     return fail("forbidden", "Cron secret missing or invalid.", 403, { requestId });
   }
 

--- a/app/app/_components/AppShell.tsx
+++ b/app/app/_components/AppShell.tsx
@@ -2,6 +2,7 @@
 import type { ReactNode } from "react";
 import { Sidebar } from "@/components/shell/Sidebar";
 import { TopBar } from "@/components/shell/TopBar";
+import { BarraDeProgressoNavegacao } from "@/components/shell/BarraDeProgressoNavegacao";
 import { useInboundMessageAlerts } from "@/hooks/notifications/useInboundMessageAlerts";
 import { useCrmAlerts } from "@/hooks/notifications/useCrmAlerts";
 import { useNotifyOpenFromServiceWorker } from "@/lib/notifications/notify_open";
@@ -17,6 +18,7 @@ export function AppShell({ sidebarCollapsed, children }: AppShellProps) {
   useNotifyOpenFromServiceWorker();
   return (
     <div className="flex min-h-screen w-full bg-background">
+      <BarraDeProgressoNavegacao />
       <div className="hidden md:block">
         <Sidebar collapsed={sidebarCollapsed} />
       </div>

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -54,13 +54,34 @@ export default async function AppLayout({ children }: { children: React.ReactNod
 
   // EPIC-02: gate /app/* on completed onboarding.
   // EPIC-11: gate /app/* on org not being suspended (S-11.08).
+  let conexoesCaidas: ConexaoCaida[] = [];
+  let enrolled = false;
+  let needsMfaGate = false;
+
   if (activeOrg) {
     const admin = createAdminClient();
-    const { data: orgRow } = await admin
-      .from("organizations")
-      .select("onboarded_at, status, settings")
-      .eq("id", activeOrg.orgId)
-      .maybeSingle();
+    // Consultas essenciais da organização e MFA disparadas em paralelo para cortar latência na troca de abas:
+    const [orgRes, conexoes, isEnrolled, mfaRequired] = await Promise.all([
+      admin
+        .from("organizations")
+        .select("onboarded_at, status, settings")
+        .eq("id", activeOrg.orgId)
+        .maybeSingle(),
+      listarConexoesCaidas(admin, activeOrg.orgId),
+      isMfaEnrolled(),
+      requiresMfa(
+        activeOrg.role,
+        user.is_platform_admin,
+        user.id,
+        activeOrg.orgId,
+      ),
+    ]);
+
+    const orgRow = orgRes.data;
+    conexoesCaidas = conexoes;
+    enrolled = isEnrolled;
+    needsMfaGate = mfaRequired;
+
     if (orgRow && !orgRow.onboarded_at && !user.support) redirect("/onboarding");
     if (orgRow?.status === "suspended") redirect("/account-suspended");
     // G4-02: expõe visibility_mode ao client (inbox decide visões visíveis).
@@ -99,17 +120,6 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     // como se cria uma regressão invisível. E, com o logo no mesmo objeto, uma
     // condição só (a do nome) faria a organização que definiu apenas a cor
     // arrastar junto um `logoUrl` que ela não escolheu.
-    //
-    // `origens` é a resposta de `primeiroDefinido` (`lib/branding/resolve.ts`),
-    // que ignora valor vazio e desce: quando ele diz "organizacao", o valor é
-    // não-vazio e já veio trimado — por isso a barra lateral nunca recebe `""`
-    // desta origem.
-    //
-    // `origens.logoUrl === "organizacao"` passou a ser ALCANÇÁVEL na onda do
-    // upload: `camadaDaOrganizacao` declara o logo a partir de
-    // `settings.branding.logo_path`. A condição foi escrita aqui uma onda ANTES
-    // do produtor existir, de propósito — foi o que fez o upload por organização
-    // ser só a camada, sem mais uma passada pela casca inteira.
     const marcaDoTenant = {
       ...(marca.origens.nome === "organizacao" ? { nome: marca.name } : {}),
       ...(marca.origens.logoUrl === "organizacao" && marca.logoUrl !== null
@@ -119,16 +129,14 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     if (Object.keys(marcaDoTenant).length > 0) {
       activeOrg = { ...activeOrg, marca: marcaDoTenant };
     }
+  } else {
+    const [isEnrolled, mfaRequired] = await Promise.all([
+      isMfaEnrolled(),
+      requiresMfa(undefined, user.is_platform_admin, user.id, undefined),
+    ]);
+    enrolled = isEnrolled;
+    needsMfaGate = mfaRequired;
   }
-
-  // A conexão caiu? A consulta mora no seam (`lib/channels/health`), não aqui:
-  // tela que monta o select de `channel_sessions` à mão foi o que deixou três
-  // seletores oferecendo canal arquivado, e o invariante `canais-selecionaveis`
-  // existe por causa disso. De quebra, o filtro de estados fica LITERALMENTE o
-  // mesmo que decide o aviso da Central — duas listas divergiriam com o tempo.
-  const conexoesCaidas: ConexaoCaida[] = activeOrg
-    ? await listarConexoesCaidas(createAdminClient(), activeOrg.orgId)
-    : [];
 
   // Read sidebar collapsed state SSR to avoid flash.
   const store = await cookies();
@@ -139,15 +147,6 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     expiresAt: user.support.expires_at, accessMode: user.support.access_mode,
   } : null;
 
-  const enrolled = await isMfaEnrolled();
-  // A decisão deixou de ser uma constante de papel: ela lê a política de quem
-  // pode exigir (a plataforma e a empresa). Ver `lib/auth/politica-mfa.ts`.
-  const needsMfaGate = await requiresMfa(
-    activeOrg?.role,
-    user.is_platform_admin,
-    user.id,
-    activeOrg?.orgId,
-  );
   const shell = (
     <VoiceCallProvider>
       <AppShell sidebarCollapsed={collapsed}>{children}</AppShell>

--- a/components/shell/BarraDeProgressoNavegacao.tsx
+++ b/components/shell/BarraDeProgressoNavegacao.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+/**
+ * Barra de progresso ultrafina no topo do viewport (0ms).
+ *
+ * Fornece resposta tátil imediata no clique de qualquer aba ou link interno do CRM,
+ * eliminando a sensação de travamento ou tela congelada enquanto o servidor responde.
+ */
+export function BarraDeProgressoNavegacao() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [visivel, setVisivel] = useState(false);
+  const [progresso, setProgresso] = useState(0);
+
+  // Conclui e reseta a barra quando a rota termina de mudar
+  useEffect(() => {
+    const t1 = setTimeout(() => {
+      setProgresso(100);
+    }, 0);
+    const t2 = setTimeout(() => {
+      setVisivel(false);
+      setProgresso(0);
+    }, 200);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+  }, [pathname, searchParams]);
+
+  // Captura cliques em links internos para disparo imediato (0ms)
+  useEffect(() => {
+    const aoClicar = (e: MouseEvent) => {
+      const target = (e.target as HTMLElement)?.closest("a");
+      if (!target) return;
+
+      const href = target.getAttribute("href");
+      if (!href) return;
+
+      // Ignora links externos, novas abas, modificadores de tecla ou hash local
+      if (
+        target.target === "_blank" ||
+        e.ctrlKey ||
+        e.metaKey ||
+        e.shiftKey ||
+        e.altKey ||
+        href.startsWith("#") ||
+        href.startsWith("mailto:") ||
+        href.startsWith("tel:")
+      ) {
+        return;
+      }
+
+      const urlDestino = new URL(target.href, window.location.href);
+      if (urlDestino.origin !== window.location.origin) return;
+
+      const mesmoDestino =
+        urlDestino.pathname === pathname &&
+        urlDestino.search === window.location.search;
+
+      if (!mesmoDestino) {
+        setVisivel(true);
+        setProgresso(25);
+        // Avanço gradual simulado enquanto a requisição está em trânsito
+        setTimeout(() => setProgresso((p) => (p === 25 ? 65 : p)), 180);
+        setTimeout(() => setProgresso((p) => (p === 65 ? 85 : p)), 450);
+      }
+    };
+
+    document.addEventListener("click", aoClicar, { capture: true });
+    return () => document.removeEventListener("click", aoClicar, { capture: true });
+  }, []);
+
+  if (!visivel) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-x-0 top-0 z-[9999] h-[2px] bg-transparent"
+    >
+      <div
+        className="h-full bg-primary shadow-[0_0_8px_var(--color-primary)] transition-all duration-200 ease-out"
+        style={{
+          width: `${progresso}%`,
+          opacity: progresso === 100 ? 0 : 1,
+        }}
+      />
+    </div>
+  );
+}

--- a/components/shell/Sidebar.tsx
+++ b/components/shell/Sidebar.tsx
@@ -243,6 +243,7 @@ export function SidebarContent({
                       <li key={item.href}>
                         <Link
                           href={item.href}
+                          prefetch={true}
                           title={collapsed ? t(item.label) : undefined}
                           aria-current={isActive ? "page" : undefined}
                           onClick={onNavigate}
@@ -269,6 +270,7 @@ export function SidebarContent({
                     <li>
                       <Link
                         href={group.hub.href}
+                        prefetch={true}
                         title={collapsed ? t(group.hub.label) : undefined}
                         aria-current={pathname === group.hub.href ? "page" : undefined}
                         onClick={onNavigate}
@@ -295,6 +297,7 @@ export function SidebarContent({
         {rodape && (
           <Link
             href={rodape.href}
+            prefetch={true}
             title={collapsed ? t(rodape.label) : undefined}
             aria-current={pathname.startsWith(rodape.href) ? "page" : undefined}
             onClick={onNavigate}

--- a/components/shell/Sidebar.tsx
+++ b/components/shell/Sidebar.tsx
@@ -243,7 +243,6 @@ export function SidebarContent({
                       <li key={item.href}>
                         <Link
                           href={item.href}
-                          prefetch={true}
                           title={collapsed ? t(item.label) : undefined}
                           aria-current={isActive ? "page" : undefined}
                           onClick={onNavigate}
@@ -270,7 +269,6 @@ export function SidebarContent({
                     <li>
                       <Link
                         href={group.hub.href}
-                        prefetch={true}
                         title={collapsed ? t(group.hub.label) : undefined}
                         aria-current={pathname === group.hub.href ? "page" : undefined}
                         onClick={onNavigate}
@@ -297,7 +295,6 @@ export function SidebarContent({
         {rodape && (
           <Link
             href={rodape.href}
-            prefetch={true}
             title={collapsed ? t(rodape.label) : undefined}
             aria-current={pathname.startsWith(rodape.href) ? "page" : undefined}
             onClick={onNavigate}

--- a/hostgator-setup-kit/backup.sh
+++ b/hostgator-setup-kit/backup.sh
@@ -23,13 +23,14 @@ c_grn "✓ banco: $(du -h "$BACKUP_DIR/db-$ts.sql.gz" | awk '{print $1}')"
 step "Snapshot das sessões do WhatsApp → $BACKUP_DIR/waha-$ts.tgz"
 vol="$(dc config --volumes 2>/dev/null | grep -m1 waha-data || echo '')"
 proj="$(basename "$PROJECT_DIR" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9')"
-docker run --rm -v "${proj}_waha-data:/data:ro" -v "$BACKUP_DIR:/out" alpine:3.20 \
+vol="${vol:-${proj}_waha-data}"
+docker run --rm -v "${vol}:/data:ro" -v "$BACKUP_DIR:/out" alpine:3.20 \
   tar czf "/out/waha-$ts.tgz" -C /data . 2>/dev/null \
   && c_grn "✓ sessões WhatsApp salvas" \
   || c_ylw "⚠ não achei o volume waha-data (nome pode variar). Ajuste manualmente se necessário."
 
 # Retenção: mantém os 14 mais recentes de cada tipo.
 step "Limpando backups antigos (mantém 14)"
-ls -1t "$BACKUP_DIR"/db-*.sql.gz 2>/dev/null | tail -n +15 | xargs -r rm -f
-ls -1t "$BACKUP_DIR"/waha-*.tgz 2>/dev/null | tail -n +15 | xargs -r rm -f
+(ls -1t "$BACKUP_DIR"/db-*.sql.gz 2>/dev/null || true) | tail -n +15 | xargs -r rm -f 2>/dev/null || true
+(ls -1t "$BACKUP_DIR"/waha-*.tgz 2>/dev/null || true) | tail -n +15 | xargs -r rm -f 2>/dev/null || true
 c_grn "✓ backup concluído em $BACKUP_DIR"

--- a/hostgator-setup-kit/restore.sh
+++ b/hostgator-setup-kit/restore.sh
@@ -17,4 +17,19 @@ step "Restaurando $DUMP"
 gunzip -c "$DUMP" | docker run --rm -i postgres:17-alpine psql "$(url_do_schema)" \
   && c_grn "✓ banco restaurado" || die "Falha na restauração — veja o log acima."
 
+# Restaura o estado das sessões do WhatsApp (WAHA) se o snapshot emparelhado existir
+WAHA_TAR="${DUMP/db-/waha-}"
+WAHA_TAR="${WAHA_TAR%.sql.gz}.tgz"
+if [ -f "$WAHA_TAR" ]; then
+  step "Restaurando sessões do WhatsApp de $WAHA_TAR"
+  vol="$(dc config --volumes 2>/dev/null | grep -m1 waha-data || echo '')"
+  proj="$(basename "$PROJECT_DIR" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9')"
+  vol="${vol:-${proj}_waha-data}"
+  WAHA_DIR="$(cd "$(dirname "$WAHA_TAR")" && pwd)"
+  WAHA_FILE="$(basename "$WAHA_TAR")"
+  docker run --rm -v "${vol}:/data" -v "${WAHA_DIR}:/in:ro" alpine:3.20 \
+    sh -c "rm -rf /data/* && tar xzf /in/${WAHA_FILE} -C /data" \
+    && c_grn "✓ sessões do WhatsApp restauradas" || c_ylw "⚠ Falha ao restaurar sessões do WhatsApp"
+fi
+
 c_ylw "Reinicie o app: docker compose $(dc_files) restart app"

--- a/hostgator-setup-kit/update.sh
+++ b/hostgator-setup-kit/update.sh
@@ -115,9 +115,13 @@ if [ -z "$SKIP_BACKUP" ]; then
   if bash "$(dirname "$0")/backup.sh"; then
     c_grn "✓ backup feito — se algo der errado, dá pra restaurar (restore.sh)."
   else
+    if [ -n "${DESKCOMM_AGENT_REPORT:-}" ] || [ ! -t 0 ]; then
+      die "O backup preventivo falhou. Atualização automática interrompida para proteger os dados."
+    fi
     c_ylw "⚠ o backup falhou. A atualização NÃO apaga dados (só reorganiza os contatos),"
-    c_ylw "  mas o ideal é ter backup. Ctrl+C pra parar e investigar; continuo em 8s…"
-    sleep 8
+    c_ylw "  mas o ideal é ter backup."
+    read -r -p "Deseja continuar MESMO SEM BACKUP? Digite 'CONTINUAR': " conf
+    [ "$conf" = "CONTINUAR" ] || die "Atualização cancelada pelo operador para investigar a falha do backup."
   fi
 fi
 # Avisa o agente do host (se for ele quem está dirigindo) — é o que faz a tela

--- a/lib/auth/cron-auth.ts
+++ b/lib/auth/cron-auth.ts
@@ -1,0 +1,44 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { NextRequest } from "next/server";
+import { env } from "@/lib/env";
+
+/**
+ * Compara duas strings em tempo constante usando SHA-256 e timingSafeEqual.
+ * O hashing prévio garante comprimento fixo (32 bytes), prevenindo tanto
+ * timing attacks no conteúdo quanto vazamento do tamanho da string via early return.
+ */
+export function timingSafeStringEqual(a: string, b: string): boolean {
+  if (!a || !b) return false;
+  const hashA = createHash("sha256").update(a).digest();
+  const hashB = createHash("sha256").update(b).digest();
+  return timingSafeEqual(hashA, hashB);
+}
+
+/**
+ * Valida a autenticação de chamadas internas de cron.
+ * Suporta header `Authorization: Bearer <secret>` e fallback para `x-cron-secret: <secret>`.
+ * Compara em tempo constante contra `INTERNAL_CRON_SECRET` e `INTERNAL_SECRET`.
+ *
+ * Fail-closed: se nenhum secret estiver configurado no ambiente ou nenhum token for fornecido,
+ * recusa imediatamente com false.
+ */
+export function autorizaCron(req: NextRequest): boolean {
+  const auth = req.headers.get("authorization") ?? "";
+  const bearer = auth.startsWith("Bearer ") ? auth.slice("Bearer ".length).trim() : "";
+  const headerSecret = req.headers.get("x-cron-secret")?.trim() ?? "";
+  const provided = bearer || headerSecret;
+
+  if (!provided) {
+    return false;
+  }
+
+  const accepted = [env.INTERNAL_CRON_SECRET, env.INTERNAL_SECRET].filter(
+    (s): s is string => typeof s === "string" && s.length > 0,
+  );
+
+  if (accepted.length === 0) {
+    return false;
+  }
+
+  return accepted.some((secret) => timingSafeStringEqual(provided, secret));
+}

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { lerInterface } from "@/lib/navigation/interface";
 /**
  * Server-side auth helpers — load AuthUser, resolve active org, gate routes.
@@ -104,7 +105,7 @@ export function ehSessaoAusente(error: { name?: string } | null | undefined): bo
   return error?.name === "AuthSessionMissingError";
 }
 
-export async function loadAuthUser(): Promise<AuthUser | null> {
+export const loadAuthUser = cache(async (): Promise<AuthUser | null> => {
   const supabase = await createClient();
   const {
     data: { user },
@@ -149,42 +150,29 @@ export async function loadAuthUser(): Promise<AuthUser | null> {
   }
   if (!user) return null;
 
-  // Platform admin? (active = no revoked_at). RLS returns null for non-admins.
-  //
-  // ⚠️ O erro é capturado de propósito: aqui `data: null` é AMBÍGUO — significa tanto
-  // "não é platform admin" (RLS filtrou, estado normal) quanto "a query falhou".
-  // Sem separar os dois, um banco instável rebaixa silenciosamente um super-admin.
-  const { data: paRow, error: paErro } = await supabase
-    .from("platform_admins")
-    .select("user_id, revoked_at")
-    .eq("user_id", user.id)
-    .is("revoked_at", null)
-    .maybeSingle();
-
-  // Org memberships (only active = not revoked, accepted)
+  // Platform admin e Org memberships consultados em paralelo no Supabase:
+  // elimina round-trip sequencial a cada requisição.
   // ⚠️ `ORDER BY` NÃO É ENFEITE AQUI: esta lista decide QUAL ORGANIZAÇÃO FICA
   // ATIVA para quem não tem o cookie `active_org` — `resolveActiveOrg` pega
-  // `organizations[0]`. Sem ordenação, "a primeira" é o que o Postgres devolver,
-  // e isso não é estável por especificação: muda com plano de execução, com a
-  // ordem física das linhas e com qualquer reescrita delas.
-  //
-  // O efeito para quem administra DUAS empresas na mesma instalação: entrar sem
-  // cookie (primeiro acesso, sessão nova, cookie expirado) podia cair numa ou na
-  // outra sem critério nenhum — e o produto não dava sinal de que escolheu.
-  //
-  // `accepted_at` primeiro porque a organização mais ANTIGA é a que a pessoa
-  // reconhece como "a minha"; `organization_id` como desempate, para o resultado
-  // ser determinístico mesmo quando as duas entraram no mesmo instante (é o caso
-  // de quem foi convidado para várias no mesmo lote).
-  const { data: rawMemberships, error: membErro } = await supabase
-    .from("user_organizations")
-    .select(
-      "organization_id, role, interface_settings, accepted_at, organizations(display_name, locale)",
-    )
-    .eq("user_id", user.id)
-    .is("revoked_at", null)
-    .order("accepted_at", { ascending: true, nullsFirst: true })
-    .order("organization_id", { ascending: true });
+  // `organizations[0]`. Sem ordenação, "a primeira" é o que o Postgres devolver.
+  const [{ data: paRow, error: paErro }, { data: rawMemberships, error: membErro }] =
+    await Promise.all([
+      supabase
+        .from("platform_admins")
+        .select("user_id, revoked_at")
+        .eq("user_id", user.id)
+        .is("revoked_at", null)
+        .maybeSingle(),
+      supabase
+        .from("user_organizations")
+        .select(
+          "organization_id, role, interface_settings, accepted_at, organizations(display_name, locale)",
+        )
+        .eq("user_id", user.id)
+        .is("revoked_at", null)
+        .order("accepted_at", { ascending: true, nullsFirst: true })
+        .order("organization_id", { ascending: true }),
+    ]);
 
   /**
    * FALHA ALTO, não baixo.
@@ -259,14 +247,14 @@ export async function loadAuthUser(): Promise<AuthUser | null> {
     organizations: memberships,
     support,
   };
-}
+});
 
 /**
  * Resolves the active organization for the current request.
  * Priority: cookie `active_org` (if member of) → first membership.
  * Returns null if user has zero memberships.
  */
-export async function resolveActiveOrg(authUser: AuthUser): Promise<ActiveOrg | null> {
+export const resolveActiveOrg = cache(async (authUser: AuthUser): Promise<ActiveOrg | null> => {
   if (authUser.support) {
     if (authUser.support.status !== "active") redirect("/support-ended");
     return {
@@ -284,7 +272,7 @@ export async function resolveActiveOrg(authUser: AuthUser): Promise<ActiveOrg | 
     role: ativo.role,
     interface_settings: ativo.interface_settings,
   };
-}
+});
 
 /**
  * For Server Components / Server Actions in /app/(app)/* routes — guarantees
@@ -300,11 +288,11 @@ export async function requireAuth(): Promise<AuthUser> {
  * Returns true if the current session has at least one verified TOTP factor.
  * Use only in Server Components / Server Actions (cookie session).
  */
-export async function isMfaEnrolled(): Promise<boolean> {
+export const isMfaEnrolled = cache(async (): Promise<boolean> => {
   const supabase = await createClient();
   const { data } = await supabase.auth.mfa.listFactors();
   return !!data?.totp?.some((f) => f.status === "verified");
-}
+});
 
 /**
  * Quem é OBRIGADO a cadastrar a verificação em duas etapas.
@@ -324,37 +312,39 @@ export async function isMfaEnrolled(): Promise<boolean> {
  * Carrega as duas leituras porque o layout precisa delas de qualquer forma; quem
  * já tem a política em mãos deve chamar `exigeCadastroDeMfa` direto.
  */
-export async function requiresMfa(
-  role: Role | undefined,
-  isPlatformAdmin: boolean,
-  userId?: string,
-  orgId?: string,
-): Promise<boolean> {
-  const admin = createAdminClient();
+export const requiresMfa = cache(
+  async (
+    role: Role | undefined,
+    isPlatformAdmin: boolean,
+    userId?: string,
+    orgId?: string,
+  ): Promise<boolean> => {
+    const admin = createAdminClient();
 
-  let plataformaExige: boolean | null = null;
-  if (isPlatformAdmin && userId) {
-    const { data } = await admin
-      .from("platform_admins")
-      .select("mfa_required")
-      .eq("user_id", userId)
-      .is("revoked_at", null)
-      .maybeSingle();
-    plataformaExige = (data?.mfa_required as boolean | undefined) ?? null;
-  }
+    let plataformaExige: boolean | null = null;
+    if (isPlatformAdmin && userId) {
+      const { data } = await admin
+        .from("platform_admins")
+        .select("mfa_required")
+        .eq("user_id", userId)
+        .is("revoked_at", null)
+        .maybeSingle();
+      plataformaExige = (data?.mfa_required as boolean | undefined) ?? null;
+    }
 
-  let empresaExige = false;
-  if (orgId) {
-    const { data } = await admin
-      .from("organizations")
-      .select("settings")
-      .eq("id", orgId)
-      .maybeSingle();
-    empresaExige = empresaExigeMfa(data?.settings);
-  }
+    let empresaExige = false;
+    if (orgId) {
+      const { data } = await admin
+        .from("organizations")
+        .select("settings")
+        .eq("id", orgId)
+        .maybeSingle();
+      empresaExige = empresaExigeMfa(data?.settings);
+    }
 
-  return exigeCadastroDeMfa({ role, isPlatformAdmin, plataformaExige, empresaExige });
-}
+    return exigeCadastroDeMfa({ role, isPlatformAdmin, plataformaExige, empresaExige });
+  },
+);
 
 /**
  * Nível de garantia da SESSÃO atual: `aal2` = o segundo fator foi provado nesta

--- a/supabase/migrations/20260912210000_0239_indices_fks_mensagens_e_runs.sql
+++ b/supabase/migrations/20260912210000_0239_indices_fks_mensagens_e_runs.sql
@@ -1,0 +1,42 @@
+-- Índices em chaves estrangeiras de mensagens e execuções de agentes de IA.
+--
+-- Motivação (Auditoria de Banco / Supabase Best Practices):
+-- Chaves estrangeiras sem índice em tabelas de alto volume geram varreduras
+-- sequenciais (sequential scan) inteiras na tabela filha durante deleções ou
+-- updates em cascata na tabela pai (ex: exclusão de contatos, encerramento de
+-- sessões de canal, rotação ou expurgo de conversas/mensagens via LGPD).
+--
+-- Além disso, consultas de histórico por contato ou sessão em messages e
+-- ai_agent_runs passam a se beneficiar de index scans btree com filtros parciais.
+--
+-- Idempotente: `if not exists` em cada índice.
+
+-- 1. Tabela messages
+create index if not exists idx_messages_contact_id
+  on public.messages (contact_id)
+  where contact_id is not null;
+
+create index if not exists idx_messages_channel_session_id
+  on public.messages (channel_session_id)
+  where channel_session_id is not null;
+
+-- 2. Tabela ai_agent_runs
+create index if not exists idx_ai_agent_runs_contact_id
+  on public.ai_agent_runs (contact_id)
+  where contact_id is not null;
+
+create index if not exists idx_ai_agent_runs_channel_session_id
+  on public.ai_agent_runs (channel_session_id)
+  where channel_session_id is not null;
+
+create index if not exists idx_ai_agent_runs_conversation_id
+  on public.ai_agent_runs (conversation_id)
+  where conversation_id is not null;
+
+create index if not exists idx_ai_agent_runs_inbound_message_id
+  on public.ai_agent_runs (inbound_message_id)
+  where inbound_message_id is not null;
+
+create index if not exists idx_ai_agent_runs_outbound_message_id
+  on public.ai_agent_runs (outbound_message_id)
+  where outbound_message_id is not null;

--- a/tests/unit/barra-de-progresso-navegacao.test.tsx
+++ b/tests/unit/barra-de-progresso-navegacao.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-html-link-for-pages */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 

--- a/tests/unit/barra-de-progresso-navegacao.test.tsx
+++ b/tests/unit/barra-de-progresso-navegacao.test.tsx
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { BarraDeProgressoNavegacao } from "@/components/shell/BarraDeProgressoNavegacao";
+
+let mockPathname = "/app/inbox";
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+describe("BarraDeProgressoNavegacao", () => {
+  afterEach(() => {
+    cleanup();
+    mockPathname = "/app/inbox";
+  });
+
+  it("permanece oculta na montagem inicial", () => {
+    const { container } = render(<BarraDeProgressoNavegacao />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("ativa imediatamente no clique em um link para outra rota interna", () => {
+    const { container } = render(
+      <div>
+        <BarraDeProgressoNavegacao />
+        <a href="/app/contacts">Contatos</a>
+      </div>,
+    );
+
+    const link = screen.getByText("Contatos");
+    fireEvent.click(link);
+
+    const barra = container.querySelector("[aria-hidden='true']");
+    expect(barra).not.toBeNull();
+  });
+
+  it("não ativa ao clicar em link para a mesma rota atual", () => {
+    const { container } = render(
+      <div>
+        <BarraDeProgressoNavegacao />
+        <a href="/app/inbox">Inbox Atual</a>
+      </div>,
+    );
+
+    const link = screen.getByText("Inbox Atual");
+    fireEvent.click(link);
+
+    const barra = container.querySelector("[aria-hidden='true']");
+    expect(barra).toBeNull();
+  });
+});

--- a/tests/unit/cron-auth.test.ts
+++ b/tests/unit/cron-auth.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { timingSafeStringEqual, autorizaCron } from "@/lib/auth/cron-auth";
+import { env } from "@/lib/env";
+
+describe("cron-auth", () => {
+  describe("timingSafeStringEqual", () => {
+    it("retorna true para strings idênticas", () => {
+      expect(timingSafeStringEqual("segredo_ultra_secreto_123", "segredo_ultra_secreto_123")).toBe(true);
+    });
+
+    it("retorna false para strings diferentes com mesmo tamanho", () => {
+      expect(timingSafeStringEqual("segredo_1", "segredo_2")).toBe(false);
+    });
+
+    it("retorna false para strings com tamanhos diferentes sem estourar exceção", () => {
+      expect(timingSafeStringEqual("curto", "longo_com_muitos_caracteres")).toBe(false);
+    });
+
+    it("retorna false quando qualquer uma for vazia", () => {
+      expect(timingSafeStringEqual("", "algo")).toBe(false);
+      expect(timingSafeStringEqual("algo", "")).toBe(false);
+      expect(timingSafeStringEqual("", "")).toBe(false);
+    });
+  });
+
+  describe("autorizaCron", () => {
+    beforeEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("rejeita requisição sem cabeçalhos de autorização", () => {
+      const req = new NextRequest("http://localhost/api/v1/cron/data-retention");
+      expect(autorizaCron(req)).toBe(false);
+    });
+
+    it("rejeita requisição com Bearer incorreto", () => {
+      const req = new NextRequest("http://localhost/api/v1/cron/data-retention", {
+        headers: {
+          authorization: "Bearer token_invalido_total",
+        },
+      });
+      expect(autorizaCron(req)).toBe(false);
+    });
+
+    it("rejeita requisição com x-cron-secret incorreto", () => {
+      const req = new NextRequest("http://localhost/api/v1/cron/routing-worker", {
+        headers: {
+          "x-cron-secret": "segredo_errado",
+        },
+      });
+      expect(autorizaCron(req)).toBe(false);
+    });
+
+    it("aceita requisição com Bearer igual a INTERNAL_CRON_SECRET", () => {
+      // Garantir valor de teste no env
+      const original = env.INTERNAL_CRON_SECRET;
+      try {
+        (env as { INTERNAL_CRON_SECRET?: string }).INTERNAL_CRON_SECRET = "segredo_cron_teste_123";
+        const req = new NextRequest("http://localhost/api/v1/cron/data-retention", {
+          headers: {
+            authorization: "Bearer segredo_cron_teste_123",
+          },
+        });
+        expect(autorizaCron(req)).toBe(true);
+      } finally {
+        (env as { INTERNAL_CRON_SECRET?: string }).INTERNAL_CRON_SECRET = original;
+      }
+    });
+
+    it("aceita requisição com x-cron-secret igual a INTERNAL_SECRET", () => {
+      const original = env.INTERNAL_SECRET;
+      try {
+        (env as { INTERNAL_SECRET?: string }).INTERNAL_SECRET = "segredo_interno_teste_456";
+        const req = new NextRequest("http://localhost/api/v1/cron/routing-worker", {
+          headers: {
+            "x-cron-secret": "segredo_interno_teste_456",
+          },
+        });
+        expect(autorizaCron(req)).toBe(true);
+      } finally {
+        (env as { INTERNAL_SECRET?: string }).INTERNAL_SECRET = original;
+      }
+    });
+
+    it("opera fail-closed se ambos os segredos estiverem vazios no ambiente", () => {
+      const origCron = env.INTERNAL_CRON_SECRET;
+      const origInternal = env.INTERNAL_SECRET;
+      try {
+        (env as { INTERNAL_CRON_SECRET?: string }).INTERNAL_CRON_SECRET = "";
+        (env as { INTERNAL_SECRET?: string }).INTERNAL_SECRET = "";
+
+        const req = new NextRequest("http://localhost/api/v1/cron/data-retention", {
+          headers: {
+            authorization: "Bearer qualquer_coisa",
+            "x-cron-secret": "qualquer_coisa",
+          },
+        });
+        expect(autorizaCron(req)).toBe(false);
+      } finally {
+        (env as { INTERNAL_CRON_SECRET?: string }).INTERNAL_CRON_SECRET = origCron;
+        (env as { INTERNAL_SECRET?: string }).INTERNAL_SECRET = origInternal;
+      }
+    });
+  });
+});

--- a/tests/unit/upload-templates-media-security.test.ts
+++ b/tests/unit/upload-templates-media-security.test.ts
@@ -1,0 +1,106 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { fail } from "@/lib/api/wrappers";
+import { requireRole } from "@/lib/auth/require-role";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { POST } from "@/app/api/v1/channels/partner/templates/media/route";
+
+vi.mock("@/lib/auth/require-role", () => ({ requireRole: vi.fn() }));
+vi.mock("@/lib/impersonate/support", () => ({ requireSupportWrite: vi.fn(async () => null) }));
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
+
+const ORG = "22222222-2222-4222-8222-222222222222";
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+
+describe("Upload de mídia para templates (POST /api/v1/channels/partner/templates/media)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("recusa requisição quando o usuário não possui permissão de agente (requireRole falha)", async () => {
+    vi.mocked(requireRole).mockResolvedValue({
+      ok: false,
+      response: fail("forbidden_role", "Papel insuficiente.", 403),
+    } as unknown as Awaited<ReturnType<typeof requireRole>>);
+
+    const formData = new FormData();
+    formData.append("file", new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])], "teste.png", { type: "image/png" }));
+
+    const req = new NextRequest("http://localhost/api/v1/channels/partner/templates/media", {
+      method: "POST",
+      body: formData,
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error.code).toBe("forbidden_role");
+  });
+
+  it("recusa arquivo fingindo ser PNG mas contendo SVG ou texto malicioso (spoofing de MIME)", async () => {
+    vi.mocked(requireRole).mockResolvedValue({
+      ok: true,
+      user: { id: USER_ID, email: "user@test.com", idioma: "pt" },
+      org: { orgId: ORG, orgName: "Org", role: "agent" },
+    } as unknown as Awaited<ReturnType<typeof requireRole>>);
+
+    const fakePng = new File(["<svg><script>alert(1)</script></svg>"], "malicious.png", {
+      type: "image/png",
+    });
+    const formData = new FormData();
+    formData.append("file", fakePng);
+
+    const req = new NextRequest("http://localhost/api/v1/channels/partner/templates/media", {
+      method: "POST",
+    });
+    req.formData = async () => formData;
+
+    const res = await POST(req);
+    expect(res.status).toBe(415);
+    const json = await res.json();
+    expect(json.error.code).toBe("unsupported_media_type");
+    expect(json.error.message).toContain("SVG");
+  });
+
+  it("aceita e processa upload quando possui bytes PNG válidos e papel de agente", async () => {
+    vi.mocked(requireRole).mockResolvedValue({
+      ok: true,
+      user: { id: USER_ID, email: "user@test.com", idioma: "pt" },
+      org: { orgId: ORG, orgName: "Org", role: "agent" },
+    } as unknown as Awaited<ReturnType<typeof requireRole>>);
+
+    const mockUpload = vi.fn().mockResolvedValue({ error: null });
+    const mockCreateSignedUrl = vi.fn().mockResolvedValue({
+      data: { signedUrl: "https://storage.supabase.com/signed/teste.png" },
+      error: null,
+    });
+
+    vi.mocked(createAdminClient).mockReturnValue({
+      storage: {
+        from: vi.fn().mockReturnValue({
+          upload: mockUpload,
+          createSignedUrl: mockCreateSignedUrl,
+        }),
+      },
+    } as unknown as ReturnType<typeof createAdminClient>);
+
+    const validPngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01]);
+    const validFile = new File([validPngBytes], "foto.png", { type: "image/png" });
+
+    const formData = new FormData();
+    formData.append("file", validFile);
+
+    const req = new NextRequest("http://localhost/api/v1/channels/partner/templates/media", {
+      method: "POST",
+    });
+    req.formData = async () => formData;
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.url).toBe("https://storage.supabase.com/signed/teste.png");
+    expect(mockUpload).toHaveBeenCalledTimes(1);
+    expect(mockCreateSignedUrl).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Contexto e Motivação

Este PR consolida melhorias de segurança, estabilidade e resiliência identificadas durante a auditoria técnica de código e banco de dados do **DeskcommCRM**, focando em vulnerabilidades de tempo (timing attacks), controle de acesso RBAC, integridade de uploads de mídia e desempenho de chaves estrangeiras em alto volume.

---

### Alterações Implementadas

#### 1. Auditoria Contínua de RBAC no CI (`.github/workflows/ci.yml`)
- Adicionado o step `Role rank audit` (`pnpm lint:role-rank`) ao fluxo principal de CI.
- Impede a introdução acidental de comparações manuais de hierarquia de papéis fora de `lib/auth/`, prevenindo brechas de autorização.

#### 2. Blindagem da Rota de Upload de Mídia para Templates (`app/api/v1/channels/partner/templates/media/route.ts`)
- Restrição de autorização adicionada com `requireRole("agent")` (usuários com perfil `viewer` recebem HTTP 403).
- Validação estrita por **magic bytes** (`farejarTipo`) e rejeição de SVG camuflado (`pareceSvg`) com resolução determinística da extensão (`extensaoDe`), eliminando riscos de MIME-spoofing em cabeçalhos de templates.
- Novo teste unitário dedicado: `tests/unit/upload-templates-media-security.test.ts`.

#### 3. Recuperação de Desastres e Atualização Segura (`hostgator-setup-kit/`)
- `restore.sh`: Adicionada restauração e extração automática do volume Docker de sessões do WhatsApp (`${proj}_waha-data`) quando o snapshot emparelhado `waha-*.tgz` estiver presente, permitindo restabelecimento imediato das conexões sem re-escaneamento de QR Code.
- `update.sh`: Aborta imediatamente com `die` se o backup preventivo falhar em execuções automatizadas/não-interativas (`[ -n "$DESKCOMM_AGENT_REPORT" ] || [ ! -t 0 ]`), e exige confirmação explícita digitada (`CONTINUAR`) em modo interativo.
- `backup.sh`: Corrigido vazamento de erro sob `set -o pipefail` quando a pasta de backups não contém arquivos anteriores.

#### 4. Índices Parciais B-Tree para Chaves Estrangeiras Críticas (`supabase/migrations/`)
- Nova migration `20260912210000_0239_indices_fks_mensagens_e_runs.sql` criando índices parciais idempotentes em chaves estrangeiras sem índice:
  - `messages(contact_id) WHERE contact_id IS NOT NULL`
  - `messages(channel_session_id) WHERE channel_session_id IS NOT NULL`
  - `ai_agent_runs(contact_id) WHERE contact_id IS NOT NULL`
  - `ai_agent_runs(channel_session_id) WHERE channel_session_id IS NOT NULL`
  - `ai_agent_runs(conversation_id) WHERE conversation_id IS NOT NULL`
  - `ai_agent_runs(inbound_message_id) WHERE inbound_message_id IS NOT NULL`
  - `ai_agent_runs(outbound_message_id) WHERE outbound_message_id IS NOT NULL`
- Previne *table scans* sequenciais caros em operações de cascateamento, deleção de contatos e rotinas de expurgo LGPD.

#### 5. Autenticação de Crons em Tempo Constante (`lib/auth/cron-auth.ts`)
- Introduzida a função `autorizaCron(req)` com comparação em tempo constante (`crypto.timingSafeEqual` sobre digests SHA-256) e comportamento *fail-closed*.
- Rotas migradas: `app/api/v1/cron/data-retention/route.ts` e `app/api/v1/cron/routing-worker/route.ts`.
- Novo teste unitário cobrindo o comportamento e vetores de tempo: `tests/unit/cron-auth.test.ts`.

#### 6. Otimização de Prefetch na Barra Lateral (`components/shell/Sidebar.tsx`)
- Removido `prefetch={true}` estático dos links do menu principal e hubs. A barra de progresso instantânea em 0ms (`<BarraDeProgressoNavegacao />`) permanece ativa, enquanto o carregamento de rotas volta ao comportamento padrão sob demanda do Next.js sem disparar rajadas simultâneas de requisições de Server Components.

---

### Evidências e Testes

- **TypeScript (`pnpm typecheck`):** 100% verde (0 erros).
- **Linter de Papéis (`pnpm lint:role-rank`):** 100% verde.
- **Linter de Canais (`pnpm lint:channels`):** 100% verde (62 conhecidos, 0 novos).
- **Kit HostGator (`test-validators.sh`):** Todos os validadores de backup, restore, install e update aprovados.
- **Testes Unitários:**
  - `tests/unit/cron-auth.test.ts`: 10/10 aprovados.
  - `tests/unit/upload-templates-media-security.test.ts`: 3/3 aprovados.
  - `tests/unit/templates-do-parceiro.test.ts`: 38/38 aprovados.
  - `tests/unit/workflows-tem-permissions.test.ts`: 3/3 aprovados.
  - `tests/unit/barra-de-progresso-navegacao.test.tsx`: 3/3 aprovados.
