### PR TITLE
fix(i18n): guarda de espanhol resolve tabela de rótulo t(X[k])/t(X.k)

### DIFF
--- a/lib/i18n/dicionario.ts
+++ b/lib/i18n/dicionario.ts
@@ -8353,6 +8353,29 @@ export const DICIONARIO: Traducoes = {
   },
   "Convite reenviado.": { es: "Invitación reenviada." },
   "Convite revogado.": { es: "Invitación revocada." },
+
+  // ─── issue #651 — tabelas de rótulo que só o guarda ampliado alcança ───
+  //
+  // `chavesUsadas()` passou a resolver `t(X[k])`/`t(X.k)` quando `X` é tabela
+  // `const` de módulo. Estas 8 chaves saíam em português com o guarda antigo
+  // verde — medido rodando o guarda ampliado contra `main` antes de adicionar
+  // qualquer entrada aqui: as 8 abaixo, e só elas, reprovavam.
+  // ─── app/app/lgpd/requests/RequestsTable.tsx (SLA_LABELS) ───
+  "OK": { es: "OK" },
+  // ─── lib/kanban/score-band.ts (SCORE_BAND_LABELS) ───
+  "Frio": { es: "Frío" },
+  "Morno": { es: "Tibio" },
+  "Quente": { es: "Caliente" },
+  // ─── components/ai/GuardrailsEditor.tsx (KIND_LABELS) ───
+  //
+  // As 4 chaves abaixo já nascem em INGLÊS, não em português — bug à parte de
+  // #651: a convenção do projeto é "a chave é o texto em português", e aqui
+  // não é. Fora do escopo deste PR (é a fonte que precisa mudar, não a
+  // tradução), sinalizado no PR para abrir issue própria.
+  "Regex output block": { es: "Bloqueo de salida por regex" },
+  "RAG must hit": { es: "RAG debe coincidir" },
+  "Regex input block": { es: "Bloqueo de entrada por regex" },
+  "Contact flag": { es: "Marca de contacto" },
 };
 
 /**

--- a/tests/unit/i18n-espanhol-cobre-a-tela.test.ts
+++ b/tests/unit/i18n-espanhol-cobre-a-tela.test.ts
@@ -320,7 +320,53 @@ function textoCruDasTelas(): Achado[] {
   return achados;
 }
 
-/** Toda chave literal passada a `t()` / `traduzir()` em código de produção. */
+/**
+ * Tabelas de rótulo `const X = {...}` / `const X = [...]` declaradas no TOPO
+ * do módulo — o padrão que vira `t(X[chave])` ou `t(X.chave)` quando o rótulo
+ * depende de um enum (status, severidade, tipo).
+ *
+ * Resolve só o caso ESTÁTICO: literal de objeto/array, no mesmo arquivo, sem
+ * `require`/import remontando o valor. Isso alcança a maioria dos casos reais
+ * (issue #651) sem virar um type-checker — cross-module e wrapper (`const t =
+ * (texto) => traduzir(texto, idioma)`, ~200 ocorrências) ficam de fora de
+ * propósito: resolver esses exigiria inferência de tipo completa, e a issue
+ * #603 (proibir `t(<variável>)` na origem) é o caminho para o resto.
+ */
+function tabelasDeModulo(fonte: ts.SourceFile): Map<string, ts.Expression> {
+  const tabelas = new Map<string, ts.Expression>();
+  for (const stmt of fonte.statements) {
+    if (!ts.isVariableStatement(stmt)) continue;
+    if ((stmt.declarationList.flags & ts.NodeFlags.Const) === 0) continue;
+    for (const decl of stmt.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || !decl.initializer) continue;
+      let init = decl.initializer;
+      // `as const satisfies Record<...>` é o padrão de tabela fechada do
+      // projeto (ex.: SCORE_BAND_LABELS) — as duas camadas precisam cair para
+      // o literal aparecer.
+      while (ts.isAsExpression(init) || ts.isSatisfiesExpression(init)) init = init.expression;
+      if (ts.isObjectLiteralExpression(init) || ts.isArrayLiteralExpression(init)) {
+        tabelas.set(decl.name.text, init);
+      }
+    }
+  }
+  return tabelas;
+}
+
+/** Todo literal string dentro de uma tabela de rótulo — cada um é um rótulo possível. */
+function valoresDaTabela(tabela: ts.Expression): ts.StringLiteralLike[] {
+  const valores: ts.StringLiteralLike[] = [];
+  const coleta = (no: ts.Expression) => {
+    if (ts.isStringLiteral(no) || ts.isNoSubstitutionTemplateLiteral(no)) valores.push(no);
+  };
+  if (ts.isObjectLiteralExpression(tabela)) {
+    for (const prop of tabela.properties) if (ts.isPropertyAssignment(prop)) coleta(prop.initializer);
+  } else if (ts.isArrayLiteralExpression(tabela)) {
+    for (const el of tabela.elements) coleta(el);
+  }
+  return valores;
+}
+
+/** Toda chave literal — ou vinda de tabela de módulo resolvível — passada a `t()` / `traduzir()`. */
 function chavesUsadas(): Map<string, string[]> {
   const usadas = new Map<string, string[]>();
   const areas = ["app", "components", "hooks", "lib"];
@@ -341,6 +387,11 @@ function chavesUsadas(): Map<string, string[]> {
       const src = readFileSync(arq, "utf8");
       if (!/\bt\(|\btraduzir\(/.test(src)) continue;
       const fonte = ts.createSourceFile(arq, src, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+      const tabelas = tabelasDeModulo(fonte);
+      const registra = (texto: string, no: ts.Node) => {
+        const linha = fonte.getLineAndCharacterOfPosition(no.getStart()).line + 1;
+        usadas.set(texto, [...(usadas.get(texto) ?? []), `${rel}:${linha}`]);
+      };
       const visita = (no: ts.Node): void => {
         if (ts.isCallExpression(no) && no.arguments.length > 0) {
           const alvo = no.expression;
@@ -352,8 +403,13 @@ function chavesUsadas(): Map<string, string[]> {
           if (nome === "t" || nome === "traduzir") {
             const a = no.arguments[0];
             if (a && (ts.isStringLiteral(a) || ts.isNoSubstitutionTemplateLiteral(a))) {
-              const linha = fonte.getLineAndCharacterOfPosition(a.getStart()).line + 1;
-              usadas.set(a.text, [...(usadas.get(a.text) ?? []), `${rel}:${linha}`]);
+              registra(a.text, a);
+            } else if (a && ts.isElementAccessExpression(a) && ts.isIdentifier(a.expression)) {
+              const tabela = tabelas.get(a.expression.text);
+              if (tabela) for (const v of valoresDaTabela(tabela)) registra(v.text, a);
+            } else if (a && ts.isPropertyAccessExpression(a) && ts.isIdentifier(a.expression)) {
+              const tabela = tabelas.get(a.expression.text);
+              if (tabela) for (const v of valoresDaTabela(tabela)) registra(v.text, a);
             }
           }
         }


### PR DESCRIPTION
Fecha a **direção 1** da #651 (`t(<variável>)` era ponto cego do guarda).

## O que muda

`chavesUsadas()` (`tests/unit/i18n-espanhol-cobre-a-tela.test.ts`) passa a
resolver tabelas `const` declaradas no topo do módulo — inclusive o padrão
`as const satisfies Record<...>` — quando a chave de `t()`/`traduzir()` é um
acesso indexado (`t(X[k])`) ou de propriedade (`t(X.k)`) sobre uma delas.

**Escopo deliberadamente conservador**, e por quê:

- Só resolve tabela no **mesmo arquivo** — nada de cross-module.
- Não toca a direção 2 do issue (proibir `t(<variável>)` na origem): medi
  ~200 ocorrências do padrão `const t = (texto) => traduzir(texto, idioma)`
  nos server components, e proibir chave dinâmica reprovaria essas 200 de
  graça. Fica pra quem quiser discutir a direção 2 separadamente.
- Não toca o "Cego C" (`t()` sobre dado do operador) nem a #603 — continuam
  fora do escopo.

## Evidência (vermelho → verde)

Rodei o guarda ampliado contra `main`, **antes** de tocar o dicionário: 8
chamadas reprovaram — texto que sai em português hoje, com o guarda antigo
verde:

```
app/app/lgpd/requests/RequestsTable.tsx:197 → t("OK")
lib/kanban/score-band.ts:127 → t("Frio")
lib/kanban/score-band.ts:127 → t("Morno")
lib/kanban/score-band.ts:127 → t("Quente")
components/ai/GuardrailsEditor.tsx:100 → t("Regex output block")
components/ai/GuardrailsEditor.tsx:100 → t("RAG must hit")
components/ai/GuardrailsEditor.tsx:100 → t("Regex input block")
components/ai/GuardrailsEditor.tsx:100 → t("Contact flag")
```

As 8 ganharam `es` em `lib/i18n/dicionario.ts`. Guarda volta a passar:

```
pnpm vitest run tests/unit/i18n-espanhol-cobre-a-tela.test.ts
# 5 tests passed
```

## Achado à parte, fora do escopo deste PR

As 4 chaves de `components/ai/GuardrailsEditor.tsx` (`KIND_LABELS`) nascem em
**inglês**, não em português — quebra a convenção "a chave é o texto em
português" descrita no cabeçalho do próprio guarda. Traduzi só o `es` aqui
(pra não deixar a tela em espanhol pior do que já estava), mas a correção de
verdade é trocar a fonte em `KIND_LABELS` para português. Não fiz porque foge
do escopo de "cobertura de espanhol" — sinalizando para issue própria.

## Definition of Done

```
pnpm typecheck   # limpo
pnpm lint        # 0 errors (349 warnings pré-existentes, nenhum nos arquivos tocados)
pnpm test:unit   # 785 passed / 6 failed — os 6 falham igual em upstream/main sem este diff (confirmado com git stash), não relacionados
```

Não rodei `pnpm test:db` (exige Docker) nem `pnpm test:e2e` — sou contribuidor
externo, ver seção "Se você está contribuindo de fora" do CONTRIBUTING.

## Processo

Comentei "pego esta" em #651 antes de codar, com a medição prévia. Ainda
dentro da janela de 48h — abrindo como **draft** por isso; sinalizo aqui e
posso converter para pronto a qualquer momento se preferirem.

Deixo #603 e #755 de fora, como combinado no comentário do issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)