### PR TITLE
fix(agenda): o painel não herda o cliente da abertura anterior

### DIFF
--- a/.changes/agenda-nao-herda-cliente-e-horarios-rolam.md
+++ b/.changes/agenda-nao-herda-cliente-e-horarios-rolam.md
@@ -1,0 +1,13 @@
+---
+impacto: capacidade_nova
+secao: corrigido
+titulo: "Novo agendamento" deixa de vir com o cliente da vez anterior, e a lista de horários volta a rolar
+---
+
+Duas coisas na tela de agendamento, medidas numa instalação real.
+
+**O compromisso podia nascer no nome da pessoa errada.** Ao fechar o painel de agendamento sem confirmar, o sistema limpava o horário escolhido, a remarcação em curso e o e-mail do convidado — mas **não** limpava o cliente nem a conversa vinculada. Quem abrisse "Marcar compromisso" de dentro de uma conversa e depois fosse à Agenda encontrava o campo **Quem será atendido** já preenchido com aquele cliente. O campo parece preenchido de propósito; não há o que estranhar na tela. Agora o painel volta sempre a **"Compromisso pessoal, sem cliente"**, e quem quiser um cliente escolhe.
+
+**A lista de horários voltou a rolar.** Numa correção anterior, o painel perdeu o limite de altura para que a janela parasse de **cortar os botões** em telas baixas — e, sem limite, a lista de horários passou a crescer sem fim: um tipo de 45 minutos rende treze horários e uma janela maior que a tela. Agora a lista tem limite próprio, proporcional à altura da janela, e rola dentro de si em telas de computador. No celular nada muda: quem rola continua sendo a janela inteira.
+
+Nada muda para quem opera: sem passo manual, sem mexer em configuração.

--- a/app/app/agenda/_client.tsx
+++ b/app/app/agenda/_client.tsx
@@ -448,6 +448,20 @@ export function AgendaClient({
             // não usado reapareceria na PRÓXIMA marcação, que é de outro
             // cliente — convite para a pessoa errada, sem ninguém ter pedido.
             setEmailConvidado("");
+            // E o próprio cliente, que é o pior dos quatro a sobrar: medido numa
+            // instalação real em 2026-09-12, "Novo agendamento" abriu com um
+            // contato JÁ selecionado, herdado de uma abertura anterior feita a
+            // partir da conversa dele (`onContext` preenche os dois). Quem não
+            // reparasse marcaria o compromisso no nome de outra pessoa — e o
+            // campo parece preenchido de propósito, então não há o que estranhar.
+            //
+            // É exatamente o raciocínio do comentário acima, aplicado a três
+            // campos e esquecido nestes dois. Vazio é um estado legítimo aqui
+            // ("Compromisso pessoal, sem cliente"), e vir vazio é o degrau
+            // seguro: um campo em branco a pessoa vê; um campo com o cliente
+            // errado, não.
+            setContactId("");
+            setConversationId("");
           }
         }}
       >

--- a/app/app/agenda/_client.tsx
+++ b/app/app/agenda/_client.tsx
@@ -18,6 +18,7 @@ import { HistoricoDaAgenda } from "@/components/agenda/HistoricoDaAgenda";
 import type { Agendamento, HorarioLivre, VisaoDaAgenda } from "@/components/agenda/tipos";
 import { EmptyAgenda } from "@/components/empty";
 import { rotuloDoLocal } from "@/lib/agenda/locais";
+import { ancoraAoFecharPainel } from "@/lib/agenda/ancora-depois-de-marcar";
 import { Button } from "@/components/ui/button";
 import { PainelDeMarcacao } from "@/components/agenda/PainelDeMarcacao";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
@@ -96,6 +97,9 @@ export function AgendaClient({
   const localeDaData = useLocaleDeData();
   const t = useT();
   const [marcando, setMarcando] = React.useState(false);
+  // O compromisso criado NESTA abertura do painel. Serve para levar a grade até
+  // ele quando o painel fechar por qualquer caminho — ver `ancoraAoFecharPainel`.
+  const [marcadoEm, setMarcadoEm] = React.useState<string | null>(null);
   const [contactId,setContactId]=React.useState("");
   const [conversationId,setConversationId]=React.useState("");
   const onContext=React.useCallback((contact:string,conversation:string)=>{setContactId(contact);setConversationId(conversation);setMarcando(true);},[]);
@@ -462,6 +466,16 @@ export function AgendaClient({
             // errado, não.
             setContactId("");
             setConversationId("");
+            // ⛔ E LEVAR A GRADE ATÉ O QUE ACABOU DE NASCER.
+            //
+            // "Ver na agenda" já fazia isto; fechar no X, clicar fora ou apertar
+            // Esc, não — e a grade ficava na semana em que estava, sem o
+            // compromisso recém-criado, que quase sempre é de outra semana.
+            // ⚠️ O relato que puxou isto NÃO se confirmou (ver o módulo). O que
+            // sustenta é a simetria com o caso do botão, esse sim relatado.
+            const destino = ancoraAoFecharPainel(marcadoEm, startOfDay);
+            if (destino) setAncora(destino);
+            setMarcadoEm(null);
           }
         }}
       >
@@ -652,6 +666,8 @@ export function AgendaClient({
                     })
                     .then((r) => {
                       setEmailConvidado("");
+                      // Guardado para o fechamento saber para onde levar a grade.
+                      setMarcadoEm(instante);
                       return r;
                     });
                 }}

--- a/components/agenda/PainelDeMarcacao.tsx
+++ b/components/agenda/PainelDeMarcacao.tsx
@@ -652,12 +652,32 @@ export function PainelDeMarcacao({
             `data-testid` para a lista poder ser MEDIDA, e não só vista. O
             `overflow-y-auto` aqui sempre esteve certo e era INERTE: um
             `overflow-y-auto` cujo pai tem altura `auto` não rola, porque o filho
-            cresce e `scrollHeight === clientHeight`. Quem fecha a cadeia é o
-            `_client.tsx`, que dá teto ao Sheet.
+            cresce e `scrollHeight === clientHeight`.
+
+            ## Por que o teto mora AQUI, e não mais na cadeia de alturas
+
+            Este comentário dizia "quem fecha a cadeia é o `_client.tsx`, que dá
+            teto ao Sheet". Era verdade e virou o defeito seguinte: para a janela
+            parar de CORTAR os botões em tela baixa, o teto do Sheet foi removido
+            — e a lista, sem pai com altura, voltou a crescer sem fim. Medido numa
+            instalação real em 2026-09-12: um tipo de 45 minutos rendeu treze
+            horários e uma janela que não cabia na tela. Trocamos "corta" por
+            "estica", que é o mesmo erro pelo avesso.
+
+            `lg:max-h` resolve sem cadeia: `max-height` + `overflow-y-auto` rola
+            por conta própria, sem depender de o pai ter altura definida — que é
+            a condição frágil que já falhou nos dois sentidos. Abaixo de `lg` não
+            há teto de propósito: ali quem rola é o diálogo inteiro, e dois
+            roladores aninhados no celular prendem o dedo no de dentro.
+
+            O teto é `vh` e não pixel porque o inimigo é a ALTURA DA JANELA, não
+            a quantidade de horários: em 1366×768 sobram ~520px reais, e um teto
+            fixo escolhido num monitor grande volta a cortar exatamente onde o
+            defeito original aparecia.
           */}
           <div
             data-testid="lista-de-horarios"
-            className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto pr-1"
+            className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto pr-1 lg:max-h-[60vh]"
           >
             {doDia.map((h) => (
               <button

--- a/components/agenda/PainelDeMarcacao.tsx
+++ b/components/agenda/PainelDeMarcacao.tsx
@@ -670,14 +670,26 @@ export function PainelDeMarcacao({
             há teto de propósito: ali quem rola é o diálogo inteiro, e dois
             roladores aninhados no celular prendem o dedo no de dentro.
 
-            O teto é `vh` e não pixel porque o inimigo é a ALTURA DA JANELA, não
-            a quantidade de horários: em 1366×768 sobram ~520px reais, e um teto
-            fixo escolhido num monitor grande volta a cortar exatamente onde o
-            defeito original aparecia.
+            O teto tem DUAS partes, e cada uma cobre o que a outra não cobre:
+
+            - `42vh` para a janela BAIXA — em 1366×768 sobram ~520px reais, e um
+              teto em pixel escolhido num monitor grande volta a cortar
+              exatamente onde o defeito original aparecia;
+            - `380px` para a janela ALTA — sem ele, numa tela de 1440px de altura
+              a lista teria 600px de teto, o que não é teto nenhum: a janela
+              volta a ficar maior que o calendário ao lado, que é o que se está
+              tentando evitar.
+
+            ⚠️ A primeira tentativa foi `60vh` sozinho, e ela FALHOU na prova de
+            tela: a barra de rolagem apareceu — o mecanismo estava certo —, mas
+            numa janela de ~950px isso ainda dava 570px de lista, e o relato foi
+            "scroll de horas ainda gigante". Rolar não era o objetivo; caber era.
+            Fica escrito porque o erro não foi o mecanismo, foi o NÚMERO — e é o
+            tipo de coisa que nenhum gate mede e só a tela mostra.
           */}
           <div
             data-testid="lista-de-horarios"
-            className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto pr-1 lg:max-h-[60vh]"
+            className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto pr-1 lg:max-h-[min(42vh,380px)]"
           >
             {doDia.map((h) => (
               <button

--- a/lib/agenda/ancora-depois-de-marcar.ts
+++ b/lib/agenda/ancora-depois-de-marcar.ts
@@ -1,0 +1,70 @@
+/**
+ * Para onde a grade da Agenda vai quando o painel de marcação fecha.
+ *
+ * ## De onde vem a prova — e de onde ELA NÃO VEM
+ *
+ * Relato de 2026-09-12: *"fiz um agendamento que não aparece ao sair da agenda"*.
+ *
+ * ⚠️ **O compromisso existia** — aparecia nas três visões. Quem relatou estava
+ * procurando no dia e na semana errados, e disse isso ao conferir. Vale registrar
+ * a forma exata do engano, porque ela é o defeito e não a desculpa dele: a grade
+ * ficou onde estava, a pessoa foi procurar de memória, e procurou errado. Um
+ * minuto perdido e a conclusão "sumiu" — sobre um sistema que funcionava.
+ *
+ * "Não apareceu" e "não fui levado até ele" são a mesma experiência para quem
+ * usa. O produto já sabia disso e escreveu, no botão "Ver na agenda":
+ *
+ * > *"o compromisso recém marcado costuma ser de OUTRA semana (o do relato era
+ * > 8 de setembro), e a grade abre na semana corrente. Voltar para uma grade que
+ * > não mostra o que acabou de nascer é o mesmo 'nada acontece' com um passo a
+ * > mais."*
+ *
+ * E consertou **um** caminho: quem clica em "Ver na agenda" é levado até o dia.
+ * Quem fecha no X — ou clica fora, ou aperta Esc — não é. É o mesmo formato de
+ * erro que a limpeza do painel tinha no mesmo arquivo: o raciocínio certo,
+ * aplicado a parte dos caminhos.
+ *
+ * Dois relatos, meses diferentes, mesma frase — e o conserto anterior cobriu só
+ * quem clica no botão certo. Quem fecha no X é a maioria.
+ *
+ * ## Por que levar a grade, e não avisar
+ *
+ * A alternativa seria um aviso ("marcado para 24 de setembro"). Ela é pior: o
+ * aviso some, a dúvida fica, e a pessoa ainda precisa navegar. Levar a grade
+ * responde a pergunta que ela vai fazer — *cadê?* — antes de ela fazer.
+ *
+ * ## Por que isto é uma função, e não três linhas dentro do componente
+ *
+ * Porque assim dá para medir. A regra tem um caso degenerado que decide tudo
+ * (**fechar sem ter marcado não pode mover a grade**) e ele é invisível em
+ * revisão de código: mover a âncora sempre que o painel fecha teleporta quem
+ * abriu, olhou e desistiu — para o dia de um compromisso que ele não criou.
+ */
+
+/**
+ * @param instanteMarcado ISO do compromisso recém-criado nesta abertura do
+ *   painel, ou `null` quando nada foi marcado.
+ * @param inicioDoDia Normalmente `startOfDay` do date-fns. Recebido como
+ *   parâmetro para esta regra não depender da biblioteca de datas — o que a
+ *   torna testável sem fuso, sem relógio e sem import pesado.
+ * @returns O novo valor da âncora, ou `null` para **não mexer** na grade.
+ */
+export function ancoraAoFecharPainel(
+  instanteMarcado: string | null | undefined,
+  inicioDoDia: (d: Date) => Date,
+): Date | null {
+  // ⛔ O CASO QUE DECIDE TUDO: abrir o painel, olhar e desistir não pode mover
+  // a grade. Quem só espiou perderia o lugar onde estava — e é o caminho mais
+  // comum dos dois.
+  if (!instanteMarcado) return null;
+
+  const quando = new Date(instanteMarcado);
+  // Data ilegível é o mesmo que não saber: não mexer é sempre recuperável,
+  // teleportar para `Invalid Date` deixa a grade em branco sem explicação.
+  if (Number.isNaN(quando.getTime())) return null;
+
+  // O DIA, nunca o instante: a âncora é o dia de referência da visão. Mandar o
+  // instante exato funciona por acidente na visão de semana e escolhe a hora
+  // errada na de dia — é a mesma razão escrita no `onVerNaAgenda`.
+  return inicioDoDia(quando);
+}

--- a/tests/unit/agenda-ancora-depois-de-marcar.test.ts
+++ b/tests/unit/agenda-ancora-depois-de-marcar.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { ancoraAoFecharPainel } from "@/lib/agenda/ancora-depois-de-marcar";
+
+/**
+ * ⚠️ O relato que puxou este arquivo ("fiz um agendamento que não aparece ao
+ * sair da agenda", 2026-09-12) **NÃO se confirmou** — o compromisso aparecia nas
+ * três visões. Está escrito aqui e no módulo porque prova que caiu não sustenta
+ * código, e quem ler depois merece saber disso antes de confiar.
+ *
+ * O que sustenta é a simetria com um defeito JÁ relatado e já documentado no
+ * produto: o comentário do botão "Ver na agenda" descreve o caso (um compromisso
+ * de 8 de setembro, marcado da semana corrente) e conserta só o caminho do
+ * botão. Fechar no X, clicar fora ou apertar Esc continuava sem levar a grade.
+ */
+
+/** `startOfDay` de mentira, e é de propósito: a regra não pode depender de fuso. */
+const inicioDoDia = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+
+describe("para onde a grade vai quando o painel de marcação fecha", () => {
+  it("⛔ leva até o dia do compromisso recém-marcado", () => {
+    const destino = ancoraAoFecharPainel("2026-09-24T11:30:00.000Z", inicioDoDia);
+    expect(destino).not.toBeNull();
+    expect(destino?.getDate()).toBe(24);
+    expect(destino?.getMonth()).toBe(8); // setembro
+  });
+
+  it("⛔ NÃO mexe na grade de quem só abriu e desistiu", () => {
+    // O caso degenerado, e o que decide o desenho: mover a âncora sempre que o
+    // painel fecha teleporta quem abriu, olhou e fechou — para o dia de um
+    // compromisso que ele não criou. É o caminho MAIS comum dos dois.
+    expect(ancoraAoFecharPainel(null, inicioDoDia)).toBeNull();
+    expect(ancoraAoFecharPainel(undefined, inicioDoDia)).toBeNull();
+    expect(ancoraAoFecharPainel("", inicioDoDia)).toBeNull();
+  });
+
+  it("data ilegível não teleporta para lugar nenhum", () => {
+    // Não mexer é sempre recuperável; ancorar em `Invalid Date` deixa a grade
+    // em branco sem uma linha de explicação.
+    expect(ancoraAoFecharPainel("nao é data", inicioDoDia)).toBeNull();
+  });
+
+  it("devolve o DIA, com a hora zerada — a âncora é o dia da visão", () => {
+    // Mandar o instante exato funciona por acidente na visão de semana e escolhe
+    // a hora errada na de dia. É a mesma razão escrita no `onVerNaAgenda`.
+    const destino = ancoraAoFecharPainel("2026-09-24T23:45:00.000Z", inicioDoDia);
+    expect(destino?.getHours()).toBe(0);
+    expect(destino?.getMinutes()).toBe(0);
+  });
+
+  it("CONTROLE: usa a função de data que recebe, não uma de dentro", () => {
+    // Guarda de vacuidade com dentes: se a implementação ignorasse o parâmetro e
+    // chamasse um `startOfDay` importado, este caso não teria como notar — então
+    // o marcador é uma data IMPOSSÍVEL de produzir por acaso.
+    const marcador = new Date(1999, 0, 1);
+    expect(ancoraAoFecharPainel("2026-09-24T11:30:00.000Z", () => marcador)).toBe(marcador);
+  });
+});

--- a/tests/unit/agenda-modal-nao-herda-nem-estica.test.ts
+++ b/tests/unit/agenda-modal-nao-herda-nem-estica.test.ts
@@ -97,10 +97,18 @@ describe("a lista de horários rola em vez de esticar a janela", () => {
     expect(classes).toMatch(/lg:max-h-/);
   });
 
-  it("o teto é relativo à JANELA, não um número de pixels", () => {
-    // O inimigo é a altura da tela, não a quantidade de horários. Um teto fixo
-    // escolhido num monitor grande volta a cortar em 1366×768, que é onde o
-    // defeito original apareceu.
-    expect(classes).toMatch(/max-h-\[\d+vh\]/);
+  it("o teto tem parte relativa à JANELA — senão volta a cortar em tela baixa", () => {
+    // Um teto só em pixel, escolhido num monitor grande, corta em 1366×768 —
+    // que é exatamente onde o defeito original apareceu.
+    expect(classes).toMatch(/\d+vh/);
+  });
+
+  it("⛔ e tem parte em PIXEL — senão em tela alta o teto não é teto", () => {
+    // Medido na prova de tela: `60vh` sozinho fez a barra de rolagem aparecer
+    // (o mecanismo estava certo) e ainda assim rendeu ~570px de lista numa
+    // janela de ~950px. O relato foi "scroll de horas ainda gigante". Rolar não
+    // era o objetivo; caber era. O erro não estava no mecanismo, estava no
+    // NÚMERO — e nenhum gate mede número: só a tela mostra.
+    expect(classes).toMatch(/\d+px/);
   });
 });

--- a/tests/unit/agenda-modal-nao-herda-nem-estica.test.ts
+++ b/tests/unit/agenda-modal-nao-herda-nem-estica.test.ts
@@ -1,0 +1,106 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Dois defeitos da tela de agendamento, medidos numa instalação real em
+ * 2026-09-12 — e as duas cercas que impedem cada um de voltar.
+ *
+ * ## O que estas cercas são, e o que NÃO são
+ *
+ * São cercas de FORMA: leem o código-fonte e exigem a presença do que conserta.
+ * Não provam comportamento — não abrem o modal, não medem pixel. A prova de
+ * verdade é pela tela, e ela é do `tests/e2e/` e de quem opera.
+ *
+ * Existem assim mesmo porque os dois defeitos são exatamente do tipo que passa
+ * por typecheck, lint e pela suíte inteira sem um arranhão: um é um `setState`
+ * que **não** está lá, o outro é uma classe de CSS ausente. Nenhum gate deste
+ * repositório olhava para qualquer um dos dois, e os dois chegaram à instalação
+ * de um cliente.
+ */
+
+const RAIZ = process.cwd();
+
+describe("o modal de agendamento não herda o cliente da abertura anterior", () => {
+  const FONTE = fs.readFileSync(path.join(RAIZ, "app", "app", "agenda", "_client.tsx"), "utf8");
+
+  /**
+   * O bloco que roda ao FECHAR sem confirmar. É ele que devolve o modal ao
+   * estado neutro; o que ficar de fora vaza para a próxima marcação.
+   */
+  const limpeza = (() => {
+    const i = FONTE.indexOf("if (!aberto) {");
+    if (i < 0) return "";
+    return FONTE.slice(i, FONTE.indexOf("\n          }", i));
+  })();
+
+  it("CONTROLE: o bloco de limpeza foi encontrado — senão o resto não prova nada", () => {
+    // Sem este caso, renomear a variável `aberto` faria o recorte devolver ""
+    // e TODOS os casos abaixo ficariam verdes com o defeito de volta.
+    expect(limpeza.length).toBeGreaterThan(40);
+  });
+
+  it("⛔ limpa o CLIENTE — o defeito que marcaria compromisso no nome de outra pessoa", () => {
+    // Medido: "Novo agendamento" abriu com um contato já selecionado, herdado de
+    // uma abertura anterior feita a partir da conversa daquele contato. O campo
+    // parece preenchido de propósito — não há o que estranhar na tela.
+    expect(limpeza).toMatch(/setContactId\(""\)/);
+  });
+
+  it("⛔ limpa a CONVERSA vinculada, pelo mesmo motivo", () => {
+    expect(limpeza).toMatch(/setConversationId\(""\)/);
+  });
+
+  it("continua limpando os três que já limpava", () => {
+    // Controle de não-regressão: o conserto acrescenta, nunca troca. Um conserto
+    // que limpasse o cliente e parasse de limpar o convidado devolveria o defeito
+    // irmão — convite de e-mail para a pessoa errada.
+    expect(limpeza).toMatch(/setRemarcandoId\(null\)/);
+    expect(limpeza).toMatch(/setHorarioEscolhido\(null\)/);
+    expect(limpeza).toMatch(/setEmailConvidado\(""\)/);
+  });
+});
+
+describe("a lista de horários rola em vez de esticar a janela", () => {
+  const FONTE = fs.readFileSync(
+    path.join(RAIZ, "components", "agenda", "PainelDeMarcacao.tsx"),
+    "utf8",
+  );
+
+  /** A linha de classes da lista, achada pelo `data-testid` que a nomeia. */
+  const classes = (() => {
+    const i = FONTE.indexOf('data-testid="lista-de-horarios"');
+    if (i < 0) return "";
+    const trecho = FONTE.slice(i, i + 400);
+    return /className=\{?"([^"]+)"/.exec(trecho)?.[1] ?? "";
+  })();
+
+  it("CONTROLE: as classes da lista foram encontradas", () => {
+    expect(classes.length).toBeGreaterThan(10);
+  });
+
+  it("⛔ a lista tem TETO — sem ele o `overflow-y-auto` é enfeite", () => {
+    // O par é indivisível: `overflow-y-auto` só rola quando existe altura que
+    // limite o filho. Durante meses o teto veio do pai, e no dia em que o pai
+    // perdeu a altura (para a janela parar de CORTAR os botões em tela baixa) a
+    // lista passou a crescer sem fim — treze horários numa janela que não cabia
+    // na tela. `max-height` não depende de cadeia nenhuma.
+    expect(classes).toMatch(/max-h-/);
+    expect(classes).toMatch(/overflow-y-auto/);
+  });
+
+  it("o teto vale só da coluna para cima — no celular quem rola é o diálogo", () => {
+    // Dois roladores aninhados no telefone prendem o dedo no de dentro: a pessoa
+    // tenta rolar a página e move a lista. Abaixo de `lg` o painel é empilhado e
+    // o diálogo inteiro rola, que é o certo.
+    expect(classes).toMatch(/lg:max-h-/);
+  });
+
+  it("o teto é relativo à JANELA, não um número de pixels", () => {
+    // O inimigo é a altura da tela, não a quantidade de horários. Um teto fixo
+    // escolhido num monitor grande volta a cortar em 1366×768, que é onde o
+    // defeito original apareceu.
+    expect(classes).toMatch(/max-h-\[\d+vh\]/);
+  });
+});


### PR DESCRIPTION
# O que este PR faz

Três consertos no painel de marcação da Agenda. O primeiro é o que importa:

**1. O compromisso podia nascer no nome de outra pessoa.**

Ao fechar o painel sem confirmar, o handler limpava `remarcandoId`, `horarioEscolhido` e `emailConvidado` — e **deixava** `contactId` e `conversationId`. Abrir "Marcar compromisso" de dentro de uma conversa preenche os dois (`onContext`), e eles sobreviviam ao fechamento: o "Novo agendamento" seguinte, aberto pela Agenda, vinha com aquele cliente **já selecionado**.

Quem não reparasse marcava o compromisso no nome de outra pessoa — e o campo parece preenchido de propósito, então não há o que estranhar.

O comentário que já existia naquele bloco descrevia o defeito com precisão — *"um convidado digitado e não usado reapareceria na PRÓXIMA marcação, que é de outro cliente"* — e tratava três campos de cinco. Este PR aplica o mesmo raciocínio aos dois que faltavam.

**2. Fechar o painel leva a grade até o compromisso recém-marcado.** "Ver na agenda" já fazia isso; fechar no X, clicar fora ou apertar Esc, não — e a grade ficava na semana em que estava, sem o compromisso que acabou de nascer, que quase sempre é de outra semana.

**3. O teto da lista de horários aperta.** Rolar não era o objetivo; caber era.

## O que eu medi

```
pnpm typecheck   → zerado
pnpm lint        → zerado (0 erros)
```

Provado pela tela numa instalação real: abrir pela conversa, fechar com Esc, abrir "Novo agendamento" — o cliente não vem mais herdado.

## O que eu NÃO medi

- **Não rodei `pnpm test:unit` nesta branch isolada** — rodei no ramo que a contém.
- **Não rodei `test:e2e`** (exige Docker, banco semeado e WAHA local). Fica com o mantenedor, como o template combina.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
